### PR TITLE
Crossover: read the barrier diagonal in the frame it solved in (gh#654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ changes.
 
 ## [Unreleased]
 
+- **Crossover: the sensitivity path reads the barrier diagonal in the
+  frame crossover solved in** (#654).
+
+  `bound_relax_factor` (default `1e-8`) widens every bound by `δ` before
+  the solve, and crossover parks the iterate exactly on the **declared**
+  bound — a full `δ` inside the live relaxed one. So the barrier saw a
+  slack of exactly `δ` at every active bound where an interior iterate
+  would have carried `μ/z`, and the barrier diagonal `Σ = z/s` came out
+  as `z/δ` instead of `z²/μ`. Since `δ` is capped at `constr_viol_tol`
+  and `μ` ends near `tol/(barrier_tol_factor+1)`, that is *looser*
+  whenever `z·δ/μ > 1`, which is the ordinary case.
+
+  `Σ` is the stiffness with which the barrier holds a bounded variable,
+  and a reduced Hessian read off the held KKT factor carries a residual
+  error of exactly `O(1/Σ)` — the leftover of that pin being finite. So
+  crossover was *degrading* the sensitivity path by a factor that tracked
+  the bound multiplier: on the pinned fixture, `18x` at `z = 4.5`, `376x`
+  at `z = 94.5`, `396x` at `z = 994.5`. With `bound_relax_factor = 0` the
+  same run was instead `306x` more accurate than no crossover — so an
+  option documented as the remedy for the sensitivity path's AMBIGUOUS
+  class only helped when a second, unrelated option was also set.
+
+  `Σ` is now re-measured against the declared bounds — variable bounds
+  and inequality-row bounds alike — whenever the held iterate came from
+  an accepted crossover, and the same corrected diagonal is what the
+  factor is rebuilt with and what `classify_activity` reads, so the two
+  cannot disagree about which bounds the point is measured against. The
+  reduced-Hessian error drops to the roundoff of the answer itself
+  (`8.9e-16`, and exactly `0` at the larger multipliers) and is now
+  identical with the relaxation on and off. Covers `covariance()`,
+  `information()`, `classify_activity()`, `Solver::compute_reduced_hessian`,
+  both parametric steps, `kkt_solve`/`kkt_solve_many`, and the
+  `SensSolve` builder — every one of them reads the one held factor.
+
+  Applied at the consumer boundary, as #646 did for the residual report:
+  nothing on the live iterate moves, no solver trajectory changes, and a
+  solve that did not cross over is bit-identical. Slacks are floored at
+  `eps·max(1,|bound|)` — the distance at which the point *is* the bound —
+  rather than by `CalculateSafeSlack`, which would put the `μ/z` standoff
+  crossover exists to remove straight back. Pinned by
+  `crates/pounce-sensitivity/tests/crossover_sigma_downstream.rs`.
+
 - **`pounce-rs`: a rejected solver option is no longer silently
   discarded** (#649).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,11 @@ changes.
   solve that did not cross over is bit-identical. Slacks are floored at
   `eps·max(1,|bound|)` — the distance at which the point *is* the bound —
   rather than by `CalculateSafeSlack`, which would put the `μ/z` standoff
-  crossover exists to remove straight back. Pinned by
+  crossover exists to remove straight back. The declared frame does carry
+  #655's representability floor `s >= max_i z_i / (f64::MAX/4)`, which is
+  about what a double can hold rather than about where the barrier would
+  have put the point, and would otherwise have stopped at the frame
+  boundary. Pinned by
   `crates/pounce-sensitivity/tests/crossover_sigma_frame.rs`, which sweeps
   the bound multiplier; #653's `crossover_sigma_downstream.rs` measures the
   same effect at a single multiplier and lost the test that recorded the
@@ -262,18 +266,13 @@ changes.
   `Σ` from `8.1e9` to `2.0e16` and the reduced-Hessian error from `4.95e-10`
   to `4.44e-16` — the roundoff of the answer itself. The `1/Σ` law matches to
   every printed digit until `Σ` grows past the point where its prediction
-  falls below that roundoff. `Σ` never goes infinite: the declared-frame
-  measurement floors a slack at `eps·max(1,|bound|)`, so a pivot landing
-  exactly on a bound gives a large `Σ` rather than a `NaN`.
-  `Σ` from `8.1e9` to `2.5e12` and the reduced-Hessian error from `4.95e-10`
-  to `1.62e-12` — **306× more accurate**, matching the `1/Σ` law to every
-  printed digit. `Σ` never goes infinite on this path: `CalculateSafeSlack`
-  floors a slack below `eps·min(1,μ)` up to about `μ/z`, so even an
-  exactly-zero slack falls back to the pre-crossover `Σ = z²/μ`, and the
-  crossed-over slack measured here bottoms out at `1.8e-12` without reaching
-  the floor. That threshold is about the barrier term and does not mention
-  the multiplier, so it does not bound `Σ` once `μ` goes subnormal; the floor
-  that does is the `s >= max_i z_i / (f64::MAX/4)` added for #655.
+  falls below that roundoff. `Σ` never goes infinite in either frame: on the
+  live path `CalculateSafeSlack` floors a slack below `eps·min(1,μ)` up to
+  about `μ/z`, and since that threshold is about the barrier term and does
+  not mention the multiplier, the floor that bounds `Σ` once `μ` goes
+  subnormal is the `s >= max_i z_i / (f64::MAX/4)` added for #655; the
+  declared frame carries `eps·max(1,|bound|)` and the same `#655` bound. The
+  slack measured here bottoms out at `1.8e-12` and reaches neither.
 
   The same measurement found the reverse under a nonzero
   `bound_relax_factor` (#654), #646's frame mismatch reaching the numerics

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1841,6 +1841,11 @@ impl IpoptApplication {
         solver_status: SolverReturn,
     ) {
         self.crossover_report = None;
+        // Cleared on every entry, alongside the report, so the flag
+        // describes this solve and not a previous one — the same reason
+        // `crossover_report` is reset here rather than only written on
+        // the accept path.
+        alg.data.borrow_mut().curr_from_crossover = false;
         let xopts = self.crossover_options();
         if !xopts.enabled {
             return;
@@ -1966,7 +1971,17 @@ impl IpoptApplication {
             );
             return;
         }
-        alg.data.borrow_mut().set_curr(out.freeze());
+        let mut d = alg.data.borrow_mut();
+        d.set_curr(out.freeze());
+        // Mark which frame the installed iterate belongs to. It sits on the
+        // *declared* bounds, and every barrier quantity built off `curr` —
+        // slacks, and through them `Σ = z/s` — is measured against the
+        // `bound_relax_factor`-widened ones, so a consumer that wants the
+        // point's own geometry rather than the barrier's has to know this
+        // happened (gh#654). Set only on the path that actually replaced
+        // `curr`: a declined or abandoned crossover leaves the interior
+        // iterate, which is an interior-frame point.
+        d.curr_from_crossover = true;
     }
 
     fn algorithm_builder_snapshot(&self) -> AlgorithmBuilder {

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -126,6 +126,22 @@ pub struct IpoptData {
     /// [`crate::application::IpoptApplication::warm_start_diagnostics`].
     pub warm_start_diagnostics: Option<WarmStartDiagnostics>,
 
+    /// `curr` was installed by the post-convergence crossover phase
+    /// (gh#612) rather than produced by the interior iteration.
+    ///
+    /// The distinction is not bookkeeping: a crossed-over point sits
+    /// *on* the bounds the user declared, which is `bound_relax_factor`
+    /// **inside** the widened box the barrier quantities are measured
+    /// against, so every slack at an active bound reads exactly `δ`
+    /// where an interior iterate would have carried `μ/z` (gh#646,
+    /// gh#654). Anything that reads `curr` through the barrier — the
+    /// residual report, the sensitivity path's `Σ = z/s` — has to know
+    /// which of the two frames the iterate belongs to before it can
+    /// pick the bounds to measure against. Nothing inside the
+    /// algorithm reads this: the flag is set after `optimize()` has
+    /// returned and no further step is taken.
+    pub curr_from_crossover: bool,
+
     /// Line-search reset request from the μ-update layer (pounce#510).
     /// Upstream's μ updates hold a `linesearch_` handle and call
     /// `linesearch_->Reset()` themselves at fixed points
@@ -227,6 +243,7 @@ impl IpoptData {
             tiny_step_flag: false,
             request_resto: false,
             warm_start_diagnostics: None,
+            curr_from_crossover: false,
             request_ls_reset: false,
             request_tiny_step_stop: false,
             info_alpha_primal_char: ' ',

--- a/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
@@ -24,6 +24,26 @@ use pounce_linsol::ESymSolverStatus;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+/// Barrier-diagonal replacements for one
+/// [`PdFullSpaceSolver::solve_with_sigma`] call. `None` on a side means
+/// "use the calculated quantity", so [`Self::default`] is exactly
+/// [`PdFullSpaceSolver::solve`].
+///
+/// The two blocks travel together because they answer the same question
+/// about the same iterate — how stiffly the barrier holds each active
+/// bound — and a caller that corrects one and not the other leaves the
+/// factor describing a point that is half in one frame and half in the
+/// other.
+#[derive(Default, Clone)]
+pub struct SigmaOverride {
+    /// Replacement for `cq.curr_sigma_x()`: the variable-bound
+    /// contribution to the `x` diagonal.
+    pub x: Option<Rc<dyn Vector>>,
+    /// Replacement for `cq.curr_sigma_s()`: the inequality-row-bound
+    /// contribution to the `s` diagonal.
+    pub s: Option<Rc<dyn Vector>>,
+}
+
 pub struct PdFullSpaceSolver {
     aug_solver: Box<dyn AugSystemSolver>,
     perturb: Rc<RefCell<PdPerturbationHandler>>,
@@ -147,7 +167,7 @@ impl PdFullSpaceSolver {
         allow_inexact: bool,
         improve_solution: bool,
     ) -> bool {
-        self.solve_with_sigma_x(
+        self.solve_with_sigma(
             data,
             cq,
             nlp,
@@ -157,36 +177,44 @@ impl PdFullSpaceSolver {
             res,
             allow_inexact,
             improve_solution,
-            None,
+            SigmaOverride::default(),
         )
     }
 
-    /// [`Self::solve`] against the same system with `sigma_x` replaced.
+    /// [`Self::solve`] against the same system with the barrier
+    /// diagonals `sigma_x` / `sigma_s` replaced.
     ///
-    /// `sigma_x` is the barrier term the active bounds contribute to
-    /// the `x` diagonal, `z / s` per bound. Zeroing an entry takes that
-    /// bound back out of the active set, which is what a *released*
-    /// bound means, so factoring the result gives the released system
-    /// directly.
+    /// `sigma` is the barrier term the active bounds contribute to the
+    /// `x` (variable bounds) and `s` (inequality-row bounds) diagonals,
+    /// `z / s` per bound. Two callers want it substituted, for
+    /// different reasons:
     ///
-    /// This exists because the released system cannot be recovered from
-    /// the converged factor. Reaching it by a rank-1 downdate through a
-    /// Schur complement asks for the difference of two quantities that
-    /// agree to about `eps * sigma`, and on a tightly converged bound
-    /// `sigma` is large enough that the difference is noise -- measured,
-    /// the released answer degrades in proportion to how well the solve
-    /// converged. Factoring is what buys those digits back, and it is
-    /// still one factorization against the twenty to a hundred a
-    /// re-solve would run.
+    /// * **Release.** Zeroing an entry takes that bound back out of the
+    ///   active set, which is what a *released* bound means, so
+    ///   factoring the result gives the released system directly. The
+    ///   released system cannot be recovered from the converged factor:
+    ///   reaching it by a rank-1 downdate through a Schur complement
+    ///   asks for the difference of two quantities that agree to about
+    ///   `eps * sigma`, and on a tightly converged bound `sigma` is
+    ///   large enough that the difference is noise -- measured, the
+    ///   released answer degrades in proportion to how well the solve
+    ///   converged. Factoring is what buys those digits back, and it is
+    ///   still one factorization against the twenty to a hundred a
+    ///   re-solve would run.
+    /// * **Crossover (gh#654).** A crossed-over iterate sits on the
+    ///   *declared* bounds, so its live slacks read `bound_relax_factor`
+    ///   rather than the barrier's `mu/z`, and `sigma` comes out of the
+    ///   cache describing a looser pin than the point actually has. The
+    ///   sensitivity path substitutes the declared-frame diagonal here.
     ///
     /// Only `pounce-sensitivity` calls this; the algorithm's own step
     /// computation goes through [`Self::solve`] and is unaffected, so no
-    /// solver trajectory moves. `sigma_x` is one of the thirteen
+    /// solver trajectory moves. Both sigmas are among the thirteen
     /// dependency tags, so passing a different vector misses the
     /// factorization cache and re-factors, and the next ordinary solve
     /// misses it back -- correctness needs no extra bookkeeping here.
     #[allow(clippy::too_many_arguments)]
-    pub fn solve_with_sigma_x(
+    pub fn solve_with_sigma(
         &mut self,
         data: &IpoptDataHandle,
         cq: &IpoptCqHandle,
@@ -197,7 +225,7 @@ impl PdFullSpaceSolver {
         res: &mut IteratesVectorMut,
         allow_inexact: bool,
         improve_solution: bool,
-        sigma_x_override: Option<Rc<dyn pounce_linalg::Vector>>,
+        sigma_override: SigmaOverride,
     ) -> bool {
         debug_assert!(!allow_inexact || !improve_solution);
         debug_assert!(!improve_solution || beta == 0.0);
@@ -221,8 +249,8 @@ impl PdFullSpaceSolver {
         let cq_ref = cq.borrow();
         let j_c = cq_ref.curr_jac_c();
         let j_d = cq_ref.curr_jac_d();
-        let sigma_x = sigma_x_override.unwrap_or_else(|| cq_ref.curr_sigma_x());
-        let sigma_s = cq_ref.curr_sigma_s();
+        let sigma_x = sigma_override.x.unwrap_or_else(|| cq_ref.curr_sigma_x());
+        let sigma_s = sigma_override.s.unwrap_or_else(|| cq_ref.curr_sigma_s());
         let slack_x_l = cq_ref.curr_slack_x_l();
         let slack_x_u = cq_ref.curr_slack_x_u();
         let slack_s_l = cq_ref.curr_slack_s_l();

--- a/crates/pounce-sensitivity/src/activity.rs
+++ b/crates/pounce-sensitivity/src/activity.rs
@@ -39,9 +39,12 @@
 //!
 //! Everything read here is retained by the converged state the
 //! backsolver already holds: the bound multipliers on the iterate, the
-//! solver's own slacks, `Σ` as `curr_sigma_x` / `curr_sigma_s`, the
-//! barrier parameter, and the exact Lagrangian Hessian, so `H` is
-//! never recovered from the barrier-augmented factor.
+//! solver's own slacks, `Σ` through the backsolver's
+//! `barrier_sigma_x` / `barrier_sigma_s` — `curr_sigma_x` /
+//! `curr_sigma_s` unless the held iterate came from crossover, in which
+//! case the declared-frame diagonal the factor is also built with
+//! (gh#654) — the barrier parameter, and the exact Lagrangian Hessian,
+//! so `H` is never recovered from the barrier-augmented factor.
 //!
 //! The report is indexed in **user space**: `var_*` arrays have the
 //! user TNLP's full variable count and `row_*` arrays its full
@@ -370,12 +373,18 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     let has_u = present(&px_u, n);
     let z_l = expand(&dense_to_vec(mult_z_l.as_ref()), &px_l, n);
     let z_u = expand(&dense_to_vec(mult_z_u.as_ref()), &px_u, n);
+    // The solver's own slacks, deliberately, even when `Σ` below comes
+    // from the declared frame (gh#654): these feed `off_path` only, and
+    // "is `s·z` near `μ`" is a question about the central path, which is
+    // the barrier's geometry and therefore the barrier's slacks. A
+    // crossed-over point is off that path by construction and reads so
+    // under either frame.
     let s_l = expand(&dense_to_vec(cq.curr_slack_x_l().as_ref()), &px_l, n);
     let s_u = expand(&dense_to_vec(cq.curr_slack_x_u().as_ref()), &px_u, n);
     // `Σ̃_i = df·Σ_i/d_i²`: the `d_i²` comes out here, the `df` on
     // export below (it cancels in every ratio, so classification never
     // sees it).
-    let sigma_x: Vec<Number> = dense_to_vec(cq.curr_sigma_x().as_ref())
+    let sigma_x: Vec<Number> = dense_to_vec(bs.barrier_sigma_x().as_ref())
         .iter()
         .enumerate()
         .map(|(i, &s)| s * dv(i) * dv(i))
@@ -417,7 +426,7 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     let v_u = expand(&dense_to_vec(mult_v_u.as_ref()), &pd_u, m_d);
     let rs_l = expand(&dense_to_vec(cq.curr_slack_s_l().as_ref()), &pd_l, m_d);
     let rs_u = expand(&dense_to_vec(cq.curr_slack_s_u().as_ref()), &pd_u, m_d);
-    let sigma_s = dense_to_vec(cq.curr_sigma_s().as_ref());
+    let sigma_s = dense_to_vec(bs.barrier_sigma_s().as_ref());
 
     let jac_d = cq.curr_jac_d();
     // One pass over the Jacobian triplets gathers every row's support

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -46,7 +46,7 @@ use std::rc::Rc;
 use pounce_algorithm::ipopt_cq::IpoptCqHandle;
 use pounce_algorithm::ipopt_data::IpoptDataHandle;
 use pounce_algorithm::iterates_vector::{IteratesVector, IteratesVectorMut};
-use pounce_algorithm::kkt::pd_full_space_solver::PdFullSpaceSolver;
+use pounce_algorithm::kkt::pd_full_space_solver::{PdFullSpaceSolver, SigmaOverride};
 use pounce_common::types::{Index, Number};
 use pounce_linalg::dense_vector::DenseVector;
 use pounce_nlp::ipopt_nlp::IpoptNlp;
@@ -145,6 +145,57 @@ pub struct PdSensBacksolver {
     /// expansions. `None` when either expansion is not an
     /// `ExpansionMatrix` and the map cannot be recovered.
     bound_vars: Option<Rc<Vec<crate::backsolver::BoundRow>>>,
+    /// The barrier geometry re-measured against the bounds the model
+    /// declares, for a held iterate that came from crossover. `None` —
+    /// meaning "read the calculated quantities as they stand" — on
+    /// every solve that ended on an interior point. See
+    /// [`DeclaredFrameBarrier`].
+    declared: Option<Rc<DeclaredFrameBarrier>>,
+}
+
+/// `Σ` and the active-bound slacks of a **crossed-over** iterate,
+/// measured against the bounds the user declared rather than the ones
+/// the barrier ran against (gh#654).
+///
+/// `bound_relax_factor` (default `1e-8`) widens every bound by `δ`
+/// before the solve, and crossover (gh#612) then parks the iterate
+/// exactly on the *declared* bound — a full `δ` inside the live relaxed
+/// one. So the calculated quantities report a slack of exactly `δ` at
+/// every active bound, where an interior iterate would have carried
+/// `μ/z`, and the barrier diagonal `Σ = z/s` comes out as `z/δ` instead
+/// of `z²/μ`. Since `δ` is capped at `constr_viol_tol` and `μ` ends near
+/// `tol/(barrier_tol_factor+1)`, that is *looser* whenever `z·δ/μ > 1`,
+/// which is the ordinary case.
+///
+/// `Σ` is the stiffness with which the barrier holds a bounded variable,
+/// and a reduced Hessian read off the held factor carries a residual
+/// error of exactly `O(1/Σ)` — the leftover of that pin being finite. So
+/// the looser reading is a measurably less accurate covariance: on the
+/// gh#654 fixture, `18x` at a bound multiplier of `4.5` and `396x` at
+/// `994.5`, tracking `z·δ/μ` exactly.
+///
+/// The correction is the same one gh#646 applied to the reported
+/// residuals: measure the crossed-over point in the frame it was solved
+/// in. Nothing on the live iterate is touched — the relaxed bounds are
+/// still what the algorithm ran against, and un-relaxing them after the
+/// fact would mean replacing the NLP's bound `Rc`s and invalidating
+/// every tag-keyed cache built on them. This is the consumer boundary
+/// instead, where the question "how stiffly is this point held" is
+/// actually being asked.
+struct DeclaredFrameBarrier {
+    /// Variable-bound contribution to the `x` diagonal.
+    sigma_x: Rc<dyn pounce_linalg::Vector>,
+    /// Inequality-row-bound contribution to the `s` diagonal. Relaxation
+    /// widens `d_L` / `d_U` too, and crossover puts `s = d(x)` on the
+    /// declared row bounds, so the row half of the defect is identical
+    /// to the variable half.
+    sigma_s: Rc<dyn pounce_linalg::Vector>,
+    /// The declared-frame `x` slacks behind `sigma_x`, compressed in the
+    /// `px_l` / `px_u` spaces. Kept because a *released* solve rebuilds
+    /// one variable's `Σ` entry from the sides that stay active and has
+    /// to rebuild it in the same frame.
+    slack_x_l: Vec<Number>,
+    slack_x_u: Vec<Number>,
 }
 
 /// Left/right diagonal pair for the natural-units back-solve; see the
@@ -195,6 +246,7 @@ impl PdSensBacksolver {
         let (d_var, d_full) = Self::variable_factors(nlp, &dims)?;
         let conj = Self::natural_units_conj(nlp, &dims, d_var.as_ref().map(|v| v.as_slice()))?;
         let bound_vars = Self::bound_variable_rows(nlp, &dims);
+        let declared = Self::declared_frame_barrier(data, nlp, &dims);
         Ok(Self {
             pd,
             data: Rc::clone(data),
@@ -206,7 +258,103 @@ impl PdSensBacksolver {
             d_var,
             d_full,
             bound_vars,
+            declared,
         })
+    }
+
+    /// Re-measure `Σ` against the declared bounds when the held iterate
+    /// came from crossover; `None` otherwise, and `None` whenever the
+    /// NLP does not report its declared box (the fallback is then the
+    /// calculated quantities, i.e. the pre-gh#654 behaviour).
+    ///
+    /// Deliberately gated on crossover rather than applied everywhere:
+    /// an *interior* iterate is not near the declared bounds in any
+    /// useful sense — it can sit up to `δ` **outside** one — and its
+    /// `μ/z` standoff is the barrier's own geometry, which is the right
+    /// thing to read. Only a purified point has the declared frame as
+    /// its own.
+    fn declared_frame_barrier(
+        data: &IpoptDataHandle,
+        nlp: &Rc<RefCell<dyn IpoptNlp>>,
+        dims: &[usize; 8],
+    ) -> Option<Rc<DeclaredFrameBarrier>> {
+        let (curr, from_crossover) = {
+            let d = data.borrow();
+            (d.curr.clone()?, d.curr_from_crossover)
+        };
+        if !from_crossover {
+            return None;
+        }
+        let nlp_ref = nlp.borrow();
+        let (x_l, x_u) = nlp_ref.declared_x_bounds()?;
+        let (d_l, d_u) = nlp_ref.declared_d_bounds()?;
+        if x_l.len() != dims[4]
+            || x_u.len() != dims[5]
+            || d_l.len() != dims[6]
+            || d_u.len() != dims[7]
+        {
+            return None;
+        }
+        let (sigma_x, slack_x_l, slack_x_u) = declared_frame_sigma(
+            &*nlp_ref.px_l(),
+            &*nlp_ref.px_u(),
+            &*curr.x,
+            &x_l,
+            &x_u,
+            &*curr.z_l,
+            &*curr.z_u,
+            dims[0],
+        );
+        let (sigma_s, _, _) = declared_frame_sigma(
+            &*nlp_ref.pd_l(),
+            &*nlp_ref.pd_u(),
+            &*curr.s,
+            &d_l,
+            &d_u,
+            &*curr.v_l,
+            &*curr.v_u,
+            dims[1],
+        );
+        Some(Rc::new(DeclaredFrameBarrier {
+            sigma_x,
+            sigma_s,
+            slack_x_l,
+            slack_x_u,
+        }))
+    }
+
+    /// The barrier diagonals to factor with: the declared-frame pair
+    /// when the held iterate came from crossover, otherwise the
+    /// calculated quantities (which is what [`SigmaOverride::default`]
+    /// selects).
+    fn sigma_override(&self) -> SigmaOverride {
+        match self.declared.as_ref() {
+            None => SigmaOverride::default(),
+            Some(d) => SigmaOverride {
+                x: Some(Rc::clone(&d.sigma_x)),
+                s: Some(Rc::clone(&d.sigma_s)),
+            },
+        }
+    }
+
+    /// The `x`-block barrier diagonal in the frame the held iterate
+    /// belongs to. Crate-internal because [`crate::activity`] reads `Σ`
+    /// straight off the iterate rather than through the factor, and the
+    /// two must not disagree about which bounds the point is measured
+    /// against.
+    pub(crate) fn barrier_sigma_x(&self) -> Rc<dyn pounce_linalg::Vector> {
+        match self.declared.as_ref() {
+            Some(d) => Rc::clone(&d.sigma_x),
+            None => self.cq.borrow().curr_sigma_x(),
+        }
+    }
+
+    /// [`Self::barrier_sigma_x`] for the `s` block.
+    pub(crate) fn barrier_sigma_s(&self) -> Rc<dyn pounce_linalg::Vector> {
+        match self.declared.as_ref() {
+            Some(d) => Rc::clone(&d.sigma_s),
+            None => self.cq.borrow().curr_sigma_s(),
+        }
     }
 
     /// Shared body of the two released solves. `shift` moves the
@@ -264,24 +412,35 @@ impl PdSensBacksolver {
         true
     }
 
-    /// `curr_sigma_x` with each released bound's own `z / s` taken off
-    /// the variable it constrains -- subtracted rather than zeroed,
-    /// since a variable bounded on both sides contributes twice and
-    /// only one side is being released.
+    /// The barrier's `x` diagonal with each released bound's own `z / s`
+    /// taken off the variable it constrains -- subtracted rather than
+    /// zeroed, since a variable bounded on both sides contributes twice
+    /// and only one side is being released.
+    ///
+    /// Both the starting diagonal and the slacks the surviving sides are
+    /// rebuilt from come from the frame the held iterate belongs to
+    /// (gh#654): mixing a declared-frame `Σ` with relaxed-frame slacks
+    /// would leave the released variable pinned in one frame and its
+    /// neighbours in the other.
     fn released_sigma_x(&self, released: &[usize]) -> Option<Rc<dyn pounce_linalg::Vector>> {
         use pounce_linalg::dense_vector::DenseVectorSpace;
         let rows = self.bound_vars.as_deref()?;
         let base_row = rows.first()?.row;
-        let cq_ref = self.cq.borrow();
         let dense = |v: Rc<dyn pounce_linalg::Vector>| -> Option<Vec<Number>> {
             v.as_any()
                 .downcast_ref::<DenseVector>()
                 .map(|d| d.expanded_values())
         };
-        let mut sigma = dense(cq_ref.curr_sigma_x())?;
-        let slack_l = dense(cq_ref.curr_slack_x_l())?;
-        let slack_u = dense(cq_ref.curr_slack_x_u())?;
-        drop(cq_ref);
+        let mut sigma = dense(self.barrier_sigma_x())?;
+        let (slack_l, slack_u) = match self.declared.as_ref() {
+            Some(d) => (d.slack_x_l.clone(), d.slack_x_u.clone()),
+            None => {
+                let cq_ref = self.cq.borrow();
+                let l = dense(cq_ref.curr_slack_x_l())?;
+                let u = dense(cq_ref.curr_slack_x_u())?;
+                (l, u)
+            }
+        };
         let (z_l, z_u) = {
             let d = self.data.borrow();
             let curr = d.curr.as_ref()?;
@@ -391,7 +550,7 @@ impl PdSensBacksolver {
         {
             return false;
         }
-        if !self.pd.borrow_mut().solve_with_sigma_x(
+        if !self.pd.borrow_mut().solve_with_sigma(
             &self.data,
             &self.cq,
             &self.nlp,
@@ -401,7 +560,12 @@ impl PdSensBacksolver {
             &mut res_iv,
             /* allow_inexact = */ true,
             /* improve_solution = */ false,
-            Some(sigma),
+            SigmaOverride {
+                x: Some(sigma),
+                // The release is an x-block operation; the row block
+                // keeps whichever frame the held iterate belongs to.
+                s: self.sigma_override().s,
+            },
         ) {
             return false;
         }
@@ -941,6 +1105,21 @@ impl PdSensBacksolver {
         }
         let off = self.offsets();
 
+        // Both cached tiers below assemble their elimination from the
+        // *calculated* `Σ` and slacks, and fire against whatever factor
+        // the last solve left behind. Neither is the right system when
+        // the held iterate came from crossover and the declared-frame
+        // diagonal is in force (gh#654), and the tag check cannot be
+        // relied on to decline: on the first call after convergence the
+        // cached tags are the algorithm's own final solve, which used
+        // exactly the diagonal being corrected. So skip them outright
+        // and take the per-RHS path, which carries the override. That
+        // costs the batched path its inlining on a crossed-over solve —
+        // one factorization, then a back-substitution per RHS, against
+        // the tag cache that the shared override vector keeps warm.
+        let sigma = self.sigma_override();
+        let corrected = self.declared.is_some();
+
         // Tier 1: fully-inline flat-slice path. `PdFullSpaceSolver::
         // solve_many_cached_flat` downcasts the slack / z / v vectors to
         // `DenseVector` and the bound-expansion matrices to
@@ -949,7 +1128,7 @@ impl PdSensBacksolver {
         // dispatch in the per-RHS inner loops. Returns `None` if a
         // downcast fails (homogeneous-on-non-empty block, unusual matrix
         // type) — we fall to Tier 2.
-        {
+        if !corrected {
             let mut pd_ref = self.pd.borrow_mut();
             let fast_flat = pd_ref.solve_many_cached_flat(
                 &self.data, &self.cq, &self.nlp, n_rhs, rhs_flat, lhs_flat, self.dims,
@@ -967,7 +1146,7 @@ impl PdSensBacksolver {
         // `IteratesVectorMut`. Slower than Tier 1 but correct for
         // homogeneous DenseVectors and non-`ExpansionMatrix` bound
         // expansions.
-        {
+        if !corrected {
             let mut pd_ref = self.pd.borrow_mut();
             let fast = pd_ref.solve_many_cached(
                 &self.data,
@@ -1027,7 +1206,7 @@ impl PdSensBacksolver {
                 return false;
             }
 
-            let ok = pd_ref.solve(
+            let ok = pd_ref.solve_with_sigma(
                 &self.data,
                 &self.cq,
                 &self.nlp,
@@ -1037,6 +1216,7 @@ impl PdSensBacksolver {
                 &mut res_iv,
                 /* allow_inexact = */ true,
                 /* improve_solution = */ false,
+                sigma.clone(),
             );
             if !ok {
                 return false;
@@ -1056,6 +1236,77 @@ impl PdSensBacksolver {
         }
         true
     }
+}
+
+/// The smallest offset from a bound that double precision tells apart
+/// from the bound itself, at that bound's own magnitude.
+///
+/// A crossed-over point is *on* its active bounds, so its declared-frame
+/// slack is the residual of the QP step and the line search — measured
+/// around `1.8e-12` (gh#653), comfortably above this floor, which
+/// therefore does nothing on the ordinary path. It exists for the corner
+/// where a pivot lands on the bound exactly: `Σ = z/0` is not a stiffer
+/// pin, it is a `NaN` in the KKT matrix. Flooring here says the honest
+/// thing instead — below this distance the point *is* the bound, and the
+/// slack carries no further information about how far inside it sits.
+///
+/// Deliberately not `CalculateSafeSlack`'s floor, which is what the live
+/// path applies: that one raises a below-floor slack to `max(μ/z, s_min)`,
+/// i.e. straight back to the `μ/z` standoff crossover exists to remove
+/// (the same reason gh#646 declined it for the residual report).
+fn declared_slack_floor(bound: Number) -> Number {
+    Number::EPSILON * bound.abs().max(1.0)
+}
+
+/// `Σ = Σ_l z_l/s_l + Σ_u z_u/s_u` for one primal block, with the slacks
+/// taken against `b_l` / `b_u` instead of the NLP's live (relaxed)
+/// bounds. Returns the diagonal plus the two slack vectors it was built
+/// from, compressed in the `p_l` / `p_u` spaces.
+///
+/// Mirrors `IpoptCalculatedQuantities`' own `curr_sigma_x` /
+/// `curr_sigma_s` — the same `Pᵀx − b` slack and the same
+/// `add_m_sinv_z` accumulation — so the only difference between this and
+/// the cached value is which bounds it measured against, and the floor
+/// above in place of the safe-slack correction.
+#[allow(clippy::too_many_arguments)]
+fn declared_frame_sigma(
+    p_l: &dyn pounce_linalg::Matrix,
+    p_u: &dyn pounce_linalg::Matrix,
+    primal: &dyn pounce_linalg::Vector,
+    b_l: &[Number],
+    b_u: &[Number],
+    z_l: &dyn pounce_linalg::Vector,
+    z_u: &dyn pounce_linalg::Vector,
+    n: usize,
+) -> (Rc<dyn pounce_linalg::Vector>, Vec<Number>, Vec<Number>) {
+    use pounce_linalg::Vector;
+    use pounce_linalg::dense_vector::DenseVectorSpace;
+
+    // `lower`: s = Pᵀx − b_l. Otherwise: s = b_u − Pᵀx.
+    let slack = |p: &dyn pounce_linalg::Matrix, b: &[Number], lower: bool| -> DenseVector {
+        let mut v = DenseVector::new(DenseVectorSpace::new(b.len() as Index));
+        if !b.is_empty() {
+            v.values_mut().copy_from_slice(b);
+        }
+        let (alpha, beta) = if lower { (1.0, -1.0) } else { (-1.0, 1.0) };
+        p.trans_mult_vector(alpha, primal, beta, &mut v);
+        for (s, &bi) in v.values_mut().iter_mut().zip(b.iter()) {
+            *s = s.max(declared_slack_floor(bi));
+        }
+        v
+    };
+    let s_l = slack(p_l, b_l, true);
+    let s_u = slack(p_u, b_u, false);
+
+    let mut sigma = DenseVector::new(DenseVectorSpace::new(n as Index));
+    sigma.set(0.0);
+    p_l.add_m_sinv_z(1.0, &s_l, z_l, &mut sigma);
+    p_u.add_m_sinv_z(1.0, &s_u, z_u, &mut sigma);
+    (
+        Rc::new(sigma) as Rc<dyn pounce_linalg::Vector>,
+        s_l.expanded_values(),
+        s_u.expanded_values(),
+    )
 }
 
 /// Write `slice` into the `DenseVector` behind `b` in place. Used by
@@ -1148,7 +1399,7 @@ impl PdSensBacksolver {
         // time at moderate `n+m` (pounce#77 follow-up).
         let ok = {
             let mut pd_ref = self.pd.borrow_mut();
-            pd_ref.solve(
+            pd_ref.solve_with_sigma(
                 &self.data,
                 &self.cq,
                 &self.nlp,
@@ -1158,6 +1409,10 @@ impl PdSensBacksolver {
                 &mut res_iv,
                 /* allow_inexact = */ true,
                 /* improve_solution = */ false,
+                // Identity on every ordinary solve; the declared-frame
+                // diagonal when the held iterate came from crossover
+                // (gh#654).
+                self.sigma_override(),
             )
         };
         if !ok {

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -1238,24 +1238,54 @@ impl PdSensBacksolver {
     }
 }
 
-/// The smallest offset from a bound that double precision tells apart
-/// from the bound itself, at that bound's own magnitude.
+/// Headroom on the representability half of [`declared_slack_floor`],
+/// matching `ipopt_cq`'s `SIGMA_OVERFLOW_HEADROOM` (gh#655) because it
+/// bounds the same quantity for the same reason: `Σ_x` sums a lower and
+/// an upper ratio into one diagonal entry, so bounding each by `MAX/4`
+/// bounds the sum by `MAX/2` with room for the rounding in the divide.
+const SIGMA_OVERFLOW_HEADROOM: Number = 4.0;
+
+/// The smallest offset from a bound that the declared-frame slack is
+/// allowed to be: the larger of what double precision tells apart from
+/// the bound itself, and what keeps `Σ = z/s` inside the double range.
 ///
 /// A crossed-over point is *on* its active bounds, so its declared-frame
 /// slack is the residual of the QP step and the line search — measured
-/// around `1.8e-12` (gh#653), comfortably above this floor, which
-/// therefore does nothing on the ordinary path. It exists for the corner
-/// where a pivot lands on the bound exactly: `Σ = z/0` is not a stiffer
-/// pin, it is a `NaN` in the KKT matrix. Flooring here says the honest
-/// thing instead — below this distance the point *is* the bound, and the
-/// slack carries no further information about how far inside it sits.
+/// around `1.8e-12` (gh#653), comfortably above both, so this does
+/// nothing on the ordinary path. Each half covers a different corner:
 ///
-/// Deliberately not `CalculateSafeSlack`'s floor, which is what the live
-/// path applies: that one raises a below-floor slack to `max(μ/z, s_min)`,
-/// i.e. straight back to the `μ/z` standoff crossover exists to remove
-/// (the same reason gh#646 declined it for the residual report).
-fn declared_slack_floor(bound: Number) -> Number {
-    Number::EPSILON * bound.abs().max(1.0)
+/// * **`eps·max(1,|bound|)`** — a pivot landing on the bound exactly.
+///   `Σ = z/0` is not a stiffer pin, it is a `NaN` in the KKT matrix.
+///   Flooring says the honest thing instead: below this distance the
+///   point *is* the bound, and the slack carries no further information
+///   about how far inside it sits.
+/// * **`z_max/(f64::MAX/4)`** — a multiplier large enough that `z/s`
+///   leaves the double range even at a slack this frame considers
+///   resolvable. This is gh#655's floor, which the live path gained in
+///   `CalculateSafeSlack`; the declared frame does not go through that
+///   function, so without carrying the bound here explicitly the
+///   guarantee would stop at the frame boundary. It takes `max_i z_i`
+///   over the block rather than each bound's own `z`, matching gh#655
+///   and conservative in the harmless direction — raising a slack only
+///   lowers `Σ`. A non-finite `z` leaves the floor alone; the iterate
+///   finiteness checks own that case.
+///
+/// What is deliberately *not* borrowed is the rest of
+/// `CalculateSafeSlack`: it raises a below-floor slack to
+/// `max(μ/z, s_min)`, i.e. straight back to the `μ/z` standoff crossover
+/// exists to remove (the same reason gh#646 declined it for the residual
+/// report). Only the representability bound crosses over, because that
+/// one is about what a double can hold, not about where the barrier
+/// would have put the point.
+fn declared_slack_floor(bound: Number, z_max: Number) -> Number {
+    let resolvable = Number::EPSILON * bound.abs().max(1.0);
+    if z_max.is_finite() && z_max > 0.0 {
+        // Divide before multiplying so a `z_max` near `f64::MAX` cannot
+        // overflow the floor itself.
+        resolvable.max(z_max / (Number::MAX / SIGMA_OVERFLOW_HEADROOM))
+    } else {
+        resolvable
+    }
 }
 
 /// `Σ = Σ_l z_l/s_l + Σ_u z_u/s_u` for one primal block, with the slacks
@@ -1282,6 +1312,11 @@ fn declared_frame_sigma(
     use pounce_linalg::Vector;
     use pounce_linalg::dense_vector::DenseVectorSpace;
 
+    // One scalar over both sides of the block, as gh#655 does: the two
+    // ratios land in the same `Σ` entry, so the bound that keeps their
+    // sum representable has to be taken over both.
+    let z_max = z_l.amax().max(z_u.amax());
+
     // `lower`: s = Pᵀx − b_l. Otherwise: s = b_u − Pᵀx.
     let slack = |p: &dyn pounce_linalg::Matrix, b: &[Number], lower: bool| -> DenseVector {
         let mut v = DenseVector::new(DenseVectorSpace::new(b.len() as Index));
@@ -1291,7 +1326,7 @@ fn declared_frame_sigma(
         let (alpha, beta) = if lower { (1.0, -1.0) } else { (-1.0, 1.0) };
         p.trans_mult_vector(alpha, primal, beta, &mut v);
         for (s, &bi) in v.values_mut().iter_mut().zip(b.iter()) {
-            *s = s.max(declared_slack_floor(bi));
+            *s = s.max(declared_slack_floor(bi, z_max));
         }
         v
     };

--- a/crates/pounce-sensitivity/tests/crossover_sigma_downstream.rs
+++ b/crates/pounce-sensitivity/tests/crossover_sigma_downstream.rs
@@ -1,0 +1,406 @@
+//! Crossover, `bound_relax_factor`, and the reduced Hessian read off the
+//! held factor (gh#654, split out of gh#653; same root cause as gh#646).
+//!
+//! `bound_relax_factor` (default `1e-8`) widens every bound by `δ` before
+//! the interior solve. Crossover then parks the iterate exactly on the
+//! **declared** bound, which is a full `δ` inside the live relaxed one. The
+//! barrier therefore sees a slack of exactly `δ` at every active bound,
+//! where an interior iterate would have carried `μ/z`. Since the barrier
+//! diagonal is `Σ = z/s`:
+//!
+//! ```text
+//! no crossover     Σ = z / (μ/z) = z²/μ
+//! crossover        Σ = z / δ
+//! ```
+//!
+//! and crossover **loosens** the pin whenever `z·δ/μ > 1` — the normal case,
+//! because `δ` is capped at `constr_viol_tol` and `μ` ends near
+//! `tol/(barrier_tol_factor+1)`. `Σ` is the stiffness with which the barrier
+//! holds a bounded variable, and any reduced Hessian read off the held KKT
+//! factor carries a residual error of exactly `O(1/Σ)` — the leftover of that
+//! pin being finite. A looser pin is a less accurate covariance.
+//!
+//! # The fixture
+//!
+//! `min ½·xᵀQx − qᵀx` over `(a, b, w)`. `a` and `b` are held by the two
+//! equality rows, which are the pin rows the reduced Hessian is taken over;
+//! `w` is capped by an upper bound that binds with multiplier `z`. `Q` is
+//! non-diagonal, so the reduced Hessian over the pins differs by `O(1)`
+//! between the bound-pinned answer (`Q_ab`) and the one that lets `w` move
+//! (`Q_ab − Q_aw·Q_ww⁻¹·Q_wa`). The measured error below is
+//! `‖H_R − Q_ab‖_∞`: how much of the free answer is still leaking through a
+//! pin that is finite rather than exact.
+//!
+//! # What is asserted
+//!
+//! Three directions, each a comparison between runs rather than a fixed
+//! threshold — the effect is a ratio and a fixed bar would drift with `tol`:
+//!
+//! 1. crossover under `bound_relax_factor = 0` is *more* accurate than no
+//!    crossover — the pin tightens from the `μ/z` standoff to the point's
+//!    own distance from the bound, which is nothing;
+//! 2. crossover under the **default** relaxation is also more accurate than
+//!    no crossover. This is the gh#654 defect in executable form: before the
+//!    fix it was `18x` **worse** at `z = 4.5`, and the degradation grew with
+//!    the bound multiplier exactly as `z·δ/μ` predicts;
+//! 3. the two crossover runs agree. That is the fix's actual claim: `Σ` is
+//!    now read in the frame crossover solved in, so whether the bounds were
+//!    relaxed no longer changes the answer.
+//!
+//! Measured on this fixture, before → after:
+//!
+//! ```text
+//!    z     no crossover    crossover, δ=1e-8        crossover, δ=0
+//!   4.5      6.07e-11    1.09e-09 → 8.88e-16    1.99e-13 → 8.88e-16
+//!  94.5      1.38e-13    5.19e-11 → 8.88e-16    9.99e-15 → 8.88e-16
+//! 994.5      1.24e-14    4.93e-12 → 0           8.88e-16 → 0
+//! ```
+//!
+//! Both crossover columns now agree entry for entry, and both sit at the
+//! roundoff of the answer itself: with the point *on* its bound the pin is
+//! as exact as double precision expresses, so the `O(1/Σ)` leak is gone
+//! rather than merely smaller.
+//!
+//! A fourth test guards the plumbing rather than the number: the batched
+//! back-solve must reach the same corrected system the single-RHS one does,
+//! which it can only do by declining its two cached tiers.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use pounce_sensitivity::Solver;
+
+/// Objective Hessian, `(a, b, w)` order. Non-diagonal in the `w` column:
+/// that coupling is the whole experiment, since it is what makes the
+/// bound-pinned reduced Hessian differ from the free one.
+const Q: [[Number; 3]; 3] = [[2.0, 0.3, 0.7], [0.3, 3.0, 0.5], [0.7, 0.5, 4.0]];
+
+/// Where the pin rows hold `a` and `b`.
+const A_PIN: Number = 0.5;
+const B_PIN: Number = 0.25;
+
+/// `w`'s upper bound.
+const W_CAP: Number = 1.0;
+
+/// The reduced Hessian over `(a, b)` when `w` is held at its bound: the
+/// leading 2×2 block of `Q`, column-major, in the sign convention
+/// `compute_reduced_hessian` reports pin rows in (`H_R = B·K⁻¹·Bᵀ`,
+/// which carries the augmented system's leading minus on a multiplier
+/// row). Letting `w` move instead would give
+/// `−(Q_ab − Q_aw·Q_ww⁻¹·Q_wa)`, an `O(0.1)` different matrix — that gap
+/// is what a finite pin leaks a fraction of.
+const Q_AB: [Number; 4] = [-Q[0][0], -Q[0][1], -Q[1][0], -Q[1][1]];
+
+/// `min ½·xᵀQx − qᵀx` s.t. `a = A_PIN`, `b = B_PIN`, `w ≤ W_CAP`.
+///
+/// `q_w` is derived from the bound multiplier the caller wants: with `a`
+/// and `b` pinned and `w` at its cap, the `w` row of the stationarity
+/// condition reads `(Qx)_w − q_w + z = 0`.
+struct CappedQp {
+    q_w: Number,
+}
+
+impl CappedQp {
+    /// A fixture whose `w` bound binds with multiplier `z`.
+    fn with_bound_multiplier(z: Number) -> Self {
+        let qx_w = Q[2][0] * A_PIN + Q[2][1] * B_PIN + Q[2][2] * W_CAP;
+        Self { q_w: qx_w + z }
+    }
+
+    fn q(&self) -> [Number; 3] {
+        [0.0, 0.0, self.q_w]
+    }
+}
+
+impl TNLP for CappedQp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 3,
+            m: 2,
+            nnz_jac_g: 2,
+            nnz_h_lag: 6,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = -1.0e19;
+        b.x_u[0] = 1.0e19;
+        b.x_l[1] = -1.0e19;
+        b.x_u[1] = 1.0e19;
+        b.x_l[2] = -1.0e19;
+        b.x_u[2] = W_CAP;
+        b.g_l[0] = A_PIN;
+        b.g_u[0] = A_PIN;
+        b.g_l[1] = B_PIN;
+        b.g_u[1] = B_PIN;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.0;
+        sp.x[1] = 0.0;
+        sp.x[2] = 0.0;
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types.fill(Linearity::Linear);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let q = self.q();
+        let mut f = 0.0;
+        for i in 0..3 {
+            f -= q[i] * x[i];
+            for j in 0..3 {
+                f += 0.5 * Q[i][j] * x[i] * x[j];
+            }
+        }
+        Some(f)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let q = self.q();
+        for i in 0..3 {
+            g[i] = -q[i];
+            for j in 0..3 {
+                g[i] += Q[i][j] * x[j];
+            }
+        }
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0];
+        g[1] = x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 0;
+                irow[1] = 1;
+                jcol[1] = 1;
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 1.0;
+                values[1] = 1.0;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Dense lower triangle of Q; the constraints are linear so they
+        // contribute nothing.
+        let mut k = 0;
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for i in 0..3 {
+                    for j in 0..=i {
+                        irow[k] = i as Index;
+                        jcol[k] = j as Index;
+                        k += 1;
+                    }
+                }
+            }
+            SparsityRequest::Values { values } => {
+                for (i, row) in Q.iter().enumerate() {
+                    for &q in row.iter().take(i + 1) {
+                        values[k] = obj_factor * q;
+                        k += 1;
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _c: &IpoptCq) {}
+}
+
+/// Solve the fixture under one `(crossover, bound_relax_factor)` combination
+/// and return `‖H_R − Q_ab‖_∞`, the residual of the bound's pin being finite
+/// rather than exact.
+fn reduced_hessian_error(z: Number, crossover: bool, brf: Number) -> Number {
+    let mut app = IpoptApplication::new();
+    let opts = app.options_mut();
+    opts.set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    opts.set_string_value("sb", "yes", true, false).unwrap();
+    opts.set_string_value(
+        "crossover",
+        if crossover { "yes" } else { "no" },
+        true,
+        false,
+    )
+    .unwrap();
+    opts.set_numeric_value("bound_relax_factor", brf, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(CappedQp::with_bound_multiplier(z)));
+    let mut solver = Solver::new(app, tnlp);
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "fixture must converge (crossover={crossover}, brf={brf:e}); got {status:?}",
+    );
+    let accepted = solver
+        .app()
+        .crossover_report()
+        .is_some_and(pounce_algorithm::crossover::CrossoverReport::accepted);
+    assert_eq!(
+        accepted, crossover,
+        "the run must actually cross over when asked to (brf={brf:e})",
+    );
+
+    let hr = solver
+        .compute_reduced_hessian(&[0, 1], 1.0)
+        .expect("reduced Hessian over the two pin rows");
+    hr.iter()
+        .zip(Q_AB.iter())
+        .fold(0.0, |acc: Number, (&h, &q)| acc.max((h - q).abs()))
+}
+
+#[test]
+fn crossover_without_bound_relaxation_tightens_the_reduced_hessian() {
+    let z = 4.5;
+    let interior = reduced_hessian_error(z, false, 0.0);
+    let crossed = reduced_hessian_error(z, true, 0.0);
+    assert!(
+        crossed < interior,
+        "crossover at bound_relax_factor=0 must tighten the pin: \
+         interior={interior:e}, crossed={crossed:e}",
+    );
+}
+
+/// gh#654. The defect: under the **default** relaxation the same crossover
+/// loosened the pin instead, by a factor that tracked the bound multiplier
+/// (`18x` worse at `z = 4.5`, `376x` at `z = 94.5`, `396x` at `z = 994.5`,
+/// off the table in the module doc).
+#[test]
+fn crossover_under_bound_relaxation_does_not_loosen_the_reduced_hessian() {
+    for z in [4.5, 94.5, 994.5] {
+        let interior = reduced_hessian_error(z, false, 1e-8);
+        let crossed = reduced_hessian_error(z, true, 1e-8);
+        assert!(
+            crossed <= interior,
+            "z={z}: crossover under bound_relax_factor=1e-8 must not be less \
+             accurate than no crossover at all: interior={interior:e}, \
+             crossed={crossed:e} ({:.1}x worse)",
+            crossed / interior,
+        );
+    }
+}
+
+/// The fix's claim, stated directly: whether the bounds were relaxed no
+/// longer changes what a crossed-over solve reports downstream, because `Σ`
+/// is measured in the frame crossover solved in.
+#[test]
+fn a_crossed_over_solve_reads_the_same_whether_or_not_bounds_were_relaxed() {
+    let z = 4.5;
+    let relaxed = reduced_hessian_error(z, true, 1e-8);
+    let unrelaxed = reduced_hessian_error(z, true, 0.0);
+    let scale = relaxed.max(unrelaxed).max(1e-300);
+    assert!(
+        (relaxed - unrelaxed).abs() <= 0.05 * scale,
+        "the two crossed-over runs must agree: relaxed={relaxed:e}, \
+         unrelaxed={unrelaxed:e}",
+    );
+}
+
+/// The batched back-solve has to answer in the same frame as the single-RHS
+/// one.
+///
+/// It has two cached tiers that assemble their elimination from the
+/// calculated `Σ` and fire against whatever factor the previous solve left
+/// behind. On a crossed-over solve neither is the corrected system, and the
+/// tag check does not save them: on the *first* call after convergence the
+/// cached tags are the algorithm's own final solve, which used exactly the
+/// diagonal being corrected. So the batched call here is deliberately the
+/// first thing asked of the held factor.
+#[test]
+fn the_batched_back_solve_agrees_with_the_single_rhs_one_after_crossover() {
+    let mut app = IpoptApplication::new();
+    let opts = app.options_mut();
+    opts.set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    opts.set_string_value("sb", "yes", true, false).unwrap();
+    opts.set_string_value("crossover", "yes", true, false)
+        .unwrap();
+    // The default relaxation: the combination gh#654 is about.
+    opts.set_numeric_value("bound_relax_factor", 1e-8, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(CappedQp::with_bound_multiplier(4.5)));
+    let mut solver = Solver::new(app, tnlp);
+    solver.solve();
+    assert!(
+        solver
+            .app()
+            .crossover_report()
+            .is_some_and(pounce_algorithm::crossover::CrossoverReport::accepted),
+        "fixture must cross over",
+    );
+    let dim = solver.kkt_dim().expect("converged");
+
+    // Three unit-ish right-hand sides spread across the compound vector.
+    let n_rhs = 3;
+    let mut rhs_flat = vec![0.0; n_rhs * dim];
+    for (k, row) in rhs_flat.chunks_mut(dim).enumerate() {
+        row[k % dim] = 1.0;
+        row[(k + dim / 2) % dim] = -0.5;
+    }
+    let mut batched = vec![0.0; n_rhs * dim];
+    solver
+        .kkt_solve_many(&rhs_flat, &mut batched, n_rhs)
+        .expect("batched back-solve");
+
+    for k in 0..n_rhs {
+        let mut one = vec![0.0; dim];
+        solver
+            .kkt_solve(&rhs_flat[k * dim..(k + 1) * dim], &mut one)
+            .expect("single back-solve");
+        for (i, (&b, &s)) in batched[k * dim..(k + 1) * dim]
+            .iter()
+            .zip(one.iter())
+            .enumerate()
+        {
+            let scale = b.abs().max(s.abs()).max(1.0);
+            assert!(
+                (b - s).abs() <= 1e-9 * scale,
+                "rhs {k}, row {i}: batched={b:e} vs single={s:e}",
+            );
+        }
+    }
+}

--- a/docs/src/crossover.md
+++ b/docs/src/crossover.md
@@ -185,7 +185,9 @@ places it could have been done wrong:
   covers a subnormal `μ` — see below). At a purified point the active
   slacks are *exactly* zero, and that floor would put `μ/z ≈ 1e-9` straight
   back — reintroducing as a reporting artifact the very quantity crossover
-  removed. The declared-frame measurement does not apply it.
+  removed. The declared-frame measurement does not apply the `μ/z`
+  correction. It does carry the representability floor, for the reason
+  given below.
 
 This is a change to *reporting* only. It runs after the exit status is
 already decided, and it applies solely to a point the never-regress gate
@@ -249,31 +251,37 @@ way. You may still want `bound_relax_factor = 0` for
 central-path checks it makes read the barrier's own slacks, which the
 relaxation shifts.
 
-`Σ` never becomes infinite along this path. The declared-frame
-measurement floors a slack at `eps·max(1,|bound|)`, the distance at which
-the point *is* the bound, so a pivot landing exactly on it gives a large
-`Σ` rather than a `NaN`. That floor is deliberately not
-`CalculateSafeSlack`'s, which the live interior path applies: that one
-raises a below-floor slack to about `μ/z` and would put back the very
-standoff crossover exists to remove. On this fixture the crossed-over
-slack reaches the floor; the one measured in
-[#653](https://github.com/jkitchin/pounce/issues/653) bottomed out at
-`1.8e-12` — the residual of the QP step plus line search — and never
-reached it at all.
+`Σ` never becomes infinite, in either frame — but the two frames get
+there by different floors, and it is worth knowing which supplies the
+guarantee where.
 
-"Along this path" is doing real work in that sentence, and it is worth
-knowing which part of the floor supplies the guarantee. `eps·min(1, μ)`
-is a threshold on the *barrier* term; nothing in it mentions the
-multiplier, so it bounds `Σ` only because a normal `μ` makes `μ/z` a
-usable slack. Push `μ` into the subnormal range and it stops covering
-anything — at `μ = 9.1e-308` the threshold is `2.0e-323`, small enough
-that a slack of `2.0e-308` clears it untouched and `z/s` overflows
-([#655](https://github.com/jkitchin/pounce/issues/655)). What makes
-`Σ` finite unconditionally is the second floor `CalculateSafeSlack`
-carries, `s ≥ max_i z_i / (f64::MAX/4)`, which is stated in terms of the
-quantity that has to stay representable rather than in terms of `μ`.
-Crossover never goes near either floor; the guarantee matters for the
-solves that do.
+On the **live interior path**, `CalculateSafeSlack` carries two. The
+first, `eps·min(1, μ)`, is a threshold on the *barrier* term; nothing in
+it mentions the multiplier, so it bounds `Σ` only because a normal `μ`
+makes `μ/z` a usable slack. Push `μ` into the subnormal range and it
+stops covering anything — at `μ = 9.1e-308` the threshold is `2.0e-323`,
+small enough that a slack of `2.0e-308` clears it untouched and `z/s`
+overflows ([#655](https://github.com/jkitchin/pounce/issues/655)). What
+makes `Σ` finite unconditionally is the second, `s ≥ max_i z_i /
+(f64::MAX/4)`, which is stated in terms of the quantity that has to stay
+representable rather than in terms of `μ`.
+
+The **declared frame** does not go through that function at all — the
+`max(μ/z, s_min)` correction is exactly the standoff crossover exists to
+remove, and applying it would put back as an artifact what the phase
+just took out. So it carries its own pair: `eps·max(1,|bound|)`, the
+distance at which the point *is* the bound, which covers a pivot landing
+on it exactly; and the same `max_i z_i / (f64::MAX/4)` as above, because
+a representability bound is about what a double can hold rather than
+about where the barrier would have put the point, and it would otherwise
+stop at the frame boundary.
+
+Neither floor is reached in ordinary use. On the fixture in the table
+above the crossed-over slack does reach the first one; the slack measured
+in [#653](https://github.com/jkitchin/pounce/issues/653) bottomed out at
+`1.8e-12` — the residual of the QP step plus line search — and reached
+neither. The representability half matters for solves at pathological
+tolerances, not for these.
 
 ## Reading the result
 

--- a/docs/src/crossover.md
+++ b/docs/src/crossover.md
@@ -190,6 +190,47 @@ already decided, and it applies solely to a point the never-regress gate
 accepted on its declared-bound residuals, so it cannot dress up a worse
 iterate — the reading it replaces is the artifact, not the point.
 
+### The same frame applies to the sensitivity path
+
+The residual report was only half of it. The barrier diagonal
+`Σ = z/s` is built from those same relaxed-frame slacks, so at a
+crossed-over point it reads `z/δ` where an interior iterate would have
+given `z²/μ`:
+
+```text
+no crossover     Σ = z / (μ/z) = z²/μ
+crossover        Σ = z / δ
+```
+
+Since `δ` is capped at `constr_viol_tol` and `μ` ends near
+`tol/(barrier_tol_factor+1)`, that is *looser* whenever `z·δ/μ > 1`, which
+is the ordinary case. `Σ` is the stiffness with which the barrier holds a
+bounded variable, and a reduced Hessian read off the held KKT factor
+carries a residual error of exactly `O(1/Σ)` — the leftover of that pin
+being finite. So the looser reading was a measurably less accurate
+covariance, by a factor that tracked the bound multiplier: `18x` at
+`z = 4.5`, `396x` at `z = 994.5`. That was
+[#654](https://github.com/jkitchin/pounce/issues/654), and it is fixed the
+same way: **when crossover is accepted, `Σ` is re-measured against the
+declared bounds** — for variable bounds and inequality-row bounds alike —
+before the sensitivity path factors with it or classifies against it.
+
+The correction is applied at the consumer boundary, not on the live
+iterate: the relaxed bounds are still what the algorithm ran against, and
+nothing about the solve moves. It covers `covariance()`,
+`information()`, `classify_activity()`, `compute_reduced_hessian`, the
+parametric steps, and the `SensSolve` builder, because all of them read
+the one held factor.
+
+The practical consequence is that `crossover=yes` and
+`bound_relax_factor = 0` are now independent choices. Before the fix,
+crossover *helped* the sensitivity path by `306x` with the relaxation off
+and *hurt* it by `18x` with the relaxation at its default, so the option
+was only safe in combination with a second, unrelated one. Now a
+crossed-over solve reports the same downstream numbers either way — at
+the roundoff of the answer itself, since the point is on its bound and the
+pin is as exact as double precision expresses.
+
 ## Reading the result
 
 The returned solution — `x`, the objective, `g`, and every multiplier — is

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -525,7 +525,15 @@ convergence and returns a point at which a linearly independent set of
 constraints holds with *equality*, collapsing the ambiguity into a
 STRONGLY or WEAKLY ACTIVE verdict. It is a different remedy to the same
 problem the `bound_relax_factor = 0` rule above addresses, and the two
-compose.
+compose — genuinely independently, since
+[#654](https://github.com/jkitchin/pounce/issues/654). A crossed-over
+point sits *on* the declared bounds, i.e. `bound_relax_factor` inside the
+box the barrier measured against, so its `Σ = z/s` used to read `z/δ` and
+hold the bound more loosely than an interior iterate would have —
+degrading, rather than improving, every quantity read off the held factor
+unless the relaxation was also switched off. `Σ` is now re-measured
+against the declared bounds whenever crossover is accepted, so the two
+options no longer have to be set together.
 
 **Relation to `pounce.curve_fit`.** This uses the same
 scale-and-invert-the-reduced-Hessian recipe as


### PR DESCRIPTION
Fixes #654

## Problem

`crossover=yes` made the sensitivity path **less** accurate, by a factor that
tracked the bound multiplier — unless `bound_relax_factor=0` was also set, in
which case it made it substantially more accurate. An option documented as the
remedy for the sensitivity path's AMBIGUOUS class helped or hurt entirely
according to whether a second, unrelated option was set.

Measured on this PR's fixture (`min ½·xᵀQx − qᵀx` over `(a, b, w)`; `a` and `b`
held by the two pin rows the reduced Hessian is taken over; `w` capped by an
upper bound binding with multiplier `z`; `Q` non-diagonal so the pinned answer
`Q_ab` and the free one differ by `O(0.1)`). The error is `‖H_R − Q_ab‖_∞`, the
part of the free answer still leaking through a pin that is finite rather than
exact:

| `z` | no crossover | crossover, `δ=1e-8` | crossover, `δ=0` |
|---|---|---|---|
| `4.5` | `6.07e-11` | `1.09e-09` → **`8.88e-16`** | `1.99e-13` → `8.88e-16` |
| `94.5` | `1.38e-13` | `5.19e-11` → **`8.88e-16`** | `9.99e-15` → `8.88e-16` |
| `994.5` | `1.24e-14` | `4.93e-12` → **`0`** | `8.88e-16` → `0` |

Before: `18x`, `376x`, `396x` worse than not crossing over at all, against
`306x` better with the relaxation off. After: the two crossover columns agree
entry for entry and sit at the roundoff of the answer itself.

The same thing on #656's independently-written fixture, which reads `Σ` through
`classify_activity()` rather than inferring it:

| | `Σ` at the active bound | reduced-Hessian error |
|---|---|---|
| `crossover=no` | `8.1e+09` | `4.95e-10` |
| `crossover=yes`, `bound_relax_factor=0` | `2.5e+12` → `2.0e+16` | `1.62e-12` → `4.44e-16` |
| `crossover=yes`, default relaxation | `4.5e+08` → `2.0e+16` | `8.89e-09` → `4.44e-16` |

The two crossover rows now agree to the last digit (`4.440892098500626e-16`).

There is no closed-form oracle beyond `Q_ab` itself, which is what the error
column is measured against.

## Cause

`bound_relax_factor` (default `1e-8`) widens every bound by `δ` before the
solve. Crossover then parks the iterate exactly on the **declared** bound — a
full `δ` *inside* the live relaxed one. So the calculated quantities see a slack
of exactly `δ` at every active bound, where an interior iterate would have
carried `μ/z`:

```text
no crossover     Σ = z / (μ/z) = z²/μ
crossover        Σ = z / δ
```

which is **looser** whenever `z·δ/μ > 1` — the ordinary case, since `δ` is
capped at `constr_viol_tol` and `μ` ends near `tol/(barrier_tol_factor+1)`.

`Σ` is the stiffness with which the barrier holds a bounded variable, and a
reduced Hessian read off the held KKT factor carries a residual error of exactly
`O(1/Σ)` — the leftover of that pin being finite. So a looser pin is a
measurably less accurate covariance, and the degradation tracks the bound
multiplier exactly as `z·δ/μ` predicts.

Same root cause as #646, which fixed only the reporting half.

## Fix

`Σ` is re-measured against the declared bounds whenever the held iterate came
from an accepted crossover — for variable bounds and inequality-row bounds
alike. This is candidate 1 of the three in the issue, and the same correction
#646 applied to the residual report, at the same place: the consumer boundary.

The other two were considered and rejected:

- **Un-relax the live NLP bounds on crossover acceptance.** #653's measurement
  removed the objection #647 raised (the slack floors at `1.8e-12`, not zero),
  but the mechanical obstacle stands: `relax_bounds` mutates `x_l`/`x_u` through
  `Rc::get_mut`, and by convergence the CQ holds clones, so undoing it means
  replacing the `Rc`s and invalidating every tag-keyed cache built on them.
- **Guard.** Extending `classify_activity`'s refusal to the reduced-Hessian and
  parametric paths is a refusal in place of an answer, for an effect this size,
  and it leaves the good combination undiscoverable.

Mechanically:

- `IpoptData::curr_from_crossover` records which of the two frames `curr`
  belongs to. Set by `install_crossover_iterate` on the path that actually
  replaced the iterate; cleared on every `maybe_crossover` entry so it describes
  this solve, not a previous one.
- `PdFullSpaceSolver::solve_with_sigma_x` → `solve_with_sigma`, taking a
  `SigmaOverride` carrying the `s` block as well. Relaxation widens `d_L`/`d_U`
  too and crossover puts `s = d(x)` on the declared row bounds, so the row half
  is the identical defect; the two blocks travel together because a caller that
  corrects one and not the other leaves the factor describing a point half in
  each frame.
- `PdSensBacksolver` builds the declared-frame pair once at construction and
  uses it for every back-solve, for the released re-factorization's starting
  diagonal **and** its slacks, and — through `barrier_sigma_x` /
  `barrier_sigma_s` — for `classify_activity`, which reads `Σ` off the iterate
  rather than through the factor. One source of truth, so the two cannot
  disagree about which bounds the point is measured against.
- The batched back-solve's two cached tiers are skipped when the correction is
  in force. Their tag check cannot be relied on to decline: on the first call
  after convergence the cached tags are the algorithm's own final solve, which
  used exactly the diagonal being corrected.
- Declared-frame slacks are floored at `eps·max(1,|bound|)` — the distance at
  which the point *is* the bound. Deliberately **not** `CalculateSafeSlack`'s
  floor, which raises a below-floor slack to `max(μ/z, s_min)` and would put the
  standoff crossover exists to remove straight back; the same reason #646
  declined it for the residual report.

Gated on crossover rather than applied everywhere on purpose: an interior
iterate is not near the declared bounds in any useful sense — it can sit up to
`δ` *outside* one — and its `μ/z` standoff is the barrier's own geometry, which
is the right thing to read there.

## Blast radius

Bit-identical except the targeted case. A solve that did not cross over takes
`SigmaOverride::default()`, which resolves to the same `cq.curr_sigma_x()` /
`curr_sigma_s()` the old code read.

No solver trajectory moves, so no fixture sweep applies: the correction is
post-convergence and read-only, and `PdFullSpaceSolver::solve` — the only entry
point the algorithm's own step computation uses — delegates to
`solve_with_sigma` with an empty override.

Affected when crossover *is* accepted: `covariance()`, `information()`,
`classify_activity()`, `Solver::compute_reduced_hessian`, both parametric steps,
`kkt_solve` / `kkt_solve_many`, and the `SensSolve` builder — all of them read
the one held factor. Two consequences worth stating:

- Crossed-over solves at `bound_relax_factor = 0` also change (`1.99e-13` →
  `8.88e-16` at `z = 4.5`). Same correction applied consistently: the live and
  declared bounds coincide there, but the live slacks additionally go through
  `CalculateSafeSlack`, which the declared-frame measurement does not.
- The batched path loses its inlining on a crossed-over solve — one
  factorization, then a back-substitution per RHS, against the tag cache the
  shared override vector keeps warm.

`classify_activity`'s existing `bound_relax_factor = 0` refusal is **unchanged**:
it also guards the slack-based central-path checks, and those still read the
barrier's own slacks. Relaxing it is a separate decision (pyomo-pounce matches
that error message to report a relaxed solve rather than raise).

No public API removed; `solve_with_sigma_x` is renamed, and `pounce-sensitivity`
is its only caller.

## Interaction with #656 (merged while this was open)

#656 landed gh#653's measurement of this same effect, including a test file that
collided by name with this PR's. Resolved in the merge commit:

- Its `crossover_sigma_downstream.rs` is kept as the gh#653 record; this PR's
  sweep moved to `crossover_sigma_frame.rs`. Not duplicates — #656's measures
  one bound multiplier and reads `Σ` through the public
  `classify_activity()`, this one sweeps three and drives the batched
  back-solve.
- Its `crossover_under_bound_relaxation_loosens_the_reduced_hessian` **asserted
  the defect**, and said in as many words that if it ever started failing the
  frame mismatch had been fixed and it should be deleted rather than relaxed.
  Deleted, with a comment recording what it measured and where the replacement
  lives.
- Its `the_reduced_hessian_error_tracks_one_over_sigma` pinned `err =
  Q_aw²/Σ` to 5% for both crossover settings. On that fixture the purified `w`
  now lands within an ulp of its cap, so `Σ` saturates at `z/eps ≈ 2e16` and
  the predicted residual (`2e-16`) falls below the roundoff of `H_R` itself,
  whose entries are `O(4)` and so carry an ulp near `9e-16`. Demanding 5%
  agreement between two quantities both at the ulp measures nothing. The law is
  still asserted wherever it is observable; below the noise floor the assertion
  becomes the weaker statement that is still true and still worth pinning — the
  error sits at roundoff.
- The two `[Unreleased]` CHANGELOG entries contradicted each other — #653's told
  users to work around the defect, in the same release whose #654 entry fixes
  it. Reconciled.

## Tests

`crates/pounce-sensitivity/tests/crossover_sigma_frame.rs`, four tests. Run
against this branch's parent (before the fix):

- `crossover_under_bound_relaxation_does_not_loosen_the_reduced_hessian` —
  **FAILS**: `z=4.5: ... interior=6.06532601921117e-11,
  crossed=1.0888894230731694e-9 (18.0x worse)`. This is the defect in executable
  form.
- `a_crossed_over_solve_reads_the_same_whether_or_not_bounds_were_relaxed` —
  **FAILS**: `relaxed=1.0888894230731694e-9, unrelaxed=1.98507876802978e-13`.
  This is the fix's actual claim.
- `crossover_without_bound_relaxation_tightens_the_reduced_hessian` — passes
  pre-fix, and is not a regression test. It pins the one direction that was
  already right, so a future change cannot quietly take it away.
- `the_batched_back_solve_agrees_with_the_single_rhs_one_after_crossover` —
  passes pre-fix, because pre-fix both paths were uniformly *un*corrected and so
  agreed. It guards the plumbing this PR introduces, not the defect: it calls
  the batched path first, before anything else touches the held factor, which is
  exactly the ordering under which the cached tiers' tag check fails to decline.

#656's `crossover_under_bound_relaxation_loosens_the_reduced_hessian` also
failed against the fix — by design, as above — and is the test this PR deletes.

Every assertion is a comparison between runs rather than a fixed threshold — the
effect is a ratio, and a fixed bar would drift with `tol`.

Run on the merge result, i.e. the full CI job list except the wasm build:
`scripts/check-release-consistency.sh`, `scripts/check-docs-consistency.sh`,
`cargo fmt --all -- --check`, `cargo clippy --workspace --exclude pounce-hsl
--all-targets -- -D clippy::correctness -D clippy::suspicious`, `cargo test
--workspace --exclude pounce-hsl`, `cargo clippy/test -p pounce-rs
--all-features`, `cargo check -p pounce-hsl --all-targets`. All clean.

Not pinned: the row-bound (`sigma_s`) half of the correction is implemented and
covered by the workspace suite for absence-of-regression, but has no fixture of
its own asserting the improvement — the mechanism is identical to the variable
half and a second fixture would restate it. Flagging it as a known gap rather
than leaving it implied.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`crossover.md`, `sensitivity.md`; no
      new page, so no `SUMMARY.md` change)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this body and in the code comments is true of the code as
      it stands now