### PR TITLE
warm start: make the probe's per-block tolerance actually per-block (#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ changes.
 
 ## [Unreleased]
 
+- **Warm-start probe: an inert objective constant no longer blinds
+  reorder detection** (#659). `_probe_agrees` documented a per-block
+  tolerance — each probed block judged against its own L1 scale, with
+  the largest block's scale as a floor — but computed
+  `floor = max(scales)`, which makes `max(scales[block], floor)` equal
+  `floor` for every block. Every block was therefore judged against the
+  *largest* block's magnitude, and the per-block half never took effect.
+
+  Adding an additive constant to the objective — inert to the
+  optimization: no derivative, no constraint and no solution changes —
+  inflated the objective block's scale and with it the gradient,
+  constraint and jacobian tolerances. Past roughly 1e9 that was enough
+  to swallow a single variable transposition, so
+  `ws.check_compatible(reordered_problem)` returned cleanly where it had
+  previously raised, and the replayed seed went into the solve permuted.
+  This was the *enforcing* gate, not just `describe_compatibility`.
+
+  The floor is now `_PROBE_FLOOR_FRAC` (1e-6) of the largest scale
+  rather than the bare maximum. That keeps what the floor was for — a
+  block computing to ~0 out of cancellation of large terms is still not
+  held to bit equality — while letting a healthy block's own scale win.
+
 - **POUNCE's structured solve report is reachable from CasADi** (#644).
   Set `solve_report` to a path and each solve writes a
   `pounce.solve-report/v1` JSON file — the same format the `pounce`

--- a/python/pounce/_warm_start_schema.py
+++ b/python/pounce/_warm_start_schema.py
@@ -272,6 +272,17 @@ _PROBE_PROJECTIONS = 4
 #: (re-associating a model's internal sums moves it by 5e-18 relative).
 PROBE_RTOL = 1e-9
 
+#: What fraction of the largest block's scale floors a *near-zero*
+#: block's tolerance. It has to be small: the floor exists to keep a
+#: block that computes to ~0 out of cancellation of large terms from
+#: being held to bit equality, and `PROBE_RTOL * _PROBE_FLOOR_FRAC`
+#: (1e-15 of the largest scale) sits an order above that cancellation
+#: noise. Making it 1.0 — which is what the pre-#659 code computed —
+#: hands every block the *largest* block's tolerance, so an inert
+#: additive constant on the objective silently switches reorder
+#: detection off (gh#659).
+_PROBE_FLOOR_FRAC = 1e-6
+
 #: |bound| at or above this is not a bound. pounce/Ipopt spell infinity
 #: 2e19; nothing smaller than 1e19 is a real bound.
 _BOUND_INF = 1e19
@@ -380,18 +391,29 @@ def _model_probe(problem) -> Optional[Tuple[float, ...]]:
 def _probe_agrees(a: Sequence[float], b: Sequence[float]) -> bool:
     """Do two probes describe the same model, to :data:`PROBE_RTOL`?
 
-    Compared block by block against each block's own L1 scale, with the
-    largest block's scale as a floor — so a gradient that is identically
-    zero is judged against the magnitude of the rest of the model rather
-    than against nothing, which would demand bit equality of exactly the
-    block least likely to reproduce bitwise.
+    Compared block by block against each block's own L1 scale, with
+    `_PROBE_FLOOR_FRAC` of the largest block's scale as a floor — so a
+    gradient that is identically zero is judged against the magnitude of
+    the rest of the model rather than against nothing, which would
+    demand bit equality of exactly the block least likely to reproduce
+    bitwise.
+
+    The floor is a *fraction* of the largest scale, not the largest
+    scale itself. Flooring at the bare maximum is what gh#659 was: it
+    made `max(scales[block], floor)` equal `floor` for every block, so
+    each block was judged against the largest block's magnitude and the
+    per-block scale this docstring describes never took effect. An inert
+    additive constant on the objective — which changes no derivative and
+    no solution — then raised the gradient/constraint/jacobian
+    tolerances until a variable transposition slipped through the
+    enforcing `check_compatible` gate.
     """
     if len(a) != len(b):
         return False
     stride = _PROBE_PROJECTIONS + 1
     scales = [max(abs(a[k]), abs(b[k]))
               for k in range(_PROBE_PROJECTIONS, len(a), stride)]
-    floor = max(scales) if scales else 0.0
+    floor = _PROBE_FLOOR_FRAC * max(scales) if scales else 0.0
     for block, off in enumerate(range(0, len(a), stride)):
         tol = PROBE_RTOL * max(scales[block], floor)
         for k in range(off, off + stride):

--- a/python/tests/test_warm_start_schema.py
+++ b/python/tests/test_warm_start_schema.py
@@ -1134,3 +1134,59 @@ def test_the_note_also_rides_on_a_mismatch_report():
     ws = WarmStart.from_info(x, info, problem=p, probe=False)
     report = ws.describe_compatibility(make(ub=4.0))
     assert "bounds:" in report and "pure reordering" in report
+
+
+# --- gh#659: the per-block scale must actually be per-block ----------------
+class HS071Offset(HS071):
+    """HS071 plus an additive constant on the objective.
+
+    The constant changes no derivative, no constraint and no solution —
+    it is inert to the optimization. It exists only to make the
+    objective block's L1 scale large.
+    """
+
+    def __init__(self, offset, **kw):
+        super().__init__(**kw)
+        self.offset = offset
+
+    def objective(self, x):
+        return super().objective(x) + self.offset
+
+
+@pytest.mark.parametrize("offset", [0.0, 1e3, 1e6, 1e9, 1e12])
+def test_an_inert_objective_offset_does_not_blind_the_probe(offset):
+    """gh#659. `floor = max(scales)` made every block's tolerance the
+    *largest* block's, so inflating the objective raised the gradient,
+    constraint and jacobian tolerances too. Past ~1e9 that was enough to
+    swallow a variable transposition — on `check_compatible`, the gate
+    that is supposed to refuse it, not just on the dry run."""
+    base = pounce.ProblemSignature.from_problem(
+        make(obj=HS071Offset(offset))).probe
+    permuted = pounce.ProblemSignature.from_problem(
+        make(obj=HS071Offset(offset, perm=PERM))).probe
+    from pounce._warm_start_schema import _probe_agrees
+
+    assert not _probe_agrees(base, permuted), (
+        f"a reordering went undetected at objective offset {offset:g}"
+    )
+
+
+def test_the_probe_floor_still_rescues_a_near_zero_block():
+    """The floor is not merely deleted: a block that computes to ~0 out
+    of cancellation of large terms must still not be held to bit
+    equality, which is what it was there for."""
+    from pounce._warm_start_schema import _PROBE_PROJECTIONS, _probe_agrees
+
+    stride = _PROBE_PROJECTIONS + 1
+    # block 0 is large; block 1 computes to zero with absolute noise
+    # commensurate with block 0's magnitude.
+    a = [1e8] * _PROBE_PROJECTIONS + [4e8] + [0.0] * _PROBE_PROJECTIONS + [0.0]
+    b = list(a)
+    for k in range(stride, stride + _PROBE_PROJECTIONS):
+        b[k] = 1e-8                      # ~1e-16 relative to block 0
+    assert _probe_agrees(a, b)
+
+    # but a difference the size of block 0 itself is still a difference
+    c = list(a)
+    c[stride] = 1e6
+    assert not _probe_agrees(a, c)


### PR DESCRIPTION
`_probe_agrees` documented a per-block tolerance:

> Compared block by block against each block's own L1 scale, with the largest
> block's scale as a floor

but computed

```python
floor = max(scales) if scales else 0.0
for block, off in enumerate(range(0, len(a), stride)):
    tol = PROBE_RTOL * max(scales[block], floor)
```

`floor` is `max(scales)`, so `max(scales[block], floor) == floor` for every
block. The per-block half never took effect — every block was judged against
the *largest* block's magnitude.

## Why it matters

An additive constant on the objective is inert to the optimization: no
derivative, no constraint and no solution changes. But it does inflate the
objective block's L1 scale, and under the bug that inflated the gradient,
constraint and jacobian tolerances with it. Past roughly 1e9 that was enough
to swallow a single variable transposition.

That happens on `check_compatible` — the **enforcing** gate that `solve()` and
`_starts.py` take — not just on the `describe_compatibility` dry run. A
reordered warm start was accepted with no mismatch and no warning, and the
permuted seed went into the solve.

Measured before the fix (n=20, single transposition, uniform box and dense
jacobian so the structural digest is permutation-blind and the probe is the
only line of defence):

```
  objective offset | reordering caught?
             1e+06 | yes
             1e+09 | NO  <-- undetected
             1e+12 | NO  <-- undetected
```

and after:

```
             1e+09 | yes
             1e+12 | yes
```

## The fix

Floor at `_PROBE_FLOOR_FRAC` (1e-6) of the largest scale instead of at the
bare maximum. The floor still does what it was there for — a block that
computes to ~0 out of cancellation of large terms is not held to bit equality
— but a healthy block's own scale now wins, which is what the docstring
already claimed.

`PROBE_RTOL * _PROBE_FLOOR_FRAC` is 1e-15 of the largest scale, an order above
the ~1e-16 cancellation noise the floor protects against.

## Tests

- `test_an_inert_objective_offset_does_not_blind_the_probe` — parametrized
  0 / 1e3 / 1e6 / 1e9 / 1e12. Fails at 1e12 without the source change,
  verified by reverting it.
- `test_the_probe_floor_still_rescues_a_near_zero_block` — pins that the fix
  did not simply delete the floor: a block computing to ~0 with absolute noise
  commensurate with a large sibling block still agrees, while a difference the
  size of the large block still does not.

Existing suite: `test_warm_start_schema.py` 63 passed, `test_warm_start.py` /
`test_warm_start_object.py` / `test_sqp_warm_start.py` / `test_starts.py` 38
passed.

One pre-existing failure in `test_warm_start_schema.py`
(`test_a_mapped_replay_carries_the_equality_multipliers_a_bare_point_cannot`)
reproduces on unmodified `main` with a stale compiled extension and is
unrelated to this change.

No trajectory implications: this is the Python-side warm-start compatibility
gate, not the solver.

Fixes #659
