### PR TITLE
warm start: say when a clean compatibility check could not have seen a reordering (#660)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+- **A warm-start check that could not have seen a reordering now says
+  so** (#660). `check_compatible()` computed the "ordering unverified"
+  caveat on every path but rendered it only inside its
+  `if mismatches:` arm. The one case the caveat exists for — nothing
+  disagreed, *and* nothing in the comparison could have caught a
+  permutation — was therefore the one case that stayed silent. Only
+  `describe_compatibility()`, the opt-in dry run, ever mentioned it,
+  so the safe-looking path (just replay it) was the uninformative one.
+
+  That happens without anything exotic: an artifact captured with
+  `probe=False`, one written before #621, or a model with a domain
+  restriction that will not evaluate at the schema's interior probe
+  point. With no `var_ids` on both sides, a uniform box and a dense
+  jacobian leave the structural digests bit-identical under a
+  permutation, and the reordered seed goes into the solve.
+
+  It is now a `WarmStartOrderingUnverifiedWarning` — a warning, not a
+  refusal, because nothing actually disagreed. Callers who would rather
+  refuse than replay unverified can promote it with
+  `warnings.simplefilter("error",
+  pounce.WarmStartOrderingUnverifiedWarning)`.
+
+  The multistart ladder is exempt and stays quiet: it captures with
+  `probe=False` precisely because it resumes on the same `Problem`
+  object a moment later, so there is no reordering for the check to have
+  missed and the caveat would fire on every rung of every race.
+
 - **Crossover: the sensitivity path reads the barrier diagonal in the
   frame crossover solved in** (#654).
 

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -574,6 +574,18 @@ warm start is compatible with this problem
   caught here (pounce#621). ...)
 ```
 
+`describe_compatibility()` is the dry run, though, and you have to know
+to call it. The enforcing path — `check_compatible()`, which
+`solve(warm_start=...)` takes for you — says the same thing as a
+`WarmStartOrderingUnverifiedWarning` (#660), so a replay that could not
+have ruled a reordering out is never silent. Nothing disagreed, so it is
+a warning and not a refusal; if you would rather refuse, promote it:
+
+```python
+import warnings
+warnings.simplefilter("error", pounce.WarmStartOrderingUnverifiedWarning)
+```
+
 ### Transferring a warm start: horizon shifts and reindexing
 
 When the model *has* changed and you know how, say so. `transfer()`

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -27,6 +27,7 @@ from ._warm_start import (
     WarmStartCompatibilityError,
     WarmStartCompatibilityWarning,
     WarmStartLegacyWarning,
+    WarmStartOrderingUnverifiedWarning,
 )
 from ._continuation import (
     Continuation,
@@ -115,6 +116,7 @@ __all__ = [
     "WarmStartCompatibilityError",
     "WarmStartCompatibilityWarning",
     "WarmStartLegacyWarning",
+    "WarmStartOrderingUnverifiedWarning",
     # Predictor--corrector continuation over a repeated-NLP sequence
     # (see docs: continuation.md)
     "Continuation",

--- a/python/pounce/_starts.py
+++ b/python/pounce/_starts.py
@@ -911,6 +911,7 @@ class _Racer:
         """
         from ._minimize import _result_from_info
         from ._warm_start import WarmStart
+        from ._warm_start_schema import WarmStartOrderingUnverifiedWarning
 
         problem, solver, ws = state["problem"], state["solver"], state["ws"]
         max_iter = iter_budget - cand.iters
@@ -942,7 +943,18 @@ class _Racer:
                 # snapshot the seven `warm_start_*` / `mu_init` options
                 # outlive the rung and the next candidate's first,
                 # nominally cold, solve is not (pounce#607).
-                ws.check_compatible(problem)
+                # gh#660's note does not apply here and would fire on
+                # every rung of every race. The state a few lines below
+                # is captured with `probe=False` *because* it is
+                # captured from, and resumed on, this same `Problem`
+                # object a moment later — there is no reordering for the
+                # comparison to have missed. The check still runs; only
+                # the "could not have seen a reordering" caveat is
+                # dropped, and only where it is provably vacuous.
+                with warnings.catch_warnings():
+                    warnings.simplefilter(
+                        "ignore", WarmStartOrderingUnverifiedWarning)
+                    ws.check_compatible(problem)
                 for key, val in ws.options().items():
                     problem.add_option(key, val)
                 kw = ws.solve_kwargs()

--- a/python/pounce/_warm_start.py
+++ b/python/pounce/_warm_start.py
@@ -63,6 +63,7 @@ from ._warm_start_schema import (
     WarmStartCompatibilityError,
     WarmStartCompatibilityWarning,
     WarmStartLegacyWarning,
+    WarmStartOrderingUnverifiedWarning,
     compare,
     format_report,
     ordering_is_unverified,
@@ -75,6 +76,7 @@ __all__ = [
     "WarmStartCompatibilityError",
     "WarmStartCompatibilityWarning",
     "WarmStartLegacyWarning",
+    "WarmStartOrderingUnverifiedWarning",
 ]
 
 
@@ -422,7 +424,16 @@ class WarmStart:
         probe is best-effort: an artifact captured with ``probe=False``,
         one written before #621, or a model that will not evaluate at
         the probe point leaves the facet unrecorded, and then only
-        `var_ids` can see the reordering.
+        `var_ids` can see the reordering. When neither is available on
+        both sides the replay is still allowed — nothing disagreed — but
+        it now says so, as a
+        :class:`WarmStartOrderingUnverifiedWarning` (pounce#660).
+        Previously that caveat was rendered only inside a mismatch
+        report, so the clean-but-blind case, which is exactly the case
+        it is for, was the one case that stayed silent. Callers who
+        would rather refuse than replay unverified can promote it with
+        ``warnings.simplefilter("error",
+        WarmStartOrderingUnverifiedWarning)``.
 
         `var_ids` / `con_ids` name `problem`'s variables and constraints
         in the vocabulary this state was captured with. They remain the
@@ -470,6 +481,29 @@ class WarmStart:
             if mode == "strict":
                 raise WarmStartCompatibilityError(report)
             warnings.warn(report, WarmStartCompatibilityWarning, stacklevel=3)
+        elif unordered and self.signature is not None:
+            # gh#660. `unordered` was computed on every path but rendered
+            # only inside the `if mismatches:` arm above, so the one case
+            # the note exists for — a *clean* verdict that could not have
+            # seen a reordering — was the one case that never said it. A
+            # caller who just replays got no signal at all; only
+            # `describe_compatibility`, which you have to know to call,
+            # ever mentioned it.
+            #
+            # Scoped to signed states. An unsigned one is either read from
+            # a file, where WarmStartLegacyWarning above already says the
+            # same thing in more detail, or built in this process, which
+            # is the pre-#607 usage that stays deliberately silent.
+            #
+            # Repeats are left to the warnings module: `stacklevel=3`
+            # attributes this to the caller, so the default "once per
+            # location" filter collapses a per-rung multistart check
+            # (`_starts.py`) to a single line without a bespoke latch.
+            warnings.warn(
+                ORDERING_UNVERIFIED_NOTE,
+                WarmStartOrderingUnverifiedWarning,
+                stacklevel=3,
+            )
         return mismatches
 
     def describe_compatibility(self, problem, var_ids=None, con_ids=None) -> str:

--- a/python/pounce/_warm_start_schema.py
+++ b/python/pounce/_warm_start_schema.py
@@ -46,6 +46,7 @@ __all__ = [
     "MODEL_OPTIONS",
     "PROBE_RTOL",
     "ORDERING_UNVERIFIED_NOTE",
+    "WarmStartOrderingUnverifiedWarning",
     "ordering_is_unverified",
 ]
 
@@ -111,6 +112,19 @@ class WarmStartCompatibilityError(ValueError):
 class WarmStartCompatibilityWarning(UserWarning):
     """``compat="warn"`` counterpart of
     :class:`WarmStartCompatibilityError`."""
+
+
+class WarmStartOrderingUnverifiedWarning(UserWarning):
+    """A warm start was accepted by a comparison that could not have
+    seen a reordering of the variables.
+
+    Not a mismatch — nothing disagreed. It says that the one structural
+    change the comparison is blind to (pounce#621) was not ruled out,
+    which a bare clean verdict would otherwise leave the caller to infer.
+    Raised to an error with
+    ``warnings.simplefilter("error", WarmStartOrderingUnverifiedWarning)``
+    by callers who would rather refuse than replay unverified.
+    """
 
 
 class WarmStartLegacyWarning(UserWarning):

--- a/python/tests/test_warm_start_schema.py
+++ b/python/tests/test_warm_start_schema.py
@@ -21,6 +21,7 @@ before the schema existed.
 
 import dataclasses
 import os
+import warnings
 
 os.environ.setdefault("RUST_LOG", "off")
 
@@ -28,6 +29,7 @@ import numpy as np
 import pytest
 
 import pounce
+from pounce._warm_start_schema import ORDERING_UNVERIFIED_NOTE
 from pounce import (
     WarmStart,
     WarmStartCompatibilityError,
@@ -1134,3 +1136,73 @@ def test_the_note_also_rides_on_a_mismatch_report():
     ws = WarmStart.from_info(x, info, problem=p, probe=False)
     report = ws.describe_compatibility(make(ub=4.0))
     assert "bounds:" in report and "pure reordering" in report
+
+
+# --- gh#660: a clean verdict that could not have seen a reordering ---------
+def test_a_clean_but_unverifiable_check_warns_that_it_was_unverifiable():
+    """gh#660. `check_compatible` computed `unordered` on every path but
+    rendered it only inside `if mismatches:`, so the one case the note
+    exists for — nothing disagreed, *and* nothing could have seen a
+    reordering — was the one case that stayed silent. Only
+    `describe_compatibility`, which the caller has to know to call, ever
+    said it."""
+    ws = signed(probe=False)                      # signed, but no probe facet
+    with pytest.warns(pounce.WarmStartOrderingUnverifiedWarning,
+                      match="pounce#621"):
+        assert ws.check_compatible(make(obj=HS071(perm=PERM))) == []
+
+
+def test_a_verifiable_clean_check_stays_quiet():
+    """The note is about a *blind* comparison. When the probe ran on both
+    sides the check really did rule a reordering out, and saying
+    otherwise would train the reader to ignore it."""
+    ws = signed()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert ws.check_compatible(make()) == []
+
+
+def test_stable_ids_on_both_sides_also_silence_the_note():
+    ws = signed(var_ids=VAR_IDS, con_ids=CON_IDS)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert ws.check_compatible(make(), var_ids=VAR_IDS,
+                                   con_ids=CON_IDS) == []
+
+
+def test_the_note_can_be_raised_to_a_refusal():
+    """A warning category rather than a print is what lets a caller who
+    would rather refuse than replay unverified say so."""
+    ws = signed(probe=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter(
+            "error", pounce.WarmStartOrderingUnverifiedWarning)
+        with pytest.raises(pounce.WarmStartOrderingUnverifiedWarning):
+            make(obj=HS071(perm=PERM)).solve(warm_start=ws)
+
+
+def test_a_mismatched_check_still_carries_the_note_inline(recwarn):
+    """The pre-existing rendering — inside the report — must not have
+    turned into a second, separate warning."""
+    ws = signed(probe=False)
+    with pytest.warns(WarmStartCompatibilityWarning) as rec:
+        ws.check_compatible(make(n=5), compat="warn")
+    assert len(rec) == 1
+    assert ORDERING_UNVERIFIED_NOTE in str(rec[0].message)
+
+
+def test_a_legacy_artifact_does_not_get_told_twice(tmp_path):
+    """An unsigned artifact read from a file already gets
+    WarmStartLegacyWarning, which says the same thing in more detail.
+    Emitting both would be noise, so the new note is scoped to *signed*
+    states — which is every case gh#660 names."""
+    p, cold_x, cold_info = cold()
+    path = tmp_path / "legacy.npz"
+    _write_v1(path, WarmStart.from_info(cold_x, cold_info))
+    with pytest.warns(WarmStartLegacyWarning) as rec:
+        WarmStart.load(path).check_compatible(make())
+    assert len(rec) == 1
+    assert not any(
+        isinstance(w.message, pounce.WarmStartOrderingUnverifiedWarning)
+        for w in rec
+    )


### PR DESCRIPTION
`check_compatible()` computes the "ordering unverified" caveat on every path
but renders it only inside its `if mismatches:` arm:

```python
mismatches, unordered = self._compare(problem, var_ids, con_ids)
...
if mismatches:
    report = format_report(..., ordering_unverified=unordered)   # <- only here
    ...
return mismatches
```

So the one case the caveat exists for — nothing disagreed, **and** nothing in
the comparison could have caught a permutation — was the one case that stayed
silent. Only `describe_compatibility()`, the opt-in dry run, ever said it.
The safe-looking path (just replay it) was the uninformative one.

`describe_compatibility` already argues the point in its own docstring:

> A clean verdict says so, and — when the comparison could not have seen a
> reordering — says that too. "Compatible" on its own would otherwise read as
> a stronger claim than the check made (pounce#621).

That reasoning applies verbatim to `check_compatible`, which is the path
`solve(warm_start=...)` and `_starts.py` actually take.

## When it bites

Nothing exotic is required — the probe facet is documented as best-effort and
is genuinely absent for an artifact captured with `probe=False`, one written
before #621, or a model with a domain restriction (`log`, `sqrt`, a division)
that will not evaluate at the schema's fixed interior probe point. With no
`var_ids` on both sides, a uniform box and a dense jacobian leave the bound
and sparsity digests bit-identical under a permutation, so the reordered seed
goes into the solve.

Before:

```
probe=False check_compatible -> clean (returned [])
                warnings emitted: NONE
```

After:

```
probe=False check_compatible -> clean (returned [])
                warnings emitted: ['note: neither a model probe nor stable IDs
                were available on both sides, so a pure reordering of the
                variables would not have been caught here (pounce#621). ...']
```

## The change

- New `WarmStartOrderingUnverifiedWarning`, exported from `pounce`.
- `check_compatible` emits it on the clean-but-blind path. A **warning**, not
  a refusal, because nothing actually disagreed. Callers who would rather
  refuse can promote it:
  `warnings.simplefilter("error", pounce.WarmStartOrderingUnverifiedWarning)`.
- Scoped to **signed** states. An unsigned artifact read from a file already
  gets `WarmStartLegacyWarning`, which says the same thing in more detail, and
  an unsigned one built in-process is the pre-#607 usage that stays
  deliberately silent. Every case #660 names is a signed state with
  `probe=None`, so nothing is lost.
- Repeats are left to the `warnings` module: `stacklevel=3` attributes the
  warning to the caller, so the default once-per-location filter collapses
  repeated checks without a bespoke latch.

## The multistart exemption

Adding the warning naively made it fire on **every rung of every race** —
caught by `test_the_multistart_ladder_does_not_pay_for_the_probe`, which
started emitting it.

That one is provably vacuous. `_starts.py` captures with `probe=False`
*because* the state is captured from, and resumed on, the same `Problem`
object in the same process a moment later — there is no reordering for the
comparison to have missed. The call site now suppresses just this category,
with the reasoning in a comment. The check itself still runs.

## Tests

- `test_a_clean_but_unverifiable_check_warns_that_it_was_unverifiable` — the
  defect itself.
- `test_a_verifiable_clean_check_stays_quiet` and
  `test_stable_ids_on_both_sides_also_silence_the_note` — the note must not
  fire when the comparison really did rule a reordering out, or it trains the
  reader to ignore it.
- `test_the_note_can_be_raised_to_a_refusal` — the category is usable as an
  error.
- `test_a_mismatched_check_still_carries_the_note_inline` — the pre-existing
  in-report rendering did not turn into a second, separate warning.
- `test_a_legacy_artifact_does_not_get_told_twice` — no double-warning on the
  legacy path.

`test_warm_start_schema.py` + `test_starts.py` + `test_warm_start_object.py` +
`test_sqp_warm_start.py`: 96 passed. Full `python/tests`: 1180 passed, 6
failed — 5 in `test_starts_racing.py` and 1 in `test_warm_start_schema.py`,
all of which reproduce with identical counts on unmodified `origin/main`
(verified by stashing). They come from a stale locally-built extension; CI's
`python-test` job builds the wheel fresh with maturin, so they do not appear
there.

Docs: `docs/src/initialization.md` gains the enforcing-path half of the story
next to the existing dry-run example.

No trajectory implications — Python-side compatibility gate, not the solver.

Fixes #660
