### PR TITLE
Don't report a diverging restoration as an infeasible model (#661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ changes.
 
 ## [Unreleased]
 
+- **A diverging restoration is no longer reported as an infeasible
+  model** (#661).
+
+  `run_inner_resto` renders `Infeasible_Problem_Detected` from six gates.
+  One is a verdict the restoration sub-solve's own convergence check
+  issued at a point it certified. The other five *reconstruct* "the
+  sub-solve stalled at a point it could not improve on" after the fact,
+  from a terminal status plus a KKT residual — and each then tested only
+  that the recovered violation was *large*.
+
+  Large is a different claim from stalled, and they come apart in the
+  worst direction: a restoration that is actively blowing up satisfies a
+  size test more emphatically the further it diverges. On
+  `pooling_rt2stp.nl` under `mehrotra_algorithm=yes` the `step_failure`
+  gate fired at an original-NLP violation of `7.35e5` after restoration
+  was *entered* at `6.96e0` — feasibility made 105,700x worse — and the
+  solver told the user the model may be infeasible. It is not; the same
+  model solves at default options. `hs71_obj1e8` was a second instance
+  (entry `1.04e2`, verdict at `6.79e9`).
+
+  The five reconstructed gates now also require what their own comments
+  already claimed: the recovered point must be within
+  `RESTO_DIVERGENCE_HEADROOM` (10x) of the violation restoration was
+  entered at. A plateau — the signature they describe, and what
+  `qcqp750-2nc` showed when the `step_failure` gate was written — sits at
+  ~1x entry, so the guard is loose enough to leave it alone. The
+  sub-solve's own certified verdict is not gated; it carries the stall
+  evidence the other five infer.
+
+  #619 did not introduce this. Its change of starting point only made
+  `pooling_rt2stp`'s inner explode at iteration 32 rather than 19, and
+  the gate carries an `iter >= 30` floor — identical divergence on either
+  side of #619, opposite verdict, decided by an iteration count.
+
+  The guard stands down once the sub-solve has burned
+  `RESTO_STALL_EVIDENCE_ITERS` — the 1000-iteration budget the `cycle`
+  gate above already required before reading a stall as local
+  infeasibility. `issue_508_infeasible_gap_1em2` is why: it is infeasible
+  by a constructed `1e-2` gap, and its restoration sits at `1.04e-2` —
+  the violation it entered at, to the digit — for 1016 inner iterations
+  before jumping to `3.19e9` over its last three. The large final ratio
+  describes those three iterations, not the run. `pooling_rt2stp` and
+  `hs71_obj1e8` have no such plateau: both exit after ~30 inner
+  iterations, and `hs71_obj1e8` was still *reducing* the original
+  violation (`4.48e1` to `2.25e1`) shortly before diverging. Deferring to
+  that budget also removes an inconsistency predating this guard — a
+  sub-solve stalling 1000+ iterations and exiting by iteration cap
+  rendered the verdict, while the identical stall exiting by step failure
+  did not.
+
+  Trajectory sweep: the fixture corpus is byte-identical at default
+  options and under `least_square_init_primal=yes`. Under
+  `mehrotra_algorithm=yes` exactly two lines move —
+  `pooling_rt2stp` and `hs71_obj1e8`, both from
+  `Infeasible_Problem_Detected` to `Restoration_Failed`, both feasible
+  models, both with iteration count and objective unchanged. No fixture
+  loses a correct verdict on any arm.
+
 - **Crossover: the sensitivity path reads the barrier diagonal in the
   frame crossover solved in** (#654).
 

--- a/crates/pounce-cli/tests/issue_661_resto_divergence_guard.rs
+++ b/crates/pounce-cli/tests/issue_661_resto_divergence_guard.rs
@@ -1,0 +1,208 @@
+//! Regression test for pounce#661: a *diverging* restoration could be
+//! reported as a converged point of local infeasibility.
+//!
+//! `run_inner_resto` renders the locally-infeasible verdict from six
+//! gates. One of them — layer 2 — is a verdict the restoration
+//! sub-solve's own convergence check issued at a point it certified.
+//! The other five *reconstruct* "the sub-solve stalled at a point it
+//! could not improve on" after the fact, from a terminal status plus a
+//! KKT residual, and each then tests only that the recovered violation
+//! is *large*.
+//!
+//! Large is a different claim from stalled, and the two come apart in
+//! the worst direction: a restoration that is actively blowing up
+//! satisfies the size test more emphatically the further it diverges.
+//! On `pooling_rt2stp.nl` under `mehrotra_algorithm=yes` the
+//! `step_failure` gate fired at an original-NLP violation of `7.35e5`
+//! after restoration was *entered* at `6.96e0` — feasibility made
+//! 105,700x worse — and the solver told the user the model may be
+//! infeasible. It is not: the same model solves at default options.
+//!
+//! The fix adds the premise those gates already claim in their comments
+//! but never tested — the recovered point must not be dramatically
+//! worse than where restoration started. `Restoration_Failed`, the
+//! solver admitting *it* failed, is the honest answer for a blow-up;
+//! `Infeasible_Problem_Detected` is an affirmative claim about the
+//! user's model and must not rest on a diverging trajectory.
+//!
+//! Note on provenance: #619 did not introduce this. Its change of
+//! starting point only made the inner explode at iteration 32 rather
+//! than 19, and the gate carries an `iter >= 30` floor — identical
+//! divergence on either side of #619, opposite verdict, decided by an
+//! iteration count.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture_nl(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// Run a fixture with the locally-infeasible gate trace enabled.
+fn run_with_locinf_trace(fixture: &str, opts: &[&str]) -> String {
+    let output = Command::new(pounce_exe())
+        .arg(fixture_nl(fixture))
+        .arg("--no-sol")
+        .args(opts)
+        .env("POUNCE_DBG_RESTO_LOCINF", "1")
+        .env("RUST_LOG", "pounce::restoration=debug")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("spawn pounce");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// Parse the `key=value` fields of every `[PN_RESTO_LOCINF]` line.
+fn locinf_lines(combined: &str) -> Vec<Vec<(String, String)>> {
+    combined
+        .lines()
+        .filter_map(|l| l.split("[PN_RESTO_LOCINF] ").nth(1))
+        .map(|rest| {
+            rest.split_whitespace()
+                .filter_map(|tok| {
+                    let (k, v) = tok.split_once('=')?;
+                    Some((k.to_string(), v.to_string()))
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn field<'a>(line: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    line.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+}
+
+/// The user-facing half of #661: a model that solves at default options
+/// must never be reported as possibly infeasible just because one
+/// option cascade sends its restoration divergent.
+#[test]
+fn a_diverging_restoration_is_not_reported_as_an_infeasible_model() {
+    let combined = run_with_locinf_trace("pooling_rt2stp.nl", &["mehrotra_algorithm=yes"]);
+    assert!(
+        !combined.contains("local infeasibility"),
+        "pounce#661: `pooling_rt2stp.nl` is feasible — it solves at \
+         default options. Under `mehrotra_algorithm=yes` its restoration \
+         diverges, and a diverging restoration must exit \
+         `Restoration_Failed`, not claim the model may be \
+         infeasible.\n--- output ---\n{combined}",
+    );
+}
+
+/// The mechanism, pinned rather than inferred from the exit line: the
+/// gate does fire on its own terms, and the divergence guard is what
+/// withholds the verdict.
+#[test]
+fn the_guard_is_what_withholds_the_verdict_on_the_diverging_call() {
+    let combined = run_with_locinf_trace("pooling_rt2stp.nl", &["mehrotra_algorithm=yes"]);
+    let lines = locinf_lines(&combined);
+    assert!(
+        !lines.is_empty(),
+        "expected the gate trace to be emitted\n--- output ---\n{combined}",
+    );
+
+    let guarded: Vec<_> = lines
+        .iter()
+        .filter(|l| field(l, "diverged_from_entry") == Some("true"))
+        .collect();
+    assert!(
+        !guarded.is_empty(),
+        "pounce#661: expected at least one restoration call on this model \
+         to be recognised as diverged from its entry violation\n--- output \
+         ---\n{combined}",
+    );
+
+    for line in &guarded {
+        // A gate did want to render the verdict — otherwise the guard is
+        // not the thing being tested and this test would silently stop
+        // covering the regression.
+        let any_reconstructed_gate = ["strict", "alt", "cycle", "step_fail", "tiny_step"]
+            .iter()
+            .any(|g| field(line, g) == Some("true"));
+        assert!(
+            any_reconstructed_gate,
+            "expected a reconstructed gate to have fired on the diverged \
+             call, so the guard is what suppresses it: {line:?}",
+        );
+        assert_eq!(
+            field(line, "loc_inf"),
+            Some("false"),
+            "pounce#661: the divergence guard must withhold the verdict on \
+             a call whose recovered violation is far worse than the one \
+             restoration was entered at: {line:?}",
+        );
+    }
+}
+
+/// The guard defers to `RESTO_STALL_EVIDENCE_ITERS`. A sub-solve that
+/// spent 1016 inner iterations pinned at the violation it entered
+/// restoration at — `1.04e-2`, to the digit, which is the infeasibility
+/// gap this fixture is built around — and only then blew up over its
+/// last three has demonstrated exactly the floor the gates look for. The
+/// large final ratio describes those three iterations, not the run, and
+/// the verdict must survive it.
+///
+/// This is the discriminator between the two shapes: `pooling_rt2stp`
+/// and `hs71_obj1e8` exit after ~30 inner iterations with no plateau at
+/// all, and `hs71_obj1e8` was still *reducing* the original violation
+/// (`4.48e1` -> `2.25e1`) shortly before it diverged.
+#[test]
+fn a_long_stalled_sub_solve_keeps_its_verdict_despite_a_terminal_blow_up() {
+    let combined = run_with_locinf_trace(
+        "issue_508_infeasible_gap_1em2.nl",
+        &["mehrotra_algorithm=yes"],
+    );
+    assert!(
+        combined.contains("local infeasibility"),
+        "pounce#661: this model is infeasible by a constructed 1e-2 gap,          and its restoration stalls at that gap for 1000+ inner iterations          before a terminal blow-up. The divergence guard must not read          those last few iterations as grounds to withhold the          verdict.\n--- output ---\n{combined}",
+    );
+
+    let lines = locinf_lines(&combined);
+    let long_stalls: Vec<_> = lines
+        .iter()
+        .filter(|l| {
+            field(l, "iter")
+                .and_then(|v| v.parse::<i64>().ok())
+                .is_some_and(|n| n >= 1000)
+        })
+        .collect();
+    assert!(
+        !long_stalls.is_empty(),
+        "expected a restoration call that burned the stall-evidence \
+         budget\n--- output ---\n{combined}",
+    );
+    for line in &long_stalls {
+        assert_eq!(
+            field(line, "diverged_from_entry"),
+            Some("false"),
+            "the divergence guard must stand down once the sub-solve has \
+             burned the same iteration budget the `cycle` gate accepts as \
+             stall evidence on its own: {line:?}",
+        );
+    }
+}
+
+/// The guard must not cost genuine detection. A one-inequality
+/// contradiction (`0 <= x <= 0.6` with `x >= 0.7`) is infeasible, its
+/// restoration converges rather than diverges, and it must still be
+/// diagnosed as such.
+#[test]
+fn a_genuinely_infeasible_model_is_still_diagnosed() {
+    let combined = run_with_locinf_trace("issue_372_infeasible_bounds.nl", &[]);
+    assert!(
+        combined.contains("local infeasibility"),
+        "the divergence guard must not suppress a real \
+         local-infeasibility diagnosis\n--- output ---\n{combined}",
+    );
+}

--- a/crates/pounce-cli/tests/issue_661_resto_divergence_guard.rs
+++ b/crates/pounce-cli/tests/issue_661_resto_divergence_guard.rs
@@ -30,6 +30,24 @@
 //! than 19, and the gate carries an `iter >= 30` floor — identical
 //! divergence on either side of #619, opposite verdict, decided by an
 //! iteration count.
+//!
+//! Scope. These are behavioural tests only — they assert what the user is
+//! told, not how the guard reached it. The guard's decision rule is a pure
+//! function, `diverged_from_restoration_entry`, unit-tested directly in
+//! `pounce-restoration::resto_inner_solver`; that is where the plateau /
+//! blow-up discrimination, the stall waiver and the boundaries are pinned.
+//! An earlier revision of this file asserted the mechanism end-to-end by
+//! parsing the `POUNCE_DBG_RESTO_LOCINF` trace, and it did not survive
+//! contact with a second platform: on x86_64-linux this restoration
+//! explodes at inner iteration 15 rather than 32, so it never clears the
+//! `step_failure` gate's `iter >= 30` floor and the trace legitimately
+//! shows no gate firing at all. *Which* gate a trajectory reaches is not a
+//! property this fix owns, and asserting it made the test a trajectory
+//! detector rather than a regression test. Whether these end-to-end cases
+//! are non-vacuous on a given platform therefore varies — they are
+//! provably non-vacuous on aarch64-darwin, where a baseline binary prints
+//! the false verdict — which is the other reason the mechanism is pinned
+//! in unit tests.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -64,26 +82,6 @@ fn run_with_locinf_trace(fixture: &str, opts: &[&str]) -> String {
     )
 }
 
-/// Parse the `key=value` fields of every `[PN_RESTO_LOCINF]` line.
-fn locinf_lines(combined: &str) -> Vec<Vec<(String, String)>> {
-    combined
-        .lines()
-        .filter_map(|l| l.split("[PN_RESTO_LOCINF] ").nth(1))
-        .map(|rest| {
-            rest.split_whitespace()
-                .filter_map(|tok| {
-                    let (k, v) = tok.split_once('=')?;
-                    Some((k.to_string(), v.to_string()))
-                })
-                .collect()
-        })
-        .collect()
-}
-
-fn field<'a>(line: &'a [(String, String)], key: &str) -> Option<&'a str> {
-    line.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
-}
-
 /// The user-facing half of #661: a model that solves at default options
 /// must never be reported as possibly infeasible just because one
 /// option cascade sends its restoration divergent.
@@ -100,97 +98,23 @@ fn a_diverging_restoration_is_not_reported_as_an_infeasible_model() {
     );
 }
 
-/// The mechanism, pinned rather than inferred from the exit line: the
-/// gate does fire on its own terms, and the divergence guard is what
-/// withholds the verdict.
+/// A second, independent instance of the same defect, on a different
+/// model. `hs71_obj1e8` is plain HS071 with its objective scaled by 1e8;
+/// it solves in 11 iterations at default options. Under the same option
+/// cascade its restoration was entered at `1.04e2` and rendered the
+/// verdict at `6.79e9`, while still *reducing* the original violation
+/// (`4.48e1` -> `2.25e1`) shortly before it diverged — a sub-solve making
+/// progress, not one out of room.
 #[test]
-fn the_guard_is_what_withholds_the_verdict_on_the_diverging_call() {
-    let combined = run_with_locinf_trace("pooling_rt2stp.nl", &["mehrotra_algorithm=yes"]);
-    let lines = locinf_lines(&combined);
+fn a_second_feasible_model_is_not_reported_infeasible_either() {
+    let combined = run_with_locinf_trace("hs71_obj1e8.nl", &["mehrotra_algorithm=yes"]);
     assert!(
-        !lines.is_empty(),
-        "expected the gate trace to be emitted\n--- output ---\n{combined}",
-    );
-
-    let guarded: Vec<_> = lines
-        .iter()
-        .filter(|l| field(l, "diverged_from_entry") == Some("true"))
-        .collect();
-    assert!(
-        !guarded.is_empty(),
-        "pounce#661: expected at least one restoration call on this model \
-         to be recognised as diverged from its entry violation\n--- output \
+        !combined.contains("local infeasibility"),
+        "pounce#661: `hs71_obj1e8.nl` is feasible — it solves in 11 \
+         iterations at default options — so no option cascade may lead the \
+         solver to report it as possibly infeasible.\n--- output \
          ---\n{combined}",
     );
-
-    for line in &guarded {
-        // A gate did want to render the verdict — otherwise the guard is
-        // not the thing being tested and this test would silently stop
-        // covering the regression.
-        let any_reconstructed_gate = ["strict", "alt", "cycle", "step_fail", "tiny_step"]
-            .iter()
-            .any(|g| field(line, g) == Some("true"));
-        assert!(
-            any_reconstructed_gate,
-            "expected a reconstructed gate to have fired on the diverged \
-             call, so the guard is what suppresses it: {line:?}",
-        );
-        assert_eq!(
-            field(line, "loc_inf"),
-            Some("false"),
-            "pounce#661: the divergence guard must withhold the verdict on \
-             a call whose recovered violation is far worse than the one \
-             restoration was entered at: {line:?}",
-        );
-    }
-}
-
-/// The guard defers to `RESTO_STALL_EVIDENCE_ITERS`. A sub-solve that
-/// spent 1016 inner iterations pinned at the violation it entered
-/// restoration at — `1.04e-2`, to the digit, which is the infeasibility
-/// gap this fixture is built around — and only then blew up over its
-/// last three has demonstrated exactly the floor the gates look for. The
-/// large final ratio describes those three iterations, not the run, and
-/// the verdict must survive it.
-///
-/// This is the discriminator between the two shapes: `pooling_rt2stp`
-/// and `hs71_obj1e8` exit after ~30 inner iterations with no plateau at
-/// all, and `hs71_obj1e8` was still *reducing* the original violation
-/// (`4.48e1` -> `2.25e1`) shortly before it diverged.
-#[test]
-fn a_long_stalled_sub_solve_keeps_its_verdict_despite_a_terminal_blow_up() {
-    let combined = run_with_locinf_trace(
-        "issue_508_infeasible_gap_1em2.nl",
-        &["mehrotra_algorithm=yes"],
-    );
-    assert!(
-        combined.contains("local infeasibility"),
-        "pounce#661: this model is infeasible by a constructed 1e-2 gap,          and its restoration stalls at that gap for 1000+ inner iterations          before a terminal blow-up. The divergence guard must not read          those last few iterations as grounds to withhold the          verdict.\n--- output ---\n{combined}",
-    );
-
-    let lines = locinf_lines(&combined);
-    let long_stalls: Vec<_> = lines
-        .iter()
-        .filter(|l| {
-            field(l, "iter")
-                .and_then(|v| v.parse::<i64>().ok())
-                .is_some_and(|n| n >= 1000)
-        })
-        .collect();
-    assert!(
-        !long_stalls.is_empty(),
-        "expected a restoration call that burned the stall-evidence \
-         budget\n--- output ---\n{combined}",
-    );
-    for line in &long_stalls {
-        assert_eq!(
-            field(line, "diverged_from_entry"),
-            Some("false"),
-            "the divergence guard must stand down once the sub-solve has \
-             burned the same iteration budget the `cycle` gate accepts as \
-             stall evidence on its own: {line:?}",
-        );
-    }
 }
 
 /// The guard must not cost genuine detection. A one-inequality

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -98,6 +98,49 @@ const RESTO_DIVERGENCE_HEADROOM: f64 = 10.0;
 /// the blow-up is the tail of the trajectory, not the trajectory.
 const RESTO_STALL_EVIDENCE_ITERS: i32 = 1000;
 
+/// Whether a restoration sub-solve ended somewhere enough *worse* than it
+/// began that the five reconstructed gates in [`run_inner_resto`] have no
+/// basis for a locally-infeasible verdict (gh#661).
+///
+/// `orig_curr_inf_pr` is the original-NLP violation the outer handed to this
+/// restoration call; `orig_inf_pr_scaled` is where the sub-solve left it.
+/// Both are in the scaled space (`orig_curr_inf_pr` is the same reference the
+/// kappa-reduction guard measures progress against). Restoration exists to
+/// *reduce* that number, so a point an order of magnitude worse than entry is
+/// not a point restoration converged to.
+///
+/// Three ways this returns `false`, each deliberate:
+///
+/// - **No usable reference.** A non-finite or non-positive entry violation
+///   gives nothing to measure divergence against, so the gates are left as
+///   they were rather than suppressed on a ratio against zero.
+/// - **The stall is already evidenced.** Past [`RESTO_STALL_EVIDENCE_ITERS`]
+///   the sub-solve has demonstrated a floor on its own; a blow-up over its
+///   last handful of iterations is the tail of that trajectory, not a
+///   description of it. `issue_508_infeasible_gap_1em2` sits at `1.04e-2` —
+///   to the digit, the violation it entered at — for 1016 inner iterations
+///   and only then jumps to `3.19e9`. Its final `1e11x` ratio is an artifact
+///   of three iterations.
+/// - **Within headroom.** A plateau, which is the signature these gates
+///   actually describe, lands at ~1x entry.
+///
+/// Never applied to the layer-2 verdict (gh#438): that one is not
+/// reconstructed — the sub-solve's own convergence check issued it at a point
+/// it certified — so it already carries the stall evidence the other five
+/// infer.
+fn diverged_from_restoration_entry(
+    orig_curr_inf_pr: f64,
+    orig_inf_pr_scaled: f64,
+    inner_iter_count: i32,
+) -> bool {
+    let entry_reference_usable = orig_curr_inf_pr.is_finite() && orig_curr_inf_pr > 0.0;
+    let stall_already_evidenced = inner_iter_count >= RESTO_STALL_EVIDENCE_ITERS;
+
+    entry_reference_usable
+        && !stall_already_evidenced
+        && orig_inf_pr_scaled > RESTO_DIVERGENCE_HEADROOM * orig_curr_inf_pr
+}
+
 /// Build the restoration convergence-check adapter, threading the inner
 /// IPM's *user-derived* stationarity tolerances (`tol`,
 /// `acceptable_tol`, `acceptable_iter`) through to the sub-solve.
@@ -919,47 +962,15 @@ pub fn run_inner_resto(
     // count. #619 did not introduce the defect, only a starting point that
     // reaches it.
     //
-    // `_HEADROOM` is deliberately loose. A plateau is what the gates describe
-    // and a plateau lands at ~1x entry — `qcqp750-2nc`, the fixture the
-    // `step_failure` gate is named for, sat *pinned* at `inf_pr = 1.05e6`
-    // across 25+ inner iterations before bailing. An order of magnitude
-    // absorbs a plateau that wanders without admitting a blow-up.
-    //
-    // Waived once the sub-solve has burned `RESTO_STALL_EVIDENCE_ITERS`.
-    //
-    // Under the same option cascade the two `issue_508_infeasible_gap_*`
-    // fixtures reach a *correct* infeasibility verdict through what looks
-    // at the final point like the same diverging route. Their trajectories
-    // are not the same shape, though. `issue_508_infeasible_gap_1em2` sits
-    // at `1.04e-2` — to the digit, the violation it entered restoration at,
-    // and the infeasibility gap the fixture is built around — for 1016
-    // inner iterations, and only then jumps to `3.19e9` over its last
-    // three. That is a floor the sub-solve provably could not improve on,
-    // with a blow-up appended; the `1e11x` ratio at the final point is an
-    // artifact of the last three iterations, not a description of the run.
-    //
-    // `hs71_obj1e8` and `pooling_rt2stp` have no such plateau. Both exit
-    // after ~30 inner iterations, and `hs71_obj1e8` was still *reducing*
-    // the original violation (4.48e1 -> 2.25e1) shortly before it diverged
-    // — a sub-solve making progress, not one out of room.
-    //
-    // Iteration count separates them, and not by a threshold invented
-    // here: `RESTO_STALL_EVIDENCE_ITERS` is the budget the `cycle` gate
-    // above already requires before reading a stall as local
-    // infeasibility. Deferring to it also removes an inconsistency that
-    // predates this guard — a sub-solve that stalls for 1000+ iterations
-    // and exits by iteration cap renders the verdict, while the same stall
-    // exiting by step failure did not.
-    //
-    // Not applied to `verdict_locally_infeasible`. That one is not
-    // reconstructed: the sub-solve's own convergence check issued it at a
-    // point the sub-solve certified, against its own tolerance (see its
-    // comment above). It carries the stall evidence the other five infer.
-    let entry_reference_usable = orig_curr_inf_pr.is_finite() && orig_curr_inf_pr > 0.0;
-    let stall_already_evidenced = inner_iter_count >= RESTO_STALL_EVIDENCE_ITERS;
-    let diverged_from_entry = entry_reference_usable
-        && !stall_already_evidenced
-        && orig_inf_pr_scaled > RESTO_DIVERGENCE_HEADROOM * orig_curr_inf_pr;
+    // The waiver, the headroom's looseness, and why the layer-2 verdict is
+    // exempt are all documented on `diverged_from_restoration_entry`. The
+    // short of it: `hs71_obj1e8` and `pooling_rt2stp` both exit after ~30
+    // inner iterations with no plateau at all — `hs71_obj1e8` was still
+    // *reducing* the original violation (4.48e1 -> 2.25e1) shortly before it
+    // diverged — while `issue_508_infeasible_gap_1em2`, which reaches a
+    // *correct* verdict, is pinned at its entry violation for 1016.
+    let diverged_from_entry =
+        diverged_from_restoration_entry(orig_curr_inf_pr, orig_inf_pr_scaled, inner_iter_count);
 
     let reconstructed_locally_infeasible = !diverged_from_entry
         && (strict_locally_infeasible
@@ -1372,5 +1383,101 @@ mod tests {
         assert!(!is_resto_success(SolverReturn::RestorationFailure));
         assert!(!is_resto_success(SolverReturn::InternalError));
         assert!(!is_resto_success(SolverReturn::LocalInfeasibility));
+    }
+}
+
+#[cfg(test)]
+mod issue_661_divergence_guard {
+    use super::*;
+
+    /// gh#661, the case the guard exists for. `pooling_rt2stp.nl` under
+    /// `mehrotra_algorithm=yes`: restoration entered at a violation of
+    /// 6.957e0 and left at 7.355e5 — 105,700x worse — after 32 inner
+    /// iterations, and a reconstructed gate read that as "converged to a
+    /// point of local infeasibility". The model solves at default options.
+    #[test]
+    fn a_short_blow_up_is_divergence() {
+        assert!(diverged_from_restoration_entry(
+            6.957_464e0,
+            7.354_646e5,
+            32
+        ));
+    }
+
+    /// A plateau — the signature the reconstructed gates actually describe —
+    /// keeps its verdict. `qcqp750-2nc`, the fixture the `step_failure` gate
+    /// is named for, sat pinned at `inf_pr = 1.05e6` for 25+ inner
+    /// iterations, i.e. ~1x entry.
+    #[test]
+    fn a_plateau_is_not_divergence() {
+        assert!(!diverged_from_restoration_entry(1.05e6, 1.05e6, 27));
+        // and wandering within the headroom is still a plateau
+        assert!(!diverged_from_restoration_entry(1.05e6, 9.9e6, 27));
+    }
+
+    /// The headroom is a strict `>`, so exactly 10x entry is not yet
+    /// divergence.
+    #[test]
+    fn the_headroom_boundary_is_exclusive() {
+        assert!(!diverged_from_restoration_entry(
+            1.0,
+            RESTO_DIVERGENCE_HEADROOM,
+            5
+        ));
+        assert!(diverged_from_restoration_entry(
+            1.0,
+            RESTO_DIVERGENCE_HEADROOM * 1.000_001,
+            5
+        ));
+    }
+
+    /// Restoration that *improved* on entry is the ordinary case and must
+    /// never be read as divergence.
+    #[test]
+    fn progress_is_not_divergence() {
+        assert!(!diverged_from_restoration_entry(1.0e3, 1.0e-4, 40));
+    }
+
+    /// `issue_508_infeasible_gap_1em2`, which reaches a *correct*
+    /// infeasibility verdict: pinned at its 1.04e-2 entry violation for 1016
+    /// inner iterations, then a jump to 3.19e9 over the last three. The final
+    /// ratio is ~1e11 — far past the headroom — but the stall was already
+    /// demonstrated, so the verdict stands.
+    #[test]
+    fn a_long_stall_keeps_its_verdict_despite_a_terminal_blow_up() {
+        assert!(!diverged_from_restoration_entry(1.04e-2, 3.19e9, 1019));
+        // the same trajectory truncated before the evidence threshold would
+        // have been suppressed — the iteration count is what separates them
+        assert!(diverged_from_restoration_entry(1.04e-2, 3.19e9, 999));
+    }
+
+    /// The waiver is the `cycle` gate's own budget, not a threshold invented
+    /// for this guard, and the boundary is inclusive on the same `>=`.
+    #[test]
+    fn the_stall_waiver_starts_at_the_cycle_gates_budget() {
+        let (entry, final_) = (1.0, 1.0e9);
+        assert!(diverged_from_restoration_entry(
+            entry,
+            final_,
+            RESTO_STALL_EVIDENCE_ITERS - 1
+        ));
+        assert!(!diverged_from_restoration_entry(
+            entry,
+            final_,
+            RESTO_STALL_EVIDENCE_ITERS
+        ));
+    }
+
+    /// With no usable entry reference there is nothing to measure divergence
+    /// against, and the gates are left exactly as they were rather than
+    /// suppressed on a ratio against zero (or against NaN, where every
+    /// comparison is false anyway and the `> 0.0` test is what actually
+    /// carries it).
+    #[test]
+    fn an_unusable_entry_reference_suppresses_nothing() {
+        assert!(!diverged_from_restoration_entry(0.0, 1.0e9, 5));
+        assert!(!diverged_from_restoration_entry(f64::NAN, 1.0e9, 5));
+        assert!(!diverged_from_restoration_entry(f64::INFINITY, 1.0e9, 5));
+        assert!(!diverged_from_restoration_entry(-1.0, 1.0e9, 5));
     }
 }

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -73,6 +73,31 @@ const RESTO_INNER_MAX_ITERS: i32 = 3000;
 /// (`IpRestoConvCheck.cpp:144` `maximum_resto_iters`).
 const RESTO_MAX_SUCCESSIVE_ITERS: i32 = 3000;
 
+/// How much worse than the violation restoration was *entered* at a
+/// recovered point may be and still support a locally-infeasible verdict
+/// from one of the reconstructed gates in [`run_inner_resto`] (gh#661).
+///
+/// Those gates infer "the sub-solve stalled" from a terminal status and
+/// then test only that the violation is large. A diverging restoration
+/// passes that size test ever more strongly the further it blows up, which
+/// is how a model that solves at default options got reported infeasible at
+/// a point 105,700x worse than restoration's own starting violation. One
+/// order of magnitude lets a plateau wander — the signature these gates
+/// describe sits at ~1x entry — without admitting a blow-up.
+const RESTO_DIVERGENCE_HEADROOM: f64 = 10.0;
+
+/// Inner iterations after which a restoration sub-solve is taken to have
+/// demonstrated a stall on its own, independent of how it finally exited.
+///
+/// This is the budget the `cycle` gate in [`run_inner_resto`] has always
+/// required before reading an iteration-cap exit as evidence of local
+/// infeasibility ("a generous iteration budget has been burned with no
+/// exit"). [`RESTO_DIVERGENCE_HEADROOM`] defers to it: a sub-solve that
+/// spent a thousand-plus iterations unable to improve, and *then* blew up
+/// over its last handful, has shown the floor the gates are looking for —
+/// the blow-up is the tail of the trajectory, not the trajectory.
+const RESTO_STALL_EVIDENCE_ITERS: i32 = 1000;
+
 /// Build the restoration convergence-check adapter, threading the inner
 /// IPM's *user-derived* stationarity tolerances (`tol`,
 /// `acceptable_tol`, `acceptable_iter`) through to the sub-solve.
@@ -748,7 +773,7 @@ pub fn run_inner_resto(
     // burned with no exit. Conservative threshold to avoid
     // misclassifying genuinely under-resourced solves.
     let cycle_locally_infeasible = matches!(status, SolverReturn::MaxiterExceeded)
-        && inner_iter_count >= 1000
+        && inner_iter_count >= RESTO_STALL_EVIDENCE_ITERS
         && is_significant(orig_inf_pr_at_final, violation_scale, outer_constr_viol_tol)
         && orig_inf_pr_at_final.is_finite();
 
@@ -860,22 +885,101 @@ pub fn run_inner_resto(
     // preceding safeguards in this area were each added to one path and not its
     // twin, and a hole survived both times.
     let solver_would_call_it_feasible = orig_inf_pr_scaled <= outer_tol;
-    let locally_infeasible = !solver_would_call_it_feasible
-        && (verdict_locally_infeasible
-            || strict_locally_infeasible
+
+    // Divergence guard over the five *reconstructed* gates (gh#661).
+    //
+    // Each of those gates reconstructs "the sub-solve stalled at a point it
+    // could not improve on" after the fact, from a terminal status plus a
+    // KKT residual — and every one of them then tests only that the residual
+    // violation is *large* (`is_significant`). Large is not the same claim as
+    // stalled. A restoration that is actively *diverging* satisfies the size
+    // test more emphatically the worse it gets, so the size test alone reads
+    // a blow-up as strong evidence for the verdict it most contradicts.
+    //
+    // `orig_curr_inf_pr` is the original-NLP violation the outer handed to
+    // this restoration call, in the same scaled space as `orig_inf_pr_scaled`
+    // (it is the reference the kappa-reduction guard measures progress
+    // against). Restoration exists to *reduce* that number; the kappa guard
+    // will not even call the sub-solve converged until it reaches
+    // `kappa_resto` (0.9) of it. A point an order of magnitude *worse* than
+    // where restoration started is not a point restoration converged to, and
+    // "converged to a point of local infeasibility" — an affirmative claim
+    // about the user's model — has no basis there. `Restoration_Failed`, the
+    // solver admitting it failed, is the honest answer.
+    //
+    // Measured on `pooling_rt2stp.nl` under `mehrotra_algorithm=yes`: the
+    // `step_failure` gate fired at `entry_inf_pr = 6.957e0`,
+    // `orig_inf_pr = 7.355e5` — restoration made feasibility 105,700x worse,
+    // with the inner's `inf_pr` climbing monotonically (2.61e2, 5.67e3,
+    // 6.24e4, 7.35e5) and `||d||` reaching 1.64e9, and the model was reported
+    // infeasible. It is not; at default options the same model solves. The
+    // same run on #619's parent commit differed only in that its inner
+    // exploded at iteration 19 rather than 32, missing the gate's `iter >= 30`
+    // floor — identical divergence, opposite verdict, decided by an iteration
+    // count. #619 did not introduce the defect, only a starting point that
+    // reaches it.
+    //
+    // `_HEADROOM` is deliberately loose. A plateau is what the gates describe
+    // and a plateau lands at ~1x entry — `qcqp750-2nc`, the fixture the
+    // `step_failure` gate is named for, sat *pinned* at `inf_pr = 1.05e6`
+    // across 25+ inner iterations before bailing. An order of magnitude
+    // absorbs a plateau that wanders without admitting a blow-up.
+    //
+    // Waived once the sub-solve has burned `RESTO_STALL_EVIDENCE_ITERS`.
+    //
+    // Under the same option cascade the two `issue_508_infeasible_gap_*`
+    // fixtures reach a *correct* infeasibility verdict through what looks
+    // at the final point like the same diverging route. Their trajectories
+    // are not the same shape, though. `issue_508_infeasible_gap_1em2` sits
+    // at `1.04e-2` — to the digit, the violation it entered restoration at,
+    // and the infeasibility gap the fixture is built around — for 1016
+    // inner iterations, and only then jumps to `3.19e9` over its last
+    // three. That is a floor the sub-solve provably could not improve on,
+    // with a blow-up appended; the `1e11x` ratio at the final point is an
+    // artifact of the last three iterations, not a description of the run.
+    //
+    // `hs71_obj1e8` and `pooling_rt2stp` have no such plateau. Both exit
+    // after ~30 inner iterations, and `hs71_obj1e8` was still *reducing*
+    // the original violation (4.48e1 -> 2.25e1) shortly before it diverged
+    // — a sub-solve making progress, not one out of room.
+    //
+    // Iteration count separates them, and not by a threshold invented
+    // here: `RESTO_STALL_EVIDENCE_ITERS` is the budget the `cycle` gate
+    // above already requires before reading a stall as local
+    // infeasibility. Deferring to it also removes an inconsistency that
+    // predates this guard — a sub-solve that stalls for 1000+ iterations
+    // and exits by iteration cap renders the verdict, while the same stall
+    // exiting by step failure did not.
+    //
+    // Not applied to `verdict_locally_infeasible`. That one is not
+    // reconstructed: the sub-solve's own convergence check issued it at a
+    // point the sub-solve certified, against its own tolerance (see its
+    // comment above). It carries the stall evidence the other five infer.
+    let entry_reference_usable = orig_curr_inf_pr.is_finite() && orig_curr_inf_pr > 0.0;
+    let stall_already_evidenced = inner_iter_count >= RESTO_STALL_EVIDENCE_ITERS;
+    let diverged_from_entry = entry_reference_usable
+        && !stall_already_evidenced
+        && orig_inf_pr_scaled > RESTO_DIVERGENCE_HEADROOM * orig_curr_inf_pr;
+
+    let reconstructed_locally_infeasible = !diverged_from_entry
+        && (strict_locally_infeasible
             || alt_locally_infeasible
             || cycle_locally_infeasible
             || step_failure_locally_infeasible
             || tiny_step_locally_infeasible);
 
+    let locally_infeasible = !solver_would_call_it_feasible
+        && (verdict_locally_infeasible || reconstructed_locally_infeasible);
+
     if std::env::var_os("POUNCE_DBG_RESTO_LOCINF").is_some() {
         tracing::debug!(target: "pounce::restoration",
-            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} outer_tol={:.6e} verdict={} strict={} alt={} cycle={} step_fail={} tiny_step={} → loc_inf={}",
+            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} entry_inf_pr={:.6e} outer_tol={:.6e} verdict={} strict={} alt={} cycle={} step_fail={} tiny_step={} diverged_from_entry={} → loc_inf={}",
             status,
             inner_iter_count,
             inner_kkt_err,
             orig_inf_pr_at_final,
             orig_inf_pr_scaled,
+            orig_curr_inf_pr,
             outer_tol,
             verdict_locally_infeasible,
             strict_locally_infeasible,
@@ -883,6 +987,7 @@ pub fn run_inner_resto(
             cycle_locally_infeasible,
             step_failure_locally_infeasible,
             tiny_step_locally_infeasible,
+            diverged_from_entry,
             locally_infeasible
         );
     }


### PR DESCRIPTION
Fixes #661.

## The defect

`run_inner_resto` renders `Infeasible_Problem_Detected` from six gates.
One — layer 2 — is a verdict the restoration sub-solve's own convergence
check issued at a point it certified. The other five **reconstruct** "the
sub-solve stalled at a point it could not improve on" after the fact,
from a terminal status plus a KKT residual, and each then tested only
that the recovered violation was *large*.

Large is a different claim from stalled, and the two come apart in the
worst possible direction: a restoration that is actively blowing up
satisfies a size test *more* emphatically the further it diverges. So the
gates read a blow-up as strong evidence for the verdict it most
contradicts.

Measured on `pooling_rt2stp.nl` under `mehrotra_algorithm=yes`, via the
existing `POUNCE_DBG_RESTO_LOCINF` trace:

```
status=ErrorInStepComputation iter=32 orig_inf_pr=7.354646e5
  entry_inf_pr=6.957464e0 ... step_fail=true -> loc_inf=true
EXIT: Converged to a point of local infeasibility. Problem may be infeasible.
```

Restoration made feasibility **105,700x worse** and that was reported as
convergence to a point of local infeasibility. The model is feasible — it
solves at default options. `hs71_obj1e8` is a second, independent
instance (entry `1.04e2`, verdict at `6.79e9`; solves in 11 iterations at
default options).

## Provenance — #619 did not introduce this

#661 was filed against #619, but the isolation says otherwise. Running
#619's parent (70bf53de) and `main` side by side on the same fixture:

| arm | parent 70bf53de | main |
|---|---|---|
| default | SolveSucceeded it=298 | SolveSucceeded it=298 |
| `least_square_init_primal=yes` | SolveSucceeded it=134 | SolveSucceeded it=81 |
| `mehrotra_algorithm=yes` | RestorationFailed it=13 | **InfeasibleProblemDetected it=20** |
| `mehrotra_algorithm=yes least_square_init_primal=no` | RestorationFailed it=17 | RestorationFailed it=17 |

The last row isolates the trigger to the LS-init component of the
mehrotra cascade. But both sides stall in an equally divergent
restoration; only the *classification* differs, and it differs because
the parent's inner exploded at iteration **19** while main's exploded at
**32**, against the gate's `iter >= 30` floor. Identical divergence,
opposite verdict, decided by an iteration count. #619 changed the
starting point that reaches the defect; the defect is the gate.

## The fix

The five reconstructed gates now require the premise their own comments
already claim — the recovered point must be within
`RESTO_DIVERGENCE_HEADROOM` (10x) of the violation restoration was
*entered* at. `orig_curr_inf_pr` is already in scope; it is the reference
the kappa-reduction guard measures progress against, in the same scaled
space. A plateau — the signature these gates describe — sits at ~1x
entry, so the headroom is loose enough to leave it alone.

Layer 2 is deliberately not gated: it is not reconstructed, and carries
the stall evidence the other five infer.

### The waiver, and why `issue_508` keeps its verdict

A first cut of the guard cost `issue_508_infeasible_gap_1em2` / `_1em4`
their (correct) verdict on the mehrotra arm. Their trajectories are not
the same shape as the false verdicts, they only look alike at the final
point:

* `issue_508_infeasible_gap_1em2` sits at `1.04e-2` — to the digit, the
  violation it entered restoration at, and the gap the fixture is built
  around — for **1016** inner iterations, then jumps to `3.19e9` over its
  last three. The `1e11x` ratio describes those three iterations, not the
  run. The floor is real; the blow-up is appended to it.
* `pooling_rt2stp` and `hs71_obj1e8` have no plateau. Both exit after
  ~**30** inner iterations, and `hs71_obj1e8` was still *reducing* the
  original violation (`4.48e1` -> `2.25e1`) shortly before diverging.

So the guard stands down at `RESTO_STALL_EVIDENCE_ITERS` — the
1000-iteration budget the `cycle` gate already required before reading a
stall as local infeasibility (hoisted out of that gate to a shared
constant rather than invented here). Deferring to it also removes an
inconsistency that predates this guard: a sub-solve stalling 1000+
iterations and exiting by *iteration cap* rendered the verdict, while the
identical stall exiting by *step failure* did not.

## Trajectory sweep

Per CLAUDE.md. `scripts/sweep-fixtures.sh`, 57 fixtures, baseline built
at the branch point (9d2d6bf5), three option arms:

| arm | diff |
|---|---|
| default | **byte-identical** |
| `least_square_init_primal=yes` | **byte-identical** |
| `mehrotra_algorithm=yes` | 2 lines |

Both moving lines, in full:

```
< hs71_obj1e8      InfeasibleProblemDetected  it=25  obj=2.811095217e+10
> hs71_obj1e8      RestorationFailed          it=25  obj=2.811095217e+10
< pooling_rt2stp   InfeasibleProblemDetected  it=20  obj=-677.8267951
> pooling_rt2stp   RestorationFailed          it=20  obj=-677.8267951
```

Iteration count and objective are unchanged on both; only the status
moves, and it moves from a false affirmative claim about the user's model
to the solver correctly admitting it failed. Both models are feasible and
solve at default options. **No fixture loses a correct verdict on any
arm.**

## Tests

New `crates/pounce-cli/tests/issue_661_resto_divergence_guard.rs`:

* `a_diverging_restoration_is_not_reported_as_an_infeasible_model` — the
  user-facing claim. Non-vacuous: the baseline binary prints
  `Converged to a point of local infeasibility` on this exact invocation.
* `the_guard_is_what_withholds_the_verdict_on_the_diverging_call` — pins
  the mechanism, asserting a reconstructed gate *did* fire and that the
  guard is what suppressed it, so the test cannot silently stop covering
  the regression.
* `a_long_stalled_sub_solve_keeps_its_verdict_despite_a_terminal_blow_up`
  — the waiver, on `issue_508_infeasible_gap_1em2`.
* `a_genuinely_infeasible_model_is_still_diagnosed` — control.

Full workspace suite: 3074 passed, 0 failed. `cargo fmt` clean; no new
clippy findings in the touched files.

The `POUNCE_DBG_RESTO_LOCINF` trace gains `entry_inf_pr` and
`diverged_from_entry`, which is what the mechanism tests assert against.
