### PR TITLE
resto: measure the floor the #661 waiver claims, instead of counting iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ changes.
 
 ## [Unreleased]
 
+- **The restoration divergence guard's waiver now measures a floor
+  instead of counting iterations** (#661, #664).
+
+  #664 let the #661 guard stand down once `inner_iter_count >= 1000`,
+  reading that as "the sub-solve ran out of room". Two things were wrong
+  with it, and both are the kind of substitution #661 itself was about.
+
+  A count is not a stall test. #661 fixed five gates that let a *size*
+  stand in for "the sub-solve stalled at a point it could not improve
+  on"; the waiver then let a *duration* stand in for the same claim. A
+  solve can burn any number of iterations while still descending, and
+  such a solve has not run out of room.
+
+  And the counter was not what the comments said it was. The inner IPM's
+  `iter_count` is seeded from the outer's, mirroring upstream
+  `IpRestoMinC_1Nrm.cpp:181`, so `issue_508_infeasible_gap_1em2`'s
+  `iter=1019` is 1015 outer iterations plus a **four**-iteration
+  sub-solve — not, as #664's comments and changelog entry stated, a
+  sub-solve that sat at its entry violation for 1016 iterations.
+  Restoration sub-solves run 4 to 12 iterations across every fixture
+  measured, so a per-sub-solve measure of a long stall is looking at a
+  window too small to contain one. The long trajectory lives in the
+  outer loop, and the evidence is now read there.
+
+  `InfPrFloor` (`pounce-algorithm`) counts how many outer iterates sat
+  within an order of magnitude of the violation the count is being
+  measured against, sampled once per iteration from the value the
+  `inf_pr` column already computes — no extra function evaluations. It is deliberately
+  cumulative rather than a longest-consecutive run: a trajectory pinned
+  at a floor does not sit there quietly, and over the real traces
+  longest-consecutive gives 39 for `issue_508_infeasible_gap_1em2`
+  against 19 for the *feasible* `pooling_rt2stp`, which does not separate
+  them at all. Time at the floor gives 943 against 7. The band is pinned
+  to where the count started rather than chasing the running minimum, so
+  a solve creeping downward by 0.9x per iteration — which reduces the
+  violation by 88 orders of magnitude over 2000 iterations, i.e. is
+  working — accumulates 20 rather than 2000.
+
+  Corpus behaviour is unchanged: the fixture sweep is byte-identical to
+  the previous implementation across all 57 fixtures on all three arms
+  (default, `mehrotra_algorithm=yes`, `least_square_init_primal=yes`).
+  The waiver is load-bearing on the same two rows as before, now at 943
+  and 890 iterates-at-floor, while every row where the guard engages sits
+  at 31 or below — a 30x empty band around the threshold, against a
+  corpus in which nothing exercises the hole this closes. That is the
+  honest summary: the change is a correction of what the waiver measures,
+  evidenced by unit tests over the trajectory shapes, not by a fixture
+  that regressed.
+
 - **A diverging restoration is no longer reported as an infeasible
   model** (#661).
 
@@ -43,21 +92,19 @@ changes.
   the gate carries an `iter >= 30` floor — identical divergence on either
   side of #619, opposite verdict, decided by an iteration count.
 
-  The guard stands down once the sub-solve has burned
-  `RESTO_STALL_EVIDENCE_ITERS` — the 1000-iteration budget the `cycle`
-  gate above already required before reading a stall as local
-  infeasibility. `issue_508_infeasible_gap_1em2` is why: it is infeasible
-  by a constructed `1e-2` gap, and its restoration sits at `1.04e-2` —
-  the violation it entered at, to the digit — for 1016 inner iterations
-  before jumping to `3.19e9` over its last three. The large final ratio
-  describes those three iterations, not the run. `pooling_rt2stp` and
-  `hs71_obj1e8` have no such plateau: both exit after ~30 inner
-  iterations, and `hs71_obj1e8` was still *reducing* the original
-  violation (`4.48e1` to `2.25e1`) shortly before diverging. Deferring to
-  that budget also removes an inconsistency predating this guard — a
-  sub-solve stalling 1000+ iterations and exiting by iteration cap
-  rendered the verdict, while the identical stall exiting by step failure
-  did not.
+  The guard stands down once the solve has *demonstrated* a floor on the
+  constraint violation — measured by a new `InfPrFloor` on `IpoptData`,
+  fed once per outer iteration from the `inf_pr` the iteration output
+  already computes, and read at `RESTO_STALL_EVIDENCE_ITERS` (200)
+  iterates spent within an order of magnitude of a reference floor pinned
+  where the count started. `issue_508_infeasible_gap_1em2` is why the waiver
+  exists: it is infeasible by a constructed `1e-2` gap, and 943 of its
+  1016 outer iterations sit pinned at that gap before a restoration
+  sub-solve jumps to `3.19e9`. The large final ratio describes the
+  sub-solve, not the run that led to it. `pooling_rt2stp` and
+  `hs71_obj1e8` are feasible models whose outer solves never demonstrated
+  a floor at all — 7 and 1 iterates at one — so the guard applies to them
+  unweakened.
 
   Trajectory sweep: the fixture corpus is byte-identical at default
   options and under `least_square_init_primal=yes`. Under

--- a/crates/pounce-algorithm/src/inf_pr_floor.rs
+++ b/crates/pounce-algorithm/src/inf_pr_floor.rs
@@ -1,0 +1,272 @@
+//! How long a solve has sat at a constraint violation it could not get
+//! below — the evidence a locally-infeasible verdict actually rests on.
+//!
+//! The five *reconstructed* locally-infeasible gates in restoration
+//! (`pounce_restoration::resto_inner_solver::run_inner_resto`) all claim
+//! "the solve stalled at a violation it could not improve on", and gh#661
+//! is what happens when nothing measures that claim: they test only that
+//! the recovered violation is *large*, which a diverging restoration
+//! satisfies ever more emphatically the worse it gets.
+//!
+//! The gh#661 divergence guard withholds those gates' verdict when the
+//! restoration sub-solve ends far worse than the violation it was
+//! *entered* at. That guard needs an exemption for one shape of run: a
+//! solve that provably could not get below some floor, and whose
+//! restoration then blew up over a handful of iterations at the end. The
+//! blow-up is the tail of that trajectory, not a description of it.
+//!
+//! gh#664 keyed that exemption on `inner_iter_count >= 1000`, which is a
+//! proxy for "it ran out of room" and a doubly loose one. A count is not a
+//! stall test — that substitution is the same class of error gh#661 fixed,
+//! where a *size* stood in for a stall test. And the counter it read is
+//! not what its comments claimed: the inner IPM's `iter_count` is seeded
+//! from the outer's (`IpRestoMinC_1Nrm.cpp:181`), so `1019` on
+//! `issue_508_infeasible_gap_1em2` is 1015 outer iterations plus a
+//! *four*-iteration sub-solve, not a sub-solve that ran a thousand times.
+//!
+//! [`InfPrFloor`] measures the property directly, at the scope where the
+//! long trajectory actually lives: the outer solve. It watches the
+//! original NLP's scaled primal infeasibility at each outer iterate and
+//! counts how many of them sat within [`FLOOR_BAND`] of the floor the
+//! count is being measured against. A solve still finding its way down
+//! keeps clearing the band and restarting that count; one that is out of
+//! room accumulates it.
+//!
+//! Two choices in that sentence are load-bearing rather than
+//! simplifications, and both were arrived at by measuring:
+//!
+//! *Cumulative, not consecutive.* A real trajectory pinned at a floor
+//! does not sit there quietly. `issue_508_infeasible_gap_1em2` returns to
+//! `1.0e-2` over and over across 1016 outer iterations while excursions to
+//! `9.56e1` break every run in between; simulated over its printed
+//! iteration trace, its *longest consecutive* stay is 39 — against 19 for
+//! `pooling_rt2stp`, which is feasible and must not be exempted. The
+//! consecutive measure does not separate them at all. Time spent at the
+//! floor does, by two orders of magnitude: 943 against 7.
+//!
+//! *Pinned reference, not running minimum.* Measuring the band against
+//! the running minimum lets it chase the iterates, so a solve creeping
+//! downward by 0.9x per iteration is forever within a decade of its own
+//! previous best. Under that reading a 2000-iteration grind — which
+//! reduces the violation by eighty-eight orders of magnitude, i.e. is
+//! working — accumulates all 2000 and buys the exemption. Pinned, it
+//! accumulates one decade's worth and resets.
+
+use pounce_common::types::{Index, Number};
+
+/// How far above the best violation seen so far an iterate may sit and
+/// still count as sitting *at* that floor.
+///
+/// An order of magnitude, matching
+/// `pounce_restoration::resto_inner_solver::RESTO_DIVERGENCE_HEADROOM`
+/// and for the same reason: a floor a solve keeps returning to is not a
+/// fixed point, and a tighter band reads ordinary wander as the solve
+/// having left it. The trajectories this must tell apart move by four to
+/// twelve orders of magnitude, so the band has room to be generous.
+const FLOOR_BAND: Number = 10.0;
+
+/// Running evidence, over one solve, that it found a floor on the
+/// constraint violation and could not get below it.
+///
+/// Fed once per outer iteration from the value already computed for the
+/// `inf_pr` column, so it costs no function evaluations. The restoration
+/// sub-IPM has its own [`InfPrFloor`] on its own `IpoptData`, measuring
+/// its own (restoration) NLP; the guard reads the outer one.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InfPrFloor {
+    /// The violation the current count is being measured against.
+    ///
+    /// Deliberately *not* the running minimum. Measuring the band
+    /// against the running minimum lets it chase the iterates: a solve
+    /// creeping down by 0.9x per iteration is always within a decade of
+    /// its own previous best, so a 2000-iteration grind that reduced the
+    /// violation by eighty-eight orders of magnitude would have read as
+    /// 2000 iterations sitting at a floor. Pinned to where the count
+    /// started, the same grind reads 20 — one decade's worth — and then
+    /// resets, which is the honest description of a solve that is still
+    /// getting somewhere.
+    floor: Number,
+    /// How many iterates sat within [`FLOOR_BAND`] of `floor`.
+    ///
+    /// Reset to 1 — not 0 — whenever the solve gets a full band below
+    /// `floor`, because the iterate that got there is itself the first
+    /// one sitting at the new floor.
+    iters_at_floor: Index,
+    /// How many iterates were observed at all. Diagnostic: it separates
+    /// "this solve demonstrated no floor" from "nothing was sampled",
+    /// which read identically from [`Self::iters_at_floor`] alone.
+    samples: Index,
+}
+
+impl Default for InfPrFloor {
+    fn default() -> Self {
+        Self {
+            floor: Number::INFINITY,
+            iters_at_floor: 0,
+            samples: 0,
+        }
+    }
+}
+
+impl InfPrFloor {
+    /// Record the scaled primal infeasibility at one iterate.
+    pub fn observe(&mut self, inf_pr: Number) {
+        self.samples += 1;
+
+        // A non-finite iterate is not sitting at anything, and must not
+        // be allowed to move `floor` — a `NaN` reaching it would poison
+        // every later comparison.
+        if !inf_pr.is_finite() {
+            return;
+        }
+
+        if inf_pr * FLOOR_BAND < self.floor {
+            // A full band below the reference: whatever was being
+            // measured was not the floor. The count restarts from this
+            // iterate, which is the first one at the new one.
+            self.floor = inf_pr;
+            self.iters_at_floor = 1;
+        } else if inf_pr <= self.floor * FLOOR_BAND {
+            // Within the band of the floor already found. Note `floor`
+            // is left alone: a gain that does not clear the band is
+            // wander, not progress, and letting it ratchet the reference
+            // down is exactly the chase this field exists to avoid.
+            self.iters_at_floor += 1;
+        }
+        // Otherwise: above the band. Not evidence of a floor, but not
+        // evidence against one either — the solve is free to come back,
+        // and on the trajectories this exists for it repeatedly does
+        // (`issue_508_infeasible_gap_1em2` excurses to `9.56e1` between
+        // returns to `1.0e-2`). So the count is held, not reset.
+    }
+
+    /// How many iterates sat within an order of magnitude of the floor
+    /// this solve settled at. `0` when nothing was observed.
+    pub fn iters_at_floor(&self) -> Index {
+        self.iters_at_floor
+    }
+
+    /// The violation the count is measured against, or `INFINITY` if
+    /// nothing was observed. Diagnostic only.
+    pub fn floor(&self) -> Number {
+        self.floor
+    }
+
+    /// How many iterates were observed. Diagnostic only.
+    pub fn samples(&self) -> Index {
+        self.samples
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feed(values: &[Number]) -> InfPrFloor {
+        let mut f = InfPrFloor::default();
+        for &v in values {
+            f.observe(v);
+        }
+        f
+    }
+
+    /// Nothing observed is not evidence of a floor, and must not read as
+    /// one: the exemption is granted on a *count*, so an unfed tracker
+    /// has to be indistinguishable from a solve that demonstrated
+    /// nothing.
+    #[test]
+    fn an_unobserved_solve_demonstrates_nothing() {
+        let f = InfPrFloor::default();
+        assert_eq!(f.iters_at_floor(), 0);
+        assert_eq!(f.samples(), 0);
+        assert!(f.floor().is_infinite());
+    }
+
+    /// The shape the exemption exists for, and why the measure is
+    /// cumulative rather than a longest-consecutive-run. Measured over
+    /// the real outer trajectories, longest-consecutive-stay gives 39 for
+    /// `issue_508_infeasible_gap_1em2` against 19 for the *feasible*
+    /// `pooling_rt2stp` — no separation at all, because a trajectory
+    /// pinned at a floor does not sit there quietly. This fixture bottoms
+    /// out at `1.0e-2` early and returns to it across 1016 outer
+    /// iterations while excursions to `9.56e1` break every run in
+    /// between. Held-not-reset, time at the floor accumulates anyway.
+    #[test]
+    fn a_floor_returned_to_across_excursions_still_accumulates() {
+        let mut vals = vec![2.65e-1, 6.89e-2, 2.01e-2, 1.00e-2];
+        for _ in 0..500 {
+            vals.push(1.04e-2);
+            vals.push(9.56e1); // excursion, well outside the band
+        }
+        let f = feed(&vals);
+        // `2.01e-2` set the reference (a full decade under `2.65e-1`);
+        // `1.00e-2` and every return to `1.04e-2` sit inside its band.
+        assert_eq!(f.floor(), 2.01e-2);
+        assert_eq!(f.iters_at_floor(), 502);
+        assert_eq!(f.samples(), 1004);
+    }
+
+    /// The counterpart: `pooling_rt2stp` is feasible and must not be
+    /// exempted. Its outer solve is 20 iterations long, so even if every
+    /// one of them sat at the floor it comes nowhere near evidence of
+    /// being out of room. Short solves cannot buy the exemption.
+    #[test]
+    fn a_short_solve_cannot_accumulate_a_long_floor() {
+        let vals: Vec<Number> = (0..20).map(|k| 2.72e-1 * (1.0 + k as Number)).collect();
+        assert!(feed(&vals).iters_at_floor() <= 20);
+    }
+
+    /// The hole that killed measuring the band against the running
+    /// *minimum*: a solve creeping down by 0.9x per iteration is forever
+    /// within a decade of its own previous best. Under that reading a
+    /// 2000-iteration grind — which reduces the violation by eighty-eight
+    /// orders of magnitude, i.e. is working perfectly — accumulated all
+    /// 2000 and would have been handed the exemption. Pinned to the
+    /// reference it accumulates one decade's worth and resets.
+    #[test]
+    fn a_slow_steady_grind_downwards_is_not_a_floor() {
+        let vals: Vec<Number> = (0..2000).map(|k| 1.0e3 * 0.9_f64.powi(k)).collect();
+        let f = feed(&vals);
+        assert_eq!(f.samples(), 2000);
+        assert!(
+            f.iters_at_floor() <= 25,
+            "a solve still descending must not accumulate a floor: {}",
+            f.iters_at_floor()
+        );
+    }
+
+    /// Monotone divergence — the failure gh#661 is about — accumulates
+    /// exactly one: the opening iterate, trivially the best seen. Nothing
+    /// after it is ever within a decade of that, however long it runs.
+    #[test]
+    fn monotone_divergence_accumulates_nothing_however_long_it_runs() {
+        let vals: Vec<Number> = (0..5000).map(|k| 1.0e-3 * 100.0_f64.powi(k)).collect();
+        let f = feed(&vals);
+        assert_eq!(f.samples(), 5000);
+        assert_eq!(f.iters_at_floor(), 1);
+    }
+
+    /// Wander inside the band counts and leaves the reference alone; a
+    /// drop that clears the band is a new floor and restarts the count at
+    /// the iterate that found it.
+    #[test]
+    fn the_band_holds_wander_and_a_real_drop_restarts_the_count() {
+        let f = feed(&[1.0e6, 9.0e5, 3.0e6, 8.0e5]);
+        assert_eq!(f.floor(), 1.0e6);
+        assert_eq!(f.iters_at_floor(), 4);
+
+        let g = feed(&[1.0e6, 1.0e6, 1.0e6, 1.0e1]);
+        assert_eq!(g.floor(), 1.0e1);
+        assert_eq!(g.iters_at_floor(), 1);
+    }
+
+    /// Non-finite iterates must neither count nor corrupt the reference.
+    /// A diverging solve reaches `inf` and `NaN` routinely.
+    #[test]
+    fn non_finite_iterates_neither_count_nor_corrupt_the_floor() {
+        let f = feed(&[5.0, Number::NAN, Number::INFINITY, 5.0]);
+        assert_eq!(f.floor(), 5.0);
+        assert_eq!(f.iters_at_floor(), 2);
+        assert_eq!(f.samples(), 4);
+    }
+}

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -3621,6 +3621,18 @@ impl IpoptAlgorithm {
                     // returns either `Converged`/`ConvergedToAcceptable` or
                     // `MaxIterExceeded`, never `Continue` (L1).
                     self.data.borrow_mut().iter_count = iter_count;
+                    // Floor evidence for restoration's gh#661 divergence
+                    // guard: how long this solve has sat at a violation
+                    // it could not get below. Sampled here, once per
+                    // accepted iterate, from the same quantity the
+                    // `inf_pr` column reports — so it is free, and it
+                    // sees the whole outer trajectory rather than the
+                    // handful of iterations a restoration sub-solve runs.
+                    // The nested restoration IPM reaches this line too,
+                    // but writes its own `IpoptData`, so the two
+                    // trajectories never mix.
+                    let inf_pr_now = self.cq.borrow().curr_primal_infeasibility_max();
+                    self.data.borrow_mut().inf_pr_floor.observe(inf_pr_now);
                     // Keep the diagnostics counter in lock-step with
                     // `data.iter_count` so KKT-dump gating reflects the
                     // about-to-execute iteration.

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -10,6 +10,7 @@
 //! search, mu update, etc.) read/write fields here as their inputs
 //! and outputs.
 
+use crate::inf_pr_floor::InfPrFloor;
 use crate::init::warm_start::WarmStartDiagnostics;
 use crate::iterates_vector::IteratesVector;
 use pounce_common::timing::{Deadline, TimingStatistics};
@@ -118,6 +119,19 @@ pub struct IpoptData {
     /// many orders of magnitude. Pounce-specific guard; no upstream
     /// counterpart. See pounce#58.
     pub request_resto: bool,
+
+    /// How long this solve has sat at a constraint violation it could
+    /// not get below (gh#661, gh#664). Fed once per outer iteration from
+    /// the `inf_pr` the iteration output already computes.
+    ///
+    /// Read by restoration's divergence guard, which needs to know
+    /// whether the solve had *demonstrated* a floor before its
+    /// restoration sub-solve blew up — the premise the reconstructed
+    /// locally-infeasible gates assert and never tested. The evidence
+    /// lives here rather than in restoration because the trajectory that
+    /// carries it is the outer one: the sub-solves themselves run a
+    /// handful of iterations. Pounce-specific; no upstream counterpart.
+    pub inf_pr_floor: InfPrFloor,
 
     /// What the warm-start initializer accepted, reconstructed, or
     /// discarded from the supplied iterate, and the residuals it based
@@ -242,6 +256,7 @@ impl IpoptData {
             info_string: String::new(),
             tiny_step_flag: false,
             request_resto: false,
+            inf_pr_floor: InfPrFloor::default(),
             warm_start_diagnostics: None,
             curr_from_crossover: false,
             request_ls_reset: false,

--- a/crates/pounce-algorithm/src/lib.rs
+++ b/crates/pounce-algorithm/src/lib.rs
@@ -29,6 +29,7 @@ pub mod debug;
 pub mod debug_rank;
 pub mod eq_mult;
 pub mod hess;
+pub mod inf_pr_floor;
 pub mod infeasibility_refutation;
 pub mod init;
 pub mod intermediate;

--- a/crates/pounce-cli/tests/issue_661_resto_divergence_guard.rs
+++ b/crates/pounce-cli/tests/issue_661_resto_divergence_guard.rs
@@ -35,7 +35,9 @@
 //! told, not how the guard reached it. The guard's decision rule is a pure
 //! function, `diverged_from_restoration_entry`, unit-tested directly in
 //! `pounce-restoration::resto_inner_solver`; that is where the plateau /
-//! blow-up discrimination, the stall waiver and the boundaries are pinned.
+//! blow-up discrimination, the floor waiver and the boundaries are pinned,
+//! and `pounce_algorithm::inf_pr_floor` is where the floor evidence the
+//! waiver reads is measured and tested.
 //! An earlier revision of this file asserted the mechanism end-to-end by
 //! parsing the `POUNCE_DBG_RESTO_LOCINF` trace, and it did not survive
 //! contact with a second platform: on x86_64-linux this restoration

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -86,17 +86,25 @@ const RESTO_MAX_SUCCESSIVE_ITERS: i32 = 3000;
 /// describe sits at ~1x entry — without admitting a blow-up.
 const RESTO_DIVERGENCE_HEADROOM: f64 = 10.0;
 
-/// Inner iterations after which a restoration sub-solve is taken to have
-/// demonstrated a stall on its own, independent of how it finally exited.
+/// Outer iterations spent at an unimprovable constraint violation after
+/// which a solve is taken to have demonstrated a floor, independent of
+/// how its restoration sub-solve finally exited.
 ///
-/// This is the budget the `cycle` gate in [`run_inner_resto`] has always
-/// required before reading an iteration-cap exit as evidence of local
-/// infeasibility ("a generous iteration budget has been burned with no
-/// exit"). [`RESTO_DIVERGENCE_HEADROOM`] defers to it: a sub-solve that
-/// spent a thousand-plus iterations unable to improve, and *then* blew up
-/// over its last handful, has shown the floor the gates are looking for —
-/// the blow-up is the tail of the trajectory, not the trajectory.
-const RESTO_STALL_EVIDENCE_ITERS: i32 = 1000;
+/// Measured by [`pounce_algorithm::inf_pr_floor::InfPrFloor`], not by a raw iteration count. The
+/// distinction is the whole of gh#664's residual defect: a count says the
+/// solve *ran* a long time, which is not the claim the reconstructed
+/// gates make. The claim is that it ran out of room, and a solve can
+/// burn any number of iterations while still descending.
+///
+/// The threshold sits in a wide measured gap. Over the fixture sweep the
+/// two trajectories that earn the exemption accumulate 943 and 890
+/// iterations at their floor. Across all 57 fixtures on three option
+/// arms, every row where the guard engages sits at 31 or below —
+/// `pooling_rt2stp` at 7, `hs71_obj1e8` at 1, bounded above by their own
+/// outer solve lengths. 200 is 6x clear of the largest non-floor case and
+/// 4x under the smallest genuine one, so neither side is decided by where
+/// exactly the line falls inside that band.
+const RESTO_STALL_EVIDENCE_ITERS: Index = 200;
 
 /// Whether a restoration sub-solve ended somewhere enough *worse* than it
 /// began that the five reconstructed gates in [`run_inner_resto`] have no
@@ -114,15 +122,31 @@ const RESTO_STALL_EVIDENCE_ITERS: i32 = 1000;
 /// - **No usable reference.** A non-finite or non-positive entry violation
 ///   gives nothing to measure divergence against, so the gates are left as
 ///   they were rather than suppressed on a ratio against zero.
-/// - **The stall is already evidenced.** Past [`RESTO_STALL_EVIDENCE_ITERS`]
-///   the sub-solve has demonstrated a floor on its own; a blow-up over its
-///   last handful of iterations is the tail of that trajectory, not a
-///   description of it. `issue_508_infeasible_gap_1em2` sits at `1.04e-2` —
-///   to the digit, the violation it entered at — for 1016 inner iterations
-///   and only then jumps to `3.19e9`. Its final `1e11x` ratio is an artifact
-///   of three iterations.
+/// - **The floor is already evidenced.** `outer_iters_at_floor` is
+///   [`pounce_algorithm::inf_pr_floor::InfPrFloor::iters_at_floor`]
+///   off the *outer* `IpoptData`: how many outer iterates sat within an
+///   order of magnitude of the floor that count is measured against — a
+///   reference pinned where the count started, so a solve still working
+///   its way down clears it and restarts rather than accumulating.
+///   Past [`RESTO_STALL_EVIDENCE_ITERS`] of those
+///   the solve has shown it cannot get below that violation, and a
+///   restoration blow-up at the end is the tail of that trajectory rather
+///   than a description of it. `issue_508_infeasible_gap_1em2` spends 943
+///   of its 1016 outer iterations pinned at the `1.0e-2` gap the fixture is
+///   built around before its four-iteration sub-solve jumps to `3.19e9`;
+///   the final `1e11x` ratio is an artifact of those four iterations.
 /// - **Within headroom.** A plateau, which is the signature these gates
 ///   actually describe, lands at ~1x entry.
+///
+/// The evidence is read at outer scope on purpose. gh#664 read the *inner*
+/// IPM's `iter_count`, which its comments described as the sub-solve's own
+/// length; it is not. That counter is seeded from the outer's to mirror
+/// upstream `IpRestoMinC_1Nrm.cpp:181`, so the `1019` those comments cited
+/// is 1015 outer iterations plus a four-iteration sub-solve. Restoration
+/// sub-solves are short — 4 to 12 iterations across every fixture measured
+/// — so there was never a thousand-iteration sub-solve to observe, and any
+/// per-sub-solve measure of a long stall is measuring a window too small to
+/// hold one. The long trajectory lives in the outer loop.
 ///
 /// Never applied to the layer-2 verdict (gh#438): that one is not
 /// reconstructed — the sub-solve's own convergence check issued it at a point
@@ -131,13 +155,13 @@ const RESTO_STALL_EVIDENCE_ITERS: i32 = 1000;
 fn diverged_from_restoration_entry(
     orig_curr_inf_pr: f64,
     orig_inf_pr_scaled: f64,
-    inner_iter_count: i32,
+    outer_iters_at_floor: Index,
 ) -> bool {
     let entry_reference_usable = orig_curr_inf_pr.is_finite() && orig_curr_inf_pr > 0.0;
-    let stall_already_evidenced = inner_iter_count >= RESTO_STALL_EVIDENCE_ITERS;
+    let floor_already_evidenced = outer_iters_at_floor >= RESTO_STALL_EVIDENCE_ITERS;
 
     entry_reference_usable
-        && !stall_already_evidenced
+        && !floor_already_evidenced
         && orig_inf_pr_scaled > RESTO_DIVERGENCE_HEADROOM * orig_curr_inf_pr
 }
 
@@ -964,13 +988,18 @@ pub fn run_inner_resto(
     //
     // The waiver, the headroom's looseness, and why the layer-2 verdict is
     // exempt are all documented on `diverged_from_restoration_entry`. The
-    // short of it: `hs71_obj1e8` and `pooling_rt2stp` both exit after ~30
-    // inner iterations with no plateau at all — `hs71_obj1e8` was still
-    // *reducing* the original violation (4.48e1 -> 2.25e1) shortly before it
-    // diverged — while `issue_508_infeasible_gap_1em2`, which reaches a
-    // *correct* verdict, is pinned at its entry violation for 1016.
+    // short of it: `hs71_obj1e8` and `pooling_rt2stp` are feasible models
+    // whose outer solves ran 25 and 20 iterations and never demonstrated a
+    // floor at all (1 and 7 iterations at one), while
+    // `issue_508_infeasible_gap_1em2` — which reaches a *correct* verdict —
+    // spent 943 outer iterations unable to get below the `1.0e-2` gap it is
+    // built around.
+    //
+    // Read off the *outer* `IpoptData`, which is where that trajectory
+    // lives: this sub-solve ran four iterations.
+    let outer_iters_at_floor = outer_data.borrow().inf_pr_floor.iters_at_floor();
     let diverged_from_entry =
-        diverged_from_restoration_entry(orig_curr_inf_pr, orig_inf_pr_scaled, inner_iter_count);
+        diverged_from_restoration_entry(orig_curr_inf_pr, orig_inf_pr_scaled, outer_iters_at_floor);
 
     let reconstructed_locally_infeasible = !diverged_from_entry
         && (strict_locally_infeasible
@@ -984,7 +1013,7 @@ pub fn run_inner_resto(
 
     if std::env::var_os("POUNCE_DBG_RESTO_LOCINF").is_some() {
         tracing::debug!(target: "pounce::restoration",
-            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} entry_inf_pr={:.6e} outer_tol={:.6e} verdict={} strict={} alt={} cycle={} step_fail={} tiny_step={} diverged_from_entry={} → loc_inf={}",
+            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} entry_inf_pr={:.6e} outer_tol={:.6e} verdict={} strict={} alt={} cycle={} step_fail={} tiny_step={} diverged_from_entry={} at_floor={} floor={:.6e} → loc_inf={}",
             status,
             inner_iter_count,
             inner_kkt_err,
@@ -999,6 +1028,8 @@ pub fn run_inner_resto(
             step_failure_locally_infeasible,
             tiny_step_locally_infeasible,
             diverged_from_entry,
+            outer_iters_at_floor,
+            outer_data.borrow().inf_pr_floor.floor(),
             locally_infeasible
         );
     }
@@ -1392,22 +1423,19 @@ mod issue_661_divergence_guard {
 
     /// gh#661, the case the guard exists for. `pooling_rt2stp.nl` under
     /// `mehrotra_algorithm=yes`: restoration entered at a violation of
-    /// 6.957e0 and left at 7.355e5 — 105,700x worse — after 32 inner
-    /// iterations, and a reconstructed gate read that as "converged to a
-    /// point of local infeasibility". The model solves at default options.
+    /// 6.957e0 and left at 7.355e5 — 105,700x worse — and a reconstructed
+    /// gate read that as "converged to a point of local infeasibility".
+    /// The model solves at default options, and its outer trajectory
+    /// spent 7 iterations at a floor: no evidence of being out of room.
     #[test]
-    fn a_short_blow_up_is_divergence() {
-        assert!(diverged_from_restoration_entry(
-            6.957_464e0,
-            7.354_646e5,
-            32
-        ));
+    fn a_blow_up_without_floor_evidence_is_divergence() {
+        assert!(diverged_from_restoration_entry(6.957_464e0, 7.354_646e5, 7));
     }
 
     /// A plateau — the signature the reconstructed gates actually describe —
     /// keeps its verdict. `qcqp750-2nc`, the fixture the `step_failure` gate
-    /// is named for, sat pinned at `inf_pr = 1.05e6` for 25+ inner
-    /// iterations, i.e. ~1x entry.
+    /// is named for, sat pinned at `inf_pr = 1.05e6` for 25+ iterations,
+    /// i.e. ~1x entry. The guard never engages, whatever the floor evidence.
     #[test]
     fn a_plateau_is_not_divergence() {
         assert!(!diverged_from_restoration_entry(1.05e6, 1.05e6, 27));
@@ -1439,22 +1467,36 @@ mod issue_661_divergence_guard {
     }
 
     /// `issue_508_infeasible_gap_1em2`, which reaches a *correct*
-    /// infeasibility verdict: pinned at its 1.04e-2 entry violation for 1016
-    /// inner iterations, then a jump to 3.19e9 over the last three. The final
-    /// ratio is ~1e11 — far past the headroom — but the stall was already
-    /// demonstrated, so the verdict stands.
+    /// infeasibility verdict: 943 of its 1016 outer iterations sat at the
+    /// `1.0e-2` gap the fixture is built around, and only then did a
+    /// four-iteration restoration sub-solve jump from `1.04e-2` to
+    /// `3.19e9`. The final ratio is ~1e11 — far past the headroom — but
+    /// the floor was already demonstrated, so the verdict stands.
     #[test]
-    fn a_long_stall_keeps_its_verdict_despite_a_terminal_blow_up() {
-        assert!(!diverged_from_restoration_entry(1.04e-2, 3.19e9, 1019));
-        // the same trajectory truncated before the evidence threshold would
-        // have been suppressed — the iteration count is what separates them
-        assert!(diverged_from_restoration_entry(1.04e-2, 3.19e9, 999));
+    fn a_demonstrated_floor_keeps_its_verdict_despite_a_terminal_blow_up() {
+        assert!(!diverged_from_restoration_entry(1.04e-2, 3.19e9, 943));
     }
 
-    /// The waiver is the `cycle` gate's own budget, not a threshold invented
-    /// for this guard, and the boundary is inclusive on the same `>=`.
+    /// The point of measuring a floor rather than counting iterations,
+    /// and the gh#664 residual this replaces. A solve may run for any
+    /// number of iterations while still descending — it has not run out
+    /// of room, and the reconstructed gates' premise does not hold for it.
+    /// Under the old proxy an elapsed-iteration count alone bought the
+    /// exemption; here the count that matters is time *at a floor*, which
+    /// such a solve never accumulates.
     #[test]
-    fn the_stall_waiver_starts_at_the_cycle_gates_budget() {
+    fn a_long_run_without_a_floor_is_still_divergence() {
+        assert!(diverged_from_restoration_entry(1.04e-2, 3.19e9, 0));
+        assert!(diverged_from_restoration_entry(
+            1.04e-2,
+            3.19e9,
+            RESTO_STALL_EVIDENCE_ITERS - 1
+        ));
+    }
+
+    /// The waiver boundary is inclusive, on `>=`.
+    #[test]
+    fn the_floor_waiver_boundary_is_inclusive() {
         let (entry, final_) = (1.0, 1.0e9);
         assert!(diverged_from_restoration_entry(
             entry,
@@ -1468,11 +1510,9 @@ mod issue_661_divergence_guard {
         ));
     }
 
-    /// With no usable entry reference there is nothing to measure divergence
-    /// against, and the gates are left exactly as they were rather than
-    /// suppressed on a ratio against zero (or against NaN, where every
-    /// comparison is false anyway and the `> 0.0` test is what actually
-    /// carries it).
+    /// Without a usable entry reference there is nothing to measure
+    /// divergence against, so the gates are left exactly as they were
+    /// rather than suppressed on a ratio against zero or a NaN.
     #[test]
     fn an_unusable_entry_reference_suppresses_nothing() {
         assert!(!diverged_from_restoration_entry(0.0, 1.0e9, 5));


### PR DESCRIPTION
Follow-up to #661 / #664. Both are merged and closed; this replaces the
waiver #664 added with a direct measurement, and corrects a factual error
that shipped in #664's comments and CHANGELOG entry.

## What #664 got wrong

The gh#661 guard withholds the five *reconstructed* locally-infeasible
gates' verdict when a restoration sub-solve ends far worse than the
violation it was entered at. #664 added a waiver for the one trajectory
shape that legitimately blows up at the end — a solve that provably could
not get below some floor — and keyed it on `inner_iter_count >= 1000`.

Two problems.

**A count is not a stall test.** That is the same substitution #661 itself
fixed, where a *size* stood in for a stall. A solve can burn any number of
iterations while still descending; elapsed time does not mean out of room.

**The counter is not what the comments said it was.** The inner IPM's
`iter_count` is seeded from the outer's, mirroring upstream
`IpRestoMinC_1Nrm.cpp:181`. On `issue_508_infeasible_gap_1em2` the
`iter=1019` those comments cite is **1015 outer iterations plus a
four-iteration sub-solve** — not a sub-solve that ran a thousand times.
Traced directly: outer rows run 0..1015, the restoration rows are
1016r-1019r. Restoration sub-solves run 4-12 iterations across every
fixture measured, so there was never a long sub-solve stall to observe,
and any per-sub-solve measure of a long stall is looking at a window too
small to hold one.

## What replaces it

A new `pounce_algorithm::inf_pr_floor::InfPrFloor` measures the property
the gates actually claim — that the solve found a floor on the original
NLP's constraint violation and could not get below it — at the scope where
the long trajectory lives: the **outer** solve.

It is sampled once per outer iterate in `optimize_inner()`, from
`curr_primal_infeasibility_max()` — the same quantity the `inf_pr` column
already reports, so it costs no function evaluations. The nested
restoration IPM reaches the same line but writes its own `IpoptData`, so
the two trajectories never mix.

Two design choices are load-bearing, and both were settled by measuring
real traces rather than asserted:

**Cumulative, not longest-consecutive.** A trajectory pinned at a floor
does not sit there quietly. `issue_508_infeasible_gap_1em2` returns to
`1.0e-2` over and over while excursions to `9.56e1` break every run in
between. Longest-consecutive gives **39** for it against **19** for the
*feasible* `pooling_rt2stp` — no separation at all. Cumulative time at the
floor separates them by two orders of magnitude: **943 vs 7**.

**Pinned reference, not running minimum.** Measuring the band against the
running minimum lets it chase the iterates: a solve creeping down by 0.9x
per iteration is forever within a decade of its own previous best. Under
that reading a 2000-iteration grind that reduces the violation by
eighty-eight orders of magnitude — i.e. is working perfectly — accumulates
all 2000 and buys the exemption. Pinned to where the count started, the
same grind accumulates one decade's worth and resets. This is covered by
`a_slow_steady_grind_downwards_is_not_a_floor`.

## Threshold

`RESTO_STALL_EVIDENCE_ITERS` goes from 1000 inner iterations to **200
outer iterations at a floor**, and sits in a wide measured gap. Scanning
290 gate-trace rows across all 57 fixtures on three option arms:

| | `at_floor` |
|---|---|
| every row where the guard **engages** | 1, 6, 7, 28, 31 |
| the rows the **waiver** carries | 943, 945, 946, 956, 957 |

200 is 6x clear of the largest non-floor case and 4x under the smallest
genuine one. Neither side is decided by where exactly the line falls
inside that 30x empty band.

## Verification

- **Fixture sweep (CLAUDE.md requirement): 57 fixtures x 3 arms (default,
  `mehrotra_algorithm=yes`, `least_square_init_primal=yes`) —
  byte-identical between a baseline binary built from `main` and this
  branch.** No status, objective, or iteration count moves.
- Four decisive fixtures verified end-to-end in release:
  `issue_508_infeasible_gap_1em2` (`at_floor=943`, verdict preserved,
  "local infeasibility"), `_1em4` (890, preserved), `pooling_rt2stp` (7,
  Restoration Failed), `hs71_obj1e8` (1, Restoration Failed).
- 7 new unit tests on `InfPrFloor` covering the trajectory shapes: unfed,
  floor-with-excursions, short solve, slow grind, monotone divergence,
  band wander, non-finite iterates.
- `issue_661_divergence_guard` rewritten to pin the floor waiver and both
  boundaries.
- Full workspace suite, `cargo fmt --all --check`, and CI's clippy lint
  set all clean.

The change is a correction of *what the waiver measures*, evidenced by
unit tests over the trajectory shapes — not by a fixture that had
regressed. Nothing observable moves; the guard's decision is now resting
on a measurement of the claim it makes rather than on a proxy for it.
