### PR TITLE
casadi: stop POUNCE's log tearing lines an embedder prints from callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ changes.
 
 ## [Unreleased]
 
+- **CasADi plugin: POUNCE's log no longer tears output an embedder
+  prints from inside a callback** (#667).
+
+  If your own code printed from `iteration_callback` — or from a model
+  that logs during function evaluation — a POUNCE iteration row could
+  land in the middle of your line. A line-oriented consumer saw a line
+  arrive without its terminator and the remainder show up several rows
+  later. Reported against a 2400-variable collocation problem emitting a
+  multi-kilobyte line per iteration.
+
+  Two writers share stdout and neither knows about the other. POUNCE
+  journals from Rust, where the stream goes out on every newline; a C++
+  embedder writes through CasADi's `uout()`, which leaves the buffering
+  to `std::cout`/stdio — fully buffered behind a pipe, so a line long
+  enough to straddle that buffer leaves its tail pending. The plugin now
+  drains CasADi's streams on every exit from a callback and once before
+  the solve starts, which are the only moments it can know POUNCE is not
+  writing. That brings a C++ host to parity with `nlpsol(..., 'ipopt',
+  ...)`, whose journal shares the stream it competes with.
+
+  A **Python** host is not covered and cannot be from the plugin:
+  CasADi's bindings route output to Python's `sys.stdout` but leave the
+  flush hook at its default, so a flush issued from C++ drains a
+  different buffer. Set `sys.stdout.reconfigure(line_buffering=True)`
+  (or run `python -u`); this is sufficient, because your callback runs
+  while POUNCE is blocked. See `docs/src/casadi.md`. Routing POUNCE's
+  journal through `uout()` would remove the hazard by construction for
+  both, and is filed separately.
+
+  No solver behaviour changes: iterates, iteration counts and timings
+  are unaffected.
+
 - **The restoration divergence guard's waiver now measures a floor
   instead of counting iterations** (#661, #664).
 

--- a/casadi/.gitignore
+++ b/casadi/.gitignore
@@ -2,3 +2,4 @@
 casadi-src
 *.so
 *.dylib
+test_output_interleaving

--- a/casadi/Makefile
+++ b/casadi/Makefile
@@ -64,6 +64,12 @@ endif
 
 PLUGIN := libcasadi_nlpsol_pounce.$(SO_EXT)
 
+# gh#667 regression driver. A C++ host, not a Python one: the Python
+# bindings leave `Logger::flush` at its default, so the same check driven
+# from test_parity.py would measure CasADi's buffering rather than the
+# plugin's flushing. See the comment at the top of the source.
+TEARTEST := test_output_interleaving
+
 # Version macros CasADi's headers expect, derived from the installed
 # CasADi rather than hard-coded.
 VER_MAJOR := $(word 1,$(subst ., ,$(CASADI_VER)))
@@ -149,7 +155,11 @@ install: all
 uninstall:
 	rm -f $(CASADI_LIB)/$(PLUGIN)
 
-test: all
+$(TEARTEST): $(TEARTEST).cpp $(PLUGIN)
+	$(CXX) $(CXXFLAGS) $(DEFS) $(INCLUDES) -o $@ $< \
+	  -L$(CASADI_LIB) -lcasadi $(RPATH)
+
+test: all $(TEARTEST)
 	CASADIPATH=$(CURDIR) $(PYTHON) test_parity.py
 
 examples: all
@@ -159,4 +169,4 @@ examples: all
 	done
 
 clean:
-	rm -f $(PLUGIN)
+	rm -f $(PLUGIN) $(TEARTEST)

--- a/casadi/casadi_nlpsol_pounce.cpp
+++ b/casadi/casadi_nlpsol_pounce.cpp
@@ -23,6 +23,7 @@
 #include "pounce_runtime.hpp"
 #include <cmath>
 #include <cstring>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -167,6 +168,57 @@ namespace casadi {
 
     static const std::string meta_doc;
 
+    /// Drain CasADi's output streams before handing control back to POUNCE
+    /// (gh#667).
+    ///
+    /// Two writers share file descriptor 1 and neither knows about the
+    /// other. POUNCE journals from Rust, where `io::stdout()` is a
+    /// `LineWriter` that goes out on every newline — unconditionally, not
+    /// only on a tty. CasADi writes through `uout()`, whose streambuf holds
+    /// nothing and passes each chunk straight to `Logger::writeFun`, leaving
+    /// the buffering to whatever sits behind it. Behind a pipe that buffer is
+    /// a *fully* buffered one, so an embedder printing a line long enough to
+    /// straddle it leaves the tail sitting there — and a POUNCE iteration row
+    /// written in the meantime lands in the middle of the embedder's line.
+    /// CasADi's own ipopt plugin has no equivalent problem: Ipopt is C++ and
+    /// its journal shares the stream it is competing with.
+    ///
+    /// The only instant at which the plugin *knows* POUNCE is not writing is
+    /// while POUNCE is blocked inside one of these callbacks, so the last
+    /// thing to do before returning is empty the buffer. Doing it in
+    /// `cb_iter` alone is not enough: model code logging from inside the
+    /// oracle callbacks tears just as readily, and `guarded` is the one choke
+    /// point all seven call sites pass through.
+    ///
+    /// `uerr()` as well as `uout()` because `casadi_warning` below writes
+    /// there, and `OpenIpoptOutputFile(prob, "stderr", ...)` is a supported
+    /// way to put POUNCE's journal on that same descriptor.
+    ///
+    /// Caveats worth knowing before trusting this too far:
+    ///   * It assumes a single-threaded host. Two `nlpsol` instances solving
+    ///     on two threads can still interleave, because solver A is free to
+    ///     write while solver B sits in a callback. Ipopt is no better off.
+    ///   * It does nothing for a *Python* embedder. CasADi's Python binding
+    ///     points `Logger::writeFun` at `PySys_WriteStdout` but leaves
+    ///     `Logger::flush` at `flushDefault`, so the bytes go into Python's
+    ///     `sys.stdout` and the flush drains `std::cout` instead. There is no
+    ///     portable way to reach Python's buffer from here; the fix for that
+    ///     case is to route POUNCE's journal through `uout()` rather than to
+    ///     flush harder. See `docs/src/casadi.md` for the interim workaround.
+    ///
+    /// Nothing in here may throw. A destructor is implicitly `noexcept`, and
+    /// `Logger::flush` is a host-supplied callback, so a throwing sink would
+    /// `std::terminate` inside the very function whose job is to keep
+    /// exceptions away from Rust frames.
+    struct FlushCasadiOutputOnExit {
+      ~FlushCasadiOutputOnExit() {
+        try {
+          uout() << std::flush;
+          uerr() << std::flush;
+        } catch (...) {}                        // see above: never throw
+      }
+    };
+
     /// Run an oracle evaluation, converting *any* escaping exception into the
     /// C API's "this point could not be evaluated" answer.
     ///
@@ -184,8 +236,15 @@ namespace casadi {
     /// A KeyboardInterrupt is remembered rather than swallowed: the iteration
     /// callback then stops the solve and `solve()` re-throws it, so Ctrl-C is
     /// responsive without ever crossing the language boundary.
+    ///
+    /// It is also where CasADi's output buffer gets drained; see
+    /// `FlushCasadiOutputOnExit` below for why here and nowhere else.
     template <typename F>
     static bool guarded(PounceMemory* m, const char* what, F&& body) {
+      // Function scope, above the `try`: the destructor then runs on the
+      // ordinary return path *after* the handlers below have caught, never
+      // while an exception is still unwinding.
+      FlushCasadiOutputOnExit flush_on_exit;
       if (m->interrupted) return false;         // fail fast once stopping
       try {
         return body();
@@ -817,6 +876,12 @@ namespace casadi {
     }
 
     SetIntermediateCallback(prob, &PounceInterface::cb_iter);
+
+    // The one window `guarded` cannot close (gh#667): whatever the host and
+    // CasADi buffered before this call is still pending when POUNCE prints
+    // its banner, and no callback has fired yet to drain it. Once per solve.
+    uout() << std::flush;
+    uerr() << std::flush;
 
     enum ApplicationReturnStatus st = IpoptSolve(
       prob, m->xk.data(), ng ? m->gk.data() : nullptr, &m->obj,

--- a/casadi/test_output_interleaving.cpp
+++ b/casadi/test_output_interleaving.cpp
@@ -1,0 +1,78 @@
+// gh#667 regression: POUNCE's log must not tear a line an embedder is
+// printing from inside a CasADi callback.
+//
+// Two writers share file descriptor 1. POUNCE journals from Rust, where
+// `io::stdout()` is a `LineWriter` that goes out on every newline; a C++
+// embedder writes through `uout()`, which leaves the buffering to
+// `std::cout`/stdio — fully buffered behind a pipe. Print a line long
+// enough to straddle that buffer from an `iteration_callback` and its tail
+// is still pending when the callback returns, so POUNCE's next iteration
+// row lands in the middle of it.
+//
+// This has to be a C++ host: the Python bindings point `Logger::writeFun`
+// at `PySys_WriteStdout` but leave `Logger::flush` at `flushDefault`, so
+// the plugin's flush cannot reach Python's buffer and the same check run
+// from `test_parity.py` would be measuring CasADi, not us. See
+// `docs/src/casadi.md`.
+//
+// Writes the payload in chunks rather than one `<<`: a single write large
+// enough to exceed the buffer is pushed straight through and never leaves
+// a tail, which is exactly the case that does *not* reproduce.
+//
+// Prints to stdout; the caller pipes it and counts lines that begin with
+// SENTINEL but do not end with TERMINATOR. Pre-fix that count is nonzero.
+
+#include <casadi/casadi.hpp>
+#include <string>
+#include <vector>
+
+using namespace casadi;
+
+static const char* SENTINEL = "HOST ";
+static const char* TERMINATOR = " END";
+
+class IterPrinter : public Callback {
+ public:
+  casadi_int nx_, ng_, np_;
+  IterPrinter(casadi_int nx, casadi_int ng, casadi_int np)
+      : nx_(nx), ng_(ng), np_(np) {
+    construct("iter_printer");
+  }
+  casadi_int get_n_in() override { return nlpsol_n_out(); }
+  casadi_int get_n_out() override { return 1; }
+  std::string get_name_in(casadi_int i) override { return nlpsol_out(i); }
+  Sparsity get_sparsity_in(casadi_int i) override {
+    std::string n = nlpsol_out(i);
+    if (n == "f") return Sparsity::scalar();
+    if (n == "x" || n == "lam_x") return Sparsity::dense(nx_);
+    if (n == "g" || n == "lam_g") return Sparsity::dense(ng_);
+    if (n == "lam_p") return Sparsity::dense(np_);
+    return Sparsity(0, 0);
+  }
+  std::vector<DM> eval(const std::vector<DM>&) const override {
+    uout() << SENTINEL;
+    for (int k = 0; k < 40; ++k) uout() << std::string(1000, 'A');
+    uout() << TERMINATOR << "\n";
+    return {0};
+  }
+};
+
+int main() {
+  MX x = MX::sym("x", 2);
+  MX f = pow(1 - x(0), 2) + 100 * pow(x(1) - pow(x(0), 2), 2);
+  MX g = pow(x(0), 2) + pow(x(1), 2) - 1.5;
+  MXDict nlp = {{"x", x}, {"f", f}, {"g", g}};
+
+  IterPrinter cb(2, 1, 0);
+  Dict opts;
+  opts["iteration_callback"] = cb;
+  opts["print_time"] = false;
+  // POUNCE's own iteration rows are the competing writer: leave them on.
+  opts["pounce"] = Dict{{"print_level", 5}, {"max_iter", 40}};
+
+  Function S = nlpsol("S", "pounce", nlp, opts);
+  DMDict arg = {{"x0", std::vector<double>{0.5, 0.5}},
+                {"lbg", -inf}, {"ubg", 0}};
+  S(arg);
+  return 0;
+}

--- a/casadi/test_parity.py
+++ b/casadi/test_parity.py
@@ -959,6 +959,38 @@ def _compile_generated(solver, workdir, stem):
     return ca.external(solver.name(), so)
 
 
+def test_output_does_not_tear_embedder_lines():
+    """gh#667: POUNCE's log must not split a line the embedder is printing
+    from inside a callback.
+
+    Driven by a C++ host (`test_output_interleaving.cpp`), not from here.
+    CasADi's Python bindings point `Logger::writeFun` at `PySys_WriteStdout`
+    but leave `Logger::flush` at `flushDefault`, so the plugin's flush drains
+    `std::cout` while the bytes are sitting in Python's `sys.stdout`. Run
+    from Python this would report on CasADi's buffering, not on the plugin's
+    flushing, and would keep passing however broken the plugin got.
+
+    The driver prints a long line in chunks from `iteration_callback` while
+    POUNCE writes its iteration rows to the same descriptor. Pre-fix every
+    such line arrives without its terminator.
+    """
+    exe = os.path.join(HERE, "test_output_interleaving")
+    if not os.path.exists(exe):
+        print("SKIP  output interleaving (driver not built; run `make`)")
+        return
+    env = dict(os.environ, CASADIPATH=HERE)
+    # stdout must be a pipe: on a tty the competing buffer is line-buffered
+    # and the tear cannot happen in the first place.
+    out = subprocess.run([exe], env=env, capture_output=True, text=True,
+                         timeout=300).stdout
+    host = [ln for ln in out.splitlines() if ln.startswith("HOST ")]
+    torn = [ln for ln in host if not ln.endswith(" END")]
+    check("output: the embedder actually printed", len(host) > 1,
+          f"{len(host)} lines from the callback")
+    check("output: POUNCE does not tear embedder lines (gh#667)",
+          not torn, f"{len(torn)}/{len(host)} lines torn")
+
+
 def test_solve_report_option():
     """`solve_report` writes POUNCE's structured report (gh#644).
 
@@ -1209,6 +1241,7 @@ def main():
         test_solve_report_option,
         test_codegen_matches_the_interpreted_solve,
         test_codegen_refuses_what_it_cannot_reproduce,
+        test_output_does_not_tear_embedder_lines,
     ):
         t()
     print()

--- a/docs/src/casadi.md
+++ b/docs/src/casadi.md
@@ -587,6 +587,43 @@ language boundary. `iteration_callback_ignore_errors` (CasADi's base
 option) decides whether a *throwing iteration callback* stops the solve
 or is shrugged off.
 
+## Printing from a callback
+
+If your own code prints from inside `iteration_callback` — or from a
+model that logs during function evaluation — be aware that two writers
+share stdout. POUNCE journals from Rust, where the stream goes out on
+every newline; CasADi writes through `uout()` and leaves the buffering to
+whatever sits behind it, which behind a pipe is a fully buffered stream.
+A line long enough to straddle that buffer can therefore be split in two
+by a POUNCE iteration row landing in the middle of it. A line-oriented
+protocol reading its own stdout sees a line arrive without its
+terminator, and the remainder show up several lines later.
+
+For a **C++ host** the plugin handles this: it drains CasADi's streams on
+every exit from a callback and once more before the solve starts, which
+are the only moments it can know POUNCE is not writing (gh#667). Pinned
+by `test_output_interleaving.cpp` in the parity suite.
+
+For a **Python host** the plugin cannot help, and this is worth
+understanding rather than working around blindly. CasADi's bindings point
+`Logger::writeFun` at `PySys_WriteStdout` but leave `Logger::flush` at its
+default, so output lands in Python's `sys.stdout` while a flush from the
+plugin drains `std::cout` — a different buffer. Nothing the plugin does
+from C++ reaches Python's. Until POUNCE's journal is routed through
+`uout()` (gh#667 again — the general fix), make the buffer stop holding
+partial lines:
+
+```python
+import sys
+sys.stdout.reconfigure(line_buffering=True)     # or run python -u
+```
+
+That is sufficient, not just a mitigation: your callback runs while
+POUNCE is blocked, so a line that is flushed by the time the callback
+returns cannot be torn. The same applies to Ipopt — this is a property of
+printing from callbacks, not something specific to POUNCE, and the
+plugin's C++-side flushing brings the two to parity.
+
 ## Threads
 
 `Function.map(N, "thread")` works. CasADi hands each worker its own


### PR DESCRIPTION
Fixes #667.

## Problem

An embedder that prints from inside a CasADi callback — `iteration_callback`, or a model that logs during function evaluation — can have a single logical line split in two by an interleaved POUNCE write. A line-oriented consumer sees the line arrive without its terminator, and the remainder show up several rows later. Reported against a 2400-variable collocation problem emitting a multi-kilobyte line per iteration.

Measured with a C++ driver that prints a chunked 40 KB line from `iteration_callback` while POUNCE writes its iteration rows, counting lines that arrive without their terminator:

| Configuration | Torn lines |
|---|---|
| C++ host, parent commit | 13/13 |
| C++ host, this branch | 0/13 |
| Python host, this branch | 13/13 (see below) |
| Python host, `line_buffering=True` | 0/13 |

The pre-fix output reproduces the reporter's signature exactly: a line with no terminator, then a POUNCE iteration row, then the remainder.

## Cause

Two writers share fd 1 and neither knows about the other.

POUNCE journals from Rust. `crates/pounce-algorithm/src/ipopt_alg.rs:1860` writes iteration rows through `anstream::stdout()`, and Rust's `io::stdout()` is a `LineWriter` *unconditionally* — not tty-dependent the way C stdio is — so every row reaches fd 1 on its newline.

CasADi writes through `uout()`. `Logger::Streambuf::xsputn` holds nothing and hands each chunk straight to `Logger::writeFun`, leaving the buffering to `std::cout`/stdio, which behind a pipe is *fully* buffered. An embedder printing a line long enough to straddle that buffer leaves the tail sitting there when the callback returns — and POUNCE's next row goes out in front of it. This is also why severity scales with line length: the tear needs the buffer to fill mid-line and retain a tail.

CasADi's own ipopt plugin has no equivalent problem — Ipopt is C++ and its journal shares the stream it competes with.

## Fix

Drain CasADi's streams via an RAII guard on every exit path from `PounceInterface::guarded`, plus once immediately before `IpoptSolve`.

`guarded` is the one choke point all seven re-entry sites pass through, and the instant before it returns is the only moment the plugin knows POUNCE is not concurrently writing. Fixing `cb_iter` alone is insufficient — the reporter measured 7 tears dropping only to 2 — because model code logging from inside the oracle callbacks tears just as readily.

That choke-point argument holds because `Journalist` is `RefCell`-backed and therefore `!Sync`, so POUNCE genuinely cannot write while the callback body runs. It assumes a single-threaded host: two `nlpsol` instances solving on two threads can still interleave, and no per-callback flush fixes that. Ipopt is no better off, so it is not a regression, but the code comment records it rather than claiming more than it delivers.

Three things beyond the patch attached to the issue:

- **The destructor swallows.** Destructors are implicitly `noexcept` and `Logger::flush` is a host-supplied callback, so a throwing sink would `std::terminate` inside the very function whose purpose is keeping exceptions out of Rust frames. The guard also sits at function scope above the `try`, so it runs on the ordinary return path rather than during unwinding.
- **A flush before `IpoptSolve`.** `guarded` closes every window that opens after the first callback fires, but not the first one: POUNCE prints its banner with whatever the host buffered still pending, and no callback has run yet to drain it.
- **`uerr()` as well as `uout()`.** `casadi_warning` writes there, and `OpenIpoptOutputFile(prob, "stderr", ...)` can put POUNCE's journal on that descriptor.

**Rejected: doing this in `pounce-cinterface` instead.** The issue suggests a print-callback so the plugin could route POUNCE's journal into `uout()`, removing the hazard by construction. Right instinct, but it would not have fixed this bug as scoped: the per-iteration rows never reach the `Journalist` — `crates/pounce-algorithm/src/application.rs:582` says so outright — so a sink attached there would capture nothing that is tearing. It is really two changes, and the first (routing iteration output through the Journalist) is load-bearing and not free: the rows are styled via `anstream::stdout()`, which decides ANSI stripping from whether fd 1 is a tty, and behind an opaque host callback that decision has to move somewhere. Filing separately rather than bundling.

## Blast radius

Not a trajectory change: no solver state is touched, only the moment a buffer is emptied. Iterates and iteration counts are unchanged, so no fixture sweep applies.

No Rust changed — the diff is the plugin, its build, its tests, and docs. No C API change, no `pounce.h` change, no version-surface impact (`casadi/` is not in the crates.io publish list).

Cost is one flush per callback invocation. On 400 variables / 200 iterations at `print_level 0`, 11 runs each: minima 397.2 ms with the fix and 398.5 ms without — below noise.

**A Python host is not fixed by this, and cannot be from the plugin.** CasADi's bindings set `Logger::writeFun = pythonlogger` (writing via `PySys_WriteStdout`) but leave `Logger::flush` at `flushDefault`, so output lands in Python's `sys.stdout` while a flush issued from C++ drains `std::cout` — a different buffer. Measured at 13/13 still torn with this change in place. `sys.stdout.reconfigure(line_buffering=True)` is *sufficient* there rather than a mitigation, because the callback runs while POUNCE is blocked; `docs/src/casadi.md` now says all of this, including why it is not something the plugin can close.

## Tests

`casadi/test_output_interleaving.cpp`, run from the parity suite via `test_output_does_not_tear_embedder_lines`. It prints a chunked 40 KB line from `iteration_callback` while POUNCE writes iteration rows, and the check counts lines missing their terminator.

It fails on the parent commit for the stated reason: 13/13 lines torn, verified by rebuilding the plugin without the fix. The payload is written in chunks deliberately — a single write large enough to exceed the buffer is pushed straight through and leaves no tail, which is exactly the case that does *not* reproduce.

The driver is a C++ host on purpose. Driven from `test_parity.py` this check would have measured CasADi's Python buffering rather than the plugin's flushing, and would have passed however broken the plugin got.

Full parity suite passes and all eight examples run. Skips cleanly when the driver has not been built.

**Deliberately not pinned:** the Python-host behaviour. It depends on CasADi's binding leaving the flush hook unset, which is theirs to change, and there is nothing on our side for a test to protect.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated — `casadi.md`, already linked from `SUMMARY.md`
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — **not run; no Rust changed.** `cargo build --release -p pounce-cinterface` was run, as the plugin links it.
- [x] Every claim in this body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjLEJu1mjRm5f8vfUgQc6C

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjLEJu1mjRm5f8vfUgQc6C)_