### PR TITLE
casadi: build against both spellings of the convexify helper (#668)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,3 +647,47 @@ jobs:
           assert abs(sol[0] - 1) < 1e-6 and abs(sol[1] - 1) < 1e-6, sol
           print("wheel solves with the build tree hidden, x* =", sol)
           PY
+
+  # Compile the convexify name shim against every spelling of CasADi's
+  # runtime helper (gh#668). Cheap and hermetic: no CasADi, no Rust, no
+  # link step — mock declarations and a compiler.
+  #
+  # This job exists because the job above cannot cover it. CasADi renamed
+  # `convexify_eval` to `casadi_convexify_eval` after 3.7.2, and any one
+  # CasADi declares exactly one of the two, so a build against a real
+  # CasADi compiles one overload of the shim and leaves the other
+  # unchecked — and it is the *unchecked* one that most users get, since
+  # the wheel ships plugins for 3.6 and 3.7 and both take the fallback.
+  # The mock is what lets one runner compile both.
+  #
+  # Windows is here and nowhere else in this workflow: the Windows wheel is
+  # built with MSVC, and MSVC's two-phase lookup is the likeliest of the
+  # three to disagree about a dependent name that is not declared. That is
+  # the whole mechanism this shim rests on.
+  convexify-name-shim:
+    name: CasADi convexify name shim (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Compile against every spelling
+        if: runner.os != 'Windows'
+        run: python3 casadi/tests/convexify_compat/run.py
+
+      # `cl` is only on PATH inside a developer shell, and vswhere ships with
+      # every runner image, so no extra action is needed to find it.
+      - name: Compile against every spelling (MSVC)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set VSPATH=%%i
+          if not defined VSPATH (echo could not locate a Visual Studio install & exit /b 1)
+          call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
+          python casadi\tests\convexify_compat\run.py --cxx cl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ changes.
 
 ## [Unreleased]
 
+- **The CasADi plugin builds against CasADi master again** (#668).
+
+  CasADi renamed the runtime helper `convexify_eval` to
+  `casadi_convexify_eval` after 3.7.2. The plugin calls it from `cb_h`,
+  which is compiled whether or not `convexify_strategy` is ever used, so
+  the failure was unconditional: a plugin built against master or any
+  nightly made from it did not compile, for users who never convexify
+  anything. Reported with a diagnosis and a working patch by
+  @srikanth-gm.
+
+  Renaming the call site would fix master and break 3.7.2 — and 3.6,
+  which the wheel also ships a build for. No version macro separates the
+  two: the nightly carrying the rename reports the same
+  `CASADI_MAJOR/MINOR/PATCH` as 3.7.2, differing only in
+  `CASADI_IS_RELEASE`, which the next release will flip back while
+  keeping the new name. What distinguishes them is not a version, it is
+  which name the installed CasADi declares, so `convexify_compat.hpp`
+  detects that by overload resolution. One source tree, no build flags,
+  no configure probe, and no version test to revise at the next CasADi
+  release. The codegen SYMBOL name is unchanged and generated code never
+  reaches this helper (the plugin refuses to code generate
+  `convexify_strategy` at all), so nothing about the emitted C moves.
+
+  The shim has two overloads and any one CasADi declares exactly one of
+  the names, so building against a real CasADi compiles one of them and
+  leaves the other unchecked — and the unchecked one is what most users
+  get, since the wheel's 3.6 and 3.7 builds both take the fallback. That
+  is what `casadi/tests/convexify_compat/` is for: it compiles both
+  against mock declarations, with no CasADi installed and nothing linked,
+  asserts which overload ran and that the arguments arrive intact, and
+  checks that a CasADi declaring *neither* name is rejected rather than
+  silently resolved. `make -C casadi compat`, and the `CasADi convexify
+  name shim` CI job — which is also the only place in CI the plugin
+  source meets MSVC, the toolchain the Windows wheel is built with.
+
 - **The restoration divergence guard's waiver now measures a floor
   instead of counting iterations** (#661, #664).
 

--- a/casadi/Makefile
+++ b/casadi/Makefile
@@ -3,6 +3,8 @@
 #   make                 build libcasadi_nlpsol_pounce.so
 #   make test            build, then run the parity checks against ipopt
 #   make examples        run every script in examples/
+#   make compat          compile the convexify name shim against every
+#                        CasADi spelling (needs no CasADi at all)
 #   make clean
 #
 # Two inputs are needed and both are auto-detected where possible:
@@ -89,7 +91,7 @@ CXXFLAGS ?= -O2 -std=c++17 -fPIC -Wall
 INCLUDES  = -I$(CASADI_SRC) -I$(CASADI_INC) -I$(POUNCE_INC)
 LDFLAGS   = -L$(CASADI_LIB) -lcasadi -L$(POUNCE_LIB) -lpounce_cinterface $(RPATH)
 
-.PHONY: all check-env fetch-src abi-flags install uninstall test examples clean
+.PHONY: all check-env fetch-src abi-flags install uninstall test examples compat clean
 
 all: check-env $(PLUGIN)
 
@@ -131,7 +133,7 @@ abi-flags:
 	@echo "installed casadi $(CASADI_VER) at $(CASADI_LIB)"
 	@$(PYTHON) -c "import casadi; print(casadi.CasadiMeta.compiler_flags())"
 
-$(PLUGIN): casadi_nlpsol_pounce.cpp pounce_runtime.hpp
+$(PLUGIN): casadi_nlpsol_pounce.cpp pounce_runtime.hpp convexify_compat.hpp
 	$(CXX) -shared $(CXXFLAGS) $(DEFS) $(INCLUDES) $< -o $@ $(LDFLAGS)
 	@$(FIXUP)
 
@@ -157,6 +159,13 @@ examples: all
 	  echo "=== $$f"; \
 	  CASADIPATH=$(CURDIR) $(PYTHON) $$f || exit 1; \
 	done
+
+## Compile `convexify_compat.hpp` against every spelling of CasADi's
+## convexify runtime helper (gh#668). Needs no CasADi and no solver
+## library -- mock declarations and a compiler -- so it runs anywhere,
+## and it covers the overload the installed CasADi does not exercise.
+compat:
+	$(PYTHON) tests/convexify_compat/run.py
 
 clean:
 	rm -f $(PLUGIN)

--- a/casadi/README.md
+++ b/casadi/README.md
@@ -33,6 +33,11 @@ covers building and installing the plugin.
   `CasADi plugin parity` job.
 - `pounce_runtime.hpp` — the C the plugin emits into generated code, the
   counterpart of CasADi's `ipopt_runtime.hpp`.
+- `convexify_compat.hpp` — one shim, for one CasADi rename. See
+  *Source compatibility across CasADi versions* below.
+- `tests/convexify_compat/` — compiles that shim against every spelling,
+  with no CasADi installed. `make compat`, and the `CasADi convexify name
+  shim` job in CI.
 - `examples/` — eight runnable scripts, from hello-world to embedded codegen.
 
 ## Build
@@ -127,7 +132,38 @@ Uninstall with `make uninstall`.
 ```bash
 make test          # parity checks against ipopt — all should PASS
 make examples      # runs every script in examples/
+make compat        # the convexify name shim, against every CasADi spelling
 ```
+
+`make compat` is the odd one out: it needs neither CasADi nor the solver
+library, only a compiler. See below for what it is checking.
+
+## Source compatibility across CasADi versions
+
+CasADi renamed the runtime helper `convexify_eval` to
+`casadi_convexify_eval` after 3.7.2 (gh#668). The codegen SYMBOL name and
+the signature are unchanged, so the break is source-level only — but it is
+unconditional: the call sits in `cb_h`, which compiles whether or not
+`convexify_strategy` is ever used. A plugin built against current CasADi
+master fails for users who never convexify anything.
+
+Nothing in the version macros separates the two spellings — the nightly
+that first carried the rename reports the same
+`CASADI_MAJOR/MINOR/PATCH` as 3.7.2 — so `convexify_compat.hpp` detects
+which name the installed CasADi declares, by overload resolution. One
+source tree builds against 3.6, 3.7 and master with no build flags and no
+version test to revise at the next CasADi release.
+
+The catch, and the reason `tests/convexify_compat/` exists: a real CasADi
+declares exactly one of the two names, so building against one CasADi
+compiles one overload of the shim and leaves the other unchecked — and it
+is the unchecked one that most users get, since the wheel ships plugins
+for 3.6 and 3.7 and both take the fallback. `make compat` compiles both
+against mock declarations, so neither branch can rot unnoticed. Checked
+locally on g++ and clang; the MSVC leg — the toolchain the Windows wheel
+is built with, and the likeliest of the three to disagree about a
+dependent name — runs in CI. Add a compiler to `run.py` rather than
+trusting the mechanism on a new one.
 
 ## ABI: what has to match, and why
 

--- a/casadi/casadi_nlpsol_pounce.cpp
+++ b/casadi/casadi_nlpsol_pounce.cpp
@@ -20,6 +20,7 @@
 
 #include "casadi/core/nlpsol_impl.hpp"
 #include "casadi/core/convexify.hpp"
+#include "convexify_compat.hpp"
 #include "pounce_runtime.hpp"
 #include <cmath>
 #include <cstring>
@@ -561,8 +562,11 @@ namespace casadi {
       // which is the pattern the solver was given, so `values` is big enough.
       return guarded(m, "Hessian convexification", [&] {
         ScopedTiming tic(m->fstats.at("convexify"));
-        return convexify_eval(&self->convexify_data_.config, values, values,
-                              m->iw, m->w) == 0;
+        // `convexify_eval_compat`, not `convexify_eval`: CasADi renamed the
+        // helper after 3.7.2 and the shim picks whichever name is declared
+        // (gh#668, convexify_compat.hpp).
+        return convexify_eval_compat(0, &self->convexify_data_.config, values,
+                                     values, m->iw, m->w) == 0;
       });
     }
     // upper-triangular CCS == lower-triangular triplet (row/col swap)

--- a/casadi/convexify_compat.hpp
+++ b/casadi/convexify_compat.hpp
@@ -1,0 +1,68 @@
+// Call CasADi's convexify runtime helper under whichever name the
+// installed CasADi declares (gh#668).
+//
+// CasADi renamed the C++ helper `convexify_eval` to `casadi_convexify_eval`
+// after the 3.7.2 release. The codegen SYMBOL name is unchanged, and so are
+// the parameters and their order — the break is source-level only, and the
+// generated-code path is not affected at all (this plugin refuses to code
+// generate `convexify_strategy` in the first place).
+//
+// The distinguishing fact is not a version number, it is which of the two
+// names the installed CasADi declares. Nothing in the version macros
+// separates them: the nightly that first carried the rename reports the same
+// `CASADI_MAJOR/MINOR/PATCH` as 3.7.2, and keying on `CASADI_IS_RELEASE`
+// would then misfire on the next release, which will carry the new name with
+// `CASADI_IS_RELEASE=1`. So detect the spelling directly.
+//
+// Both calls below are dependent on the template parameters, so each is
+// looked up at instantiation; the overload naming a helper this CasADi does
+// not declare fails substitution in its trailing return type — the immediate
+// context — and is dropped rather than becoming a hard error. The unused
+// `int` / `long` first parameter exists only to rank the two, so a CasADi
+// declaring both spellings resolves to the current name. Call it as
+// `convexify_eval_compat(0, ...)`.
+//
+// Which overload survives is decided by the CasADi being built against, so
+// on any one build only one of them is ever compiled. That is what
+// `tests/convexify_compat/` is for: it compiles both against mock
+// declarations, so the branch this machine's CasADi does not exercise cannot
+// rot unnoticed.
+//
+// Note for anyone patching this downstream: a `sed` that rewrites
+// `convexify_eval(` to `casadi_convexify_eval(` also rewrites the *fallback*
+// overload's body, leaving a function whose trailing return type names one
+// helper and whose body names the other. That compiles by accident — the
+// fallback is not instantiated when the new name exists — but it is silently
+// wrong, and it is unnecessary now that this header is here.
+//
+// Requires CasADi's convexify declarations to be included first; this header
+// deliberately includes nothing, so the mock-header test can stand in for
+// them.
+//
+// Reported and diagnosed, with a working patch, by @srikanth-gm in gh#668.
+
+#ifndef POUNCE_CASADI_CONVEXIFY_COMPAT_HPP
+#define POUNCE_CASADI_CONVEXIFY_COMPAT_HPP
+
+namespace casadi {
+
+  /// CasADi after 3.7.2: the helper carries the `casadi_` prefix.
+  template <typename Config, typename T>
+  auto convexify_eval_compat(int, const Config* c, const T* Hin, T* Hout,
+                             casadi_int* iw, T* w)
+      -> decltype(casadi_convexify_eval(c, Hin, Hout, iw, w)) {
+    return casadi_convexify_eval(c, Hin, Hout, iw, w);
+  }
+
+  /// CasADi 3.6.x and 3.7.x: the unprefixed name. Lower-ranked, so it is
+  /// chosen only when the prefixed one is not declared.
+  template <typename Config, typename T>
+  auto convexify_eval_compat(long, const Config* c, const T* Hin, T* Hout,
+                             casadi_int* iw, T* w)
+      -> decltype(convexify_eval(c, Hin, Hout, iw, w)) {
+    return convexify_eval(c, Hin, Hout, iw, w);
+  }
+
+}  // namespace casadi
+
+#endif  // POUNCE_CASADI_CONVEXIFY_COMPAT_HPP

--- a/casadi/tests/convexify_compat/mock_casadi.hpp
+++ b/casadi/tests/convexify_compat/mock_casadi.hpp
@@ -1,0 +1,90 @@
+// Mock stand-in for CasADi's convexify runtime declarations, for the
+// compile-time test of `convexify_compat.hpp` (gh#668).
+//
+// The point of the test is to compile *both* overloads of the shim. A real
+// CasADi declares exactly one of the two spellings, so a machine with one
+// CasADi installed can only ever compile one of them — and the wheel ships
+// builds for casadi 3.6 and 3.7, both of which take the fallback, while
+// CI builds against whatever release is current. Mocking the declarations
+// is what lets one machine compile every combination.
+//
+// Faithful to the real header in the things the shim depends on: namespace,
+// the config template, `casadi_int`, and the parameter list and its order
+// (`const casadi_convexify_config<T1>*, const T1*, T1*, casadi_int*, T1*`,
+// returning `int`). Everything else is deliberately absent.
+//
+// Define exactly one of MOCK_OLD_NAME / MOCK_NEW_NAME to model a released
+// CasADi (3.6.x, 3.7.x) or CasADi after 3.7.2; define both to model a
+// transitional CasADi carrying an alias; define neither to check that the
+// shim fails loudly rather than silently picking something.
+
+#ifndef POUNCE_MOCK_CASADI_HPP
+#define POUNCE_MOCK_CASADI_HPP
+
+namespace casadi {
+
+  typedef long long int casadi_int;
+
+  template <typename T1>
+  struct casadi_convexify_config {
+    int strategy;
+    T1 margin;
+  };
+
+  /// Sentinels the probe reads back, so the test can tell *which* helper ran
+  /// rather than only that the call compiled.
+  enum { MOCK_CALLED_OLD = 10, MOCK_CALLED_NEW = 20 };
+
+  /// Set by whichever helper is called, to the arguments it received.
+  struct MockCall {
+    const void* c = nullptr;
+    const void* Hin = nullptr;
+    void* Hout = nullptr;
+    void* iw = nullptr;
+    void* w = nullptr;
+  };
+  inline MockCall& mock_call() {
+    static MockCall call;
+    return call;
+  }
+
+  template <typename T1>
+  inline void mock_record(const casadi_convexify_config<T1>* c, const T1* Hin,
+                          T1* Hout, casadi_int* iw, T1* w) {
+    MockCall& call = mock_call();
+    call.c = c;
+    call.Hin = Hin;
+    call.Hout = Hout;
+    call.iw = iw;
+    call.w = w;
+  }
+
+#ifdef MOCK_OLD_NAME
+  // SYMBOL "convexify_eval"   -- casadi <= 3.7.2
+  template <typename T1>
+  int convexify_eval(const casadi_convexify_config<T1>* c, const T1* Hin,
+                     T1* Hout, casadi_int* iw, T1* w) {
+    mock_record(c, Hin, Hout, iw, w);
+    return MOCK_CALLED_OLD;
+  }
+#endif
+
+#ifdef MOCK_NEW_NAME
+  // SYMBOL "convexify_eval"   -- casadi after 3.7.2; C++ name prefixed
+  template <typename T1>
+  int casadi_convexify_eval(const casadi_convexify_config<T1>* c, const T1* Hin,
+                            T1* Hout, casadi_int* iw, T1* w) {
+    mock_record(c, Hin, Hout, iw, w);
+    return MOCK_CALLED_NEW;
+  }
+#endif
+
+  /// Stands in for `ConvexifyData`, whose `config` member is what the plugin
+  /// takes the address of at the call site.
+  struct ConvexifyData {
+    casadi_convexify_config<double> config;
+  };
+
+}  // namespace casadi
+
+#endif  // POUNCE_MOCK_CASADI_HPP

--- a/casadi/tests/convexify_compat/probe.cpp
+++ b/casadi/tests/convexify_compat/probe.cpp
@@ -1,0 +1,63 @@
+// Compile and run the real `convexify_compat.hpp` shim against mock CasADi
+// declarations, in the shape the plugin uses it (gh#668).
+//
+// Built once per declaration state by `run.py`; see that file and
+// `mock_casadi.hpp` for why this is not simply done against a real CasADi.
+
+#include "mock_casadi.hpp"
+#include "../../convexify_compat.hpp"
+
+#include <cstdio>
+
+namespace casadi {
+
+  /// Mirrors `PounceInterface::cb_h`'s call: a *non-template* member reached
+  /// through a `const` pointer, so `&self->convexify_data_.config` is a
+  /// pointer to const, `values` is passed as both `Hin` and `Hout`, and the
+  /// work arrays come from the memory object.
+  struct FakeInterface {
+    ConvexifyData convexify_data_;
+
+    static int cb_h(const FakeInterface* self, double* values, casadi_int* iw,
+                    double* w) {
+      return convexify_eval_compat(0, &self->convexify_data_.config, values,
+                                   values, iw, w);
+    }
+  };
+
+}  // namespace casadi
+
+int main() {
+  casadi::FakeInterface self;
+  self.convexify_data_.config.strategy = 2;
+  self.convexify_data_.config.margin = 1e-7;
+
+  double values[3] = {1.0, 2.0, 3.0};
+  double w[8] = {0.0};
+  casadi::casadi_int iw[8] = {0};
+
+  const int rc = casadi::FakeInterface::cb_h(&self, values, iw, w);
+
+  const char* selected = nullptr;
+  if (rc == casadi::MOCK_CALLED_NEW) {
+    selected = "NEW";
+  } else if (rc == casadi::MOCK_CALLED_OLD) {
+    selected = "OLD";
+  } else {
+    std::printf("FAIL: helper returned %d, which is neither sentinel\n", rc);
+    return 1;
+  }
+
+  // The shim forwards, it does not rearrange. An overload that compiled but
+  // swapped `Hin`/`Hout` or dropped a work array would pass a bare
+  // "it built" check and then convexify against the wrong buffer.
+  const casadi::MockCall& call = casadi::mock_call();
+  if (call.c != &self.convexify_data_.config || call.Hin != values ||
+      call.Hout != values || call.iw != iw || call.w != w) {
+    std::printf("FAIL: arguments did not arrive intact\n");
+    return 1;
+  }
+
+  std::printf("selected=%s\n", selected);
+  return 0;
+}

--- a/casadi/tests/convexify_compat/run.py
+++ b/casadi/tests/convexify_compat/run.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Compile the convexify name shim against every CasADi spelling (gh#668).
+
+`convexify_compat.hpp` has two overloads and any one CasADi declares the
+helper under exactly one name, so a build against a real CasADi compiles
+one of them and leaves the other unchecked. The wheel ships plugins for
+casadi 3.6 and 3.7 -- both of which take the *fallback* -- while CI builds
+against whatever release is current, so the branch nobody compiles is the
+branch most users get. This compiles both, against mock declarations, with
+no CasADi installed and nothing linked.
+
+    python3 run.py                 # every compiler found on PATH
+    python3 run.py --cxx g++       # just this one
+
+Runs the matrix (declaration state x compiler x -std), checks that the
+expected overload is the one that ran, and checks the negative case: with
+neither name declared the shim must fail to compile rather than resolve to
+something else.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PROBE = os.path.join(HERE, "probe.cpp")
+
+# (label, defines, expected selection or None for "must not compile")
+CASES = [
+    ("casadi <= 3.7.2 (unprefixed)", ["MOCK_OLD_NAME"], "OLD"),
+    ("casadi > 3.7.2 (prefixed)", ["MOCK_NEW_NAME"], "NEW"),
+    ("both spellings declared", ["MOCK_OLD_NAME", "MOCK_NEW_NAME"], "NEW"),
+    ("neither spelling declared", [], None),
+]
+
+# The plugin is built as C++17 (see the Makefile), but the shim uses nothing
+# past C++11 and a user building the source into their own tree may be on an
+# older standard, so hold it to that.
+STANDARDS = ["c++11", "c++14", "c++17"]
+
+
+def compilers(requested):
+    if requested:
+        return [c for c in requested]
+    found = [c for c in ("g++", "clang++") if shutil.which(c)]
+    # MSVC builds the Windows wheel, and it is the compiler whose two-phase
+    # lookup is likeliest to disagree about a dependent name that is not
+    # declared. It is only on PATH inside a developer shell.
+    if shutil.which("cl"):
+        found.append("cl")
+    return found
+
+
+def command(cxx, std, defines, out, is_msvc):
+    if is_msvc:
+        # /W4 without /WX: an unrelated MSVC warning in a future toolset
+        # should not fail a test about name lookup.
+        cmd = ["cl", "/nologo", "/EHsc", "/W4", f"/std:{std}", PROBE,
+               f"/Fe:{out}", f"/Fo:{out}.obj"]
+        return cmd[:-3] + [f"/D{d}" for d in defines] + cmd[-3:]
+    return ([cxx, f"-std={std}", "-Wall", "-Wextra", "-Werror"]
+            + [f"-D{d}" for d in defines] + [PROBE, "-o", out])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cxx", action="append", default=[],
+                    help="compiler to use (repeatable); default: all found")
+    args = ap.parse_args()
+
+    found = compilers(args.cxx)
+    if not found:
+        print("error: no C++ compiler found (looked for g++, clang++, cl)",
+              file=sys.stderr)
+        return 2
+
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        for cxx in found:
+            # exact match: "clang++" also begins with "cl"
+            is_msvc = os.path.basename(cxx).lower() in ("cl", "cl.exe")
+            for std in STANDARDS:
+                if is_msvc and std == "c++11":
+                    continue  # MSVC has no /std:c++11; c++14 is its floor
+                for label, defines, expect in CASES:
+                    out = os.path.join(tmp, "probe.exe")
+                    for stale in (out, out + ".obj"):
+                        if os.path.exists(stale):
+                            os.remove(stale)
+                    build = subprocess.run(
+                        command(cxx, std, defines, out, is_msvc),
+                        capture_output=True, text=True, cwd=tmp)
+                    what = f"{cxx:8s} {std:6s} {label:30s}"
+
+                    if expect is None:
+                        if build.returncode == 0:
+                            print(f"{what} FAIL: compiled with neither helper "
+                                  "declared; the shim is resolving to "
+                                  "something it should not see")
+                            failures += 1
+                        else:
+                            print(f"{what} ok (rejected, as it must be)")
+                        continue
+
+                    if build.returncode != 0:
+                        print(f"{what} FAIL: did not compile")
+                        print((build.stderr or build.stdout).strip()[:2000])
+                        failures += 1
+                        continue
+
+                    run = subprocess.run([out], capture_output=True, text=True)
+                    got = ""
+                    for line in run.stdout.splitlines():
+                        if line.startswith("selected="):
+                            got = line.split("=", 1)[1].strip()
+                    if run.returncode != 0 or got != expect:
+                        print(f"{what} FAIL: expected {expect}, got "
+                              f"{got or '(nothing)'}")
+                        print((run.stdout + run.stderr).strip()[:2000])
+                        failures += 1
+                    else:
+                        print(f"{what} ok (selected {got})")
+
+    print()
+    if failures:
+        print(f"{failures} failure(s)")
+        return 1
+    print("convexify name shim resolves correctly on every spelling")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/src/casadi.md
+++ b/docs/src/casadi.md
@@ -107,6 +107,12 @@ mismatch surfaces as an undefined-symbol error at load time.
 [`casadi/README.md`](https://github.com/jkitchin/pounce/blob/main/casadi/README.md)
 has the details and the failure signatures.
 
+Building against a CasADi *nightly* works too. CasADi renamed a runtime
+helper the plugin calls after 3.7.2 (gh#668), which broke the build for
+anyone on master; the source now detects which name the installed CasADi
+declares, so one tree compiles against 3.6, 3.7 and master unchanged,
+with no build flags to pass.
+
 ## Options
 
 | CasADi option | Meaning |


### PR DESCRIPTION
Fixes #668.

Reported, diagnosed and patched by @srikanth-gm, who is building POUNCE through
the `Nlpsol` plugin against a CasADi nightly and has been carrying this as a
local patch. The mechanism below is theirs; what is added here is the test that
keeps it honest.

## Problem

The plugin does not compile against CasADi master, or any nightly built from
it. CasADi renamed the runtime helper `convexify_eval` to
`casadi_convexify_eval` after 3.7.2:

```
casadi_nlpsol_pounce.cpp:564:16: error: 'convexify_eval' was not declared in this scope
  564 |         return convexify_eval(&self->convexify_data_.config, values, values,
```

The failure is unconditional. The call sits in `cb_h`, a non-template member
compiled whether or not `convexify_strategy` is ever set, so the build fails
for users who never convexify anything.

| plugin source | vs casadi 3.7.2 | vs casadi master `973b086` |
|---|---|---|
| before | compiles | **error at :564** |
| after | compiles | compiles |

Not urgent for release users — 3.7.2 is still latest on PyPI, so nothing is red
today. It is not optional either: CI installs `casadi` unpinned and derives the
header checkout from `casadi.__version__`, so the day the next CasADi release
ships this becomes a red `CasADi plugin parity` on both legs, and a failed wheel
build for that minor, with no change on our side.

## Cause

A source-level rename, and nothing else. The codegen SYMBOL name is unchanged
(`// SYMBOL "convexify_eval"` on both), the signature is unchanged, and the
generated-code path never reaches this helper at all — the plugin refuses to
code generate `convexify_strategy` (`casadi_nlpsol_pounce.cpp:1093`).

Verified against upstream rather than taken from the report: `master` declares
only `casadi_convexify_eval`, with no deprecated alias and no macro providing
the old spelling; `3.7.2` declares only `convexify_eval`. **3.6.7 declares the
old name too** — which matters below.

## Fix

`casadi/convexify_compat.hpp` detects which name the installed CasADi declares,
by overload resolution: two `convexify_eval_compat` overloads, each naming one
spelling in its trailing return type, so the one whose helper is not declared
fails substitution in the immediate context and drops out. An unused `int` /
`long` first parameter ranks them, so a CasADi declaring both resolves to the
current name. The call site becomes `convexify_eval_compat(0, ...)`.

**Rejected: renaming the call site.** It fixes master and breaks 3.7.2 *and*
3.6 — the wheel ships a build for each, under `_plugins/{minor}/`, so this is
not a hypothetical older version, it is both shipped artifacts.

**Rejected: a version test.** No macro separates the two. The nightly carrying
the rename reports the same `CASADI_MAJOR/MINOR/PATCH` as 3.7.2, differing only
in `CASADI_IS_RELEASE` — which the next release flips back while keeping the new
name. The Makefile hard-codes `CASADI_IS_RELEASE=1` anyway.

**Rejected: a configure probe in the Makefile.** It works for our own builds,
but this `.cpp` is compiled by users with their own build systems; the detection
belongs in the source, where it needs no cooperation from the caller.

The result is one source tree building against 3.6, 3.7 and master with no build
flags and nothing to revise at the next CasADi release. If CasADi renames it a
third time, the failure is a legible overload-resolution error naming both
candidates rather than silence.

## Blast radius

Bit-identical except that the plugin now compiles. Same helper, same arguments,
same in-place operation on the same widened pattern — **not a trajectory
change**, so no fixture sweep is owed. `convexify_eval` was the only unprefixed
CasADi runtime helper the plugin called (`casadi_copy` was always prefixed), so
the blast radius is one call site. The emitted C is untouched, per the codegen
refusal above.

Nothing else in CasADi master breaks the plugin: it compiles clean against
`973b086` in full, not just past this line.

No Rust changed (0 `.rs` files in the diff).

## Tests

`casadi/tests/convexify_compat/` — compiles **both** overloads against mock
CasADi declarations, with no CasADi installed and nothing linked. It exists
because of a gap that outlives this PR: any one CasADi declares exactly one of
the two names, so *any* build compiles one overload and leaves the other
unchecked — and the unchecked one is what most users get, since the wheel's 3.6
and 3.7 builds both take the fallback while CI builds against the current
release. Mocking is what lets one machine compile every combination.

It asserts which overload ran, that the arguments arrive intact (an overload
that compiled but swapped `Hin`/`Hout` would pass a bare "it built" check and
then convexify against the wrong buffer), and that a CasADi declaring *neither*
name is rejected rather than silently resolved to something else.

`make -C casadi compat`, plus a `CasADi convexify name shim` CI job on Linux,
macOS and **Windows** — the only place in CI the plugin source meets MSVC, which
is the toolchain the Windows wheel is built with and the one compiler nobody had
pointed at this mechanism.

Verified:

| check | result |
|---|---|
| shim: g++ 13 + clang, `-std=c++11/14/17`, 4 declaration states | 24/24 as expected |
| shim: **MSVC** (VS 2026, `cl` 18.8.2), `/std:c++14` and `/std:c++17`, same 4 states | 8/8, in CI on this PR |
| plugin vs real casadi 3.7.2 headers (fallback overload) | compiles, g++ and clang |
| plugin vs real casadi master `973b086` (prefixed overload) | compiles, g++ and clang |
| **pre-fix** source vs master | reproduces the reported error, at the reported line |
| `make -C casadi test` — parity vs bundled Ipopt, incl. convexification | all checks pass |

MSVC was the one leg that had not been run when this PR was opened — the
mechanism is standard SFINAE and MSVC's two-phase lookup is the likeliest of the
three to disagree, so it was the gap worth naming rather than assuming away. It
has now run green on this PR, including the negative case, which is why the
claim above is a measurement rather than an expectation.

On "tests fail on the parent commit": the compat test is a new file and cannot
run on the parent, so the pre-fix check in the table above is what stands in for
it — the parent's source, compiled against master headers, fails with the
reported error at the reported line, and stops failing with this diff applied.

## Rebased onto #669

#669 (gh#667) landed in `casadi/` while this was open — the output-tearing flush
guard in `guarded`, a `test_output_interleaving.cpp` target, and its own
CHANGELOG and `docs/src/casadi.md` sections. Merged with no textual conflicts,
but the convexify call site now sits inside a `guarded` lambda whose scope also
carries that flush guard, so the merged tree was re-verified rather than assumed:
`make -C casadi compat` green, the plugin compiles against real 3.7.2 and real
master on g++ and clang, and the full parity suite passes — including #669's own
`output: POUNCE does not tear embedder lines` check (0/13 lines torn).

---

- [x] Tests fail on the parent commit for the stated reason — see the note above
      on how this was checked for a new-file test
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`docs/src/casadi.md`); no
      `SUMMARY.md` change — not a new page
- [x] `cargo fmt --all -- --check` clean; `cargo clippy` / `cargo test` not
      re-run — the diff contains no Rust
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now — body re-read against the final diff after the #669
      merge, and the MSVC row updated from "not yet run" to the result