### PR TITLE
Q3 review copy: move the quadratic recognizer to `pounce-nl` and stop it recursing

### DIFF
--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -35,9 +35,8 @@
 //! (PSD) test uses a tolerance and routes "inconclusive within
 //! tolerance" to the safe side, never to the convex path.
 
-use crate::nl_reader::{BinOp, Expr, NlProblem, UnaryOp};
+use crate::nl_reader::NlProblem;
 use pounce_common::types::{lower_bound_present, upper_bound_present};
-use std::collections::BTreeMap;
 
 /// Tolerance for the smallest-eigenvalue sign test in the convexity
 /// check. A Hessian eigenvalue below `-PSD_TOL` is treated as a genuine
@@ -381,7 +380,7 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
     }
 
     // Objective curvature.
-    let obj_quad = match analyze_quadratic(&prob.obj_nonlinear, prob.n) {
+    let obj_quad = match analyze_quadratic(&prob.obj_nonlinear) {
         Some(q) => q,
         // Objective has a non-quadratic nonlinear term ⇒ NLP.
         None => return (ProblemClass::Nlp, ClassReason::ObjectiveNotQuadratic),
@@ -394,7 +393,7 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
         if is_trivially_zero(c) {
             continue;
         }
-        match analyze_quadratic(c, prob.n) {
+        match analyze_quadratic(c) {
             Some(q) if q.is_empty() => {} // purely linear after all
             Some(_) => any_quadratic_constraint = true,
             None => {
@@ -445,7 +444,7 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
             if is_trivially_zero(c) {
                 continue;
             }
-            match analyze_quadratic(c, prob.n) {
+            match analyze_quadratic(c) {
                 Some(q) if q.is_empty() => {} // purely linear after all
                 Some(q) => {
                     let lo = prob.g_l[row];
@@ -630,237 +629,15 @@ fn mismatch_msg(class: ProblemClass, forced: &str, expected: &str) -> String {
 // Quadratic-form analysis
 // ---------------------------------------------------------------------
 
-/// The symmetric Hessian of a quadratic form, stored as a sparse upper-
-/// triangular (i ≤ j) map of `(i, j) -> ∂²/∂xᵢ∂xⱼ`. Empty means the
-/// expression is (at most) linear.
-pub(crate) type QuadHessian = BTreeMap<(usize, usize), f64>;
-
-/// Full quadratic read-out: `(Hessian, [(var, linear coef), …], constant)`.
-/// The linear and constant parts are the pieces AMPL/Pyomo fold into the
-/// nonlinear objective tree (see [`analyze_quadratic_full`]).
-pub(crate) type QuadForm = (QuadHessian, Vec<(usize, f64)>, f64);
-
-/// Attempt to read an expression as a polynomial of total degree ≤ 2 and
-/// return its Hessian (constant, since the form is quadratic). Returns
-/// `None` if the expression contains any term the classifier cannot
-/// prove is degree-≤2 polynomial (transcendental ops, division by a
-/// non-constant, `Pow` with exponent ∉ {0,1,2}, products of degree > 2,
-/// external calls, …). `None` ⇒ treat as general nonlinear.
-pub(crate) fn analyze_quadratic(e: &Expr, n: usize) -> Option<QuadHessian> {
-    analyze_quadratic_full(e, n).map(|(h, _, _)| h)
-}
-
-/// Like [`analyze_quadratic`] but also returns the degree-1 (linear)
-/// coefficients *and* the degree-0 (constant) term of the form:
-/// `(Hessian, [(var, coef), …], constant)`.
-///
-/// AMPL folds the linear part of a nonlinear term into the objective's
-/// nonlinear expression tree (the `−6·x₀` of `(x₀−3)²`, say) rather than
-/// the linear section. Callers building the QP objective vector `c` must
-/// add these in, exactly as the NLP path's `eval_f` sums the linear
-/// section *and* the nonlinear tree — otherwise the linear shift is
-/// silently dropped and the convex solve minimizes the wrong objective.
-///
-/// The **constant** is returned for the same reason: AMPL/Pyomo also fold
-/// the objective's degree-0 term into the nonlinear tree (the `+9` of
-/// `(x₀−3)²`), where it does *not* land in `NlProblem::obj_constant`. It
-/// is irrelevant to the minimizer but is part of the *reported objective
-/// value*; dropping it makes the convex solve report an objective off by
-/// that constant versus the NLP path (see `qp_extract`).
-pub(crate) fn analyze_quadratic_full(e: &Expr, _n: usize) -> Option<QuadForm> {
-    let poly = to_poly(e)?;
-    if poly.max_degree() > 2 {
-        return None;
-    }
-    let mut h: QuadHessian = BTreeMap::new();
-    let mut lin: Vec<(usize, f64)> = Vec::new();
-    let mut constant = 0.0;
-    for (vars, coef) in &poly.terms {
-        match vars.as_slice() {
-            // Constant term: no gradient/Hessian contribution, but it is
-            // part of the objective *value* — accumulate, don't drop.
-            [] => constant += *coef,
-            // Linear term c·xᵢ.
-            [i] => lin.push((*i, *coef)),
-            // Quadratic term c·xᵢ·xⱼ.
-            [i, j] => {
-                let (i, j) = (*i.min(j), *i.max(j));
-                // ∂²(c·xᵢxⱼ)/∂xᵢ∂xⱼ = c for i≠j; ∂²(c·xᵢ²)/∂xᵢ² = 2c.
-                let contrib = if i == j { 2.0 * coef } else { *coef };
-                *h.entry((i, j)).or_insert(0.0) += contrib;
-            }
-            _ => return None,
-        }
-    }
-    // Drop explicit zeros so `is_empty()` means "linear".
-    h.retain(|_, v| v.abs() > 0.0);
-    Some((h, lin, constant))
-}
-
-/// A multivariate polynomial as a map from a sorted variable-index
-/// multiset (the monomial) to its coefficient. `[]` is the constant
-/// term, `[i]` is `xᵢ`, `[i, i]` is `xᵢ²`, `[i, j]` is `xᵢxⱼ`.
-#[derive(Debug, Clone, Default)]
-struct Poly {
-    terms: BTreeMap<Vec<usize>, f64>,
-}
-
-impl Poly {
-    fn constant(c: f64) -> Self {
-        let mut terms = BTreeMap::new();
-        if c != 0.0 {
-            terms.insert(Vec::new(), c);
-        }
-        Poly { terms }
-    }
-
-    fn var(i: usize) -> Self {
-        let mut terms = BTreeMap::new();
-        terms.insert(vec![i], 1.0);
-        Poly { terms }
-    }
-
-    fn max_degree(&self) -> usize {
-        self.terms.keys().map(|m| m.len()).max().unwrap_or(0)
-    }
-
-    fn as_constant(&self) -> Option<f64> {
-        match self.terms.len() {
-            0 => Some(0.0),
-            1 => self.terms.get(&Vec::new()).copied(),
-            _ => None,
-        }
-    }
-
-    fn add(mut self, other: &Poly) -> Poly {
-        for (m, c) in &other.terms {
-            *self.terms.entry(m.clone()).or_insert(0.0) += c;
-        }
-        self.prune();
-        self
-    }
-
-    fn neg(mut self) -> Poly {
-        for c in self.terms.values_mut() {
-            *c = -*c;
-        }
-        self
-    }
-
-    fn scale(mut self, s: f64) -> Poly {
-        if s == 0.0 {
-            return Poly::default();
-        }
-        for c in self.terms.values_mut() {
-            *c *= s;
-        }
-        self
-    }
-
-    /// Multiply two polynomials, bailing (`None`) if any product
-    /// monomial would exceed total degree 2 — past that the classifier
-    /// gives up and the caller routes to NLP.
-    fn mul(&self, other: &Poly) -> Option<Poly> {
-        let mut out = Poly::default();
-        for (ma, ca) in &self.terms {
-            for (mb, cb) in &other.terms {
-                if ma.len() + mb.len() > 2 {
-                    return None;
-                }
-                let mut m = ma.clone();
-                m.extend_from_slice(mb);
-                m.sort_unstable();
-                *out.terms.entry(m).or_insert(0.0) += ca * cb;
-            }
-        }
-        out.prune();
-        Some(out)
-    }
-
-    fn prune(&mut self) {
-        self.terms.retain(|_, c| c.abs() > 0.0);
-    }
-}
-
-/// Lower an `Expr` to a [`Poly`] of total degree ≤ 2, or `None` if it
-/// contains anything outside that class. `Cse` nodes are inlined (they
-/// are mathematically equivalent to their body).
-fn to_poly(e: &Expr) -> Option<Poly> {
-    match e {
-        Expr::Const(c) => Some(Poly::constant(*c)),
-        Expr::Var(i) => Some(Poly::var(*i)),
-        Expr::Cse(body) => to_poly(body),
-        Expr::Sum(items) => {
-            // Accumulate every monomial into one map, pruning ONCE at the
-            // end. The previous `acc = acc.add(&to_poly(it)?)` called the
-            // self-pruning `add` per item, and `prune` rescans the entire
-            // accumulated map, making an N-term sum O(N²). On QCQP forms
-            // (a quadratic over n vars expands to up to ~n² monomials) this
-            // hung the `solver_selection=auto` classifier for >300 s before
-            // the solver ever started. Merge-then-prune is O(N log N).
-            let mut acc = Poly::default();
-            for it in items {
-                let p = to_poly(it)?;
-                for (m, c) in &p.terms {
-                    *acc.terms.entry(m.clone()).or_insert(0.0) += c;
-                }
-            }
-            acc.prune();
-            Some(acc)
-        }
-        Expr::Unary(op, a) => match op {
-            UnaryOp::Neg => Some(to_poly(a)?.neg()),
-            // Everything else is transcendental / non-polynomial.
-            _ => None,
-        },
-        Expr::Binary(op, a, b) => {
-            let pa = to_poly(a)?;
-            let pb = to_poly(b)?;
-            match op {
-                BinOp::Add => Some(pa.add(&pb)),
-                BinOp::Sub => Some(pa.add(&pb.neg())),
-                BinOp::Mul => pa.mul(&pb),
-                BinOp::Div => {
-                    // Division is polynomial only by a nonzero constant.
-                    let d = pb.as_constant()?;
-                    if d == 0.0 {
-                        None
-                    } else {
-                        Some(pa.scale(1.0 / d))
-                    }
-                }
-                BinOp::Pow => {
-                    // Polynomial only for constant integer exponents in
-                    // {0, 1, 2}.
-                    let exp = pb.as_constant()?;
-                    if exp == 0.0 {
-                        Some(Poly::constant(1.0))
-                    } else if exp == 1.0 {
-                        Some(pa)
-                    } else if exp == 2.0 {
-                        pa.mul(&pa)
-                    } else {
-                        None
-                    }
-                }
-                // atan2 and any other binary opcodes are non-polynomial.
-                _ => None,
-            }
-        }
-        // External function calls are opaque ⇒ not provably polynomial.
-        Expr::Funcall { .. } => None,
-        // Comparisons, logicals, conditionals, and n-ary min/max (the
-        // smooth-/control-flow `.nl` opcodes) are non-polynomial ⇒ not a
-        // convex QP, so the classifier routes them to the NLP solver.
-        _ => None,
-    }
-}
-
-/// True if the expression is the literal constant zero the `.nl` reader
-/// uses for "no nonlinear part".
-fn is_trivially_zero(e: &Expr) -> bool {
-    matches!(e, Expr::Const(c) if *c == 0.0)
-}
+// The recognizer itself lives in `pounce-nl` (`nl_quadratic`), next to the
+// `Expr` DAG it walks, so that the consumers that are not this binary can
+// use it — see that module's docs. What stays here is the *routing*: which
+// `ProblemClass` a recognized form implies, and which guards a QCQP has to
+// clear to reach the conic path. These re-exports keep the call sites in
+// `qp_extract` and in the tests below spelled as they were.
+pub(crate) use pounce_nl::nl_quadratic::{
+    QuadHessian, analyze_quadratic, analyze_quadratic_full, is_trivially_zero,
+};
 
 // ---------------------------------------------------------------------
 // PSD test
@@ -996,7 +773,7 @@ fn coupled_hessian_is_psd(h: &QuadHessian) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nl_reader::parse_nl_text;
+    use crate::nl_reader::{BinOp, Expr, UnaryOp, parse_nl_text};
 
     // --- SolverSelection parsing ---
 
@@ -1130,7 +907,7 @@ mod tests {
             )),
             Box::new(Expr::Const(2.0)),
         );
-        let h = analyze_quadratic(&e, 1).expect("degree-2 polynomial");
+        let h = analyze_quadratic(&e).expect("degree-2 polynomial");
         // d²/dx0² (x0²) = 2
         assert_eq!(h.get(&(0, 0)), Some(&2.0));
     }
@@ -1139,7 +916,7 @@ mod tests {
     fn poly_rejects_transcendental() {
         // sin(x0) is not polynomial.
         let e = Expr::Unary(UnaryOp::Sin, Box::new(Expr::Var(0)));
-        assert!(analyze_quadratic(&e, 1).is_none());
+        assert!(analyze_quadratic(&e).is_none());
     }
 
     #[test]
@@ -1150,14 +927,14 @@ mod tests {
             Box::new(Expr::Var(0)),
             Box::new(Expr::Const(3.0)),
         );
-        assert!(analyze_quadratic(&e, 1).is_none());
+        assert!(analyze_quadratic(&e).is_none());
     }
 
     #[test]
     fn cross_term_hessian() {
         // x0 * x1  =>  H[0,1] = 1
         let e = Expr::Binary(BinOp::Mul, Box::new(Expr::Var(0)), Box::new(Expr::Var(1)));
-        let h = analyze_quadratic(&e, 2).expect("degree-2");
+        let h = analyze_quadratic(&e).expect("degree-2");
         assert_eq!(h.get(&(0, 1)), Some(&1.0));
     }
 
@@ -1166,20 +943,24 @@ mod tests {
         // Regression guard for the `solver_selection=auto` classifier hang
         // (mittelmann QCQP/bearing_400/qssp180 emitted zero iterations and
         // burned the full CPU budget). A quadratic expressed as a large
-        // `Sum` of monomials must lower to a `Poly` in O(N log N): the old
-        // `acc = acc.add(&to_poly(it)?)` ran the self-pruning `add` per
-        // item, and `prune` rescans the whole accumulated map, so an
-        // N-monomial sum was O(N²) and spun for >300 s before the solver
-        // started (Ipopt solved the same problems in seconds). Build a
-        // 5000-term sum of distinct squares and confirm the full diagonal
-        // Hessian is recovered — this path completes effectively instantly
-        // once the per-`add` prune is gone.
+        // `Sum` of monomials must lower in O(N log N): the recognizer used
+        // to re-scan the whole accumulated polynomial for zeros on every
+        // merged item, so an N-monomial sum was O(N²) and spun for >300 s
+        // before the solver started (Ipopt solved the same problems in
+        // seconds). Build a 5000-term sum of distinct squares and confirm
+        // the full diagonal Hessian is recovered.
+        //
+        // That fix covered the n-ary `Sum` node only. The same quadratic
+        // written as a chain of binary `Add`s — which is what a `.nl` writer
+        // emitting `o0` produces — kept the re-scan until Q3 moved the
+        // per-merge zero check onto the merged terms; see
+        // `wide_diagonal_convex_qcqp_keeps_conic` for that shape.
         const N: usize = 5000;
         let terms: Vec<Expr> = (0..N)
             .map(|i| Expr::Binary(BinOp::Mul, Box::new(Expr::Var(i)), Box::new(Expr::Var(i))))
             .collect();
         let e = Expr::Sum(terms);
-        let h = analyze_quadratic(&e, N).expect("degree-2 sum of squares is a QP");
+        let h = analyze_quadratic(&e).expect("degree-2 sum of squares is a QP");
         assert_eq!(h.len(), N, "every xᵢ² contributes one diagonal entry");
         assert_eq!(h.get(&(0, 0)), Some(&2.0));
         assert_eq!(h.get(&(N - 1, N - 1)), Some(&2.0));
@@ -1770,20 +1551,29 @@ mod tests {
     }
 
     /// A diagonal row is factored in `O(k)`, so width alone must not push a
-    /// separable QCQP off the conic path — 1000 uncoupled variables cost 1000
-    /// flops, where the same width densely coupled would cost 1e9.
+    /// separable QCQP off the conic path — 100 000 uncoupled variables cost
+    /// 100 000 flops, where the same width densely coupled would cost 1e15.
     ///
-    /// `k` is held at 1000 by an unrelated defect, not by the cost model: the
-    /// constraint is a left-deep `Add` tree, and `to_poly` walks it
-    /// recursively, so a sum of ~5000 squares overflows the stack during
-    /// classification. That is a real crash on a legitimate model and it is
-    /// Q3's to fix (make the recognizer iterative); the cost model itself is
-    /// indifferent to `k`.
+    /// `k` was held at 1 000 by an unrelated defect rather than by the cost
+    /// model: the constraint is a left-deep `Add` tree, the recognizer walked
+    /// it recursively, and a sum of a few thousand squares overflowed the
+    /// stack during classification (Q1 found this; a left-deep `o0` chain is
+    /// what a `.nl` writer emits for a long sum). Q3 made the recognizer
+    /// iterative, so the cost model can now be tested at a width that means
+    /// something. See `pounce_nl::nl_quadratic` for the depth tests
+    /// themselves.
+    ///
+    /// The problem is leaked rather than dropped: `Expr`'s derived `Drop` is
+    /// still recursive and would overflow tearing a tree this deep down. That
+    /// is a real remaining defect on the same shape — the Python bindings
+    /// work around it with a big-stack worker thread (pounce#472) — and it is
+    /// not this test's subject.
     #[test]
     fn wide_diagonal_convex_qcqp_keeps_conic() {
-        let k = 1_000;
+        let k = 100_000;
         let prob = separable_convex_qcqp_with_k_vars(k);
         assert_eq!(classify_problem(&prob), ProblemClass::ConvexQcqp);
+        std::mem::forget(prob);
     }
 
     /// Classification mirror of the boundary guard: a QP whose only

--- a/crates/pounce-cli/src/lib.rs
+++ b/crates/pounce-cli/src/lib.rs
@@ -14,7 +14,7 @@ pub mod debug_repl;
 // now lives in the leaf `pounce-nl` crate so the Python bindings can reuse
 // it. Re-export the modules so existing `crate::nl_reader::…` /
 // `pounce_cli::nl_reader::…` paths keep resolving unchanged.
-pub use pounce_nl::{nl_external, nl_fbbt_translate, nl_reader, nl_tape};
+pub use pounce_nl::{nl_external, nl_fbbt_translate, nl_quadratic, nl_reader, nl_tape};
 // The AMPL `.sol` writer moved to `pounce-nl` alongside the `.nl` reader it
 // inverts, so the wasm frontend can emit the same file. Re-exported under its
 // historical name to keep `nl_writer::…` call sites resolving.

--- a/crates/pounce-cli/src/qp_extract.rs
+++ b/crates/pounce-cli/src/qp_extract.rs
@@ -79,7 +79,7 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
 
     // --- objective Hessian P (lower triangle) + nonlinear-tree linear part
     //     + nonlinear-tree constant (degree-0 term, for reporting only) ---
-    let (hess, obj_nl_linear, obj_nl_constant) = analyze_quadratic_full(&prob.obj_nonlinear, n)?;
+    let (hess, obj_nl_linear, obj_nl_constant) = analyze_quadratic_full(&prob.obj_nonlinear)?;
     let mut p_lower: Vec<Triplet> = Vec::with_capacity(hess.len());
     for ((i, j), v) in &hess {
         // analyze_quadratic returns (i ≤ j) upper-ish keys; store as
@@ -121,7 +121,7 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
         // silently solves the wrong constraint. The folded constant
         // shifts the bounds: `g_l ≤ row + k ≤ g_u  ⇔  g_l−k ≤ row ≤ g_u−k`.
         // This mirrors the SOCP extractor's linear-constraint handling.
-        let (nl_lin, const_shift) = analyze_quadratic_full(&prob.con_nonlinear[row], n)
+        let (nl_lin, const_shift) = analyze_quadratic_full(&prob.con_nonlinear[row])
             .map(|(_, l, k)| (l, k))
             .unwrap_or_default();
         let mut coef = vec![0.0; n];
@@ -383,7 +383,7 @@ pub fn extract_socp_with_map(
     let sign = if prob.minimize { 1.0 } else { -1.0 };
 
     // --- objective P (lower triangle) + folded linear / constant terms ---
-    let (hess, obj_nl_linear, obj_nl_constant) = analyze_quadratic_full(&prob.obj_nonlinear, n)?;
+    let (hess, obj_nl_linear, obj_nl_constant) = analyze_quadratic_full(&prob.obj_nonlinear)?;
     let mut p_lower: Vec<Triplet> = Vec::with_capacity(hess.len());
     for ((i, j), v) in &hess {
         let (row, col) = if i >= j { (*i, *j) } else { (*j, *i) };
@@ -411,7 +411,7 @@ pub fn extract_socp_with_map(
         let lo = prob.g_l[row];
         let hi = prob.g_u[row];
         let nl = &prob.con_nonlinear[row];
-        let quad = analyze_quadratic_full(nl, n);
+        let quad = analyze_quadratic_full(nl);
         let is_quadratic = matches!(&quad, Some((hmap, _, _)) if !hmap.is_empty());
 
         if is_quadratic {

--- a/crates/pounce-cli/tests/quad_recognizer_differential.rs
+++ b/crates/pounce-cli/tests/quad_recognizer_differential.rs
@@ -1,0 +1,473 @@
+//! The Q3 recognizer against the one it replaced, bit for bit (gh #588).
+//!
+//! Q3 moved degree-≤2 recognition out of `pounce-cli`'s `dispatch` and into
+//! [`pounce_cli::nl_quadratic`], and swapped the `BTreeMap<Vec<usize>, f64>`
+//! polynomial for a fixed-shape `Quad2`. The new recognizer is iterative
+//! where the old one recursed, which is the point of the phase — but it is
+//! also *arithmetic*, and the series has already been bitten once by
+//! arithmetic that was equivalent rather than identical: in Q1 a one-ulp
+//! difference in a single cone coefficient moved a fixture from 17 to 12
+//! conic iterations, and only the fixture sweep saw it.
+//!
+//! So the pre-Q3 recognizer is kept here verbatim as an oracle, and the two
+//! are compared **bitwise** — not to a tolerance — on:
+//!
+//! * every objective and every constraint row of every `.nl` file in the
+//!   repository, which covers rows no fixture's *solve* reaches;
+//! * a deterministic pseudo-random battery of small expression trees, which
+//!   covers operator combinations the corpus happens not to contain.
+//!
+//! The oracle cannot be run at depth — recursing is exactly what it did
+//! wrong — so the deep-tree tests live next to the new recognizer in
+//! `pounce-nl`, where there is nothing to compare against.
+
+use std::cell::Cell;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use pounce_cli::nl_quadratic::{QuadForm, analyze_quadratic_full};
+use pounce_cli::nl_reader::{BinOp, Expr, UnaryOp, read_nl_file};
+
+// ---------------------------------------------------------------------
+// The oracle: the recognizer as it stood at 688ccd45, verbatim except for
+// the allocation counter and the dropped (already unused) `_n` argument.
+// ---------------------------------------------------------------------
+
+// Monomial keys the legacy recognizer put on the heap. Every `Vec` it
+// allocates as a map key is counted once; `Vec::new()` for the constant term
+// is not (it does not allocate) and neither is the reallocation
+// `extend_from_slice` may do inside `mul`, so this is a lower bound on what
+// the representation cost.
+//
+// Per thread, because the harness runs the tests in this file in parallel and
+// a shared counter would be counting all three of them.
+thread_local! {
+    static LEGACY_MONOMIAL_ALLOCS: Cell<usize> = const { Cell::new(0) };
+}
+
+fn bump() {
+    LEGACY_MONOMIAL_ALLOCS.with(|c| c.set(c.get() + 1));
+}
+
+fn allocs_so_far() -> usize {
+    LEGACY_MONOMIAL_ALLOCS.with(Cell::get)
+}
+
+type LegacyHessian = BTreeMap<(usize, usize), f64>;
+
+#[derive(Debug, Clone, Default)]
+struct Poly {
+    terms: BTreeMap<Vec<usize>, f64>,
+}
+
+impl Poly {
+    fn constant(c: f64) -> Self {
+        let mut terms = BTreeMap::new();
+        if c != 0.0 {
+            terms.insert(Vec::new(), c);
+        }
+        Poly { terms }
+    }
+
+    fn var(i: usize) -> Self {
+        let mut terms = BTreeMap::new();
+        bump();
+        terms.insert(vec![i], 1.0);
+        Poly { terms }
+    }
+
+    fn max_degree(&self) -> usize {
+        self.terms.keys().map(|m| m.len()).max().unwrap_or(0)
+    }
+
+    fn as_constant(&self) -> Option<f64> {
+        match self.terms.len() {
+            0 => Some(0.0),
+            1 => self.terms.get(&Vec::new()).copied(),
+            _ => None,
+        }
+    }
+
+    fn add(mut self, other: &Poly) -> Poly {
+        for (m, c) in &other.terms {
+            bump();
+            *self.terms.entry(m.clone()).or_insert(0.0) += c;
+        }
+        self.prune();
+        self
+    }
+
+    fn neg(mut self) -> Poly {
+        for c in self.terms.values_mut() {
+            *c = -*c;
+        }
+        self
+    }
+
+    fn scale(mut self, s: f64) -> Poly {
+        if s == 0.0 {
+            return Poly::default();
+        }
+        for c in self.terms.values_mut() {
+            *c *= s;
+        }
+        self
+    }
+
+    fn mul(&self, other: &Poly) -> Option<Poly> {
+        let mut out = Poly::default();
+        for (ma, ca) in &self.terms {
+            for (mb, cb) in &other.terms {
+                if ma.len() + mb.len() > 2 {
+                    return None;
+                }
+                bump();
+                let mut m = ma.clone();
+                m.extend_from_slice(mb);
+                m.sort_unstable();
+                *out.terms.entry(m).or_insert(0.0) += ca * cb;
+            }
+        }
+        out.prune();
+        Some(out)
+    }
+
+    fn prune(&mut self) {
+        self.terms.retain(|_, c| c.abs() > 0.0);
+    }
+}
+
+// The oracle is kept as it was written, including the shapes clippy would
+// rather see collapsed: an edit made to quiet a lint is an edit that could
+// change what it answers, which is the one thing it must not do.
+#[allow(clippy::collapsible_match)]
+fn to_poly(e: &Expr) -> Option<Poly> {
+    match e {
+        Expr::Const(c) => Some(Poly::constant(*c)),
+        Expr::Var(i) => Some(Poly::var(*i)),
+        Expr::Cse(body) => to_poly(body),
+        Expr::Sum(items) => {
+            let mut acc = Poly::default();
+            for it in items {
+                let p = to_poly(it)?;
+                for (m, c) in &p.terms {
+                    bump();
+                    *acc.terms.entry(m.clone()).or_insert(0.0) += c;
+                }
+            }
+            acc.prune();
+            Some(acc)
+        }
+        Expr::Unary(op, a) => match op {
+            UnaryOp::Neg => Some(to_poly(a)?.neg()),
+            _ => None,
+        },
+        Expr::Binary(op, a, b) => {
+            let pa = to_poly(a)?;
+            let pb = to_poly(b)?;
+            match op {
+                BinOp::Add => Some(pa.add(&pb)),
+                BinOp::Sub => Some(pa.add(&pb.neg())),
+                BinOp::Mul => pa.mul(&pb),
+                BinOp::Div => {
+                    let d = pb.as_constant()?;
+                    if d == 0.0 {
+                        None
+                    } else {
+                        Some(pa.scale(1.0 / d))
+                    }
+                }
+                BinOp::Pow => {
+                    let exp = pb.as_constant()?;
+                    if exp == 0.0 {
+                        Some(Poly::constant(1.0))
+                    } else if exp == 1.0 {
+                        Some(pa)
+                    } else if exp == 2.0 {
+                        pa.mul(&pa)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        }
+        Expr::Funcall { .. } => None,
+        _ => None,
+    }
+}
+
+fn legacy_analyze(e: &Expr) -> Option<QuadForm> {
+    let poly = to_poly(e)?;
+    if poly.max_degree() > 2 {
+        return None;
+    }
+    let mut h: LegacyHessian = BTreeMap::new();
+    let mut lin: Vec<(usize, f64)> = Vec::new();
+    let mut constant = 0.0;
+    for (vars, coef) in &poly.terms {
+        match vars.as_slice() {
+            [] => constant += *coef,
+            [i] => lin.push((*i, *coef)),
+            [i, j] => {
+                let (i, j) = (*i.min(j), *i.max(j));
+                let contrib = if i == j { 2.0 * coef } else { *coef };
+                *h.entry((i, j)).or_insert(0.0) += contrib;
+            }
+            _ => return None,
+        }
+    }
+    h.retain(|_, v| v.abs() > 0.0);
+    Some((h, lin, constant))
+}
+
+// ---------------------------------------------------------------------
+// Bitwise comparison
+// ---------------------------------------------------------------------
+
+/// Equality down to the bit pattern of every coefficient, including the
+/// sign of zero. `assert_eq!` on `f64` would call `2.0 == 2.0000000000000004`
+/// unequal too, but it would call `0.0 == -0.0` equal, and the whole point
+/// of this file is that "close enough" is not the property being checked.
+fn identical(a: &Option<QuadForm>, b: &Option<QuadForm>) -> bool {
+    match (a, b) {
+        (None, None) => true,
+        (Some((ha, la, ca)), Some((hb, lb, cb))) => {
+            ha.len() == hb.len()
+                && ha
+                    .iter()
+                    .zip(hb.iter())
+                    .all(|((ka, va), (kb, vb))| ka == kb && va.to_bits() == vb.to_bits())
+                && la.len() == lb.len()
+                && la
+                    .iter()
+                    .zip(lb.iter())
+                    .all(|((ia, va), (ib, vb))| ia == ib && va.to_bits() == vb.to_bits())
+                && ca.to_bits() == cb.to_bits()
+        }
+        _ => false,
+    }
+}
+
+fn check(e: &Expr, what: &str) {
+    let old = legacy_analyze(e);
+    let new = analyze_quadratic_full(e);
+    assert!(
+        identical(&old, &new),
+        "{what}: the Q3 recognizer disagrees with the one it replaced\n  \
+         legacy = {old:?}\n  quad2  = {new:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// The corpus
+// ---------------------------------------------------------------------
+
+fn all_fixtures() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().is_some_and(|x| x == "nl") {
+                out.push(p);
+            }
+        }
+    }
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut out = Vec::new();
+    walk(&base.join("fixtures"), &mut out);
+    walk(&base.join("fixtures_issue_49"), &mut out);
+    out.sort();
+    out
+}
+
+/// Every nonlinear part of every model in the repository, read both ways.
+///
+/// This is deliberately wider than the fixture sweep: the sweep only sees
+/// rows that a *solve* depends on, and a recognizer that got a row wrong in
+/// a model that solves anyway would slip through it.
+#[test]
+fn every_fixture_row_reads_identically_under_both_recognizers() {
+    let fixtures = all_fixtures();
+    assert!(
+        fixtures.len() >= 50,
+        "expected the fixture corpus, found {} files",
+        fixtures.len()
+    );
+    let mut rows = 0usize;
+    let mut quadratic = 0usize;
+    for f in &fixtures {
+        let Ok(prob) = read_nl_file(f) else { continue };
+        let name = f.display();
+        check(&prob.obj_nonlinear, &format!("{name}: objective"));
+        rows += 1;
+        if analyze_quadratic_full(&prob.obj_nonlinear).is_some() {
+            quadratic += 1;
+        }
+        for (i, c) in prob.con_nonlinear.iter().enumerate() {
+            check(c, &format!("{name}: row {i}"));
+            rows += 1;
+            if analyze_quadratic_full(c).is_some() {
+                quadratic += 1;
+            }
+        }
+    }
+    // Not a target, a floor: if a refactor ever leaves this test walking a
+    // handful of rows it should fail rather than pass vacuously.
+    // Measured on this corpus: 1631 objectives and rows, of which 1131 are
+    // recognized as degree ≤ 2 and 500 are not.
+    assert!(
+        rows > 1_500 && quadratic > 1_000 && rows - quadratic > 400,
+        "the corpus should exercise both answers: {rows} rows, {quadratic} recognized"
+    );
+}
+
+// ---------------------------------------------------------------------
+// A random battery
+// ---------------------------------------------------------------------
+
+/// A deterministic xorshift, so a failure is reproducible from the seed
+/// printed in the assertion rather than "sometimes".
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn below(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+}
+
+/// A small random expression over 4 variables, deep enough to nest but
+/// shallow enough that the recursive oracle survives it.
+fn random_expr(rng: &mut Rng, depth: u32) -> Expr {
+    // Constants are drawn from a set with exact and inexact members, so
+    // both `x/3` (inexact reciprocal) and `x/2` (exact) get exercised.
+    const CONSTS: [f64; 8] = [0.0, 1.0, 2.0, 3.0, -1.0, 0.5, 1e-8, 1e8];
+    if depth == 0 || rng.below(4) == 0 {
+        return if rng.below(2) == 0 {
+            Expr::Var(rng.below(4) as usize)
+        } else {
+            Expr::Const(CONSTS[rng.below(8) as usize])
+        };
+    }
+    match rng.below(10) {
+        0 => Expr::Binary(
+            BinOp::Add,
+            Box::new(random_expr(rng, depth - 1)),
+            Box::new(random_expr(rng, depth - 1)),
+        ),
+        1 => Expr::Binary(
+            BinOp::Sub,
+            Box::new(random_expr(rng, depth - 1)),
+            Box::new(random_expr(rng, depth - 1)),
+        ),
+        2 => Expr::Binary(
+            BinOp::Mul,
+            Box::new(random_expr(rng, depth - 1)),
+            Box::new(random_expr(rng, depth - 1)),
+        ),
+        3 => Expr::Binary(
+            BinOp::Div,
+            Box::new(random_expr(rng, depth - 1)),
+            Box::new(random_expr(rng, depth - 1)),
+        ),
+        4 => Expr::Binary(
+            BinOp::Pow,
+            Box::new(random_expr(rng, depth - 1)),
+            Box::new(random_expr(rng, depth - 1)),
+        ),
+        5 => Expr::Unary(UnaryOp::Neg, Box::new(random_expr(rng, depth - 1))),
+        // A transcendental, so the bail-out paths are exercised too.
+        6 => Expr::Unary(UnaryOp::Sin, Box::new(random_expr(rng, depth - 1))),
+        7 => Expr::Cse(std::sync::Arc::new(random_expr(rng, depth - 1))),
+        _ => {
+            let n = 1 + rng.below(4) as usize;
+            Expr::Sum((0..n).map(|_| random_expr(rng, depth - 1)).collect())
+        }
+    }
+}
+
+#[test]
+fn random_expression_battery_reads_identically_under_both_recognizers() {
+    let mut recognized = 0usize;
+    let mut refused = 0usize;
+    for seed in 1..=4_000u64 {
+        let mut rng = Rng(seed.wrapping_mul(0x9e37_79b9_7f4a_7c15) | 1);
+        let e = random_expr(&mut rng, 5);
+        let old = legacy_analyze(&e);
+        let new = analyze_quadratic_full(&e);
+        assert!(
+            identical(&old, &new),
+            "seed {seed}: the Q3 recognizer disagrees with the one it replaced\n  \
+             expr   = {e:?}\n  legacy = {old:?}\n  quad2  = {new:?}"
+        );
+        if new.is_some() {
+            recognized += 1;
+        } else {
+            refused += 1;
+        }
+    }
+    // Both verdicts have to be represented or the battery proves nothing.
+    assert!(
+        recognized > 200 && refused > 200,
+        "battery is one-sided: {recognized} recognized, {refused} refused"
+    );
+}
+
+// ---------------------------------------------------------------------
+// What the representation cost
+// ---------------------------------------------------------------------
+
+/// The allocation the phase removed, stated as a number.
+///
+/// One dense quadratic row over 500 variables — the `qcqp500-3c` shape —
+/// expands to ~n²/2 monomials, and the legacy representation put every one
+/// of them on the heap as its own `Vec`, allocating another on every merge.
+/// `Quad2` keys its terms on `usize` and `(usize, usize)` inline, so the
+/// per-monomial allocation is not reduced, it is gone: the count below is
+/// structurally zero for the new recognizer, which is why only the legacy
+/// side is instrumented.
+///
+/// The classifier expands each row two or three times per solve (class,
+/// convexity, extraction), and a benchmark instance has ten such rows —
+/// which is where the design note's "2.32 M `Vec`s per pass" came from. The
+/// single-row count asserted here is the part that can be measured in a
+/// unit test on any machine.
+#[test]
+fn legacy_representation_allocated_one_vec_per_monomial() {
+    let n = 500usize;
+    // (Σ xᵢ)² — one dense row, n(n+1)/2 distinct monomials.
+    let row = Expr::Binary(
+        BinOp::Pow,
+        Box::new(Expr::Sum((0..n).map(Expr::Var).collect())),
+        Box::new(Expr::Const(2.0)),
+    );
+
+    let before = allocs_so_far();
+    let old = legacy_analyze(&row);
+    let allocs = allocs_so_far() - before;
+    let new = analyze_quadratic_full(&row);
+    assert!(identical(&old, &new), "dense row must read identically");
+
+    let monomials = old.expect("dense row is quadratic").0.len();
+    assert_eq!(monomials, n * (n + 1) / 2);
+    // n² keys from the product (one per pair of factors, before any of them
+    // are merged), plus n merging the sum, plus n for the variables
+    // themselves. For a 500-variable row that is 251 000 heap allocations to
+    // describe 125 250 distinct monomials — and the classifier expands each
+    // row two or three times per solve.
+    assert_eq!(
+        allocs,
+        n * n + 2 * n,
+        "the legacy monomial-key allocation count is the number this phase removed"
+    );
+}

--- a/crates/pounce-nl/src/lib.rs
+++ b/crates/pounce-nl/src/lib.rs
@@ -12,6 +12,10 @@
 //!   `funcadd_ASL` ABI.
 //! - [`nl_fbbt_translate`] lowers an `Expr` to an `FbbtTape` for
 //!   feasibility-based bound tightening.
+//! - [`nl_quadratic`] recognizes a degree-≤2 polynomial in an `Expr` DAG and
+//!   reads off its Hessian, linear part, and constant — the algebra behind
+//!   the CLI's LP/QP/QCQP routing, kept here so the evaluator and the
+//!   extractors can share it.
 //! - [`sol_writer`] is the reader's inverse: it formats a solve's primals,
 //!   duals, and suffixes as an AMPL `.sol` file. It lives here (rather than
 //!   in the CLI, which owned it until the browser frontend needed it too) so
@@ -24,6 +28,7 @@
 
 pub mod nl_external;
 pub mod nl_fbbt_translate;
+pub mod nl_quadratic;
 pub mod nl_reader;
 pub mod nl_tape;
 pub mod sol_writer;

--- a/crates/pounce-nl/src/nl_quadratic.rs
+++ b/crates/pounce-nl/src/nl_quadratic.rs
@@ -1,0 +1,605 @@
+//! Degree-≤2 recognition over an [`Expr`] DAG.
+//!
+//! This is the classifier's "is this row a quadratic, and which one?"
+//! question, answered once and reused. `pounce-cli`'s `dispatch` owns the
+//! *routing* decision (which `ProblemClass`, which solver); what lives here
+//! is only the algebra, so the consumers that are not the CLI —
+//! `NlTnlp`'s constant-structure evaluation, the parse-time recognizer, the
+//! `QcqpProblem` extractor — can reach it without depending on the
+//! command-line driver. It moved out of `pounce-cli/src/dispatch.rs` in
+//! Q3 of the #588 series; see
+//! `dev-notes/quadratic-structure-exploitation.md`.
+//!
+//! ## Two properties this module is built around
+//!
+//! **It is iterative.** The walk carries its own work stack rather than
+//! recursing, because the trees it is handed are not shallow: a `.nl`
+//! writer that emits `o0` (binary `+`) chains for a long sum — Pyomo does —
+//! produces a left-deep `Add` tree one level per term. The recursive
+//! predecessor aborted the process somewhere between 4 000 and 6 000 terms
+//! on a 2 MB thread (which is what a test gets, and where the crash was
+//! first reproduced) and between 16 000 and 24 000 on the CLI's 8 MB main
+//! thread. A stack overflow is an abort, not an error return, so the depth a
+//! *recognizer* survives must not depend on which thread called it.
+//!
+//! It is worth knowing what this does **not** fix: `nl_reader`'s parser
+//! recurses too, with a fatter frame — it gives out at ~6 000 on that same
+//! 8 MB thread — so a deep `.nl` file still fails to load, and it fails
+//! before reaching this module. What is fixed is every path where the tree
+//! is already built (`NlProblem::from_expressions`, a model handed across
+//! threads) and the ceiling this module used to impose on the parser's
+//! successor.
+//!
+//! **It never allocates per monomial.** The predecessor keyed monomials on
+//! `BTreeMap<Vec<usize>, f64>`, so every term cost a heap allocation and
+//! every merge cloned one (`entry(m.clone())`). A degree-≤2 form has only
+//! three shapes of term, so [`Quad2`] stores them in three fields with
+//! inline keys and the allocation disappears. The same change removes the
+//! `O(N²)` accumulation on `Add` chains: the old `add` re-scanned the whole
+//! accumulated map for zeros on *every* merge, which is quadratic down a
+//! left-deep chain. Zeros can only appear where a merge touched, so that is
+//! all this one looks at.
+
+use crate::nl_reader::{BinOp, Expr, UnaryOp};
+use std::collections::BTreeMap;
+
+/// The symmetric Hessian of a quadratic form, stored as a sparse upper-
+/// triangular (i ≤ j) map of `(i, j) -> ∂²/∂xᵢ∂xⱼ`. Empty means the
+/// expression is (at most) linear.
+pub type QuadHessian = BTreeMap<(usize, usize), f64>;
+
+/// Full quadratic read-out: `(Hessian, [(var, linear coef), …], constant)`.
+/// The linear and constant parts are the pieces AMPL/Pyomo fold into the
+/// nonlinear objective tree (see [`analyze_quadratic_full`]).
+pub type QuadForm = (QuadHessian, Vec<(usize, f64)>, f64);
+
+/// A polynomial of total degree ≤ 2 in its own shape: a constant, the
+/// linear coefficients keyed by variable, and the quadratic coefficients
+/// keyed by the (i ≤ j) variable pair.
+///
+/// This replaces a general `BTreeMap<Vec<usize>, f64>` polynomial. Degree
+/// is a property of the *type* here rather than of the data, so the
+/// "is it still quadratic?" test is three `is_empty()` calls instead of a
+/// scan, and no monomial key is ever allocated or cloned.
+///
+/// ### Zero coefficients
+///
+/// Stored coefficients are nonzero: [`add`](Quad2::add) and
+/// [`mul`](Quad2::mul) drop any entry they leave at exactly zero, which is
+/// what makes [`degree`](Quad2::degree) and [`as_constant`](Quad2::as_constant)
+/// answerable in `O(1)`. `constant` is the one exception and needs none:
+/// both `0.0` and `-0.0` in that field mean "no constant term", every
+/// consumer guards on `!= 0.0`, and [`analyze_quadratic_full`] normalizes
+/// the sign on the way out.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Quad2 {
+    constant: f64,
+    linear: BTreeMap<usize, f64>,
+    quadratic: QuadHessian,
+}
+
+impl Quad2 {
+    /// The degree-0 term.
+    pub fn constant(&self) -> f64 {
+        self.constant
+    }
+
+    /// The degree-1 terms, ascending by variable index.
+    pub fn linear(&self) -> &BTreeMap<usize, f64> {
+        &self.linear
+    }
+
+    /// The degree-2 terms as *polynomial* coefficients keyed `(i ≤ j)` —
+    /// the coefficient of `xᵢxⱼ`, **not** the Hessian entry (they differ by
+    /// a factor of 2 on the diagonal; [`analyze_quadratic_full`] applies it).
+    pub fn quadratic(&self) -> &QuadHessian {
+        &self.quadratic
+    }
+
+    fn of_constant(c: f64) -> Self {
+        Quad2 {
+            // `-0.0` and `0.0` alike mean "no constant term"; normalizing
+            // here keeps `Neg(Const(0.0))` from reporting `-0.0`.
+            constant: if c != 0.0 { c } else { 0.0 },
+            ..Quad2::default()
+        }
+    }
+
+    fn of_var(i: usize) -> Self {
+        let mut q = Quad2::default();
+        q.linear.insert(i, 1.0);
+        q
+    }
+
+    /// Total degree: 0, 1, or 2.
+    fn degree(&self) -> usize {
+        if !self.quadratic.is_empty() {
+            2
+        } else if !self.linear.is_empty() {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// The value, when this form has no variables in it.
+    fn as_constant(&self) -> Option<f64> {
+        (self.degree() == 0).then_some(self.constant)
+    }
+
+    /// Number of stored (nonzero) variable terms.
+    fn width(&self) -> usize {
+        self.linear.len() + self.quadratic.len()
+    }
+
+    /// `a + b`.
+    ///
+    /// Two things here are not incidental. **Only the entries the smaller
+    /// side contributes are re-checked for zero** — the predecessor
+    /// re-scanned the whole accumulated map on every merge, which is `O(k²)`
+    /// down a `k`-term `Add` chain, and an `o0` chain is how a long sum
+    /// reaches this code. And **the smaller side is merged into the larger**,
+    /// whichever operand it is, so the same chain costs `O(k log k)` leaning
+    /// either way rather than only when it leans left. Choosing the direction
+    /// is free of arithmetic consequence: IEEE addition is commutative bit
+    /// for bit, `-0.0` included.
+    fn add(a: Quad2, b: Quad2) -> Quad2 {
+        let (mut acc, small) = if a.width() >= b.width() {
+            (a, b)
+        } else {
+            (b, a)
+        };
+        if small.constant != 0.0 {
+            acc.constant += small.constant;
+        }
+        for (i, c) in &small.linear {
+            merge(&mut acc.linear, *i, *c);
+        }
+        for (k, c) in &small.quadratic {
+            merge(&mut acc.quadratic, *k, *c);
+        }
+        acc
+    }
+
+    fn neg(mut self) -> Quad2 {
+        self.constant = -self.constant;
+        for c in self.linear.values_mut() {
+            *c = -*c;
+        }
+        for c in self.quadratic.values_mut() {
+            *c = -*c;
+        }
+        self
+    }
+
+    fn scale(mut self, s: f64) -> Quad2 {
+        if s == 0.0 {
+            return Quad2::default();
+        }
+        self.constant *= s;
+        for c in self.linear.values_mut() {
+            *c *= s;
+        }
+        for c in self.quadratic.values_mut() {
+            *c *= s;
+        }
+        self
+    }
+
+    /// `self · other`, or `None` when the product would exceed total
+    /// degree 2 — past that the recognizer gives up and the caller routes
+    /// to the general NLP path.
+    fn mul(&self, other: &Quad2) -> Option<Quad2> {
+        if self.degree() + other.degree() > 2 {
+            return None;
+        }
+        let mut out = Quad2::default();
+        if self.constant != 0.0 && other.constant != 0.0 {
+            out.constant = self.constant * other.constant;
+        }
+        // constant × (linear, quadratic), both ways round.
+        for (a, b) in [(self, other), (other, self)] {
+            if a.constant == 0.0 {
+                continue;
+            }
+            for (i, c) in &b.linear {
+                *out.linear.entry(*i).or_insert(0.0) += a.constant * c;
+            }
+            for (k, c) in &b.quadratic {
+                *out.quadratic.entry(*k).or_insert(0.0) += a.constant * c;
+            }
+        }
+        // linear × linear. The degree guard above means at most one of the
+        // two operands carries quadratic terms, so this runs only when
+        // neither does and no ordering question arises.
+        for (i, a) in &self.linear {
+            for (j, b) in &other.linear {
+                let key = (*i.min(j), *i.max(j));
+                *out.quadratic.entry(key).or_insert(0.0) += a * b;
+            }
+        }
+        out.linear.retain(|_, c| is_live(*c));
+        out.quadratic.retain(|_, c| is_live(*c));
+        Some(out)
+    }
+}
+
+/// Add `c` to `map[key]`, keeping the "no stored zeros" invariant.
+///
+/// Only the touched key can have become zero, which is what keeps a merge
+/// proportional to what it merged rather than to what it merged *into*.
+fn merge<K: Ord>(map: &mut BTreeMap<K, f64>, key: K, c: f64) {
+    use std::collections::btree_map::Entry;
+    match map.entry(key) {
+        Entry::Occupied(mut e) => {
+            let v = *e.get() + c;
+            if is_live(v) {
+                e.insert(v);
+            } else {
+                e.remove();
+            }
+        }
+        Entry::Vacant(e) => {
+            if is_live(c) {
+                e.insert(c);
+            }
+        }
+    }
+}
+
+/// Is this coefficient worth storing? Exact zeros are dropped so that
+/// "has a quadratic term" is a structural question; `NaN` is dropped for
+/// the same reason its predecessor's `c.abs() > 0.0` retention dropped it.
+fn is_live(c: f64) -> bool {
+    c.abs() > 0.0
+}
+
+/// One entry on the recognizer's explicit work stack.
+enum Step<'a> {
+    /// Lower this subexpression onto the value stack.
+    Visit(&'a Expr),
+    /// Combine values already on the value stack.
+    Apply(Op),
+}
+
+/// A pending combination, popped once its operands have been lowered.
+enum Op {
+    Neg,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Pow,
+    /// n-ary sum over the top `n` values.
+    Sum(usize),
+}
+
+/// Lower an [`Expr`] to a [`Quad2`], or `None` if it contains anything the
+/// recognizer cannot prove is a degree-≤2 polynomial (transcendental ops,
+/// division by a non-constant, `Pow` with an exponent ∉ {0, 1, 2}, products
+/// of degree > 2, external calls, comparisons, `if-then-else`, `min`/`max`,
+/// …). `None` ⇒ treat as general nonlinear.
+///
+/// `Cse` nodes are inlined: a reference is mathematically its body, and
+/// every reference is an independent occurrence. A body reached `r` times
+/// is therefore lowered `r` times, exactly as the recursive predecessor did
+/// — memoizing on the `Arc` identity is a pure win still on the table for
+/// Q5, not a behaviour change made here.
+///
+/// The walk is iterative. See the module docs for why that is a
+/// correctness property and not a style choice.
+pub fn recognize_expr(e: &Expr) -> Option<Quad2> {
+    let mut work: Vec<Step<'_>> = vec![Step::Visit(e)];
+    let mut vals: Vec<Quad2> = Vec::new();
+
+    while let Some(step) = work.pop() {
+        match step {
+            Step::Visit(e) => match e {
+                Expr::Const(c) => vals.push(Quad2::of_constant(*c)),
+                Expr::Var(i) => vals.push(Quad2::of_var(*i)),
+                Expr::Cse(body) => work.push(Step::Visit(body)),
+                Expr::Sum(items) => {
+                    work.push(Step::Apply(Op::Sum(items.len())));
+                    // Pushed forward, so they pop back to front and land on
+                    // the value stack with item 0 on top — the sum then
+                    // accumulates front to back, the order the recursive
+                    // version summed in.
+                    for it in items {
+                        work.push(Step::Visit(it));
+                    }
+                }
+                Expr::Unary(UnaryOp::Neg, a) => {
+                    work.push(Step::Apply(Op::Neg));
+                    work.push(Step::Visit(a));
+                }
+                // Every other unary op is transcendental.
+                Expr::Unary(..) => return None,
+                Expr::Binary(op, a, b) => {
+                    let op = match op {
+                        BinOp::Add => Op::Add,
+                        BinOp::Sub => Op::Sub,
+                        BinOp::Mul => Op::Mul,
+                        BinOp::Div => Op::Div,
+                        BinOp::Pow => Op::Pow,
+                        // atan2 and any other binary opcode.
+                        _ => return None,
+                    };
+                    work.push(Step::Apply(op));
+                    // `b` under `a`: `a` pops first and is lowered first.
+                    work.push(Step::Visit(b));
+                    work.push(Step::Visit(a));
+                }
+                // External calls are opaque; comparisons, logicals,
+                // conditionals and n-ary min/max are the control-flow `.nl`
+                // opcodes. None is provably polynomial ⇒ route to NLP.
+                _ => return None,
+            },
+            Step::Apply(op) => {
+                let combined = match op {
+                    Op::Sum(n) => {
+                        // The items are the top `n` values, item 0 on top.
+                        let at = vals.len().checked_sub(n)?;
+                        let mut acc = Quad2::default();
+                        for p in vals.drain(at..) {
+                            acc = Quad2::add(acc, p);
+                        }
+                        acc
+                    }
+                    Op::Neg => vals.pop()?.neg(),
+                    Op::Add => {
+                        let (a, b) = pop2(&mut vals)?;
+                        Quad2::add(a, b)
+                    }
+                    Op::Sub => {
+                        let (a, b) = pop2(&mut vals)?;
+                        Quad2::add(a, b.neg())
+                    }
+                    Op::Mul => {
+                        let (a, b) = pop2(&mut vals)?;
+                        a.mul(&b)?
+                    }
+                    Op::Div => {
+                        // Division is polynomial only by a nonzero constant,
+                        // and scales by the reciprocal (not `c / d`) so the
+                        // arithmetic matches what the recursive predecessor
+                        // produced bit for bit.
+                        let (a, b) = pop2(&mut vals)?;
+                        let d = b.as_constant()?;
+                        if d == 0.0 {
+                            return None;
+                        }
+                        a.scale(1.0 / d)
+                    }
+                    Op::Pow => {
+                        // Polynomial only for constant exponents in {0, 1, 2}.
+                        let (a, b) = pop2(&mut vals)?;
+                        let exp = b.as_constant()?;
+                        if exp == 0.0 {
+                            Quad2::of_constant(1.0)
+                        } else if exp == 1.0 {
+                            a
+                        } else if exp == 2.0 {
+                            a.mul(&a)?
+                        } else {
+                            return None;
+                        }
+                    }
+                };
+                vals.push(combined);
+            }
+        }
+    }
+
+    debug_assert_eq!(vals.len(), 1, "one value per lowered expression");
+    vals.pop()
+}
+
+/// Pop a binary operator's two operands, left first.
+fn pop2(vals: &mut Vec<Quad2>) -> Option<(Quad2, Quad2)> {
+    let b = vals.pop()?;
+    let a = vals.pop()?;
+    Some((a, b))
+}
+
+/// Attempt to read an expression as a polynomial of total degree ≤ 2 and
+/// return its Hessian (constant, since the form is quadratic). `None` if
+/// the expression is not provably quadratic ⇒ treat as general nonlinear.
+pub fn analyze_quadratic(e: &Expr) -> Option<QuadHessian> {
+    analyze_quadratic_full(e).map(|(h, _, _)| h)
+}
+
+/// Like [`analyze_quadratic`] but also returns the degree-1 (linear)
+/// coefficients *and* the degree-0 (constant) term of the form:
+/// `(Hessian, [(var, coef), …], constant)`.
+///
+/// AMPL folds the linear part of a nonlinear term into the objective's
+/// nonlinear expression tree (the `−6·x₀` of `(x₀−3)²`, say) rather than
+/// the linear section. Callers building the QP objective vector `c` must
+/// add these in, exactly as the NLP path's `eval_f` sums the linear
+/// section *and* the nonlinear tree — otherwise the linear shift is
+/// silently dropped and the convex solve minimizes the wrong objective.
+///
+/// The **constant** is returned for the same reason: AMPL/Pyomo also fold
+/// the objective's degree-0 term into the nonlinear tree (the `+9` of
+/// `(x₀−3)²`), where it does *not* land in `NlProblem::obj_constant`. It
+/// is irrelevant to the minimizer but is part of the *reported objective
+/// value*; dropping it makes the convex solve report an objective off by
+/// that constant versus the NLP path.
+pub fn analyze_quadratic_full(e: &Expr) -> Option<QuadForm> {
+    let q = recognize_expr(e)?;
+    // ∂²(c·xᵢxⱼ)/∂xᵢ∂xⱼ = c for i≠j; ∂²(c·xᵢ²)/∂xᵢ² = 2c.
+    let mut h: QuadHessian = q
+        .quadratic
+        .iter()
+        .map(|(&(i, j), c)| ((i, j), if i == j { 2.0 * c } else { *c }))
+        .collect();
+    // Drop explicit zeros so `is_empty()` means "linear".
+    h.retain(|_, v| v.abs() > 0.0);
+    let lin: Vec<(usize, f64)> = q.linear.iter().map(|(i, c)| (*i, *c)).collect();
+    // `0.0 +` normalizes `-0.0`, which is how this form spells "absent".
+    Some((h, lin, 0.0 + q.constant))
+}
+
+/// True if the expression is the literal constant zero the `.nl` reader
+/// uses for "no nonlinear part".
+pub fn is_trivially_zero(e: &Expr) -> bool {
+    matches!(e, Expr::Const(c) if *c == 0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sq(i: usize) -> Expr {
+        Expr::Binary(
+            BinOp::Pow,
+            Box::new(Expr::Var(i)),
+            Box::new(Expr::Const(2.0)),
+        )
+    }
+
+    #[test]
+    fn quadratic_diagonal() {
+        // (x0 - 1)^2  =>  x0^2 - 2 x0 + 1
+        let e = Expr::Binary(
+            BinOp::Pow,
+            Box::new(Expr::Binary(
+                BinOp::Sub,
+                Box::new(Expr::Var(0)),
+                Box::new(Expr::Const(1.0)),
+            )),
+            Box::new(Expr::Const(2.0)),
+        );
+        let (h, lin, c) = analyze_quadratic_full(&e).expect("degree-2 polynomial");
+        assert_eq!(h.get(&(0, 0)), Some(&2.0));
+        assert_eq!(lin, vec![(0, -2.0)]);
+        assert_eq!(c, 1.0);
+    }
+
+    #[test]
+    fn cross_term_hessian() {
+        // x0 · x1 => H[0,1] = 1
+        let e = Expr::Binary(BinOp::Mul, Box::new(Expr::Var(0)), Box::new(Expr::Var(1)));
+        let h = analyze_quadratic(&e).expect("degree-2");
+        assert_eq!(h.get(&(0, 1)), Some(&1.0));
+    }
+
+    #[test]
+    fn rejects_transcendental_and_cubic() {
+        assert!(analyze_quadratic(&Expr::Unary(UnaryOp::Sin, Box::new(Expr::Var(0)))).is_none());
+        let cubic = Expr::Binary(
+            BinOp::Pow,
+            Box::new(Expr::Var(0)),
+            Box::new(Expr::Const(3.0)),
+        );
+        assert!(analyze_quadratic(&cubic).is_none());
+        // x0² · x1 — degree 3 by multiplication rather than by exponent.
+        let deg3 = Expr::Binary(BinOp::Mul, Box::new(sq(0)), Box::new(Expr::Var(1)));
+        assert!(analyze_quadratic(&deg3).is_none());
+    }
+
+    #[test]
+    fn division_by_a_constant_scales_by_the_reciprocal() {
+        // x0² / 3 — the coefficient must be `2 · (1/3)`, which is what the
+        // Hessian of `x0²/3` came out as before this module existed, and is
+        // *not* bitwise `2/3`.
+        let e = Expr::Binary(BinOp::Div, Box::new(sq(0)), Box::new(Expr::Const(3.0)));
+        let h = analyze_quadratic(&e).expect("degree-2");
+        assert_eq!(h.get(&(0, 0)), Some(&(2.0 * (1.0 / 3.0))));
+        // Division by a variable is not polynomial.
+        let e = Expr::Binary(BinOp::Div, Box::new(sq(0)), Box::new(Expr::Var(1)));
+        assert!(analyze_quadratic(&e).is_none());
+    }
+
+    #[test]
+    fn cancellation_drops_the_term_and_the_degree_with_it() {
+        // x0² − x0² is linear (empty Hessian), not a quadratic with a zero
+        // coefficient — otherwise `x0²−x0²` times `x1` would be refused as
+        // degree 3.
+        let zero = Expr::Binary(BinOp::Sub, Box::new(sq(0)), Box::new(sq(0)));
+        let h = analyze_quadratic(&zero).expect("degree-2 at worst");
+        assert!(h.is_empty());
+        let times_x1 = Expr::Binary(BinOp::Mul, Box::new(zero), Box::new(Expr::Var(1)));
+        assert!(analyze_quadratic(&times_x1).is_some());
+    }
+
+    #[test]
+    fn cse_bodies_are_inlined_at_every_reference() {
+        // c = x0; c · c is x0².
+        let body = std::sync::Arc::new(Expr::Var(0));
+        let e = Expr::Binary(
+            BinOp::Mul,
+            Box::new(Expr::Cse(body.clone())),
+            Box::new(Expr::Cse(body)),
+        );
+        let h = analyze_quadratic(&e).expect("degree-2");
+        assert_eq!(h.get(&(0, 0)), Some(&2.0));
+    }
+
+    #[test]
+    fn nary_sum_accumulates_front_to_back() {
+        // Σ xᵢ² over 5000 terms as one `o54` node.
+        const N: usize = 5000;
+        let e = Expr::Sum((0..N).map(sq).collect());
+        let h = analyze_quadratic(&e).expect("sum of squares is a QP");
+        assert_eq!(h.len(), N);
+        assert_eq!(h.get(&(N - 1, N - 1)), Some(&2.0));
+    }
+
+    /// The reason this module is iterative.
+    ///
+    /// A `.nl` writer that emits `o0` (binary `+`) chains for a long sum
+    /// hands the recognizer a left-deep `Add` tree one level deep per term.
+    /// The recursive predecessor aborted the process — a stack overflow is
+    /// not a catchable error — somewhere under 8 000 terms on a 2 MB thread
+    /// and under 24 000 on the CLI's 8 MB main thread. The depth below is
+    /// far past both, and the test runs on a **default-sized test thread**
+    /// deliberately: what a recognizer survives must not depend on who
+    /// called it.
+    ///
+    /// The tree is leaked rather than dropped, because `Expr`'s derived
+    /// `Drop` is still recursive and would overflow tearing this down.
+    /// That is a real and separate defect (pounce#472 works around it in
+    /// the Python bindings with a big-stack worker thread); it is not what
+    /// this test is measuring.
+    #[test]
+    fn deep_add_chain_does_not_overflow_the_stack() {
+        const K: usize = 250_000;
+        let mut e = sq(0);
+        for i in 1..K {
+            e = Expr::Binary(BinOp::Add, Box::new(e), Box::new(sq(i)));
+        }
+        let h = analyze_quadratic(&e).expect("a sum of squares is a QP at any depth");
+        assert_eq!(h.len(), K, "every xᵢ² contributes one diagonal entry");
+        assert_eq!(h.get(&(K - 1, K - 1)), Some(&2.0));
+        std::mem::forget(e);
+    }
+
+    /// Same shape, right-deep — the value stack, not the work stack, is
+    /// what grows here. Both live on the heap.
+    #[test]
+    fn deep_right_leaning_chain_does_not_overflow_the_stack() {
+        const K: usize = 250_000;
+        let mut e = sq(K - 1);
+        for i in (0..K - 1).rev() {
+            e = Expr::Binary(BinOp::Add, Box::new(sq(i)), Box::new(e));
+        }
+        let h = analyze_quadratic(&e).expect("a sum of squares is a QP at any depth");
+        assert_eq!(h.len(), K);
+        std::mem::forget(e);
+    }
+
+    /// A non-quadratic node deep inside a deep tree must return `None`
+    /// rather than unwind — the bail-out path drops the work and value
+    /// stacks, and neither is recursive.
+    #[test]
+    fn deep_chain_with_a_transcendental_bails_without_overflowing() {
+        const K: usize = 250_000;
+        let mut e = Expr::Unary(UnaryOp::Sin, Box::new(Expr::Var(0)));
+        for i in 1..K {
+            e = Expr::Binary(BinOp::Add, Box::new(e), Box::new(sq(i)));
+        }
+        assert!(analyze_quadratic(&e).is_none());
+        std::mem::forget(e);
+    }
+}

--- a/dev-notes/quadratic-structure-exploitation.md
+++ b/dev-notes/quadratic-structure-exploitation.md
@@ -30,7 +30,7 @@ describes.
 | Q0 — control experiments (no ship) | **done** | (this commit) | Q10 cut; Q9 premise revised — see §0a |
 | Q1 — sparse SOC extraction + cost-model routing | **done** | (this commit) | extractor fixed (134 GB/row → 32 B/row); routing **unchanged** — the note's forecast was wrong, see §0b |
 | Q2 — `.nl` header nonlinearity counts | **done** | (this commit) | census kept; `get_number_of_nonlinear_variables` implemented (60/60 fixtures answer, was `-1`); the LP-fast-path forecast was wrong and was **not** shipped — see §0c |
-| Q3 — recognizer to `pounce-nl`, `Poly` → `Quad2` | pending | — | — |
+| Q3 — recognizer to `pounce-nl`, `Poly` → `Quad2` | **done** | (this commit) | recognizer iterative and allocation-free per monomial; classification of an `o0` chain was `O(k²)` and is now linear (k=16 000: 0.77 s → 0.020 s); the crash Q1 reported is real but unreachable through the CLI — see §0d |
 | Q4 — `QuadraticStructure` + `NlTnlp` fast path | pending | — | — |
 | Q5 — parse-time recognition | pending | — | — |
 | Q6 — the four constant-derivative hints | pending | — | — |
@@ -322,6 +322,146 @@ L-BFGS ignores the linear-variable hint, so the wrappers in
 worth stating plainly: Q2's deliverable is a correct answer where there was a
 `-1`, a diagnostic where there was silence, and a measured refutation of the
 routing shortcut the note proposed.
+
+---
+
+## 0d. Q3 — the recognizer moves to `pounce-nl` and stops recursing (measured 2026-08-18)
+
+### What shipped
+
+1. **`pounce_nl::nl_quadratic`.** Degree-≤2 recognition left
+   `pounce-cli/src/dispatch.rs` for the crate that owns the `Expr` DAG, so
+   Q4's `NlTnlp` fast path, Q5's parse-time recognizer, and Q7's
+   `QcqpProblem` extractor can reach it without depending on the CLI.
+   `dispatch` keeps the *routing* — which `ProblemClass`, which guard — and
+   re-exports `analyze_quadratic`/`analyze_quadratic_full`/
+   `is_trivially_zero`, so no call site in `qp_extract` or the tests moved.
+   `header_census` stayed with the verdict it prints: it is a *classifier*
+   diagnostic about the `.nl` header, not part of the algebra.
+
+2. **`Quad2` replaces `Poly`.** A degree-≤2 form has three shapes of term, so
+   it gets three fields — `f64`, `BTreeMap<usize, f64>`,
+   `BTreeMap<(usize, usize), f64>` — with keys that live inline. Degree
+   becomes a property of the type rather than of the data, and the
+   `Vec<usize>` monomial key, allocated once per term and cloned once per
+   merge, is gone.
+
+3. **`recognize_expr` is iterative**, carrying its own work and value stacks.
+
+4. **The zero-scan is proportional to what was merged**, not to what it was
+   merged into, and a merge folds the smaller side into the larger whichever
+   operand that is (IEEE addition is commutative bit for bit, so choosing the
+   direction cannot change an answer).
+
+### Measured: the shape the note is actually about
+
+A left-deep `Add` chain of `k` squares — what a `.nl` writer that emits `o0`
+for a long sum produces — classified on an 8 MB stack, release build:
+
+| k | before | after | |
+|---|---|---|---|
+| 1 000 | 0.0044 s | 0.0006 s | 7.3× |
+| 2 000 | 0.0133 s | 0.0017 s | 7.8× |
+| 4 000 | 0.0481 s | 0.0030 s | 16× |
+| 8 000 | 0.1800 s | 0.0066 s | 27× |
+| 16 000 | 0.7697 s | 0.0197 s | **39×** |
+| 24 000 | **stack overflow (abort)** | 0.0254 s | — |
+| 100 000 | stack overflow | 0.1017 s | — |
+| 1 000 000 | stack overflow | 1.1030 s | — |
+
+Before is `O(k²)`; after is linear (10× the width costs 10.8× the time from
+100 k to 1 M). **The `O(N²)` the note blames for the >300 s classifier hang
+was still live**, on this shape, today — see the correction below.
+
+A dense row `(Σᵢxᵢ)²` written as one n-ary `Sum`, i.e. the path that fix
+*did* cover, is a pure representation win:
+
+| n | before | after | |
+|---|---|---|---|
+| 100 | 0.0085 s | 0.0043 s | 2.0× |
+| 200 | 0.0342 s | 0.0167 s | 2.0× |
+| 500 | 0.3028 s | 0.1270 s | 2.4× |
+| 1 000 | 1.4178 s | 0.6646 s | 2.1× |
+
+**Allocations.** Expanding that row costs the legacy form exactly `n² + 2n`
+monomial `Vec`s — 251 000 at `n = 500`, to describe 125 250 distinct
+monomials — and the classifier expands each row two or three times per
+solve, so the note's "2.32 M `Vec`s per pass" for a ten-row `qcqp500-3c` is
+corroborated rather than refuted. `Quad2` allocates none of them: the count
+is not reduced, the category is gone. `crates/pounce-cli/tests/quad_recognizer_differential.rs`
+pins the legacy number so the claim stays a measurement.
+
+**The corpus.** Total classification time over all 62 `.nl` files in the
+repo: 4.61–5.06 ms → 3.75–3.96 ms, the heaviest single file (`airport.nl`)
+3.35 ms → 2.32 ms. Real, and immaterial: five milliseconds is not a solve.
+
+### The crash Q1 found is real, and unreachable through the CLI
+
+Q1 reproduced a stack overflow in `to_poly` while building a ~5 000-term
+separable constraint and pinned its test at `k = 1 000`. That reproduces —
+on a **2 MB thread**, which is what the test harness gives a test. The
+threshold depends on the caller:
+
+| stack | before | after |
+|---|---|---|
+| 2 MB (a test thread) | classifies 4 000, aborts by 6 000 | 1 000 000 ✓ |
+| 8 MB (the CLI's main thread) | classifies 16 000, aborts by 24 000 | 1 000 000 ✓ |
+
+But on the CLI's `.nl` route the recognizer is **not the first thing to
+fall over**. `read_nl_file` recurses too, with a fatter frame: on generated
+`.nl` files carrying exactly this shape, the parser classifies `k = 5 000`
+and aborts at `k = 6 000` — before `to_poly` is ever called, and identically
+before and after this commit (rc 134, "has overflowed its stack", both
+binaries). So:
+
+* the recognizer's ceiling is gone, and it is no longer what limits `k` in
+  `wide_diagonal_convex_qcqp_keeps_conic` (pin raised 1 000 → 100 000);
+* the crash is reachable from any caller whose stack is smaller than the one
+  the tree was built on — a test thread today, a thread pool or an embedder
+  tomorrow, and `NlProblem::from_expressions` models that never went through
+  the parser at all;
+* **the recursive parser is now the lowest ceiling on this shape.** That is
+  a defect Q5 inherits, not one Q3 fixed, and this note should not be read
+  as claiming a deep `.nl` file loads now. It does not.
+
+`Expr`'s derived `Drop` is recursive for the same reason and is untouched
+here; the deep tests leak their trees deliberately rather than pretend
+otherwise.
+
+### No trajectory change — asserted, not assumed
+
+* `scripts/sweep-fixtures.sh`, 57 models: **diff empty**.
+* `Problem class:` line over all 62 `.nl` files: **diff empty**.
+* **A differential test is the stronger claim.** The pre-Q3 recognizer is
+  kept verbatim as an oracle in
+  `crates/pounce-cli/tests/quad_recognizer_differential.rs`, and the two are
+  compared **bitwise** — coefficient bit patterns, sign of zero included —
+  on every objective and every row of every `.nl` file in the repository
+  (1 631 expressions, 1 131 recognized and 500 refused) and on a
+  deterministic 4 000-sample random-expression battery. That covers rows no
+  fixture's *solve* reaches, which is what the sweep cannot do. Q1's 2-ulp
+  line is why this is bitwise and not `assert_relative_eq`.
+
+The one place the two can differ is documented rather than papered over: a
+coefficient that underflows to exactly zero inside a `Div` stays stored in
+`Quad2` where the legacy full re-scan would eventually drop it, so the new
+recognizer can refuse a form the old one proved quadratic. That direction is
+the safe one (a refusal routes to the NLP path), and nothing in the corpus
+or the battery reaches it.
+
+### Measurement gap, stated
+
+`$POUNCE_BENCH_DATA` is still **not present on this machine**, so
+`qbench.py --set quad` could not be run on either side — the same gap Q2
+recorded, unchanged. Q3's forecast is 0% on solve and its argument is the
+counters above, not a stopwatch; §10's ~1.3× noise floor would not have
+supported a runtime claim in either direction anyway.
+
+`cargo test --workspace --exclude pounce-hsl`: 2974 passed, 0 failed (2961 at
+Q2; the 13 new ones are this phase’s).
+`cargo fmt --check` clean; `cargo clippy --workspace --exclude pounce-hsl
+--all-targets` exit 0, with no new lint class (the `expect_used` warnings in
+the new test files are the ones every test file here produces).
 
 ---
 
@@ -1161,6 +1301,35 @@ hung for >300 s before the merge-then-prune fix at `dispatch.rs:597`.
 precisely because these DAGs overflow the stack, and `to_poly` has the same
 latent bug today. **Win: 0% on solve**; unblocks everything; no trajectory change.
 
+**Done — the 0%-on-solve forecast holds and three of the details above are
+wrong; §0d has the measurement.** Shipped: `pounce_nl::nl_quadratic` with an
+iterative `recognize_expr`, `Quad2` in place of `Poly`, and a merge whose
+zero-scan is proportional to what it merged. Corrections, in ascending order
+of how much they change the phase:
+
+1. The allocation count is right (measured: `n² + 2n` monomial `Vec`s per
+   expansion of one dense `n`-variable row, so 251 000 at `n = 500` and
+   ~2.5 M for a ten-row `qcqp500-3c`), but **the `O(N²)` it is blamed on was
+   never fixed**. The merge-then-prune change covered `Expr::Sum` only. The
+   same defect was still live on the left-deep `Add` chain — which is the
+   very shape this paragraph cites as the reason to go iterative — and
+   classifying a 16 000-term chain took 0.77 s until this commit, against
+   0.020 s after. (The `dispatch.rs:597` reference is also stale; the code
+   was at line 800 by 688ccd45.)
+2. `pounce-py/src/nl_problem.rs:654` does **not** implement an iterative
+   `Expr` drop. It moves a *recursive* drop onto a 64 MB worker thread and
+   refuses depths past `MAX_DEPTH = 10 000` at parse time. The precedent is a
+   bigger stack, not a different algorithm — and `Expr`'s `Drop` is still
+   recursive after Q3.
+3. The latent bug is real but **narrower than Q1 recorded**: on the CLI's
+   `.nl` route the *parser* overflows first, at `k ≈ 6 000` against the
+   recognizer's `k ≈ 24 000` on the same 8 MB main thread. A deep `.nl` file
+   did not load before this commit and still does not. What Q3 removes is the
+   recognizer's ceiling — which binds on any caller with a smaller stack (a
+   2 MB test thread, which is exactly where Q1 hit it) and on
+   `from_expressions` models that never met the parser — and it makes the
+   recursive parser the next thing to fix, for Q5.
+
 **Q4 — `QuadraticStructure` + the `NlTnlp` fast path.** The payload, and the
 widest-applying single change (it pays on all 358 structured problems, convex or
 not). Forecast on `qcqp500-3c`: `eval_h` 1.513 s → ~0.02 s, `eval_g` 0.862 s →
@@ -1436,13 +1605,13 @@ line is individually explained.
 
 | file | role |
 |---|---|
-| `crates/pounce-nl/src/quadratic.rs` *(new)* | `Quad2`, `recognize_expr`, `canonicalize`, `parse_expr_quadratic` |
+| `crates/pounce-nl/src/nl_quadratic.rs` *(new, landed in Q3)* | `Quad2`, `recognize_expr`, `analyze_quadratic{,_full}`, `is_trivially_zero`; `parse_expr_quadratic` is Q5's. Named for the crate's `nl_*` module convention, not the bare `quadratic.rs` this row first guessed |
 | `crates/pounce-nlp/src/quadratic.rs` *(new)* | `QuadForm`, `QuadraticStructure`, `QuadScratch`, `ConstantDerivatives`, kernels |
 | `crates/pounce-convex/src/qcqp.rs` *(new)* | `QuadRow`, `QcqpProblem`, `QuadJacobian`, `to_socp` |
 | `crates/pounce-convex/src/qcqp_ipm.rs` *(new)* | `QcqpKkt`, `solve_qcqp_ipm` |
 | `crates/pounce-convex/src/correctors.rs` *(new)* | Gondzio loop lifted from `hsde.rs:865-940` |
 | `crates/pounce-nl/src/nl_reader.rs` | header `:1142`, `'C'`/`'O'` arms `:618-641`, `NlProblem:202`, `try_new:3067`, `lower_pairs:3179`, `jac_cols:3222`, `eval_g:3903`, `eval_jac_g:3947`, `eval_h:4046`, linearity/FBBT consumers `:2414,:2480,:3755,:4259,:4276,:4303` |
-| `crates/pounce-cli/src/dispatch.rs` | delete `Poly`/`to_poly`/`analyze_quadratic*` `:410-628`; `SOCP_SIZE_BUDGET:65`, `QCQP_SOCP_COUPLED_VARS:90`, `ProblemClass:93-110`, `classify_problem:206-323`, `resolve_solver:333-390` |
+| `crates/pounce-cli/src/dispatch.rs` | ~~delete `Poly`/`to_poly`/`analyze_quadratic*`~~ *(done in Q3; the analyzers are re-exported from `pounce-nl` so no call site moved)*; `SOCP_SIZE_BUDGET:65`, `QCQP_SOCP_COUPLED_VARS:90`, `ProblemClass:93-110`, `classify_problem:206-323`, `resolve_solver:333-390` |
 | `crates/pounce-cli/src/qp_extract.rs` | `dense_symmetric:584`, `psd_outer_factor:600`, `extract_socp_with_map:367`; new `extract_qcqp_with_map` |
 | `crates/pounce-nlp/src/orig_ipopt_nlp.rs` | cache keying for the hints: `eval_grad_f:1587`, `eval_jac_c:1766`, `eval_h_internal:1823`, `set_new_problem:1214` |
 | `crates/pounce-algorithm/src/unimplemented_options.rs` | empty `UNEXPLOITED_HINTS:200-206`, paired with `pounce-cli/tests/unimplemented_options.rs:126-133` |


### PR DESCRIPTION
**Review-only PR. Do not merge.** This exists so Q3 of the #588 series can be
read as a single-phase diff. The real series PR is #603; its branch
`feat/588-quadratic-structure` already contains this commit. The base here is
pinned at Q2 (`688ccd45`) so the diff below is *exactly* Q3 — commit
`fd738d46` — and nothing else.

## Problem

Two distinct defects in the degree-≤2 recognizer, both in `dispatch.rs`.

**Quadratic blowup.** The merge-then-prune fix already in the tree covered
`Expr::Sum` only. The identical `O(N²)` was still live on binary `Add` chains —
the exact shape the design note cites as the motivating case. Measured on a
left-deep `o0` chain with an 8 MB stack:

| left-deep `o0` chain | before | after |
|---|---|---|
| k = 16 000 | 0.7697 s | 0.0197 s (**39×**) |
| k = 24 000 | **stack-overflow abort** | 0.0254 s |
| k = 1 000 000 | abort | 1.1030 s |

Before is `O(k²)`; after is linear. Dense `(Σxᵢ)²` row at n = 500: 0.3028 →
0.1270 s. Whole 62-file corpus classification: 4.61–5.06 ms → 3.75–3.96 ms.

**Recursion.** `to_poly` recursed over the `Expr` DAG, so a left-deep `Add` tree
of squares — a legitimate model shape — aborted the process during
classification. Q1 reproduced this and pinned its test at `k = 1000` with a
comment saying the limit was the recursion, not the cost model.

## Cause

`Poly` keyed monomials on `BTreeMap<Vec<usize>, f64>` — one heap allocation per
monomial. Legacy cost is now measured and pinned rather than estimated:
**`n² + 2n` monomial `Vec`s per expansion** (251 000 at n = 500). Merging two
polynomials rescanned the whole accumulator for zeros on every merge, which is
where the quadratic term came from.

## Fix

`Quad2` replaces `Poly`: three fields with inline keys, so degree is a property
of the type rather than something re-derived from a map. `recognize_expr` is
iterative (explicit work and value stacks). The per-merge zero scan is now
proportional to what was merged, folding the smaller side into the larger in
either direction.

The algebra moved to `crates/pounce-nl/src/nl_quadratic.rs` — the crate that
owns the `Expr` DAG. `dispatch` keeps routing and re-exports
`analyze_quadratic{,_full}` / `is_trivially_zero`, so no call site in
`qp_extract.rs` or in the tests moved; only the already-unused `n` argument was
dropped. `header_census` deliberately stayed in `dispatch` — it is a classifier
diagnostic about the `.nl` header, not part of the algebra.

**Three things the design note got wrong, corrected in place:**

1. The `O(N²)` was never fully fixed — only the `Sum` half. The
   `dispatch.rs:597` reference is also stale; the code was at line 800. (The
   "2.32 M `Vec`s" figure *is* corroborated.)
2. `pounce-py/src/nl_problem.rs:654` does **not** implement an iterative `Expr`
   drop. It moves a *recursive* drop onto a 64 MB worker thread plus a
   `MAX_DEPTH = 10 000` refusal. The cited precedent is a bigger stack, not a
   different algorithm.
3. Q1's crash is real but narrower than recorded: on the CLI's `.nl` route the
   **parser** overflows first (k ≈ 6 000, versus the recognizer's k ≈ 24 000 on
   the same 8 MB thread), identically before and after. A deep `.nl` file did
   not load before this change and still does not.

## Blast radius

Bit-identical except for the targeted case.

- `scripts/sweep-fixtures.sh` against baseline `688ccd45`: **empty diff**, 57 models.
- `Problem class:` line over all 62 `.nl` files under `crates/`: **empty diff**.
- Differential oracle: **bitwise identical** on 1 631 expressions from the
  corpus plus a 4 000-sample random battery.

`$POUNCE_BENCH_DATA` is not present on this machine, so no `quad` / `control`
set numbers are claimed here — stated in the commit and the note as well. The
timings above are from the recognizer microbenchmarks and the in-repo fixture
corpus, which are what this phase's claims actually rest on.

## Tests

- 10 unit tests in `nl_quadratic`, including three at **depth 250 000**
  (left-deep, right-deep, and early-bail). These abort on the parent commit, for
  the stated reason — stack overflow in the recursive walk.
- `crates/pounce-cli/tests/quad_recognizer_differential.rs` keeps the pre-Q3
  recognizer verbatim as an oracle and compares bitwise. This is the pattern Q1's
  "2-ulp line" argues for: a coefficient differing by one ulp moved a fixture
  from 17 to 12 conic iterations, and only a differential check sees that.
- Q1's `k = 1000` pin raised to **100 000**.

Deliberately not pinned: the `.nl` **parser's** recursion ceiling (k ≈ 6 000).
It is unchanged by this phase and is now the lowest ceiling on deep models —
recorded as a known gap rather than silently fixed here.

`cargo test --workspace --exclude pounce-hsl`: 2974 passed, 0 failed.
`cargo fmt --check` clean. `cargo clippy --workspace --exclude pounce-hsl
--all-targets` exit 0, no new lint class.

---

- [x] Tests fail on the parent commit for the stated reason
- [ ] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

The two unticked boxes are deliberate and are properties of the series, not
oversights: Q3 is an internal refactor with no user-visible behaviour change, so
there is nothing to say in `CHANGELOG.md` in the user's terms and no book page
to update. The user-facing entry belongs to the series as a whole and lands with
#603.

Refs #588

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZTh36oN4JK9t6fN2CzXC9)_