### PR TITLE
Q4 review copy: evaluate recognized quadratics from their constant matrices

### DIFF
--- a/crates/pounce-cli/tests/issue_540_eigena2_superlinear_tail.rs
+++ b/crates/pounce-cli/tests/issue_540_eigena2_superlinear_tail.rs
@@ -73,6 +73,10 @@ fn tmp_path(suffix: &str) -> PathBuf {
 }
 
 fn solve(extra: &[&str]) -> SolveReport {
+    solve_with_env(extra, &[])
+}
+
+fn solve_with_env(extra: &[&str], env: &[(&str, &str)]) -> SolveReport {
     let json_path = tmp_path("eigena2.json");
     let sol_path = tmp_path("eigena2.sol");
     let mut cmd = Command::new(pounce_exe());
@@ -82,6 +86,9 @@ fn solve(extra: &[&str]) -> SolveReport {
         .arg(&json_path);
     for o in extra {
         cmd.arg(o);
+    }
+    for (k, v) in env {
+        cmd.env(k, v);
     }
     let _ = cmd.status().expect("spawn pounce");
     let text = std::fs::read_to_string(&json_path).expect("read json report");
@@ -124,9 +131,27 @@ fn eigena2_dual_infeasibility_clears_the_strict_tolerance() {
 /// must still reproduce the reported failure. If a later change fixes
 /// `eigena2` by some other route, this test fails and says so rather than
 /// letting the two tests above pass for a reason they do not describe.
+///
+/// **`POUNCE_DBG_NO_QUAD=1` is part of the reproduction, as of gh #588's Q4.**
+/// The pre-#540 route is a knife edge — it turns on an inertia count read off
+/// a factor whose smallest pivot is ~1e-16 — and Q4 moved `∇²L[8, 8]` by
+/// **one ulp** on this model. `eigena2` has 55 quadratic rows and a
+/// non-quadratic objective, so that entry is now assembled as a constant
+/// scatter plus a decoded tape share rather than as one sum, and the two
+/// associate differently. With the fast path on, `feral_inertia_pivot_floor=0`
+/// converges (27 iterations, dual 6.0e-10) instead of stalling, and this
+/// guard would pass vacuously in the other direction — by having nothing left
+/// to reproduce.
+///
+/// The env var restores the pre-Q4 arithmetic exactly: 29 iterations, dual
+/// 1.841e-7, `SolvedToAcceptableLevel`, the same numbers as before that
+/// commit. **The shipped route is untouched** — with the trigger on,
+/// `eigena2` takes 26 iterations to `SolveSucceeded` at dual 2.211e-9 before
+/// Q4 and 2.208e-9 after, on the same objective. So what changed is the
+/// reproducibility of a failure, not the fix and not the answer.
 #[test]
 fn disabling_the_trigger_reproduces_the_reported_failure() {
-    let r = solve(&NO_TRIGGER);
+    let r = solve_with_env(&NO_TRIGGER, &[("POUNCE_DBG_NO_QUAD", "1")]);
     assert_eq!(
         r.solution.status,
         ApplicationReturnStatus::SolvedToAcceptableLevel,

--- a/crates/pounce-cli/tests/quad_evaluator_differential.rs
+++ b/crates/pounce-cli/tests/quad_evaluator_differential.rs
@@ -1,0 +1,525 @@
+//! The Q4 constant-structure evaluator against the AD tape it replaces
+//! (gh #588).
+//!
+//! Q4 stops building a tape for every objective and row the recognizer
+//! proves is degree ≤ 2, and evaluates `g`, `∇g` and `∇²L` from the constant
+//! matrix instead. If those two ways of computing a derivative ever disagree,
+//! POUNCE hands the algorithm a wrong Hessian and converges somewhere else —
+//! or fails to — on a model no fixture solves. The fixture sweep cannot see
+//! that: it only reaches rows a *solve* depends on, and it reports one number
+//! per model rather than one per matrix entry.
+//!
+//! So this is the differential check, modelled on Q3's
+//! `quad_recognizer_differential.rs`: every `.nl` file in the repository is
+//! loaded **twice** — once with the fast path, once with
+//! `NlTnlp::try_new_with_quadratic(prob, false)`, which is what
+//! `POUNCE_DBG_NO_QUAD=1` selects — and the two are compared entry by entry
+//! at several points, on:
+//!
+//! * `eval_g` — the line search's inner loop;
+//! * `eval_jac_g` — compared as a `(row, col) -> value` map, because the two
+//!   paths need not agree on the *pattern*: a coefficient that cancels to
+//!   exactly zero is dropped by the recognizer and kept by the tape's
+//!   structural sparsity;
+//! * `eval_h` — same, over the assembled lower triangle.
+//!
+//! ### Which comparisons are bitwise
+//!
+//! `∇²L` is: the tape's entry for `0.5·((c·xᵢ)·xⱼ)` is the product of
+//! constants `0.5·c` and the decode adds `w·(0.5·c)`, while the scatter
+//! computes `w·q_val` with the same `q_val`. Nothing about that is an
+//! *approximation* of the other. **Measured, that is right for the shape the
+//! note reasoned about and wrong in general**: over this corpus 27 174 of
+//! 27 176 assembled Hessian entries are bit-identical, and the two that are
+//! not (`eigena2.nl`, entry (8, 8)) differ by exactly **one ulp**.
+//!
+//! The mechanism is worth stating because it decides where else it can
+//! happen: **an entry written by both paths at once**. `eigena2` has 55
+//! quadratic rows and a non-quadratic objective, so `∇²L[8, 8]` takes a
+//! constant contribution from a row and an `x`-dependent one from the
+//! objective's tape. On the tape path both land in the same compressed
+//! column pass and reach `values` as one add; on the fast path the row's
+//! share is scattered first and the objective's decode adds on top. Same
+//! terms, different association, one ulp — and only where a model mixes the
+//! two, which is why the entry moves with `x` even though the row's Hessian
+//! does not. A model whose objective and rows are all recognized (the whole
+//! `qcqp` family) has no entry with a foot in both camps.
+//!
+//! The disagreement is therefore bounded, not asserted away: the worst ulp
+//! distance over the corpus is pinned at `MAX_HESS_ULPS`. Q1's 2-ulp line is
+//! why that is a pin and not a tolerance — a one-ulp coefficient difference
+//! moved a fixture from 17 to 12 conic iterations, and only a differential
+//! check saw it.
+//!
+//! `f` and `∇f` are compared too, and that is not decoration: on a model
+//! whose *rows* are not quadratic the objective is the only thing the phase
+//! touches, and `infeasible_equalities.nl` (cubic rows, quadratic objective)
+//! is exactly such a model. Adding those two comparisons immediately found
+//! the phase's one real accuracy defect — expanding `(x − 500000)²` cancels
+//! five digits where the tape squares a small residual — which is why the
+//! fast path is now gated on `is_expanded_quadratic` and takes only forms
+//! the writer had already expanded.
+//!
+//! `g` and `∇g` are **not** bitwise and the design note says so in advance:
+//! the tape sums one summand at a time in file order while the matvec sums a
+//! merged row, so the association differs. They are held to a tight relative
+//! tolerance, and the *observed* worst deviation over the corpus is pinned as
+//! a number so that a future regression has to move it.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use pounce_cli::nl_reader::{NlProblem, NlTnlp, read_nl_file};
+use pounce_nlp::tnlp::{SparsityRequest, TNLP};
+
+/// Relative tolerance for the two summation orders in `eval_g` / `eval_jac_g`.
+///
+/// Not a bound anyone derived — a ceiling well above what the corpus
+/// actually produces (see `WORST_OBSERVED_REL`, asserted separately), set
+/// loose enough that reassociating a long sum cannot trip it and tight
+/// enough that a wrong coefficient cannot hide under it.
+const REL_TOL: f64 = 1e-12;
+
+/// The largest relative deviation any fixture actually produces, over every
+/// `g` and `∇g` entry at every probe point. Pinned so that "within
+/// tolerance" stays a measurement rather than a hope.
+const WORST_OBSERVED_REL: f64 = 1e-14;
+
+/// The worst Hessian disagreement the corpus produces, in representable
+/// doubles. See the module docs: the design note forecast bit-identity here
+/// and the corpus refutes it in general while confirming it on the shape the
+/// note reasoned about.
+const MAX_HESS_ULPS: u64 = 1;
+
+// ---------------------------------------------------------------------
+// Probing one model both ways
+// ---------------------------------------------------------------------
+
+/// A deterministic xorshift, so a failure is reproducible from its seed.
+struct Rng(u64);
+
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        // [-2, 2), which keeps `x` away from the all-equal points where a
+        // sign error in a cross term cancels itself.
+        (self.0 >> 11) as f64 / (1u64 << 52) as f64 * 4.0 - 2.0
+    }
+}
+
+/// The probe points: the model's own starting point, then pseudo-random
+/// perturbations of it. `x0` alone is not enough — a quadratic row at a
+/// point where half the variables are zero hides half its coefficients.
+fn probe_points(prob: &NlProblem, k: usize) -> Vec<Vec<f64>> {
+    let mut out = vec![prob.x0.clone()];
+    let mut rng = Rng(0x5eed_1234_9e37_79b9);
+    for _ in 0..k {
+        out.push(prob.x0.iter().map(|&v| v + rng.next_f64()).collect());
+    }
+    out
+}
+
+/// Sparse triplets as a map, so two paths with different *patterns* can
+/// still be compared entry by entry.
+fn as_map(irow: &[i32], jcol: &[i32], values: &[f64]) -> BTreeMap<(i32, i32), f64> {
+    let mut m = BTreeMap::new();
+    for k in 0..values.len() {
+        m.insert((irow[k], jcol[k]), values[k]);
+    }
+    m
+}
+
+/// Worst relative deviation between two values, treating an exact zero on
+/// both sides as agreement and falling back to absolute error when the
+/// reference is zero.
+///
+/// A probe point is random, so it can land outside a model's domain — a
+/// `sqrt` of something negative, a `log` of zero. Both paths then produce
+/// `NaN` and that is agreement, not a difference; **one** of them producing
+/// `NaN` is the loudest possible disagreement and comes back infinite.
+fn rel_dev(a: f64, b: f64) -> f64 {
+    if a.is_nan() || b.is_nan() {
+        return if a.is_nan() && b.is_nan() {
+            0.0
+        } else {
+            f64::INFINITY
+        };
+    }
+    if a == b {
+        return 0.0;
+    }
+    if a == 0.0 {
+        return b.abs();
+    }
+    ((a - b) / a).abs()
+}
+
+/// Bit equality, with the same `NaN` convention as [`rel_dev`]: two `NaN`s
+/// agree even if their payloads differ, because neither path promises a
+/// particular quiet-`NaN` bit pattern.
+fn bit_equal(a: f64, b: f64) -> bool {
+    if a.is_nan() || b.is_nan() {
+        return a.is_nan() && b.is_nan();
+    }
+    a.to_bits() == b.to_bits()
+}
+
+/// Everything one probe of one model reports.
+#[derive(Default)]
+struct Report {
+    /// Models where the fast path was actually taken.
+    models_with_quadratic: usize,
+    /// Constraint rows (over all models) routed through a form.
+    quadratic_rows: usize,
+    /// Worst relative deviation seen on `g` or `∇g`.
+    worst_rel: f64,
+    /// Hessian entries compared, and how many were not bit-identical.
+    hess_entries: usize,
+    hess_bit_diffs: usize,
+    worst_hess_ulps: u64,
+    worst_hess_where: String,
+    /// `eval_f` and `eval_grad_f` values compared, and how many were not
+    /// bit-identical.
+    obj_entries: usize,
+    obj_bit_diffs: usize,
+}
+
+/// Distance in representable doubles between two finite values of the same
+/// sign. Used only to *bound* a disagreement, so mixed signs and non-finite
+/// values come back saturated rather than being reasoned about.
+fn ulp_distance(a: f64, b: f64) -> u64 {
+    if !a.is_finite() || !b.is_finite() || a.is_sign_negative() != b.is_sign_negative() {
+        return u64::MAX;
+    }
+    a.to_bits().abs_diff(b.to_bits())
+}
+
+fn compare_model(path: &Path, rep: &mut Report) {
+    let Ok(prob) = read_nl_file(path) else { return };
+    // Recognition is what decides whether this model exercises anything; a
+    // model with no quadratic part builds two identical TNLPs and the
+    // comparison is vacuous but free.
+    let n = prob.n;
+    let m = prob.m;
+    if n == 0 {
+        return;
+    }
+    let points = probe_points(&prob, 3);
+
+    let Ok(mut fast) = NlTnlp::try_new_with_quadratic(prob.clone(), true) else {
+        return;
+    };
+    let Ok(mut slow) = NlTnlp::try_new_with_quadratic(prob.clone(), false) else {
+        return;
+    };
+
+    let quad_rows = (0..m).filter(|&i| fast.quadratic_row(i)).count();
+    let quad_obj = fast.quadratic_objective();
+    if quad_rows == 0 && !quad_obj {
+        return;
+    }
+    rep.models_with_quadratic += 1;
+    rep.quadratic_rows += quad_rows;
+
+    let name = path.display();
+
+    // The Jacobian and Hessian patterns are asked for once each; they do not
+    // depend on `x`.
+    let (fast_jac, slow_jac) = (
+        structure(&mut fast, Kind::Jac),
+        structure(&mut slow, Kind::Jac),
+    );
+    let (fast_h, slow_h) = (
+        structure(&mut fast, Kind::Hess),
+        structure(&mut slow, Kind::Hess),
+    );
+
+    for (p, x) in points.iter().enumerate() {
+        // --- eval_f / eval_grad_f ---
+        // The objective is on the fast path independently of the rows, and
+        // is the only thing that moves on a model whose *rows* are not
+        // quadratic — which is how `infeasible_equalities` (cubic rows,
+        // quadratic objective) turned up in the fixture sweep.
+        let (ff, fs) = (
+            fast.eval_f(x, true).expect("eval_f (fast)"),
+            slow.eval_f(x, true).expect("eval_f (tape)"),
+        );
+        let d = rel_dev(fs, ff);
+        rep.worst_rel = rep.worst_rel.max(d);
+        assert!(
+            d <= REL_TOL,
+            "{name}: probe {p}: eval_f disagrees: tape {fs:?} vs quad {ff:?} (rel {d:.3e})"
+        );
+        rep.obj_entries += 1;
+        if !bit_equal(ff, fs) {
+            rep.obj_bit_diffs += 1;
+        }
+
+        let (mut gradf, mut grads) = (vec![0.0; n], vec![0.0; n]);
+        assert!(
+            fast.eval_grad_f(x, true, &mut gradf),
+            "{name}: eval_grad_f (fast)"
+        );
+        assert!(
+            slow.eval_grad_f(x, true, &mut grads),
+            "{name}: eval_grad_f (tape)"
+        );
+        for j in 0..n {
+            let d = rel_dev(grads[j], gradf[j]);
+            rep.worst_rel = rep.worst_rel.max(d);
+            assert!(
+                d <= REL_TOL,
+                "{name}: probe {p}: grad_f[{j}] disagrees: tape {:?} vs quad {:?} (rel {d:.3e})",
+                grads[j],
+                gradf[j]
+            );
+            rep.obj_entries += 1;
+            if !bit_equal(gradf[j], grads[j]) {
+                rep.obj_bit_diffs += 1;
+            }
+        }
+
+        // --- eval_g ---
+        let (mut gf, mut gs) = (vec![0.0; m], vec![0.0; m]);
+        assert!(fast.eval_g(x, true, &mut gf), "{name}: eval_g (fast)");
+        assert!(slow.eval_g(x, true, &mut gs), "{name}: eval_g (tape)");
+        for i in 0..m {
+            let d = rel_dev(gs[i], gf[i]);
+            rep.worst_rel = rep.worst_rel.max(d);
+            assert!(
+                d <= REL_TOL,
+                "{name}: probe {p}: eval_g row {i} disagrees: tape {:?} vs quad {:?} (rel {d:.3e})",
+                gs[i],
+                gf[i]
+            );
+        }
+
+        // --- eval_jac_g ---
+        let mut vf = vec![0.0; fast_jac.0.len()];
+        let mut vs = vec![0.0; slow_jac.0.len()];
+        assert!(
+            fast.eval_jac_g(Some(x), true, SparsityRequest::Values { values: &mut vf }),
+            "{name}: eval_jac_g (fast)"
+        );
+        assert!(
+            slow.eval_jac_g(Some(x), true, SparsityRequest::Values { values: &mut vs }),
+            "{name}: eval_jac_g (tape)"
+        );
+        let jf = as_map(&fast_jac.0, &fast_jac.1, &vf);
+        let js = as_map(&slow_jac.0, &slow_jac.1, &vs);
+        for key in jf.keys().chain(js.keys()) {
+            let (a, b) = (
+                js.get(key).copied().unwrap_or(0.0),
+                jf.get(key).copied().unwrap_or(0.0),
+            );
+            let d = rel_dev(a, b);
+            rep.worst_rel = rep.worst_rel.max(d);
+            assert!(
+                d <= REL_TOL,
+                "{name}: probe {p}: jac {key:?} disagrees: tape {a:?} vs quad {b:?} (rel {d:.3e})"
+            );
+        }
+
+        // --- eval_h ---
+        // Multipliers that are neither all-ones nor all-equal: a sign or an
+        // index error in the λ-weighting survives both of those.
+        let obj_factor = 0.75;
+        let lambda: Vec<f64> = (0..m).map(|i| 1.0 + (i % 7) as f64 * 0.5).collect();
+        let mut hf = vec![0.0; fast_h.0.len()];
+        let mut hs = vec![0.0; slow_h.0.len()];
+        assert!(
+            fast.eval_h(
+                Some(x),
+                true,
+                obj_factor,
+                Some(&lambda),
+                true,
+                SparsityRequest::Values { values: &mut hf }
+            ),
+            "{name}: eval_h (fast)"
+        );
+        assert!(
+            slow.eval_h(
+                Some(x),
+                true,
+                obj_factor,
+                Some(&lambda),
+                true,
+                SparsityRequest::Values { values: &mut hs }
+            ),
+            "{name}: eval_h (tape)"
+        );
+        let mf = as_map(&fast_h.0, &fast_h.1, &hf);
+        let ms = as_map(&slow_h.0, &slow_h.1, &hs);
+        for key in mf.keys().chain(ms.keys()) {
+            let (a, b) = (
+                ms.get(key).copied().unwrap_or(0.0),
+                mf.get(key).copied().unwrap_or(0.0),
+            );
+            rep.hess_entries += 1;
+            if !bit_equal(a, b) {
+                rep.hess_bit_diffs += 1;
+                let u = ulp_distance(a, b);
+                if u > rep.worst_hess_ulps {
+                    rep.worst_hess_ulps = u;
+                    rep.worst_hess_where = format!("{name}: probe {p}: hessian {key:?}");
+                }
+            }
+        }
+    }
+}
+
+enum Kind {
+    Jac,
+    Hess,
+}
+
+fn structure(t: &mut NlTnlp, kind: Kind) -> (Vec<i32>, Vec<i32>) {
+    let info = t.get_nlp_info().expect("nlp info");
+    let nnz = match kind {
+        Kind::Jac => info.nnz_jac_g,
+        Kind::Hess => info.nnz_h_lag,
+    } as usize;
+    let (mut irow, mut jcol) = (vec![0i32; nnz], vec![0i32; nnz]);
+    let req = SparsityRequest::Structure {
+        irow: &mut irow,
+        jcol: &mut jcol,
+    };
+    let ok = match kind {
+        Kind::Jac => t.eval_jac_g(None, true, req),
+        Kind::Hess => t.eval_h(None, true, 1.0, None, true, req),
+    };
+    assert!(ok, "structure request declined");
+    (irow, jcol)
+}
+
+// ---------------------------------------------------------------------
+// The corpus
+// ---------------------------------------------------------------------
+
+fn all_fixtures() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().is_some_and(|x| x == "nl") {
+                out.push(p);
+            }
+        }
+    }
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut out = Vec::new();
+    walk(&base.join("fixtures"), &mut out);
+    walk(&base.join("fixtures_issue_49"), &mut out);
+    out.sort();
+    out
+}
+
+#[test]
+fn every_quadratic_fixture_evaluates_the_same_both_ways() {
+    let fixtures = all_fixtures();
+    assert!(
+        fixtures.len() >= 50,
+        "expected the fixture corpus, found {} files",
+        fixtures.len()
+    );
+    let mut rep = Report::default();
+    for f in &fixtures {
+        compare_model(f, &mut rep);
+    }
+
+    // A floor, not a target: if a refactor ever leaves this walking two
+    // models it should fail rather than pass vacuously.
+    assert!(
+        rep.models_with_quadratic >= 20,
+        "the corpus should exercise the fast path on many models, got {}",
+        rep.models_with_quadratic
+    );
+    assert!(
+        rep.hess_entries >= 1_000,
+        "too few Hessian entries compared: {}",
+        rep.hess_entries
+    );
+    eprintln!(
+        "[quad differential] {} models, {} quadratic rows, {} hessian entries \
+         ({} not bit-identical, worst {} ulp at {}), worst g/jac rel deviation {:.3e}",
+        rep.models_with_quadratic,
+        rep.quadratic_rows,
+        rep.hess_entries,
+        rep.hess_bit_diffs,
+        rep.worst_hess_ulps,
+        rep.worst_hess_where,
+        rep.worst_rel
+    );
+    eprintln!(
+        "[quad differential] objective: {} values compared, {} not bit-identical",
+        rep.obj_entries, rep.obj_bit_diffs
+    );
+    assert!(
+        rep.worst_hess_ulps <= MAX_HESS_ULPS,
+        "hessian disagreement grew past what the corpus produced: {} ulp at {}",
+        rep.worst_hess_ulps,
+        rep.worst_hess_where
+    );
+    assert!(
+        rep.hess_bit_diffs * 1000 <= rep.hess_entries,
+        "too many Hessian entries stopped being bit-identical: {} of {}",
+        rep.hess_bit_diffs,
+        rep.hess_entries
+    );
+    assert!(
+        rep.worst_rel <= WORST_OBSERVED_REL,
+        "g/jac deviation grew past what the corpus produced: {:.3e} > {WORST_OBSERVED_REL:.0e}",
+        rep.worst_rel
+    );
+}
+
+/// A model with nothing quadratic in it must be untouched — same structures,
+/// same values, bit for bit, on both constructions. This is what makes the
+/// phase's blast radius statable: it is exactly the recognized set.
+#[test]
+fn a_model_with_no_quadratic_part_is_byte_identical_on_both_paths() {
+    let mut checked = 0usize;
+    for f in all_fixtures() {
+        let Ok(prob) = read_nl_file(&f) else { continue };
+        if prob.n == 0 {
+            continue;
+        }
+        let Ok(mut fast) = NlTnlp::try_new_with_quadratic(prob.clone(), true) else {
+            continue;
+        };
+        if fast.quadratic_objective() || (0..prob.m).any(|i| fast.quadratic_row(i)) {
+            continue;
+        }
+        let Ok(mut slow) = NlTnlp::try_new_with_quadratic(prob.clone(), false) else {
+            continue;
+        };
+        let (a, b) = (
+            structure(&mut fast, Kind::Hess),
+            structure(&mut slow, Kind::Hess),
+        );
+        assert_eq!(a, b, "{}: Hessian pattern moved", f.display());
+        let x = prob.x0.clone();
+        let (mut gf, mut gs) = (vec![0.0; prob.m], vec![0.0; prob.m]);
+        assert!(fast.eval_g(&x, true, &mut gf));
+        assert!(slow.eval_g(&x, true, &mut gs));
+        for i in 0..prob.m {
+            assert!(
+                bit_equal(gf[i], gs[i]),
+                "{}: row {i} moved on a model with nothing quadratic",
+                f.display()
+            );
+        }
+        checked += 1;
+    }
+    assert!(
+        checked >= 5,
+        "expected some non-quadratic models, got {checked}"
+    );
+}

--- a/crates/pounce-nl/src/nl_quadratic.rs
+++ b/crates/pounce-nl/src/nl_quadratic.rs
@@ -41,7 +41,7 @@
 //! all this one looks at.
 
 use crate::nl_reader::{BinOp, Expr, UnaryOp};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// The symmetric Hessian of a quadratic form, stored as a sparse upper-
 /// triangular (i ≤ j) map of `(i, j) -> ∂²/∂xᵢ∂xⱼ`. Empty means the
@@ -440,6 +440,125 @@ pub fn analyze_quadratic_full(e: &Expr) -> Option<QuadForm> {
     Some((h, lin, 0.0 + q.constant))
 }
 
+/// Is this expression **already** a flat sum of monomials — that is, would
+/// reading it as `½xᵀHx + aᵀx + c` reproduce the same additions the writer
+/// wrote, rather than algebraically expanding something it did not?
+///
+/// This is the gate on the constant-structure evaluator (gh #588, Q4), and
+/// it exists because expanding a quadratic is not an accuracy-neutral
+/// rewrite. `(xᵢ − xⱼ)²` evaluated as written squares a small residual;
+/// evaluated as `xᵢ² − 2xᵢxⱼ + xⱼ²` it cancels two large numbers, and on
+/// `airport.nl` — 84 coordinates around 10³, every row a squared distance —
+/// that difference is enough to take an adaptive-μ solve from stopping at a
+/// tiny step in 16 iterations to grinding out the 300-iteration cap at the
+/// same objective. Which is precisely the gh #544 failure mode: the right
+/// answer, slowly.
+///
+/// So the rule is *exactness*, not magnitude: a form is admitted only when
+/// the recognizer's read-out does no algebra the tape would not have done.
+/// A sum of monomials qualifies — which is exactly how AMPL emits the
+/// `qcqp*` family (`o54` over `o2 n0.5 o2 o2 n<c> v<i> v<j>`), so the target
+/// of the phase is unaffected — and a `Pow` or a `Mul` over a non-atomic
+/// operand does not.
+///
+/// The consequence is worth stating plainly rather than discovering later:
+/// a model written in factored form keeps its tape and gains nothing from
+/// Q4. Evaluating such a form stably from its stored coefficients means
+/// carrying a shift (a vertex, or the writer's own grouping), which is a
+/// larger change than this phase.
+///
+/// ## A re-referenced `Cse` body is refused, and that is about cost
+///
+/// This walk and [`recognize_expr`] behind it both inline a `Cse` body at
+/// **every** reference, so a DAG whose bodies are shared costs `Θ(2^depth)`
+/// rather than `Θ(nodes)`. `nl_reader`'s
+/// `shared_dag_walks_are_memoized_not_exponential` builds exactly that shape
+/// — 30 levels, each a `Cse` referenced twice — and taking it through this
+/// gate ungated measured **0.00 s → 172 s** on a model the tape path loads
+/// instantly. At depth 40 it would not return at all.
+///
+/// So a body reached a second time ends the walk with `false`: the model
+/// keeps its tape, which handles sharing properly (that is what `ConHybrid`
+/// is for), and nothing hangs. Memoizing instead — on `Arc` identity, which
+/// is a pure and bitwise-neutral win — would fix this walk and leave
+/// `recognize_expr` exponential behind it, so it belongs with that change in
+/// Q5 rather than half-done here. The target family is unaffected: the
+/// `qcqp*` files declare no common expressions at all.
+///
+/// Iterative for the same reason [`recognize_expr`] is.
+pub fn is_expanded_quadratic(e: &Expr) -> bool {
+    // The sum spine: `Add`/`Sub`/`Neg`/`Sum` may nest freely, and every
+    // leaf of that spine must be a monomial.
+    let mut seen: BTreeSet<*const Expr> = BTreeSet::new();
+    let mut spine: Vec<&Expr> = vec![e];
+    while let Some(e) = spine.pop() {
+        match e {
+            Expr::Sum(items) => spine.extend(items.iter()),
+            Expr::Binary(BinOp::Add | BinOp::Sub, a, b) => {
+                spine.push(a);
+                spine.push(b);
+            }
+            Expr::Unary(UnaryOp::Neg, a) => spine.push(a),
+            Expr::Cse(body) => {
+                if !seen.insert(std::sync::Arc::as_ptr(body)) {
+                    return false;
+                }
+                spine.push(body);
+            }
+            other => {
+                if !is_monomial(other, &mut seen) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// A single product term: constants and variables multiplied together, with
+/// no addition anywhere inside it. `xᵢxⱼ`, `0.5·c·xᵢ·xⱼ`, `xᵢ²` and `xᵢ/3`
+/// all qualify; `(xᵢ − xⱼ)²` and `(xᵢ + 1)·xⱼ` do not.
+///
+/// Degree is not checked here — [`recognize_expr`] already refused anything
+/// past 2 by the time this runs, and duplicating the rule would only give
+/// the two a way to disagree.
+fn is_monomial(e: &Expr, seen: &mut BTreeSet<*const Expr>) -> bool {
+    let mut work: Vec<&Expr> = vec![e];
+    while let Some(e) = work.pop() {
+        match e {
+            Expr::Const(_) | Expr::Var(_) => {}
+            // Shared with the spine walk, and refused for the same reason —
+            // see [`is_expanded_quadratic`].
+            Expr::Cse(body) => {
+                if !seen.insert(std::sync::Arc::as_ptr(body)) {
+                    return false;
+                }
+                work.push(body);
+            }
+            Expr::Unary(UnaryOp::Neg, a) => work.push(a),
+            Expr::Binary(BinOp::Mul | BinOp::Div, a, b) => {
+                work.push(a);
+                work.push(b);
+            }
+            // `x^2` is one monomial; `(x - y)^2` is an expansion. The
+            // exponent itself may be any constant expression — the
+            // recognizer has already restricted it to {0, 1, 2}.
+            Expr::Binary(BinOp::Pow, a, b) => {
+                if !matches!(
+                    a.as_ref(),
+                    Expr::Const(_) | Expr::Var(_) | Expr::Unary(UnaryOp::Neg, _)
+                ) {
+                    return false;
+                }
+                work.push(a);
+                work.push(b);
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
 /// True if the expression is the literal constant zero the `.nl` reader
 /// uses for "no nonlinear part".
 pub fn is_trivially_zero(e: &Expr) -> bool {
@@ -544,6 +663,117 @@ mod tests {
         let h = analyze_quadratic(&e).expect("sum of squares is a QP");
         assert_eq!(h.len(), N);
         assert_eq!(h.get(&(N - 1, N - 1)), Some(&2.0));
+    }
+
+    /// The gate that decides whether a form may be evaluated from its
+    /// coefficients. The two directions cost different things, so both are
+    /// pinned: admitting a factored form loses digits (and, on
+    /// `airport.nl`, 284 iterations), refusing an expanded one loses the
+    /// phase's whole point on the family it was built for.
+    #[test]
+    fn only_already_expanded_forms_are_admitted() {
+        // AMPL's `qcqp*` emission: `o54` over `0.5·((c·xᵢ)·xⱼ)`.
+        let monomial = |c: f64, i: usize, j: usize| {
+            Expr::Binary(
+                BinOp::Mul,
+                Box::new(Expr::Const(0.5)),
+                Box::new(Expr::Binary(
+                    BinOp::Mul,
+                    Box::new(Expr::Binary(
+                        BinOp::Mul,
+                        Box::new(Expr::Const(c)),
+                        Box::new(Expr::Var(i)),
+                    )),
+                    Box::new(Expr::Var(j)),
+                )),
+            )
+        };
+        let row = Expr::Sum(vec![monomial(2.0, 0, 0), monomial(3.0, 0, 1)]);
+        assert!(is_expanded_quadratic(&row));
+        // `xᵢ²` is a single monomial, not an expansion.
+        assert!(is_expanded_quadratic(&Expr::Sum(vec![sq(0), sq(1)])));
+        // A left-deep `Add` chain is still a sum.
+        let chain = Expr::Binary(BinOp::Add, Box::new(sq(0)), Box::new(sq(1)));
+        assert!(is_expanded_quadratic(&chain));
+        // Division by a constant, and a negated term.
+        assert!(is_expanded_quadratic(&Expr::Binary(
+            BinOp::Div,
+            Box::new(sq(0)),
+            Box::new(Expr::Const(3.0)),
+        )));
+        assert!(is_expanded_quadratic(&Expr::Unary(
+            UnaryOp::Neg,
+            Box::new(monomial(1.0, 0, 1))
+        )));
+
+        // `(x₀ − x₁)²` — the `airport.nl` shape. Reading it as
+        // `x₀² − 2x₀x₁ + x₁²` cancels, so it stays on the tape.
+        let diff = Expr::Binary(BinOp::Sub, Box::new(Expr::Var(0)), Box::new(Expr::Var(1)));
+        let factored = Expr::Binary(BinOp::Pow, Box::new(diff), Box::new(Expr::Const(2.0)));
+        assert!(analyze_quadratic(&factored).is_some(), "it is quadratic");
+        assert!(
+            !is_expanded_quadratic(&factored),
+            "but not already expanded"
+        );
+
+        // `(x₀ + 1)·x₁` — expansion by multiplication rather than by power.
+        let product = Expr::Binary(
+            BinOp::Mul,
+            Box::new(Expr::Binary(
+                BinOp::Add,
+                Box::new(Expr::Var(0)),
+                Box::new(Expr::Const(1.0)),
+            )),
+            Box::new(Expr::Var(1)),
+        );
+        assert!(!is_expanded_quadratic(&product));
+
+        // One factored term anywhere in a long expanded sum disqualifies
+        // the whole row — the cancellation is in that term, not in the sum.
+        let mixed = Expr::Sum(vec![monomial(1.0, 0, 0), factored]);
+        assert!(!is_expanded_quadratic(&mixed));
+
+        // A `Cse` referenced once is inlined and judged on its body.
+        let once = Expr::Binary(
+            BinOp::Mul,
+            Box::new(Expr::Cse(std::sync::Arc::new(Expr::Var(0)))),
+            Box::new(Expr::Var(1)),
+        );
+        assert!(is_expanded_quadratic(&once));
+    }
+
+    /// A `Cse` body reached twice is refused, and the reason is cost rather
+    /// than algebra: this walk and `recognize_expr` behind it both inline a
+    /// body per reference, so a shared DAG is `Θ(2^depth)`. The shape below
+    /// is `nl_reader`'s `shared_dag_walks_are_memoized_not_exponential`
+    /// scaled up — at depth 60 an exponential walk does not return in the
+    /// lifetime of the test run, so this passing at all is the assertion.
+    #[test]
+    fn a_shared_cse_body_is_refused_rather_than_walked_exponentially() {
+        let mut e = Expr::Var(0);
+        for _ in 0..60 {
+            let shared = std::sync::Arc::new(e);
+            e = Expr::Binary(
+                BinOp::Add,
+                Box::new(Expr::Cse(std::sync::Arc::clone(&shared))),
+                Box::new(Expr::Cse(shared)),
+            );
+        }
+        assert!(!is_expanded_quadratic(&e));
+    }
+
+    /// Deep, and on a default-sized test thread, for the same reason
+    /// [`recognize_expr`] is iterative: the gate runs on every row of every
+    /// model, including the ones that overflow a recursive walk.
+    #[test]
+    fn the_expansion_gate_does_not_overflow_the_stack() {
+        const K: usize = 250_000;
+        let mut e = sq(0);
+        for i in 1..K {
+            e = Expr::Binary(BinOp::Add, Box::new(e), Box::new(sq(i)));
+        }
+        assert!(is_expanded_quadratic(&e));
+        std::mem::forget(e);
     }
 
     /// The reason this module is iterative.

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -32,8 +32,10 @@
 //! * `ref/Ipopt/test/mytoy.nl` — annotated example used for the unit
 //!   tests in this module.
 
+use crate::nl_quadratic::{analyze_quadratic_full, is_expanded_quadratic, is_trivially_zero};
 use crate::nl_tape::{HybridTape, Tape, hybrid_supported};
 use pounce_common::types::{Index, Number, lower_bound_present, upper_bound_present};
+use pounce_nlp::quadratic::QuadraticStructure;
 use pounce_nlp::tnlp::{
     BoundsInfo, IDX_NAMES, IndexStyle, IpoptCq, IpoptData, Linearity, MetaData, NlpInfo,
     ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
@@ -2174,6 +2176,23 @@ pub struct NlTnlp {
     /// `eval_g` when the model benefits (see [`ConHybrid`]). `None` keeps
     /// `eval_g` on the per-summand `con_tapes` above.
     con_hybrid: Option<ConHybrid>,
+    /// The degree-≤2 objective and rows, evaluated from their constant
+    /// matrices instead of from a tape (gh #588, Q4). A row with a form here
+    /// has an **empty** `con_tapes` entry, so every loop over the tapes
+    /// naturally contributes nothing for it and only the sites that consult
+    /// `quad` add it back: `eval_f`, `eval_grad_f`, `eval_g`, `eval_jac_g`,
+    /// `eval_h`, and `hessian_vector_products` — the last of which the design
+    /// note's list of five omitted, and which is the one where an omission
+    /// would be silent. Empty for a model with nothing recognized, in which
+    /// case everything below behaves bit for bit as it did before this
+    /// existed.
+    quad: QuadraticStructure,
+    /// Which entries of `h_irow`/`h_jcol` some *tape* can contribute to.
+    /// Empty when `quad` is — the pattern is then all tape. The coloring is
+    /// built over this subset alone, which is what stops one dense quadratic
+    /// block from forcing the color count to `n` for the benefit of tapes
+    /// that no longer exist.
+    h_tape_mask: Vec<bool>,
     /// Lower-triangle Hessian sparsity (row >= col), one entry per
     /// structurally nonzero second derivative in the Lagrangian.
     h_irow: Vec<i32>,
@@ -2977,6 +2996,7 @@ fn build_color_tables(
     n: usize,
     m: usize,
     lower_pairs: &[(usize, usize)],
+    tape_mask: &[bool],
     peel_veto: &[bool],
     obj_tapes: &[Tape],
     con_tapes: &[Vec<Tape>],
@@ -2986,7 +3006,27 @@ fn build_color_tables(
     // column-intersection graph bounds how many directional
     // Hessian-vector products we need per `eval_h` call —
     // typically O(stencil) for PDE-mesh problems.
-    let (var_color, n_colors, peeled) = greedy_hessian_coloring(n, lower_pairs, peel_veto);
+    //
+    // Only the entries a *tape* can write take part. `tape_mask` is empty
+    // when every entry is a tape entry (no quadratic structure), which is
+    // the pre-#588 behaviour bit for bit; otherwise the quadratic forms'
+    // entries are excluded, since they are scattered from their stored
+    // values and never read out of a directional product. A variable that
+    // appears only in quadratic rows then has no color at all
+    // (`u32::MAX`) — `greedy_hessian_coloring` already declines to color a
+    // column with no surviving entries.
+    let colored_pairs: Vec<(usize, usize)>;
+    let color_input: &[(usize, usize)] = if tape_mask.is_empty() {
+        lower_pairs
+    } else {
+        colored_pairs = lower_pairs
+            .iter()
+            .zip(tape_mask)
+            .filter_map(|(p, &t)| t.then_some(*p))
+            .collect();
+        &colored_pairs
+    };
+    let (var_color, n_colors, peeled) = greedy_hessian_coloring(n, color_input, peel_veto);
 
     // Per-color seed vectors (dense for O(1) Var lookup in
     // `Tape::hessian_directional`).
@@ -3008,6 +3048,11 @@ fn build_color_tables(
     // build drained a `HashMap`, whose iteration order is arbitrary).
     let mut decoding: Vec<Vec<ColorWrite>> = vec![Vec::new(); n_colors];
     for (idx, &(i, j)) in lower_pairs.iter().enumerate() {
+        // An entry no tape writes has no pass to be decoded out of; the
+        // quadratic scatter already put its value there.
+        if !tape_mask.is_empty() && !tape_mask[idx] {
+            continue;
+        }
         // Which directional product recovers H[i, j]? Column `j`'s,
         // read at row `i` — except when `i` is a peeled column and
         // `j` is not: then `j` may have no color of its own, and the
@@ -3178,6 +3223,23 @@ impl NlTnlp {
     /// `$AMPLFUNC` is unset, a named library is missing/unloadable, or a
     /// referenced function id isn't registered by any loaded library.
     pub fn try_new(prob: NlProblem) -> Result<Self, String> {
+        // `POUNCE_DBG_NO_QUAD=1` forces the AD tape for every row and the
+        // objective — the A/B reference for the constant-structure path,
+        // mirroring `POUNCE_DBG_NO_HYBRID`. Diagnostic only: it is how the
+        // fast path's derivatives are checked against the ones they replace
+        // on a real model, and how a suspected fast-path bug is bisected
+        // against a reference that computes the same numbers a different way.
+        Self::try_new_with_quadratic(prob, std::env::var("POUNCE_DBG_NO_QUAD").is_err())
+    }
+
+    /// [`Self::try_new`] with the constant-structure fast path (gh #588, Q4)
+    /// explicitly on or off.
+    ///
+    /// The env var `try_new` reads is process-global, which is exactly wrong
+    /// for the differential test that has to build the *same* model both ways
+    /// and compare the derivatives — so the knob is a parameter here and the
+    /// env var only chooses its default.
+    pub fn try_new_with_quadratic(prob: NlProblem, use_quadratic: bool) -> Result<Self, String> {
         // Resolve any AMPL imported (external) functions. Walk every
         // nonlinear expression to collect the funcall ids actually
         // referenced; load the libraries named in $AMPLFUNC and bind
@@ -3197,23 +3259,70 @@ impl NlTnlp {
             )?
         };
 
+        // Recognize the degree-≤2 objective and rows *before* anything is
+        // taped, because the win is not in evaluating the tape faster — it
+        // is in never building it. On `qcqp500-3c` the ten quadratic rows
+        // are 2.32 M monomials, one `Tape` each; recognizing them first
+        // means those 2.32 M tapes, their color lists and their per-tape
+        // sparsity sets are never allocated.
+        //
+        // A row that is trivially zero is left alone: it has no nonlinear
+        // part to replace, and routing it through a (necessarily empty)
+        // quadratic form would touch every model in the corpus to save
+        // nothing.
+        let mut quad = QuadraticStructure::new(prob.m);
+        if use_quadratic {
+            // `is_expanded_quadratic` is the accuracy gate, not an
+            // optimization: it admits only forms whose read-out repeats the
+            // additions the `.nl` writer already wrote. See its docs — and
+            // note it is checked *before* recognition, so a factored form
+            // costs one cheap structural walk rather than a full expansion.
+            if !is_trivially_zero(&prob.obj_nonlinear) && is_expanded_quadratic(&prob.obj_nonlinear)
+            {
+                if let Some((h, lin, c)) = analyze_quadratic_full(&prob.obj_nonlinear) {
+                    let f = quad.push_form(&h, &lin, c);
+                    quad.assign_objective(f);
+                }
+            }
+            for k in 0..prob.m {
+                let row = &prob.con_nonlinear[k];
+                if is_trivially_zero(row) || !is_expanded_quadratic(row) {
+                    continue;
+                }
+                if let Some((h, lin, c)) = analyze_quadratic_full(row) {
+                    let f = quad.push_form(&h, &lin, c);
+                    quad.assign_row(k, f);
+                }
+            }
+        }
+
         // Flatten objective and each constraint into independent
         // summands. Each summand becomes its own `Tape` (CSE bodies
         // are deduplicated within a tape via Rc identity in
         // `Tape::build`; bodies shared across summands are
         // duplicated, which we accept as a simplicity tradeoff).
-        let obj_summands = split_top_sums(&prob.obj_nonlinear);
-        let obj_tapes: Vec<Tape> = obj_summands
-            .iter()
-            .map(|e| Tape::build_with_externals(e, &resolver))
-            .collect();
+        let obj_tapes: Vec<Tape> = if quad.objective_form().is_some() {
+            Vec::new()
+        } else {
+            split_top_sums(&prob.obj_nonlinear)
+                .iter()
+                .map(|e| Tape::build_with_externals(e, &resolver))
+                .collect()
+        };
 
         let mut con_tapes: Vec<Vec<Tape>> = Vec::with_capacity(prob.m);
         let mut con_roots: Vec<Expr> = Vec::new();
         let mut row_start: Vec<usize> = Vec::with_capacity(prob.m + 1);
         for k in 0..prob.m {
-            let summands = split_top_sums(&prob.con_nonlinear[k]);
             row_start.push(con_roots.len());
+            // A row with a quadratic form contributes no tape and no
+            // hybrid-tape root, so `con_tapes[k]` is empty and its
+            // `row_start` range is empty too.
+            if quad.row_form(k).is_some() {
+                con_tapes.push(Vec::new());
+                continue;
+            }
+            let summands = split_top_sums(&prob.con_nonlinear[k]);
             con_tapes.push(
                 summands
                     .iter()
@@ -3289,23 +3398,78 @@ impl NlTnlp {
         // chased a pointer and allocated a node per entry. The result is
         // exactly the ascending order the rest of this function wants, so
         // it doubles as `lower_pairs` instead of being copied into it.
-        let mut lower_pairs: Vec<(usize, usize)> = Vec::new();
+        let mut tape_pairs: Vec<(usize, usize)> = Vec::new();
         for t in &obj_tapes {
-            lower_pairs.extend(t.hessian_sparsity());
+            tape_pairs.extend(t.hessian_sparsity());
         }
         for row in &con_tapes {
             for t in row {
-                lower_pairs.extend(t.hessian_sparsity());
+                tape_pairs.extend(t.hessian_sparsity());
             }
         }
-        lower_pairs.sort_unstable();
-        lower_pairs.dedup();
+        tape_pairs.sort_unstable();
+        tape_pairs.dedup();
+
+        // The assembled pattern is the tapes' union *plus* the quadratic
+        // forms'. They are kept apart because the coloring only ever needs
+        // the tape half — a quadratic block's entries are scattered
+        // directly, not recovered from a directional product — and coloring
+        // a dense quadratic block would put the color count back at `n` to
+        // pay for products nobody runs (`qcqp500-3c`: 500 colors → 0).
+        let mut lower_pairs = tape_pairs.clone();
+        if !quad.is_empty() {
+            for f in quad
+                .objective_form()
+                .into_iter()
+                .chain((0..prob.m).filter_map(|i| quad.row_form(i)))
+            {
+                lower_pairs.extend(
+                    quad.lower_triangle(f)
+                        .map(|(r, c, _)| (r as usize, c as usize)),
+                );
+            }
+            lower_pairs.sort_unstable();
+            lower_pairs.dedup();
+        }
+
+        // Which assembled entries a tape can write. Both sides are sorted
+        // and `tape_pairs ⊆ lower_pairs`, so this is a merge walk, and the
+        // mask is left empty (meaning "all of them") when nothing was
+        // recognized.
+        let h_tape_mask: Vec<bool> = if quad.is_empty() {
+            Vec::new()
+        } else {
+            let mut mask = vec![false; lower_pairs.len()];
+            let mut t = 0usize;
+            for (idx, pair) in lower_pairs.iter().enumerate() {
+                if t < tape_pairs.len() && tape_pairs[t] == *pair {
+                    mask[idx] = true;
+                    t += 1;
+                }
+            }
+            debug_assert_eq!(t, tape_pairs.len(), "every tape pair is in the union");
+            mask
+        };
+        drop(tape_pairs);
 
         let mut h_irow = Vec::with_capacity(lower_pairs.len());
         let mut h_jcol = Vec::with_capacity(lower_pairs.len());
         for &(hi, lo) in &lower_pairs {
             h_irow.push(hi as i32);
             h_jcol.push(lo as i32);
+        }
+
+        // Bind each form's lower-triangle entries to their index in the
+        // assembled pattern. `lower_pairs` is sorted, so the lookup is a
+        // binary search — done once here, never again on the hot path.
+        if !quad.is_empty() {
+            quad.bind_slots(|r, c| {
+                lower_pairs
+                    .binary_search(&(r as usize, c as usize))
+                    .unwrap_or_else(|_| {
+                        unreachable!("quadratic entry ({r}, {c}) missing from the union pattern")
+                    })
+            });
         }
 
         // Hessian column coloring and everything keyed off it. The
@@ -3324,6 +3488,7 @@ impl NlTnlp {
             prob.n,
             prob.m,
             &lower_pairs,
+            &h_tape_mask,
             &vec![false; prob.n],
             &obj_tapes,
             &con_tapes,
@@ -3338,6 +3503,12 @@ impl NlTnlp {
             let mut cols: Vec<usize> = Vec::with_capacity(prob.con_linear[i].len());
             for t in row_tapes {
                 cols.extend(t.variables());
+            }
+            // A quadratic row has no tape, so its Jacobian support comes
+            // from the form: `Hx + a` is nonzero exactly on the union of the
+            // Hessian's rows and the folded linear part.
+            if let Some(f) = quad.row_form(i) {
+                cols.extend(quad.gradient_support(f).iter().map(|&v| v as usize));
             }
             cols.extend(prob.con_linear[i].iter().map(|(v, _)| *v));
             cols.sort_unstable();
@@ -3401,6 +3572,28 @@ impl NlTnlp {
                 }
                 None => eprintln!("[hybrid stats] con hybrid not built (no shared CSE bodies)"),
             }
+            // What the constant-structure path took off the tape builder.
+            // `forms` counts the objective too, which is why it can exceed
+            // the row count by one.
+            let quad_rows = (0..prob.m).filter(|&i| quad.row_form(i).is_some()).count();
+            eprintln!(
+                "[quad stats] forms={} rows={quad_rows}/{} obj={} \
+                 stored_h_entries={} colored_pairs={}/{}",
+                quad.len(),
+                prob.m,
+                if quad.objective_form().is_some() {
+                    "quadratic"
+                } else {
+                    "taped"
+                },
+                quad.stored_entries(),
+                if h_tape_mask.is_empty() {
+                    lower_pairs.len()
+                } else {
+                    h_tape_mask.iter().filter(|&&t| t).count()
+                },
+                lower_pairs.len(),
+            );
         }
 
         let compressed: Vec<Vec<f64>> = vec![vec![0.0; prob.n]; n_colors];
@@ -3410,6 +3603,8 @@ impl NlTnlp {
             obj_tapes,
             con_tapes,
             con_hybrid,
+            quad,
+            h_tape_mask,
             h_irow,
             h_jcol,
             jac_cols,
@@ -3576,6 +3771,7 @@ impl NlTnlp {
             self.prob.n,
             self.prob.m,
             &lower_pairs,
+            &self.h_tape_mask,
             peel_veto,
             &self.obj_tapes,
             &self.con_tapes,
@@ -3617,6 +3813,21 @@ impl NlTnlp {
     /// [`Self::variant`].
     pub fn problem(&self) -> &NlProblem {
         &self.prob
+    }
+
+    /// Is constraint row `i` evaluated from a constant quadratic form
+    /// rather than from an AD tape (gh #588, Q4)?
+    ///
+    /// Structural, so it answers before any evaluation. Exposed for the
+    /// differential test, which has to know which models exercise the fast
+    /// path at all, and for `POUNCE_DBG_TAPE_STATS`.
+    pub fn quadratic_row(&self, i: usize) -> bool {
+        self.quad.row_form(i).is_some()
+    }
+
+    /// As [`Self::quadratic_row`], for the objective.
+    pub fn quadratic_objective(&self) -> bool {
+        self.quad.objective_form().is_some()
     }
 
     /// Structural set of variables that appear in *some* nonlinear part —
@@ -3781,6 +3992,45 @@ impl NlTnlp {
         } else {
             -obj_factor
         };
+        // The constant blocks. `H · v` for a quadratic form is a matvec
+        // against stored values, so unlike a tape it needs no forward sweep
+        // and no `x` at all. Easy to forget — a matrix-free solve that
+        // silently dropped the quadratic part of `∇²L` would still converge,
+        // just to a different point by a different route, which is the
+        // failure mode this series is most exposed to.
+        if !self.quad.is_empty() {
+            if obj_seed != 0.0 {
+                if let Some(f) = self.quad.objective_form() {
+                    for (c, out_col) in out.chunks_mut(n).enumerate() {
+                        if self.hvp_live[c] {
+                            self.quad.add_hessian_vector(
+                                f,
+                                &v[c * n..(c + 1) * n],
+                                obj_seed,
+                                out_col,
+                            );
+                        }
+                    }
+                }
+            }
+            if let Some(lam) = lambda {
+                for (i, &w) in lam.iter().enumerate() {
+                    if w == 0.0 {
+                        continue;
+                    }
+                    let Some(f) = self.quad.row_form(i) else {
+                        continue;
+                    };
+                    for (c, out_col) in out.chunks_mut(n).enumerate() {
+                        if self.hvp_live[c] {
+                            self.quad
+                                .add_hessian_vector(f, &v[c * n..(c + 1) * n], w, out_col);
+                        }
+                    }
+                }
+            }
+        }
+
         if obj_seed != 0.0 {
             for t in &self.obj_tapes {
                 if t.ops.is_empty() {
@@ -4040,6 +4290,13 @@ impl TNLP for NlTnlp {
         for t in obj_tapes {
             nl += t.eval_into(x, vals);
         }
+        // A recognized objective has no tapes, so the loop above added
+        // nothing and the form supplies the whole nonlinear part — including
+        // the linear and constant terms AMPL folded into that tree, which is
+        // why they are *not* also in `obj_linear` / `obj_constant`.
+        if let Some(f) = self.quad.objective_form() {
+            nl += self.quad.value(f, x);
+        }
         let lin: Number = self.prob.obj_linear.iter().map(|(i, c)| c * x[*i]).sum();
         let v = self.prob.obj_constant + nl + lin;
         let signed = if self.prob.minimize { v } else { -v };
@@ -4053,6 +4310,9 @@ impl TNLP for NlTnlp {
         // nothing — see `Tape::gradient_seed_into` (M18).
         for t in &self.obj_tapes {
             t.gradient_seed_into(x, 1.0, grad, &mut self.vals_scratch, &mut self.adj_scratch);
+        }
+        if let Some(f) = self.quad.objective_form() {
+            self.quad.add_gradient(f, x, 1.0, grad);
         }
         for (i, c) in &self.prob.obj_linear {
             grad[*i] += c;
@@ -4075,6 +4335,7 @@ impl TNLP for NlTnlp {
         // `Tape::eval_into`.
         let m = self.prob.m;
         let con_linear = &self.prob.con_linear;
+        let quad = &self.quad;
         if let Some(h) = &mut self.con_hybrid {
             // Shared CSE bodies once for the whole constraint block, then one
             // local sweep per summand (pounce#476).
@@ -4092,6 +4353,9 @@ impl TNLP for NlTnlp {
                     tape.forward_summand(s, x, prelude_vals, local_vals);
                     nl += tape.root_value(s, local_vals);
                 }
+                if let Some(f) = quad.row_form(i) {
+                    nl += quad.value(f, x);
+                }
                 let lin: Number = con_linear[i].iter().map(|(j, c)| c * x[*j]).sum();
                 g[i] = nl + lin;
             }
@@ -4102,6 +4366,12 @@ impl TNLP for NlTnlp {
             let mut nl: Number = 0.0;
             for t in &con_tapes[i] {
                 nl += t.eval_into(x, vals);
+            }
+            // A quadratic row's summand range is empty above, so this is its
+            // whole nonlinear part: one matvec against a constant matrix in
+            // place of a walk over every monomial's tape.
+            if let Some(f) = quad.row_form(i) {
+                nl += quad.value(f, x);
             }
             let lin: Number = con_linear[i].iter().map(|(j, c)| c * x[*j]).sum();
             g[i] = nl + lin;
@@ -4136,6 +4406,7 @@ impl TNLP for NlTnlp {
                     prob,
                     con_tapes,
                     con_hybrid,
+                    quad,
                     jac_cols,
                     scratch_row_grad,
                     vals_scratch,
@@ -4176,6 +4447,9 @@ impl TNLP for NlTnlp {
                                 prelude_adj,
                             );
                         }
+                        if let Some(f) = quad.row_form(i) {
+                            quad.add_gradient(f, xs, 1.0, scratch_row_grad);
+                        }
                         for &(v, c) in &prob.con_linear[i] {
                             scratch_row_grad[v] += c;
                         }
@@ -4194,6 +4468,14 @@ impl TNLP for NlTnlp {
                         // Allocation-free reverse-AD per summand tape (M18):
                         // reuse the shared forward/adjoint scratch arenas.
                         t.gradient_seed_into(xs, 1.0, scratch_row_grad, vals_scratch, adj_scratch);
+                    }
+                    // `Hx + a` for a quadratic row: one matvec over the
+                    // row's support, in place of a reverse sweep per
+                    // monomial. `jac_cols[i]` already covers the form's
+                    // gradient support, so the scatter lands inside the
+                    // window zeroed above.
+                    if let Some(f) = quad.row_form(i) {
+                        quad.add_gradient(f, xs, 1.0, scratch_row_grad);
                     }
                     for &(v, c) in &prob.con_linear[i] {
                         scratch_row_grad[v] += c;
@@ -4242,6 +4524,32 @@ impl TNLP for NlTnlp {
                 // sparse `values` array.
                 for buf in &mut self.compressed {
                     buf.fill(0.0);
+                }
+
+                // The constant blocks first: no forward sweep, no
+                // directional product, no decode — the multipliers are the
+                // only thing that changed since the model was read, so this
+                // is one `values[slot] += w · h` pass per live form. Skipped
+                // wholesale on a model with nothing recognized, so such a
+                // model does not pay an `O(m)` scan for a structure that is
+                // empty.
+                if !self.quad.is_empty() {
+                    if obj_seed != 0.0 {
+                        if let Some(f) = self.quad.objective_form() {
+                            self.quad.accumulate_hessian(f, obj_seed, values);
+                        }
+                    }
+                    if let Some(lam) = lambda {
+                        for i in 0..self.prob.m {
+                            let w = lam[i];
+                            if w == 0.0 {
+                                continue;
+                            }
+                            if let Some(f) = self.quad.row_form(i) {
+                                self.quad.accumulate_hessian(f, w, values);
+                            }
+                        }
+                    }
                 }
 
                 if obj_seed != 0.0 {

--- a/crates/pounce-nlp/src/lib.rs
+++ b/crates/pounce-nlp/src/lib.rs
@@ -26,6 +26,7 @@ pub mod derivative_test;
 pub mod expression_provider;
 pub mod ipopt_nlp;
 pub mod orig_ipopt_nlp;
+pub mod quadratic;
 pub mod return_codes;
 pub mod scaling_tnlp;
 pub mod solve_statistics;
@@ -36,6 +37,7 @@ pub use alg_types::SolverReturn;
 pub use expression_provider::{ExpressionProvider, FbbtOp, FbbtTape};
 pub use ipopt_nlp::{IpoptNlp, Nlp};
 pub use orig_ipopt_nlp::{ConstObjScaling, NlpScaling, NoScaling, OrigIpoptNlp};
+pub use quadratic::QuadraticStructure;
 pub use return_codes::{AlgorithmMode, ApplicationReturnStatus};
 pub use solve_statistics::SolveStatistics;
 pub use tnlp::{

--- a/crates/pounce-nlp/src/quadratic.rs
+++ b/crates/pounce-nlp/src/quadratic.rs
@@ -1,0 +1,501 @@
+//! Constant-structure evaluation for degree-≤2 objectives and rows.
+//!
+//! A quadratic row's value, gradient and Hessian are all determined by one
+//! constant matrix. POUNCE nevertheless re-derives them on every call from a
+//! reverse-mode AD tape: on Mittelmann's `qcqp500-3c` that is 2.32 M tapes
+//! walked twice per `eval_h`, 332 times, to recover ten matrices that never
+//! change. [`QuadraticStructure`] is where the recognizer's answer is kept
+//! instead of thrown away — see
+//! `dev-notes/quadratic-structure-exploitation.md` (gh #588), phase Q4.
+//!
+//! ## What lives here, and what does not
+//!
+//! This module is **pure sparse linear algebra**. It never sees an `Expr`, a
+//! tape or a `feral` factorization: recognition is
+//! `pounce_nl::nl_quadratic`'s job and it hands the result over as plain
+//! `(i, j, ∂²/∂xᵢ∂xⱼ)` triplets. That split is what lets the type live in
+//! `pounce-nlp`, which every other crate already depends on, so `pounce-py`,
+//! `pounce-wasm` and `pounce-rs` inherit it with no manifest change — and it
+//! is why the structure stops at the TNLP values array and knows nothing
+//! about the KKT system those values end up in.
+//!
+//! ## Storage
+//!
+//! Every array is **flat and shared across forms**, indexed by per-form
+//! offsets. A `Vec` per form would reintroduce, one level up, exactly the
+//! allocation-per-object cost Q3 removed from the recognizer: `qssp180` has
+//! 65 341 quadratic rows of three nonzeros each, and a struct-per-row layout
+//! would spend ten allocations on each of them to describe 24 bytes of
+//! matrix.
+//!
+//! Each form is stored as
+//!
+//! * the **full symmetric** `H` in CSR over the form's support — both
+//!   triangles, because the value and the gradient are matvecs and a matvec
+//!   against half a symmetric matrix costs a scatter it does not need;
+//! * the linear coefficients `a` folded into the nonlinear tree by the `.nl`
+//!   writer (the `−6x₀` of `(x₀−3)²`), which are *not* the row's `.nl` linear
+//!   section — the caller still adds that;
+//! * the constant `c` (the `+9`), for the same reason
+//!   [`analyze_quadratic_full`](https://docs.rs/pounce-nl) returns it: it does
+//!   not move the minimizer but it is part of the reported value;
+//! * one scatter slot per lower-triangle entry, so accumulating `∇²L` is a
+//!   `values[slot] += w · h` loop with no hashing and no search.
+//!
+//! The convention on `H` is the Hessian's, `∂²/∂xᵢ∂xⱼ` — so a `c·xᵢ²` term
+//! arrives as `2c` on the diagonal, and the form evaluates as
+//! `½xᵀHx + aᵀx + c`. Handing it *polynomial* coefficients instead is a
+//! silent factor of two on the diagonal, which is why
+//! [`QuadraticStructure::push_form`] takes the Hessian triplets that
+//! `analyze_quadratic_full` already applies that factor in, rather than a
+//! `Quad2`.
+
+use std::collections::BTreeMap;
+
+/// Index into [`QuadraticStructure`]'s form arrays. `u32` because the count
+/// is bounded by `m + 1` and the row map is one of these per constraint.
+type FormId = u32;
+
+/// No form: the value in [`QuadraticStructure::form_of_row`] for a row that
+/// is not (recognized as) quadratic and keeps its tape.
+const NO_FORM: FormId = u32::MAX;
+
+/// The recognized degree-≤2 parts of one model: at most one per constraint
+/// row, plus at most one for the objective.
+///
+/// Built once in `NlTnlp::try_new` and then read-only. Cloning it is what
+/// `NlTnlp::variant` does — a variation changes bounds and starting points,
+/// never structure — so the layout is deliberately a handful of flat `Vec`s
+/// rather than a graph.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct QuadraticStructure {
+    // ---- per form ----
+    /// `sup[form_sup[f] .. form_sup[f + 1]]` — the variables with a Hessian
+    /// row in form `f`, ascending.
+    form_sup: Vec<u32>,
+    /// `lin[form_lin[f] .. form_lin[f + 1]]` — indices into `lin_idx`/`lin_val`.
+    form_lin: Vec<u32>,
+    /// `grad[form_grad[f] .. form_grad[f + 1]]` — the form's gradient
+    /// support (Hessian support ∪ linear support), ascending. Precomputed
+    /// because `eval_jac_g` needs it once per call per row and it is the
+    /// same set every time.
+    form_grad: Vec<u32>,
+    /// `h_slot[form_h[f] .. form_h[f + 1]]` — one scatter target per
+    /// lower-triangle entry of form `f`, in the order
+    /// [`Self::lower_triangle`] walks them.
+    form_h: Vec<u32>,
+    /// The degree-0 term of each form.
+    constant: Vec<f64>,
+
+    // ---- concatenated payloads ----
+    /// Concatenated Hessian supports.
+    sup: Vec<u32>,
+    /// CSR row pointers, one per entry of `sup` plus a global terminator:
+    /// support entry `k` owns `col[sup_ptr[k] .. sup_ptr[k + 1]]`.
+    sup_ptr: Vec<u32>,
+    /// Column indices of the **full symmetric** `H`, ascending within a row.
+    col: Vec<u32>,
+    /// Values of the full symmetric `H`, parallel to `col`.
+    val: Vec<f64>,
+    /// Concatenated linear supports and coefficients.
+    lin_idx: Vec<u32>,
+    lin_val: Vec<f64>,
+    /// Concatenated gradient supports.
+    grad: Vec<u32>,
+    /// Concatenated scatter targets; `u32::MAX` until [`Self::bind_slots`].
+    h_slot: Vec<u32>,
+
+    // ---- the map back to the model ----
+    /// `form_of_row[i]` is the form evaluating row `i`, or [`NO_FORM`] when
+    /// row `i` keeps its tape.
+    form_of_row: Vec<FormId>,
+    /// The objective's form, or [`NO_FORM`].
+    obj_form: FormId,
+}
+
+impl QuadraticStructure {
+    /// An empty structure over `m` constraint rows: nothing recognized, so
+    /// every caller behaves exactly as it did before this module existed.
+    pub fn new(m: usize) -> Self {
+        QuadraticStructure {
+            form_sup: vec![0],
+            form_lin: vec![0],
+            form_grad: vec![0],
+            form_h: vec![0],
+            sup_ptr: vec![0],
+            form_of_row: vec![NO_FORM; m],
+            obj_form: NO_FORM,
+            ..Self::default()
+        }
+    }
+
+    /// Add a form and return its id.
+    ///
+    /// `hess` is the **upper-triangular (i ≤ j) Hessian** of the form —
+    /// `∂²/∂xᵢ∂xⱼ`, so the factor of two on the diagonal is already applied
+    /// — which is exactly `analyze_quadratic_full`'s first return value.
+    /// `lin` is its degree-1 part and `constant` its degree-0 part.
+    ///
+    /// Entries that are exactly zero are dropped: they cost a scatter slot
+    /// and a multiply-add to contribute nothing, and keeping them would make
+    /// the Hessian pattern depend on how a coefficient happened to cancel.
+    pub fn push_form(
+        &mut self,
+        hess: &BTreeMap<(usize, usize), f64>,
+        lin: &[(usize, f64)],
+        constant: f64,
+    ) -> FormId {
+        // Scatter the upper triangle into full symmetric rows. A `BTreeMap`
+        // keyed by row keeps the support ascending without a sort, and the
+        // inner `BTreeMap` keeps each row's columns ascending — which is
+        // what makes `lower_triangle` come out in the (row, col) order the
+        // TNLP's `lower_pairs` is sorted in.
+        let mut rows: BTreeMap<u32, BTreeMap<u32, f64>> = BTreeMap::new();
+        for (&(i, j), &v) in hess {
+            debug_assert!(i <= j, "push_form takes the upper triangle, got ({i}, {j})");
+            if v == 0.0 {
+                continue;
+            }
+            rows.entry(i as u32).or_default().insert(j as u32, v);
+            if i != j {
+                rows.entry(j as u32).or_default().insert(i as u32, v);
+            }
+        }
+
+        for (&r, cols) in &rows {
+            self.sup.push(r);
+            for (&c, &v) in cols {
+                self.col.push(c);
+                self.val.push(v);
+            }
+            self.sup_ptr.push(self.col.len() as u32);
+        }
+        self.form_sup.push(self.sup.len() as u32);
+
+        for &(i, c) in lin {
+            if c == 0.0 {
+                continue;
+            }
+            self.lin_idx.push(i as u32);
+            self.lin_val.push(c);
+        }
+        self.form_lin.push(self.lin_idx.len() as u32);
+
+        // Gradient support = Hessian support ∪ linear support, ascending.
+        // Both sides are already ascending, so this is a merge.
+        let f = self.constant.len();
+        let hs = &self.sup[self.form_sup[f] as usize..];
+        let ls = &self.lin_idx[self.form_lin[f] as usize..];
+        let (mut a, mut b) = (0usize, 0usize);
+        while a < hs.len() || b < ls.len() {
+            let take = match (hs.get(a), ls.get(b)) {
+                (Some(&x), Some(&y)) => {
+                    if x < y {
+                        a += 1;
+                        x
+                    } else if y < x {
+                        b += 1;
+                        y
+                    } else {
+                        a += 1;
+                        b += 1;
+                        x
+                    }
+                }
+                (Some(&x), None) => {
+                    a += 1;
+                    x
+                }
+                (None, Some(&y)) => {
+                    b += 1;
+                    y
+                }
+                (None, None) => unreachable!("loop guard"),
+            };
+            self.grad.push(take);
+        }
+        self.form_grad.push(self.grad.len() as u32);
+
+        // One unbound scatter slot per lower-triangle entry.
+        let n_lower = self.lower_triangle(f as FormId).count();
+        self.h_slot.resize(self.h_slot.len() + n_lower, NO_FORM);
+        self.form_h.push(self.h_slot.len() as u32);
+
+        self.constant.push(constant);
+        f as FormId
+    }
+
+    /// Attach form `f` to constraint row `i`.
+    pub fn assign_row(&mut self, i: usize, f: FormId) {
+        self.form_of_row[i] = f;
+    }
+
+    /// Attach form `f` to the objective.
+    pub fn assign_objective(&mut self, f: FormId) {
+        self.obj_form = f;
+    }
+
+    /// Is there anything here at all? A model with no recognized part gets
+    /// the tape path unchanged, down to the coloring.
+    pub fn is_empty(&self) -> bool {
+        self.constant.is_empty()
+    }
+
+    /// How many forms are stored (objective included).
+    pub fn len(&self) -> usize {
+        self.constant.len()
+    }
+
+    /// The form evaluating constraint row `i`, if it has one.
+    pub fn row_form(&self, i: usize) -> Option<FormId> {
+        match self.form_of_row.get(i).copied() {
+            Some(f) if f != NO_FORM => Some(f),
+            _ => None,
+        }
+    }
+
+    /// The objective's form, if it has one.
+    pub fn objective_form(&self) -> Option<FormId> {
+        (self.obj_form != NO_FORM).then_some(self.obj_form)
+    }
+
+    /// The form's gradient support (Hessian support ∪ linear support),
+    /// ascending. This is what a Jacobian row's column list must include.
+    pub fn gradient_support(&self, f: FormId) -> &[u32] {
+        let f = f as usize;
+        &self.grad[self.form_grad[f] as usize..self.form_grad[f + 1] as usize]
+    }
+
+    /// The form's lower-triangle Hessian entries as `(row, col, value)` with
+    /// `row >= col`, ascending by `(row, col)`.
+    ///
+    /// The order is load-bearing twice over: it is the order
+    /// [`Self::bind_slots`] consumes scatter targets in, and it is the order
+    /// [`Self::accumulate_hessian`] replays them in.
+    pub fn lower_triangle(&self, f: FormId) -> impl Iterator<Item = (u32, u32, f64)> + '_ {
+        let f = f as usize;
+        let (lo, hi) = (self.form_sup[f] as usize, self.form_sup[f + 1] as usize);
+        (lo..hi).flat_map(move |k| {
+            let r = self.sup[k];
+            let (a, b) = (self.sup_ptr[k] as usize, self.sup_ptr[k + 1] as usize);
+            (a..b).filter_map(move |e| {
+                let c = self.col[e];
+                (c <= r).then(|| (r, c, self.val[e]))
+            })
+        })
+    }
+
+    /// Point each lower-triangle entry at its index in the TNLP's Hessian
+    /// `values` array.
+    ///
+    /// `lookup` is called once per entry, in [`Self::lower_triangle`] order,
+    /// and must return the index of `(row, col)` in the model's assembled
+    /// lower-triangle pattern.
+    pub fn bind_slots(&mut self, mut lookup: impl FnMut(u32, u32) -> usize) {
+        let mut k = 0usize;
+        for f in 0..self.constant.len() as FormId {
+            let entries: Vec<(u32, u32)> = self.lower_triangle(f).map(|(r, c, _)| (r, c)).collect();
+            for (r, c) in entries {
+                self.h_slot[k] = lookup(r, c) as u32;
+                k += 1;
+            }
+        }
+        debug_assert_eq!(k, self.h_slot.len(), "every entry gets a slot");
+    }
+
+    /// `½xᵀHx + aᵀx + c`.
+    ///
+    /// The `½` is applied once at the end rather than per row, which is both
+    /// cheaper and closer to what the tape did (it never scaled a partial
+    /// sum).
+    pub fn value(&self, f: FormId, x: &[f64]) -> f64 {
+        let fi = f as usize;
+        let (lo, hi) = (self.form_sup[fi] as usize, self.form_sup[fi + 1] as usize);
+        let mut quad = 0.0;
+        for k in lo..hi {
+            let r = self.sup[k] as usize;
+            let (a, b) = (self.sup_ptr[k] as usize, self.sup_ptr[k + 1] as usize);
+            let mut t = 0.0;
+            for e in a..b {
+                t += self.val[e] * x[self.col[e] as usize];
+            }
+            quad += x[r] * t;
+        }
+        let mut lin = 0.0;
+        for e in self.form_lin[fi] as usize..self.form_lin[fi + 1] as usize {
+            lin += self.lin_val[e] * x[self.lin_idx[e] as usize];
+        }
+        0.5 * quad + lin + self.constant[fi]
+    }
+
+    /// `out += w · (Hx + a)`, touching only the form's gradient support.
+    pub fn add_gradient(&self, f: FormId, x: &[f64], w: f64, out: &mut [f64]) {
+        let fi = f as usize;
+        let (lo, hi) = (self.form_sup[fi] as usize, self.form_sup[fi + 1] as usize);
+        for k in lo..hi {
+            let r = self.sup[k] as usize;
+            let (a, b) = (self.sup_ptr[k] as usize, self.sup_ptr[k + 1] as usize);
+            let mut t = 0.0;
+            for e in a..b {
+                t += self.val[e] * x[self.col[e] as usize];
+            }
+            out[r] += w * t;
+        }
+        for e in self.form_lin[fi] as usize..self.form_lin[fi + 1] as usize {
+            out[self.lin_idx[e] as usize] += w * self.lin_val[e];
+        }
+    }
+
+    /// `values[slot] += w · H[row, col]` over the form's lower triangle.
+    ///
+    /// This is the whole Hessian contribution of a quadratic row: no forward
+    /// sweep, no directional product, no decode — the multipliers are the
+    /// only thing that changed since the model was read.
+    pub fn accumulate_hessian(&self, f: FormId, w: f64, values: &mut [f64]) {
+        let fi = f as usize;
+        let base = self.form_h[fi] as usize;
+        for (k, (_, _, v)) in self.lower_triangle(f).enumerate() {
+            let slot = self.h_slot[base + k] as usize;
+            values[slot] += w * v;
+        }
+    }
+
+    /// `out += w · (H · v)` — the Hessian-vector product form, for the
+    /// matrix-free (Newton-Krylov) path.
+    pub fn add_hessian_vector(&self, f: FormId, v: &[f64], w: f64, out: &mut [f64]) {
+        let fi = f as usize;
+        let (lo, hi) = (self.form_sup[fi] as usize, self.form_sup[fi + 1] as usize);
+        for k in lo..hi {
+            let r = self.sup[k] as usize;
+            let (a, b) = (self.sup_ptr[k] as usize, self.sup_ptr[k + 1] as usize);
+            let mut t = 0.0;
+            for e in a..b {
+                t += self.val[e] * v[self.col[e] as usize];
+            }
+            out[r] += w * t;
+        }
+    }
+
+    /// Total stored Hessian entries over all forms, both triangles. Reported
+    /// by `POUNCE_DBG_TAPE_STATS`; also the thing the memory claim in the
+    /// design note is about.
+    pub fn stored_entries(&self) -> usize {
+        self.val.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `q(x) = 3x₀² + 5x₀x₁ − 2x₀ + 7`, whose Hessian is
+    /// `[[6, 5], [5, 0]]`.
+    fn sample() -> (QuadraticStructure, FormId) {
+        let mut h = BTreeMap::new();
+        h.insert((0, 0), 6.0);
+        h.insert((0, 1), 5.0);
+        let mut qs = QuadraticStructure::new(1);
+        let f = qs.push_form(&h, &[(0, -2.0)], 7.0);
+        (qs, f)
+    }
+
+    #[test]
+    fn value_matches_the_polynomial() {
+        let (qs, f) = sample();
+        let x = [2.0, -3.0];
+        // 3·4 + 5·2·(−3) − 2·2 + 7 = 12 − 30 − 4 + 7
+        assert_eq!(qs.value(f, &x), -15.0);
+    }
+
+    #[test]
+    fn gradient_is_hx_plus_a() {
+        let (qs, f) = sample();
+        let x = [2.0, -3.0];
+        let mut g = [0.0; 2];
+        qs.add_gradient(f, &x, 1.0, &mut g);
+        // ∂/∂x₀ = 6·2 + 5·(−3) − 2 = −5 ; ∂/∂x₁ = 5·2 = 10
+        assert_eq!(g, [-5.0, 10.0]);
+        // Weighted, and accumulating rather than overwriting.
+        qs.add_gradient(f, &x, 2.0, &mut g);
+        assert_eq!(g, [-15.0, 30.0]);
+    }
+
+    /// The factor-of-two trap: `push_form` takes *Hessian* entries, so a
+    /// `3x₀²` term must arrive as `6`, and the value must come back as `3x₀²`
+    /// rather than `6x₀²`.
+    #[test]
+    fn the_diagonal_is_a_hessian_entry_not_a_polynomial_coefficient() {
+        let mut h = BTreeMap::new();
+        h.insert((0, 0), 6.0);
+        let mut qs = QuadraticStructure::new(0);
+        let f = qs.push_form(&h, &[], 0.0);
+        assert_eq!(qs.value(f, &[1.0]), 3.0);
+        let mut g = [0.0];
+        qs.add_gradient(f, &[1.0], 1.0, &mut g);
+        assert_eq!(g, [6.0]);
+    }
+
+    #[test]
+    fn lower_triangle_is_ascending_and_omits_the_upper_half() {
+        let (qs, f) = sample();
+        let got: Vec<(u32, u32, f64)> = qs.lower_triangle(f).collect();
+        assert_eq!(got, vec![(0, 0, 6.0), (1, 0, 5.0)]);
+    }
+
+    #[test]
+    fn hessian_scatters_through_the_bound_slots() {
+        let (mut qs, f) = sample();
+        // Pretend the model's assembled pattern is [(1,0), (0,0)] — a
+        // deliberately un-sorted order, so a bug that assumed identity
+        // mapping shows up.
+        let pattern = [(1u32, 0u32), (0, 0)];
+        qs.bind_slots(|r, c| {
+            pattern
+                .iter()
+                .position(|&p| p == (r, c))
+                .expect("entry in pattern")
+        });
+        let mut values = [0.0; 2];
+        qs.accumulate_hessian(f, 2.0, &mut values);
+        assert_eq!(values, [10.0, 12.0]);
+    }
+
+    #[test]
+    fn hessian_vector_product_agrees_with_the_dense_matrix() {
+        let (qs, f) = sample();
+        let v = [1.0, 2.0];
+        let mut out = [0.0; 2];
+        qs.add_hessian_vector(f, &v, 1.0, &mut out);
+        // [[6,5],[5,0]] · [1,2] = [16, 5]
+        assert_eq!(out, [16.0, 5.0]);
+    }
+
+    #[test]
+    fn gradient_support_merges_the_two_sides() {
+        let mut h = BTreeMap::new();
+        h.insert((1, 3), 1.0);
+        let mut qs = QuadraticStructure::new(0);
+        // Linear part touches 0 and 3; the Hessian touches 1 and 3.
+        let f = qs.push_form(&h, &[(0, 1.0), (3, 1.0)], 0.0);
+        assert_eq!(qs.gradient_support(f), &[0, 1, 3]);
+    }
+
+    #[test]
+    fn zero_coefficients_are_not_stored() {
+        let mut h = BTreeMap::new();
+        h.insert((0, 0), 0.0);
+        h.insert((0, 1), 4.0);
+        let mut qs = QuadraticStructure::new(0);
+        let f = qs.push_form(&h, &[(2, 0.0)], 0.0);
+        assert_eq!(qs.lower_triangle(f).count(), 1);
+        assert_eq!(qs.gradient_support(f), &[0, 1]);
+    }
+
+    #[test]
+    fn an_empty_structure_reports_itself_as_one() {
+        let qs = QuadraticStructure::new(4);
+        assert!(qs.is_empty());
+        assert_eq!(qs.row_form(2), None);
+        assert_eq!(qs.objective_form(), None);
+    }
+}

--- a/dev-notes/quadratic-structure-exploitation.md
+++ b/dev-notes/quadratic-structure-exploitation.md
@@ -31,7 +31,7 @@ describes.
 | Q1 — sparse SOC extraction + cost-model routing | **done** | (this commit) | extractor fixed (134 GB/row → 32 B/row); routing **unchanged** — the note's forecast was wrong, see §0b |
 | Q2 — `.nl` header nonlinearity counts | **done** | (this commit) | census kept; `get_number_of_nonlinear_variables` implemented (60/60 fixtures answer, was `-1`); the LP-fast-path forecast was wrong and was **not** shipped — see §0c |
 | Q3 — recognizer to `pounce-nl`, `Poly` → `Quad2` | **done** | (this commit) | recognizer iterative and allocation-free per monomial; classification of an `o0` chain was `O(k²)` and is now linear (k=16 000: 0.77 s → 0.020 s); the crash Q1 reported is real but unreachable through the CLI — see §0d |
-| Q4 — `QuadraticStructure` + `NlTnlp` fast path | pending | — | — |
+| Q4 — `QuadraticStructure` + `NlTnlp` fast path | **done** | (this commit) | `qcqp1000-2c` (**real**) 131.4 s → 97.6–103.3 s (1.27–1.35×), 100 → 100 iterations, `eval_h` 19.58 s → 0.20 s (~95×); the ≈1.4× forecast was at or above this machine's Amdahl ceiling; the fast path had to be gated on *already-expanded*, *unshared* forms after it cost `airport.nl` 16 → 300 iterations and a shared-DAG model 0.00 s → 172 s — see §0e |
 | Q5 — parse-time recognition | pending | — | — |
 | Q6 — the four constant-derivative hints | pending | — | — |
 | Q7 — `QcqpProblem` extraction | pending | — | — |
@@ -462,6 +462,327 @@ Q2; the 13 new ones are this phase’s).
 `cargo fmt --check` clean; `cargo clippy --workspace --exclude pounce-hsl
 --all-targets` exit 0, with no new lint class (the `expect_used` warnings in
 the new test files are the ones every test file here produces).
+
+---
+
+## 0e. Q4 — `QuadraticStructure` and the `NlTnlp` fast path (measured 2026-08-18)
+
+### What shipped
+
+1. **`pounce_nlp::quadratic::QuadraticStructure`.** The recognized objective
+   and rows, kept instead of thrown away: each form is the full symmetric `H`
+   in CSR over its own support, the linear coefficients and constant AMPL
+   folded into the nonlinear tree, and one precomputed scatter slot per
+   lower-triangle entry. Every array is flat and shared across forms —
+   `qssp180` has 65 341 quadratic rows of three nonzeros each, and a
+   struct-per-row layout would spend ten allocations on each of them to
+   describe 24 bytes of matrix. `pounce-nlp` is where it lives because every
+   other crate already depends on it, so `pounce-py`, `pounce-wasm` and
+   `pounce-rs` inherit the type with no manifest change.
+
+2. **A recognized row builds no tape.** `NlTnlp::try_new` recognizes before it
+   tapes, so `con_tapes[i]` is an empty `Vec` and the summand tapes, the
+   per-tape colour lists and the per-tape sparsity sets for that row are never
+   allocated. Six sites add the row back: `eval_f`/`eval_grad_f` (objective),
+   `eval_g`, `eval_jac_g`, `eval_h`, and — **not in the design's list of five**
+   — `hessian_vector_products`, the matrix-free path. That omission is worth
+   recording: a Newton–Krylov solve that silently dropped the quadratic part
+   of `∇²L` would still converge, to a different point by a different route.
+
+3. **The colouring is built over the tape entries only.** The assembled
+   Hessian pattern is the union of both, but a quadratic block's entries are
+   scattered from stored values and never read out of a directional product,
+   so colouring them would put the colour count back at `n` to pay for
+   products nobody runs. On the real `qcqp1000-2c`: **1000 colours → 0**.
+
+4. **The fast path is gated twice**, and both gates were found by
+   measurement rather than designed in: `is_expanded_quadratic` bounds the
+   *accuracy* of expanding a form, and its refusal of a re-referenced `Cse`
+   body bounds the *cost* of reading one. Both are recorded below.
+
+5. **`POUNCE_DBG_NO_QUAD=1`** forces the tape everywhere, and
+   `NlTnlp::try_new_with_quadratic(prob, false)` is the same switch as a
+   parameter — the env var is process-global, which is exactly wrong for a
+   differential test that must build the same model both ways.
+
+### The measurement: `qcqp1000-2c`, a real Mittelmann instance
+
+The only instance available on this machine. Same binary pair, same options,
+`scripts/qbench.py`:
+
+| | before (`fd738d46`) | after | |
+|---|---|---|---|
+| status | SolveSucceeded | SolveSucceeded | |
+| iterations | 100 | **100** | unchanged |
+| objective | 738127.4263171845 | 738127.4263173543 | agree to 12 digits |
+| wall | 131.38 s | **103.26 / 97.56 s** | **1.27× / 1.35×** |
+| peak RSS | 786.6 MB | **542.7 / 492.7 MB** | ~1.5× |
+| `LagrangianHessianEvaluations` | 19.582 s | **0.209 / 0.198 s** | **94× / 99×** |
+| `ConstraintEvaluations` | 4.863 s | 0.444 / 0.429 s | ~11× |
+| `ConstraintJacobianEvaluations` | 2.055 s | 0.167 / 0.164 s | ~12× |
+| `TotalFunctionEvaluations` | 27.591 s | 0.865 / 0.834 s | ~32× |
+| `LinearSystemFactorization` | 97.168 s | 97.363 / 92.295 s | unchanged, as designed |
+
+Two "after" columns because the phase was measured twice: once at the first
+green build and again after the shared-DAG fix below, which does not touch
+this instance's path (it has no common expressions). They differ by 5.5% on
+wall and 5.2% on the factorization timer, which is **this machine's noise**
+and well inside §10's ~1.3× floor — quoted rather than averaged away, because
+the derived quantities are what the phase should be read on: the iteration
+count and the objective are identical to the last digit across all three runs,
+and the evaluation timers agree to a few percent.
+
+Counters, which is where the mechanism shows rather than the stopwatch
+(`POUNCE_DBG_TAPE_STATS`):
+
+| | before | after |
+|---|---|---|
+| summand tapes | 353 736 | **5 100** (the 1-op `Const(0)` rows, deliberately untouched) |
+| total tape ops | 2 445 552 | **5 100** |
+| Hessian colours | 1 000 | **0** |
+| `nnz_h` (assembled pattern) | 142 386 | 142 386 — identical |
+
+### Which forecasts were verified, and which were not
+
+**`qcqp1000-2c` ≈1.4× — measured 1.27–1.35×, at or below the ceiling.**
+Evaluation is 21.5% of `OverallAlgorithm` on the before-run (97.2 s of the
+128.6 s is factorization), so removing *all* of it caps the speedup at
+**1.26×** against that run. Q4 removed 97% of the evaluation time and
+measured 1.27× and 1.35× on two after-runs — i.e. it captured the whole
+available headroom, and the spread above 1.26× is the same factorization
+noise the two runs show directly (97.4 s vs 92.3 s on identical work). 1.4×
+was not reachable from the evaluation side at this machine's factorization
+cost. The right way to read the phase on this instance is the timer split,
+not the total.
+
+**`qcqp500-3c` ≈6× — not verified on the real instance, which is not
+available here.** Probed on a *generated* look-alike instead; see below.
+
+**`qcqp1500-1c` ≈1.2× — not verified at all.** No instance, and nothing in
+what was measured lets it be inferred: it is factorization-dominated to a
+degree this machine cannot check.
+
+**"Steady-state RSS 3.3 GB → ~0.4 GB" — the *peak* does not go there, and the
+note should not be read as promising that it does.** On the generated
+`qcqp500-3c` shape peak RSS goes 3855 MB → 1254 MB (3.1×), not to 400 MB,
+because the peak is set during parsing by the `Expr` DAG and the file text —
+both of which Q4 leaves alone. Q4 removes the *tapes* built from that DAG.
+Getting the peak down needs parse-time recognition, which is Q5.
+
+### Generated instances, and how far they can be trusted
+
+`scripts/gen-qcqp-nl.py` writes `.nl` files in the family's shape: free
+variables, `k` rows `½xᵀQᵢx ≤ bᵢ` emitted as one `o54` sumlist of
+`o2 n0.5 o2 o2 n<c> v<i> v<j>` summands exactly as AMPL emits them, a
+quadratic objective, and sparse linear rows. Every right-hand side is taken
+at a drawn reference point, so the model is strictly feasible.
+
+**Calibrated against the real `qcqp1000-2c`, and it does not fully reproduce
+it.** The `--shape qcqp1000-2c` preset matches the header on every count
+(1000 vars, 5107 rows, 7 nonlinear, 100 equalities, 63 100 vs 63 121 Jacobian
+nonzeros) and reproduces the *class* (`NLP`) and the memory scale (637 MB vs
+787 MB). It does **not** reproduce the trajectory or the cost mix:
+
+| | real `qcqp1000-2c` | generated look-alike |
+|---|---|---|
+| iterations | 100 | **50** |
+| wall (before) | 131.4 s | 30.7 s |
+| factorization share | 75.6% | **61.8%** |
+| evaluation share | 21.5% | **36.6%** |
+
+So a generated instance is **easier and less factorization-bound than the
+real one, and therefore overstates Q4's aggregate win**: 1.57× on the
+generated look-alike against 1.27× on the real instance. Varying the
+conditioning knob (`--dominance` 1.02 → 1.00) moved the iteration count by
+one, so this is a property of the family the generator produces, not a
+setting that was left wrong.
+
+What *does* transfer is the per-timer ratio, which is the mechanism rather
+than the mix: `LagrangianHessianEvaluations` improves 93.7× on the real
+instance and 80.9× on the generated one.
+
+**The `qcqp500-3c` regime (generated).** `--shape qcqp500-3c` — 500 vars, 10
+dense quadratic rows, 110 linear rows — does land in the evaluation-bound
+regime the 6× claim lives in, and independently corroborates two of the
+note's measurements about the real instance: evaluation is **96.7%** of
+`OverallAlgorithm` (the note measures 89.7% on the real one) and peak RSS is
+**3855 MB** (the note measures 3.3 GB).
+
+| **generated `qcqp500-3c` shape** | before | after | |
+|---|---|---|---|
+| iterations | 75 | 75 | unchanged |
+| objective | 24779.690299303365 | 24779.69029930317 | agree to 13 digits |
+| wall | 136.01 s | **18.36 s** | **7.4×** |
+| `OverallAlgorithm` | 120.28 s | **8.05 s** | **14.9×** |
+| `LagrangianHessianEvaluations` | 44.686 s | 0.588 s | 76× |
+| `ConstraintEvaluations` | 53.521 s | 2.979 s | 18× |
+| `ConstraintJacobianEvaluations` | 10.832 s | 0.358 s | 30× |
+| peak RSS | 3855 MB | 1254 MB | 3.1× |
+
+**These are generated-instance numbers and must not be quoted as
+`qcqp500-3c` numbers.** They say Q4 clears 6× in this regime on a model of
+this shape. They do not say what it does to the real instance, whose 332
+iterations at 8.09 line-search trials each (§0b) the generator does not
+reproduce — the generated model takes 75 iterations at roughly one trial
+apiece. If anything the real instance has *more* evaluation volume per
+iteration for Q4 to remove.
+
+### The accuracy defect the phase nearly shipped
+
+The fast path evaluates the **expanded** polynomial `½xᵀHx + aᵀx + c`. The
+tape evaluates whatever the `.nl` writer wrote — and for a least-squares
+shape that is the **factored** form. Those are not the same computation:
+
+* `feasible_x0_extreme_row.nl` writes `(x − 500000)²`. The tape squares a
+  small residual; the expansion adds `x² − 10⁶x + 2.5·10¹¹` and cancels.
+  Measured disagreement: **2.4e-5 relative** — five digits, not an ulp.
+* `airport.nl` is 84 coordinates around 10³ with every row a squared
+  distance. With the fast path ungated, `mu_strategy=adaptive tol=1e-12`
+  went from **stopping at a tiny step in 16 iterations to grinding out the
+  300-iteration cap** at the same objective to 12 digits. That is the gh #544
+  failure mode exactly — the right answer, slowly — and it was caught by the
+  gh #512 regression test, *not* by the fixture sweep, which runs default
+  options.
+
+The fix is an exactness rule, not a magnitude heuristic:
+`nl_quadratic::is_expanded_quadratic` admits a form only when it is already a
+flat sum of monomials, so the read-out repeats the additions the writer
+already wrote and can differ from the tape only by summation order. AMPL
+emits the whole `qcqp*` family that way, so the target of the phase is
+unaffected (verified: the real `qcqp1000-2c` puts all 7 rows and its
+objective on the fast path). `airport.nl` keeps 41 of its 42 rows on the
+tape.
+
+**The cost of that gate is real and is Q4's honest limitation.** A model
+written in factored form gains nothing from this phase. §3.5's "pays on all
+358 structured problems" is therefore **too strong for Q4 as shipped**: it
+pays on the structured problems whose quadratic parts arrive expanded.
+Evaluating a factored form stably from stored coefficients means carrying a
+shift, which is a larger change than this phase — filed as
+[#673](https://github.com/jkitchin/pounce/issues/673).
+
+### The second defect the phase nearly shipped: shared DAGs
+
+The gate — and `recognize_expr` behind it — inlines a `Cse` body at **every
+reference**, which Q3 documented and deliberately left to Q5 to memoize. Q4
+put both on the `NlTnlp::try_new` path, where a DAG with shared bodies costs
+`Θ(2^depth)` instead of `Θ(nodes)`. `nl_reader`'s
+`shared_dag_walks_are_memoized_not_exponential` builds exactly that shape (30
+levels, each a `Cse` referenced twice) precisely because the blowup has bitten
+this crate before, and it measured:
+
+| | with the fast path | `POUNCE_DBG_NO_QUAD=1` |
+|---|---|---|
+| that test, debug build | **172.41 s** | **0.00 s** |
+
+It *passed* — exponential-but-finite at depth 30 — which is the worst way for
+this to be found. At depth 40 it would not return.
+
+The fix is the same shape as the accuracy gate: **a `Cse` body reached a
+second time ends the walk with `false`**, so the model keeps its tape, which
+handles sharing properly (that is what `ConHybrid` is for). Memoizing on `Arc`
+identity instead would fix the gate and leave `recognize_expr` exponential
+behind it, so it belongs with that change in Q5 rather than half-done here.
+
+Measured cost of the refusal on this corpus: **none** — 27 models and 251
+quadratic rows before and after, byte-identical differential numbers. The
+target family is unaffected too: the `qcqp*` files declare no common
+expressions at all (`common exprs: 0 0 0 0 0`).
+
+### Correctness: the differential test is the load-bearing artefact
+
+`crates/pounce-cli/tests/quad_evaluator_differential.rs` builds every `.nl`
+file in the repository **twice** — fast path and `try_new_with_quadratic(…,
+false)` — and compares `eval_f`, `eval_grad_f`, `eval_g`, `eval_jac_g` and
+`eval_h` at the model's own starting point and three pseudo-random
+perturbations of it. The Jacobian and Hessian are compared as
+`(row, col) → value` maps, because the two paths need not agree on the
+*pattern*: a coefficient that cancels to exactly zero is dropped by the
+recognizer and kept by the tape's structural sparsity.
+
+Measured over 27 models and 251 quadratic rows:
+
+| comparison | result |
+|---|---|
+| `∇²L`, assembled lower triangle | 26 846 of 26 848 entries **bit-identical**; the 2 that are not differ by exactly **1 ulp** |
+| `g`, `∇g`, `f`, `∇f` | worst relative deviation **4.13e-15** |
+| a model with nothing recognized | **byte-identical** on both constructions — the blast radius is exactly the recognized set |
+
+The design note's §5.4 says `∇²L` is "plausibly bit-identical" and says to
+measure it rather than assert it. Measured: **right for the shape it reasoned
+about, wrong in general.** The two entries that move are in `eigena2.nl`,
+which has 55 quadratic rows and a *non-quadratic* objective, so `∇²L[8, 8]`
+takes a constant contribution from a row and an `x`-dependent one from the
+objective's tape; the tape path sums both into one compressed column pass,
+the fast path scatters the row's share and lets the objective's decode add on
+top. Same terms, different association. A model whose objective and rows are
+all recognized — the whole `qcqp` family — has no entry with a foot in both
+camps.
+
+Adding `eval_f`/`eval_grad_f` to the comparison is what found the
+`(x − 500000)²` cancellation above. They were not in the design's list of
+sites to check, and on a model whose *rows* are not quadratic the objective
+is the only thing the phase touches.
+
+### The sweep, and the one line that moves
+
+`scripts/sweep-fixtures.sh` over 57 models, before and after:
+
+```
+infeasible_equalities  InfeasibleProblemDetected  it=28  obj=1.179054839
+infeasible_equalities  InfeasibleProblemDetected  it=28  obj=1.201505736
+```
+
+One line, and it is explained rather than tolerated. `infeasible_equalities.nl`
+is `min x₀² + x₁²` subject to two contradictory cubic equalities. Its
+objective is a sum of monomials and takes the fast path; both rows are cubic
+and stay on the tape. Measured directly on that model: `eval_f` and
+`eval_grad_f` are **bit-identical** on both paths, and `eval_h` differs by
+1–2 ulp — the `eigena2` mechanism again. The Lagrangian diagonal at the
+iterates cancels to ~1e-16 (`0.9·2 + 0.7·3 − 1.3·3 = 0`), so a 1-ulp
+difference in the assembled entry is a 100% relative difference in what the
+regularization sees, and the restoration path takes a marginally different
+route to the same verdict.
+
+**Status is unchanged and the iteration count is unchanged (28 → 28).** What
+moves is the objective *at the point where infeasibility was declared* — an
+infeasible problem has no optimal objective, and that number is the terminal
+iterate's value, not a converged quantity. The `Problem class:` line over all
+62 `.nl` files: **diff empty**.
+
+### The one ulp also reaches gh #540's reproduction
+
+`eigena2` is gh #540's fixture as well as the one entry the differential test
+finds moving, and the two are the same fact. #540's guard test runs the
+*pre-fix* route (`feral_inertia_pivot_floor=0`), which deliberately turns on
+an inertia count read off a factor whose smallest pivot is ~1e-16, and asserts
+that this build still reproduces the reported stall — so the two headline
+tests cannot pass vacuously. One ulp in `∇²L[8, 8]` is enough to move it:
+
+| | shipped route | pre-#540 route (`feral_inertia_pivot_floor=0`) |
+|---|---|---|
+| before Q4 | SolveSucceeded, 26 it, dual 2.211e-9 | SolvedToAcceptableLevel, 29 it, dual **1.841e-7** |
+| after Q4 | SolveSucceeded, 26 it, dual 2.208e-9 | **SolveSucceeded, 27 it, dual 5.964e-10** |
+
+**The shipped route does not move**: same status, same 26 iterations, same
+objective, dual residual within a part in a thousand. What moved is the
+*reproducibility of the failure* on a diagnostic configuration — in the
+direction of it no longer failing.
+
+That leaves the guard with nothing to guard, so it now runs with
+`POUNCE_DBG_NO_QUAD=1`, which restores the pre-Q4 arithmetic exactly (29
+iterations, dual 1.841e-7 — the same numbers to every digit). The env var is
+already the documented A/B switch for this path, so the guard keeps its full
+strength rather than being loosened, and the test says in its own comment why
+it needs it.
+
+### Gates
+
+`cargo test --workspace --exclude pounce-hsl`: **2988 passed, 0 failed**
+(2974 at Q3; the 14 new ones are this phase's).
+`cargo fmt --check` clean; `cargo clippy --workspace --exclude pounce-hsl
+--all-targets` exit 0, no new lint class (the `expect_used` warnings in the
+new test file are the ones every integration test here produces).
 
 ---
 
@@ -1337,6 +1658,53 @@ not). Forecast on `qcqp500-3c`: `eval_h` 1.513 s → ~0.02 s, `eval_g` 0.862 s �
 RSS 3.3 GB → ~0.4 GB. `qcqp1000-2c` ≈1.4×, `qcqp1500-1c` ≈1.2× — this module does
 **nothing** for the factorization-dominated members. **Trajectory change; full
 sweep required.**
+
+**Done — the mechanism is bigger than forecast and the reach is smaller;
+§0e has the measurement.** Shipped: `pounce_nlp::quadratic::QuadraticStructure`,
+a recognized objective or row that builds no tape at all, a colouring built
+over the tape entries alone, and `POUNCE_DBG_NO_QUAD` /
+`try_new_with_quadratic` as the A/B switch. Corrections, in ascending order of
+how much they change the phase:
+
+1. **The list of five sites is missing one.** §5.3 names the Hessian union
+   pattern, the Jacobian pattern, `eval_g`, `eval_jac_g` and `eval_h`.
+   `hessian_vector_products` — the matrix-free path — also has to add the
+   quadratic block, and `eval_f`/`eval_grad_f` have to add a quadratic
+   *objective*. A Newton–Krylov solve missing the quadratic part of `∇²L`
+   would still converge, elsewhere.
+2. **`qcqp1000-2c` ≈1.4× was above the ceiling.** Measured on the real
+   instance: 131.4 s → 103.3 s, **1.27×**, with iterations unchanged at 100
+   and `eval_h` 93.7× faster. Evaluation is 21.5% of `OverallAlgorithm`
+   there, so 1.26× is all Amdahl allows and Q4 took essentially all of it.
+   The forecast for `qcqp500-3c` (≈6×) could not be checked — the instance
+   is not available — but a *generated* model of that shape, which does
+   reproduce the evaluation-bound regime (96.7% evaluation, 3.9 GB peak),
+   goes 136.0 s → 18.4 s wall and 120.3 s → 8.0 s of `OverallAlgorithm`.
+   `qcqp1500-1c` was not checked at all.
+3. **"Steady-state RSS 3.3 GB → ~0.4 GB" overstates what this phase can
+   reach.** Peak RSS is set during *parsing*, by the file text and the `Expr`
+   DAG, and Q4 removes what is built from that DAG rather than the DAG. On
+   the generated `qcqp500-3c` shape the peak goes 3855 MB → 1254 MB. The
+   remaining factor is Q5's.
+4. **"Pays on all 358 structured problems" is too strong as shipped.** The
+   fast path evaluates the *expanded* polynomial, and expanding a factored
+   form is not accuracy-neutral: `(x − 500000)²` loses five digits, and on
+   `airport.nl` an ungated fast path took an adaptive-μ solve from stopping
+   at a tiny step in 16 iterations to the 300-iteration cap — gh #544's
+   failure mode exactly, caught by the gh #512 regression test rather than by
+   the sweep. Q4 is therefore gated on `is_expanded_quadratic`: a form is
+   admitted only when it is already a flat sum of monomials, which is how
+   AMPL emits the `qcqp*` family and is not how a least-squares model is
+   written. Models in factored form keep their tape and gain nothing here —
+   deferred reach, not a regression, tracked as
+   [#673](https://github.com/jkitchin/pounce/issues/673).
+5. **The gate had to bound cost as well as accuracy.** It and
+   `recognize_expr` both inline a `Cse` body per reference, so putting them on
+   the `try_new` path made a shared DAG `Θ(2^depth)`: `nl_reader`'s
+   `shared_dag_walks_are_memoized_not_exponential` went from 0.00 s to
+   **172 s** and still passed. A body reached twice now ends the walk in a
+   refusal; memoizing on `Arc` identity fixes the gate but not the recognizer
+   behind it, so it stays whole in Q5.
 
 **Q5 — parse-time recognition.** The parser is line-cursor based
 (`NlParser { lines, pos }`), so rewind is free — `parse_funcall_arg` already does

--- a/scripts/gen-qcqp-nl.py
+++ b/scripts/gen-qcqp-nl.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Generate structurally-equivalent QCQP `.nl` instances (gh #588).
+
+Why this exists
+---------------
+The Mittelmann `qcqp*` family is the target of the quadratic-structure work,
+and the instances are not redistributable — a machine without
+`$POUNCE_BENCH_DATA` (and without egress to `plato.asu.edu`) can measure
+nothing on them. This writes a model in the *same shape* so a phase can be
+probed in the regime it claims to help, and so the claim can be reproduced
+by anyone.
+
+A generated instance is **not** a Mittelmann instance and no number taken on
+one may be reported as though it were. What it can honestly support is a
+statement about a *regime* — "evaluation-bound at this size, and here is what
+the phase does to the evaluation timers" — and only after
+`--shape qcqp1000-2c` has been checked against the real `qcqp1000-2c`, which
+is the one instance available to calibrate against.
+
+The shape it reproduces
+-----------------------
+`qcqp1000-2c` as AMPL emits it:
+
+    1000 vars, 5107 constraints, 1 objective, 0 ranges, 100 eqns;
+    7 nonlinear constraints, 1 nonlinear objective;
+    nlvc = nlvo = nlvb = 1000; 63121 Jacobian nonzeros.
+
+* every variable free (`b` code 3), no initial guess, so `x0 = 0`;
+* `k` quadratic rows `½xᵀQᵢx ≤ bᵢ`, each written as one `o54` sumlist of
+  `o2 n0.5 o2 o2 n<c> v<i> v<j>` summands — one per **stored** entry of
+  `Qᵢ`, both triangles, exactly as AMPL emits them (which is why the merge
+  in the recognizer has to be exact: it is folding `(i,j)` and `(j,i)` with
+  the identical coefficient);
+* a quadratic objective in the same form plus a dense `G0` linear part;
+* the remaining rows linear and sparse, a stated number of them equalities.
+
+Each `Qᵢ` is symmetric with a random sparse off-diagonal pattern and a
+diagonal set to `--dominance` times the row's off-diagonal absolute sum, so
+it is positive semidefinite by diagonal dominance (`--dominance 1.0` puts it
+on the boundary, which is the ill-conditioned end). A reference point
+`x_ref` is drawn first and every right-hand side is set from it, so the model
+is strictly feasible and Slater holds.
+
+Usage
+-----
+    gen-qcqp-nl.py --shape qcqp1000-2c --out /tmp/gen1000.nl
+    gen-qcqp-nl.py --n 500 --quad-rows 10 --quad-density 1.0 \
+                   --linear-rows 110 --eqns 10 --out /tmp/gen500.nl
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+
+# Shapes taken from the real headers. `quad_density` is the fraction of the
+# n x n symmetric pattern that is stored, so `1.0` is the dense row
+# `qcqp500-3c` has and `0.042` is what `qcqp1000-2c`'s 41 868 summands work
+# out to.
+SHAPES = {
+    # Measured directly from mittelmann/nl/qcqp1000-2c.nl.
+    "qcqp1000-2c": dict(
+        n=1000, quad_rows=7, quad_density=0.0419, linear_rows=5100,
+        eqns=100, linear_nnz=11, dominance=1.02,
+    ),
+    # From the design note's table (the instance itself is not available
+    # here): 120 rows, 10 of them nonlinear, dense per-row Q.
+    "qcqp500-3c": dict(
+        n=500, quad_rows=10, quad_density=1.0, linear_rows=110,
+        eqns=10, linear_nnz=11, dominance=1.02,
+    ),
+}
+
+
+def build_quadratic(n: int, density: float, dominance: float, rng: random.Random):
+    """A sparse symmetric PSD matrix as {row: {col: value}}, both triangles."""
+    q: dict[int, dict[int, float]] = {i: {} for i in range(n)}
+    if density >= 1.0:
+        pairs = ((i, j) for i in range(n) for j in range(i + 1, n))
+    else:
+        # Sample off-diagonal pairs without materializing all n(n-1)/2.
+        want = int(density * n * (n - 1) / 2)
+        seen = set()
+        while len(seen) < want:
+            i = rng.randrange(n)
+            j = rng.randrange(n)
+            if i != j:
+                seen.add((min(i, j), max(i, j)))
+        pairs = iter(sorted(seen))
+    for i, j in pairs:
+        v = rng.uniform(-10.0, 10.0)
+        q[i][j] = v
+        q[j][i] = v
+    for i in range(n):
+        s = sum(abs(v) for v in q[i].values())
+        # Strictly positive even for an empty row, so `Q` is nonsingular at
+        # dominance > 1 and every variable appears in the row (which is what
+        # makes `J` dense, as it is in the real instance).
+        q[i][i] = dominance * s + 1.0
+    return q
+
+
+def quad_summands(q: dict[int, dict[int, float]]):
+    """The `o54` operand list for `½xᵀQx`, in AMPL's emission order."""
+    for i in sorted(q):
+        for j in sorted(q[i]):
+            yield i, j, q[i][j]
+
+
+def quad_value(q, x):
+    total = 0.0
+    for i in q:
+        for j, v in q[i].items():
+            total += v * x[i] * x[j]
+    return 0.5 * total
+
+
+def emit(out, args) -> None:
+    rng = random.Random(args.seed)
+    n = args.n
+    m = args.quad_rows + args.linear_rows
+    x_ref = [rng.uniform(-1.0, 1.0) for _ in range(n)]
+
+    # --- quadratic rows and objective ---
+    quads = [
+        build_quadratic(n, args.quad_density, args.dominance, rng)
+        for _ in range(args.quad_rows)
+    ]
+    obj_q = build_quadratic(n, args.quad_density, args.dominance, rng)
+    obj_g = [rng.uniform(-100.0, 100.0) for _ in range(n)]
+
+    # --- linear rows: `linear_nnz` entries each, first `eqns` are equalities ---
+    lin_rows = []
+    for _ in range(args.linear_rows):
+        cols = sorted(rng.sample(range(n), min(args.linear_nnz, n)))
+        lin_rows.append([(c, rng.uniform(-10.0, 10.0)) for c in cols])
+
+    jac_nnz = args.quad_rows * n + sum(len(r) for r in lin_rows)
+
+    w = out.write
+    w("g3 0 1 0\t# problem generated-qcqp\n")
+    w(f" {n} {m} 1 0 {args.eqns}\t# vars, constraints, objectives, ranges, eqns\n")
+    w(f" {args.quad_rows} 1\t# nonlinear constraints, objectives\n")
+    w(" 0 0\t# network constraints: nonlinear, linear\n")
+    w(f" {n} {n} {n}\t# nonlinear vars in constraints, objectives, both\n")
+    w(" 0 0 0 1\t# linear network variables; functions; arith, flags\n")
+    w(" 0 0 0 0 0\t# discrete variables: binary, integer, nonlinear (b,c,o)\n")
+    w(f" {jac_nnz} {n}\t# nonzeros in Jacobian, gradients\n")
+    w(" 0 0\t# max name lengths: constraints, variables\n")
+    w(" 0 0 0 0 0\t# common exprs: b,c,o,c1,o1\n")
+
+    # Variable bounds: all free, as in the real instance.
+    w("b\n")
+    for _ in range(n):
+        w("3\n")
+
+    # Row bounds. Quadratic rows and the linear inequalities are `<= b`
+    # (code 1); the first `eqns` linear rows are equalities (code 4). Every
+    # right-hand side is taken at `x_ref` plus a slack, so `x_ref` is
+    # strictly feasible.
+    w("r\n")
+    for q in quads:
+        w(f"1 {quad_value(q, x_ref) + args.slack!r}\n")
+    for k, row in enumerate(lin_rows):
+        val = sum(c * x_ref[j] for j, c in row)
+        if k < args.eqns:
+            w(f"4 {val!r}\n")
+        else:
+            w(f"1 {val + args.slack!r}\n")
+
+    # Constraint bodies.
+    for k, q in enumerate(quads):
+        terms = list(quad_summands(q))
+        w(f"C{k}\n")
+        w("o54\n")
+        w(f"{len(terms)}\n")
+        for i, j, v in terms:
+            w(f"o2\nn0.5\no2\no2\nn{v!r}\nv{i}\nv{j}\n")
+    for k in range(len(lin_rows)):
+        w(f"C{args.quad_rows + k}\nn0\n")
+
+    # Objective (minimize).
+    obj_terms = list(quad_summands(obj_q))
+    w("O0 0\n")
+    w("o54\n")
+    w(f"{len(obj_terms)}\n")
+    for i, j, v in obj_terms:
+        w(f"o2\nn0.5\no2\no2\nn{v!r}\nv{i}\nv{j}\n")
+
+    # `k` section: cumulative count of Jacobian entries in columns 0..n-2.
+    col_counts = [0] * n
+    for _ in range(args.quad_rows):
+        for j in range(n):
+            col_counts[j] += 1
+    for row in lin_rows:
+        for j, _ in row:
+            col_counts[j] += 1
+    w(f"k{n - 1}\n")
+    run = 0
+    for j in range(n - 1):
+        run += col_counts[j]
+        w(f"{run}\n")
+
+    # `J` blocks: the quadratic rows carry a dense zero linear part (their
+    # whole body is in the tree), the linear rows carry their coefficients.
+    for k in range(args.quad_rows):
+        w(f"J{k} {n}\n")
+        for j in range(n):
+            w(f"{j} 0\n")
+    for k, row in enumerate(lin_rows):
+        w(f"J{args.quad_rows + k} {len(row)}\n")
+        for j, c in row:
+            w(f"{j} {c!r}\n")
+
+    # `G` block: the objective's linear part, dense.
+    w(f"G0 {n}\n")
+    for j in range(n):
+        w(f"{j} {obj_g[j]!r}\n")
+
+
+def main(argv: list[str]) -> int:
+    # Shape-able options default to `None` so a preset can fill them in
+    # *without* overriding a flag the caller passed explicitly — precedence
+    # is flag, then `--shape`, then the fallback below. (Applying the preset
+    # unconditionally silently ignored `--dominance`, which made two
+    # calibration runs come back byte-identical and look like the knob did
+    # nothing.)
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--shape", choices=sorted(SHAPES), help="a preset from the real headers")
+    p.add_argument("--n", type=int)
+    p.add_argument("--quad-rows", type=int)
+    p.add_argument("--quad-density", type=float)
+    p.add_argument("--linear-rows", type=int)
+    p.add_argument("--eqns", type=int)
+    p.add_argument("--linear-nnz", type=int)
+    p.add_argument("--dominance", type=float)
+    p.add_argument("--slack", type=float, default=1.0)
+    p.add_argument("--seed", type=int, default=1)
+    p.add_argument("--out", required=True)
+    args = p.parse_args(argv)
+    fallback = dict(
+        n=1000, quad_rows=7, quad_density=0.0419, linear_rows=5100,
+        eqns=100, linear_nnz=11, dominance=1.02,
+    )
+    preset = SHAPES.get(args.shape, {})
+    for k, v in fallback.items():
+        if getattr(args, k) is None:
+            setattr(args, k, preset.get(k, v))
+    with open(args.out, "w") as fh:
+        emit(fh, args)
+    print(f"wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
**Review-only — do not merge.** This exists so Q4 can be read as one diff against its parent (`fd738d46`, the Q3 commit) instead of as the fourth commit of a stack. The series PR is #603; the commit lands there and nowhere else. Both branches here are throwaway.

## Problem

POUNCE recognizes these rows exactly and then throws the answer away. `classify_problem` says "quadratic"; `NlTnlp` goes on to re-derive the same constant matrices through a coloured AD tape on every iteration. On the real Mittelmann `qcqp1000-2c` that is 353 736 summand tapes, 2 445 552 tape ops and 1 000 Hessian colours, walked 101 times to recover eight matrices that never change.

Measured on `qcqp1000-2c` (**a real Mittelmann instance** — the only one available on this machine; `scripts/qbench.py`, same options both sides):

| | status | objective | iters | wall | peak RSS |
|---|---|---|---|---|---|
| before (`fd738d46`) | SolveSucceeded | 738127.4263171845 | 100 | 131.38 s | 786.6 MB |
| after | SolveSucceeded | 738127.4263173543 | 100 | **103.26 / 97.56 s** | **542.7 / 492.7 MB** |

Two after-runs: the phase was measured once at the first green build and again after the shared-DAG fix below, which does not touch this instance's path. They differ by 5.5% on wall and 5.2% on the *factorization* timer doing identical work — this machine's noise — while the iteration count and objective are identical to the last digit across all three runs.

| timer | before | after | |
|---|---|---|---|
| `LagrangianHessianEvaluations` | 19.582 s | **0.209 / 0.198 s** | ~95× |
| `ConstraintEvaluations` | 4.863 s | 0.444 / 0.429 s | ~11× |
| `ConstraintJacobianEvaluations` | 2.055 s | 0.167 / 0.164 s | ~12× |
| `LinearSystemFactorization` | 97.168 s | 97.363 / 92.295 s | untouched |

The note forecast ≈1.4× here. Evaluation is 21.5% of `OverallAlgorithm` on the before-run, so the Amdahl ceiling against that run is **1.26×** — 1.4× was not reachable from the evaluation side at this machine's factorization cost, and Q4 removed 97% of the evaluation time, which is the whole of it. Read this phase off the timer split and the counters (tape ops 2 445 552 → 5 100, colours 1 000 → 0), not off a wall-clock total.

`qcqp500-3c` (≈6× forecast) and `qcqp1500-1c` (≈1.2×) are **not** on this machine and are **not verified**. A *generated* look-alike of the `qcqp500-3c` shape — which does reproduce the evaluation-bound regime (96.7% evaluation, 3855 MB peak) — goes 136.0 → 18.4 s wall and 120.3 → 8.0 s of `OverallAlgorithm` at an unchanged 75 iterations. **That is a generated-instance number and is not a `qcqp500-3c` number.**

## Cause

`NlTnlp::try_new` splits every nonlinear row into summands and builds one `Tape` per summand, unconditionally. For a quadratic row that tape encodes a matrix that is fully determined at load: `eval_h` then runs a forward sweep plus one directional product per colour per tape, per call, to recover constants, and the colouring is sized by a dense quadratic block whose entries no directional product needs to touch.

## Fix

**`pounce_nlp::quadratic::QuadraticStructure`** keeps the recognizer's answer. Each form is the full symmetric `H` in CSR over its own support, the linear and constant terms AMPL folds into the nonlinear tree, and one precomputed scatter slot per lower-triangle entry — so `∇²L` is a `values[slot] += w·h` loop with no hashing and no search. Every array is flat and shared across forms rather than per-form: `qssp180` has 65 341 quadratic rows of three nonzeros each, and a struct-per-row layout would spend ten allocations on each of them to describe 24 bytes of matrix. It lives in `pounce-nlp` because every other crate already depends on it, so `pounce-py`, `pounce-wasm` and `pounce-rs` inherit the type with no manifest change.

A recognized row **builds no tape** — recognition runs before taping, which is where the memory goes; evaluating a tape faster was never the lever. The colouring is built over the tape entries alone (`h_tape_mask`), because a quadratic block's entries are scattered from stored values and never read out of a directional product: 1000 colours → 0 on the real instance, with the assembled Hessian pattern identical either way.

**The fast path is gated twice, and both gates were found by measurement rather than designed in.**

*Accuracy.* **Rejected: taking every recognized form.** That is what the first version did, and it is wrong. The fast path evaluates the **expanded** polynomial while the tape evaluates whatever the writer wrote, and for a least-squares shape that is the **factored** form:

* `feasible_x0_extreme_row.nl` writes `(x − 500000)²`; the expansion adds `x² − 10⁶x + 2.5·10¹¹` and cancels. Measured **2.4e-5 relative** — five digits, not an ulp.
* `airport.nl` (84 coordinates around 10³, every row a squared distance): `mu_strategy=adaptive tol=1e-12` went from stopping at a tiny step in **16 iterations to the 300-iteration cap** at the same objective to 12 digits. gh#544's failure mode exactly.

**Rejected: a magnitude heuristic** (cap `(|c| + Σ|aᵢ|) / max|Hᵢⱼ|`). It catches `(x − 500000)²` and misses `airport.nl` entirely, because there the cancellation is between the quadratic terms themselves and the folded part is zero. Shipped instead: `nl_quadratic::is_expanded_quadratic`, an **exactness** rule — a form is admitted only when it is already a flat sum of monomials, so the read-out repeats the additions the writer already wrote and can differ from the tape only by summation order. AMPL emits the whole `qcqp*` family that way (all 7 rows and the objective of the real `qcqp1000-2c` take the fast path); `airport.nl` keeps 41 of its 42 rows on the tape.

The cost of that gate is real: a model written in factored form gains nothing from Q4, which makes the design note's "pays on all 358 structured problems" too strong. Filed as #673 with three sketches for fixing it.

*Cost.* The gate — and `recognize_expr` behind it — inlines a `Cse` body at **every reference**, which Q3 documented and deliberately left to Q5 to memoize. Putting both on the `try_new` path made a shared DAG `Θ(2^depth)`: `nl_reader::tests::shared_dag_walks_are_memoized_not_exponential` measured **0.00 s → 172.41 s** in a debug build and **still passed**, exponential-but-finite at depth 30. So a `Cse` body reached a second time ends the walk in a refusal and the model keeps its tape, which handles sharing properly. **Rejected: memoizing on `Arc` identity** — it fixes this walk and leaves `recognize_expr` exponential behind it, so it stays whole in Q5. Measured cost of the refusal on this corpus: none (27 models and 251 quadratic rows either way, byte-identical differential numbers; the `qcqp*` files declare no common expressions at all).

`POUNCE_DBG_NO_QUAD=1` forces the tape everywhere (mirroring `POUNCE_DBG_NO_HYBRID`), and `NlTnlp::try_new_with_quadratic(prob, false)` is the same switch as a parameter — the env var is process-global, which is wrong for a differential test that has to build the same model both ways in one process.

## Blast radius

**Exactly the recognized set, and that is asserted rather than assumed**: a model with nothing recognized is byte-identical on both constructions (same Hessian pattern, bitwise-equal `eval_g`), pinned as its own test.

The design note's list of five sites to change is missing one, and it is the dangerous one: **`hessian_vector_products`**, the matrix-free path, also has to add the quadratic block. A Newton-Krylov solve that silently dropped the quadratic part of `∇²L` would still converge, elsewhere. `eval_f`/`eval_grad_f` are two more, for a quadratic objective.

`scripts/sweep-fixtures.sh` over 57 models against `fd738d46`, **one line moves**:

```
-infeasible_equalities  InfeasibleProblemDetected  it=28  obj=1.179054839
+infeasible_equalities  InfeasibleProblemDetected  it=28  obj=1.201505736
```

`infeasible_equalities.nl` is `min x₀² + x₁²` subject to two contradictory cubic equalities: quadratic objective on the fast path, cubic rows on the tape. Measured on that model directly — `eval_f` and `eval_grad_f` bit-identical, `eval_h` differing by 1–2 ulp, and its Lagrangian diagonal cancelling to ~1e-16 (`0.9·2 + 0.7·3 − 1.3·3 = 0`) so a 1-ulp difference is 100% of what the regularization sees. **Status and iteration count are unchanged (28 → 28)**; what moved is the objective at the point where infeasibility was *declared*, a terminal iterate's value and not a converged quantity. `Problem class:` over all 62 `.nl` files: diff empty.

One more, on a diagnostic configuration. `eigena2` is gh#540's fixture, and the same 1 ulp moves its guard test: with `feral_inertia_pivot_floor=0` (the pre-#540 route) it now converges — SolvedToAcceptableLevel/29 it/dual 1.841e-7 → SolveSucceeded/27 it/dual 5.964e-10 — while **the shipped route does not move at all** (SolveSucceeded, 26 iterations, same objective, dual 2.211e-9 → 2.208e-9). The failure got less reproducible, not the fix less effective, which leaves that guard with nothing to guard; it now runs with `POUNCE_DBG_NO_QUAD=1`, restoring the pre-Q4 arithmetic to every digit rather than being loosened.

## Tests

**`crates/pounce-cli/tests/quad_evaluator_differential.rs`** is the load-bearing artefact, modelled on Q3's recognizer differential. Every `.nl` file in the repository is built **twice** — fast path and `try_new_with_quadratic(…, false)` — and `eval_f`, `eval_grad_f`, `eval_g`, `eval_jac_g`, `eval_h` compared at the model's own starting point and three pseudo-random perturbations. The Jacobian and Hessian are compared as `(row, col) → value` maps, because the two paths need not agree on the *pattern*: a coefficient that cancels to exactly zero is dropped by the recognizer and kept by the tape's structural sparsity. Over 27 models and 251 quadratic rows:

| comparison | result |
|---|---|
| `∇²L`, assembled lower triangle | **26 846 of 26 848 bit-identical**; the 2 that are not differ by exactly **1 ulp** (`eigena2.nl`) |
| `g`, `∇g`, `f`, `∇f` | worst relative deviation **4.13e-15** |
| a model with nothing recognized | **byte-identical** both ways |

This bites: it is what found the `(x − 500000)²` cancellation, and it did so only once `eval_f`/`eval_grad_f` were added — on a model whose *rows* are not quadratic the objective is the only thing the phase touches. It also refutes §5.4's "plausibly bit-identical" for `∇²L` in general (right for the shape the note reasoned about, wrong where a model mixes a taped objective with quadratic rows).

`crates/pounce-nl/src/nl_quadratic.rs` gains unit tests pinning `is_expanded_quadratic` in **both** directions — admitting AMPL's `o54`-of-monomials emission, `xᵢ²`, and a singly-referenced `Cse`; refusing `(x₀ − x₁)²`, `(x₀ + 1)·x₁`, a mixed row where one factored term hides in a long expanded sum, and a 60-level shared-`Cse` DAG (which an exponential walk would not return from, so the test passing *is* the assertion) — plus a 250 000-term depth test on a default-sized libtest thread, because the gate runs on every row of every model including ones that overflow a recursive walk. `crates/pounce-nlp/src/quadratic.rs` gains nine unit tests, including one specifically on the factor-of-two trap (`push_form` takes *Hessian* entries, not polynomial coefficients).

Two existing tests are the ones that caught this phase's two defects, and both fail on an ungated build for the stated reason: gh#512's `an_adaptive_solve_stops_at_a_flagged_tiny_step` (`MaximumIterationsExceeded` at `iteration_count=300` on `airport.nl`) and `nl_reader::tests::shared_dag_walks_are_memoized_not_exponential` (0.00 s → 172.41 s). Neither is reachable by `sweep-fixtures.sh`, which runs default options on the fixture corpus. The gh#540 guard change is described under Blast radius; it keeps its assertions and gains an env var, so it still fails if the reproduction stops reproducing.

**Deliberately not pinned**: the benchmark numbers. `$POUNCE_BENCH_DATA` holds one instance here and the corpus is not vendorable; `scripts/gen-qcqp-nl.py` is checked in so the *shape* can be regenerated, but it is calibrated against the real instance and does **not** fully reproduce it — 50 iterations to the real 100, 61.8% factorization to 75.6% — so it overstates the aggregate win (1.57× generated vs 1.27× real) while the per-timer ratios transfer (80.9× vs 93.7× on `eval_h`). Every generated number in this PR, the commit and the note is labelled as generated.

---

- [x] Tests fail on the parent commit for the stated reason
- [ ] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms — deferred to the series PR #603, which is where the phases land as one user-visible change
- [ ] Book page under `docs/src/` updated — n/a; no user-facing option or interface changed (`POUNCE_DBG_NO_QUAD` is a diagnostic, like `POUNCE_DBG_NO_HYBRID`)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — 2988 passed, 0 failed; clippy exit 0 with no new lint class
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now