### PR TITLE
Q5 review copy: parse-time quadratic recognition (never build the Expr tree)

### DIFF
--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -336,9 +336,9 @@ fn header_census(prob: &NlProblem) -> String {
     let tree_rows = prob
         .con_nonlinear
         .iter()
-        .filter(|e| !is_trivially_zero(e))
+        .filter(|b| !b.is_trivially_zero())
         .count();
-    let tree_obj = usize::from(!is_trivially_zero(&prob.obj_nonlinear));
+    let tree_obj = usize::from(!prob.obj_nonlinear.is_trivially_zero());
     let Some(c) = prob.nl_counts else {
         return format!("no .nl header census; trees: nl_rows={tree_rows} nl_obj={tree_obj}");
     };
@@ -373,14 +373,14 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
     // claim would route a model to the LP solver on the strength of a
     // header field, which is not a trade this classifier makes anywhere
     // else. The header is logged beside the verdict instead.
-    let obj_nl = !is_trivially_zero(&prob.obj_nonlinear);
-    let cons_nl = prob.con_nonlinear.iter().any(|e| !is_trivially_zero(e));
+    let obj_nl = !prob.obj_nonlinear.is_trivially_zero();
+    let cons_nl = prob.con_nonlinear.iter().any(|b| !b.is_trivially_zero());
     if !obj_nl && !cons_nl {
         return (ProblemClass::Lp, ClassReason::NoNonlinearParts);
     }
 
     // Objective curvature.
-    let obj_quad = match analyze_quadratic(&prob.obj_nonlinear) {
+    let obj_quad = match prob.obj_nonlinear.analyze_quadratic() {
         Some(q) => q,
         // Objective has a non-quadratic nonlinear term ⇒ NLP.
         None => return (ProblemClass::Nlp, ClassReason::ObjectiveNotQuadratic),
@@ -390,10 +390,10 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
     // any non-quadratic constraint term makes the whole problem NLP.
     let mut any_quadratic_constraint = false;
     for (row, c) in prob.con_nonlinear.iter().enumerate() {
-        if is_trivially_zero(c) {
+        if c.is_trivially_zero() {
             continue;
         }
-        match analyze_quadratic(c) {
+        match c.analyze_quadratic() {
             Some(q) if q.is_empty() => {} // purely linear after all
             Some(_) => any_quadratic_constraint = true,
             None => {
@@ -441,10 +441,10 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
         // filter-IPM finds a local minimum either way).
         let mut reform_flops: u128 = 0;
         for (row, c) in prob.con_nonlinear.iter().enumerate() {
-            if is_trivially_zero(c) {
+            if c.is_trivially_zero() {
                 continue;
             }
-            match analyze_quadratic(c) {
+            match c.analyze_quadratic() {
                 Some(q) if q.is_empty() => {} // purely linear after all
                 Some(q) => {
                     let lo = prob.g_l[row];
@@ -635,9 +635,9 @@ fn mismatch_msg(class: ProblemClass, forced: &str, expected: &str) -> String {
 // `ProblemClass` a recognized form implies, and which guards a QCQP has to
 // clear to reach the conic path. These re-exports keep the call sites in
 // `qp_extract` and in the tests below spelled as they were.
-pub(crate) use pounce_nl::nl_quadratic::{
-    QuadHessian, analyze_quadratic, analyze_quadratic_full, is_trivially_zero,
-};
+pub(crate) use pounce_nl::nl_quadratic::QuadHessian;
+#[cfg(test)]
+use pounce_nl::nl_quadratic::analyze_quadratic;
 
 // ---------------------------------------------------------------------
 // PSD test
@@ -773,6 +773,7 @@ fn coupled_hessian_is_psd(h: &QuadHessian) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::nl_reader::NlBody;
     use crate::nl_reader::{BinOp, Expr, UnaryOp, parse_nl_text};
 
     // --- SolverSelection parsing ---
@@ -1124,14 +1125,16 @@ mod tests {
         // minimize x0 + x1 s.t. x0 + x1 <= 1, no nonlinear parts.
         // Build an NlProblem directly for a hermetic test.
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0), (1, 1.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![Expr::Const(0.0)],
+            con_nonlinear: vec![NlBody::Tree(Expr::Const(0.0))],
             con_linear: vec![vec![(0, 1.0), (1, 1.0)]],
             x_l: vec![0.0, 0.0],
             x_u: vec![f64::INFINITY, f64::INFINITY],
@@ -1298,21 +1301,23 @@ mod tests {
     /// two routing caps (`SOCP_REFORM_FLOP_BUDGET`, `SOCP_SOLVE_SIZE_CAP`)
     /// without allocating `n×n` data.
     fn convex_qcqp_at_size(n: usize, m: usize) -> NlProblem {
-        let mut con_nonlinear = vec![Expr::Const(0.0); m];
-        con_nonlinear[0] = Expr::Binary(
+        let mut con_nonlinear = vec![NlBody::Tree(Expr::Const(0.0)); m];
+        con_nonlinear[0] = NlBody::Tree(Expr::Binary(
             BinOp::Pow,
             Box::new(Expr::Var(0)),
             Box::new(Expr::Const(2.0)),
-        );
+        ));
         let g_l = vec![f64::NEG_INFINITY; m];
         let mut g_u = vec![f64::INFINITY; m];
         g_u[0] = 1.0; // upper-only bound ⇒ convex feasible set
         NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n,
             m,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0)],
             obj_constant: 0.0,
             con_nonlinear,
@@ -1413,14 +1418,14 @@ mod tests {
 
         // −x0² ≤ 1 — upper-bounded, but the Hessian is negative definite.
         let mut prob = convex_qcqp_at_size(10, 10);
-        prob.con_nonlinear[0] = Expr::Unary(
+        prob.con_nonlinear[0] = NlBody::Tree(Expr::Unary(
             UnaryOp::Neg,
             Box::new(Expr::Binary(
                 BinOp::Pow,
                 Box::new(Expr::Var(0)),
                 Box::new(Expr::Const(2.0)),
             )),
-        );
+        ));
         let (class, reason) = classify_problem_explained(&prob);
         assert_eq!(class, ProblemClass::Nlp);
         assert_eq!(reason, ClassReason::ConstraintHessianIndefinite { row: 0 });
@@ -1461,14 +1466,16 @@ mod tests {
         // PSD (rank 1) and fully coupled across all k variables.
         let con = Expr::Binary(BinOp::Pow, Box::new(sum), Box::new(Expr::Const(2.0)));
         NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: k,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![con],
+            con_nonlinear: vec![NlBody::Tree(con)],
             con_linear: vec![vec![]],
             x_l: vec![f64::NEG_INFINITY; k],
             x_u: vec![f64::INFINITY; k],
@@ -1501,14 +1508,16 @@ mod tests {
             con = Expr::Binary(BinOp::Add, Box::new(con), Box::new(sq(i)));
         }
         NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: k,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![con],
+            con_nonlinear: vec![NlBody::Tree(con)],
             con_linear: vec![vec![]],
             x_l: vec![f64::NEG_INFINITY; k],
             x_u: vec![f64::INFINITY; k],
@@ -1693,8 +1702,12 @@ mod tests {
     /// objective and per-constraint nonlinear parts. Linear parts and
     /// bounds are filled with benign defaults.
     fn qp_stub(obj_nonlinear: Expr, con_nonlinear: Vec<Expr>) -> NlProblem {
+        let obj_nonlinear = NlBody::Tree(obj_nonlinear);
+        let con_nonlinear: Vec<NlBody> = con_nonlinear.into_iter().map(NlBody::Tree).collect();
         let m = con_nonlinear.len();
         NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m,
             num_obj: 1,
@@ -1778,7 +1791,7 @@ G0 2
         // `x0 + x1 + 3 <= 6` is `x0 + x1 <= 3`.
         assert!((prob.g_u[0] - 3.0).abs() < 1e-12, "g_u = {}", prob.g_u[0]);
         assert!(
-            matches!(prob.con_nonlinear[0], Expr::Const(c) if c == 0.0),
+            prob.con_nonlinear[0].is_trivially_zero(),
             "the row body should be the identity zero: {:?}",
             prob.con_nonlinear[0]
         );

--- a/crates/pounce-cli/src/qp_extract.rs
+++ b/crates/pounce-cli/src/qp_extract.rs
@@ -29,7 +29,6 @@
 //!   the *opposite* sentinel (an upper bound of `-5e20`) is an ordinary
 //!   bound and is kept.
 
-use crate::dispatch::analyze_quadratic_full;
 use crate::nl_reader::NlProblem;
 // Bound presence is read **directionally** — a lower bound is absent only at
 // or below `-1e19`, an upper bound only at or above `+1e19`. This file used a
@@ -79,7 +78,7 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
 
     // --- objective Hessian P (lower triangle) + nonlinear-tree linear part
     //     + nonlinear-tree constant (degree-0 term, for reporting only) ---
-    let (hess, obj_nl_linear, obj_nl_constant) = analyze_quadratic_full(&prob.obj_nonlinear)?;
+    let (hess, obj_nl_linear, obj_nl_constant) = prob.obj_nonlinear.analyze_quadratic_full()?;
     let mut p_lower: Vec<Triplet> = Vec::with_capacity(hess.len());
     for ((i, j), v) in &hess {
         // analyze_quadratic returns (i ≤ j) upper-ish keys; store as
@@ -121,7 +120,8 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
         // silently solves the wrong constraint. The folded constant
         // shifts the bounds: `g_l ≤ row + k ≤ g_u  ⇔  g_l−k ≤ row ≤ g_u−k`.
         // This mirrors the SOCP extractor's linear-constraint handling.
-        let (nl_lin, const_shift) = analyze_quadratic_full(&prob.con_nonlinear[row])
+        let (nl_lin, const_shift) = prob.con_nonlinear[row]
+            .analyze_quadratic_full()
             .map(|(_, l, k)| (l, k))
             .unwrap_or_default();
         let mut coef = vec![0.0; n];
@@ -383,7 +383,7 @@ pub fn extract_socp_with_map(
     let sign = if prob.minimize { 1.0 } else { -1.0 };
 
     // --- objective P (lower triangle) + folded linear / constant terms ---
-    let (hess, obj_nl_linear, obj_nl_constant) = analyze_quadratic_full(&prob.obj_nonlinear)?;
+    let (hess, obj_nl_linear, obj_nl_constant) = prob.obj_nonlinear.analyze_quadratic_full()?;
     let mut p_lower: Vec<Triplet> = Vec::with_capacity(hess.len());
     for ((i, j), v) in &hess {
         let (row, col) = if i >= j { (*i, *j) } else { (*j, *i) };
@@ -411,7 +411,7 @@ pub fn extract_socp_with_map(
         let lo = prob.g_l[row];
         let hi = prob.g_u[row];
         let nl = &prob.con_nonlinear[row];
-        let quad = analyze_quadratic_full(nl);
+        let quad = nl.analyze_quadratic_full();
         let is_quadratic = matches!(&quad, Some((hmap, _, _)) if !hmap.is_empty());
 
         if is_quadratic {
@@ -752,6 +752,7 @@ fn psd_outer_factor(mut a: Vec<f64>, n: usize) -> Vec<Vec<f64>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::nl_reader::NlBody;
     use crate::nl_reader::{BinOp, Expr};
     use pounce_convex::{QpOptions, QpStatus, solve_qp_ipm, solve_socp_ipm};
     use pounce_feral::FeralSolverInterface;
@@ -775,18 +776,20 @@ mod tests {
     #[test]
     fn extract_and_solve_socp_ball() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, -1.0), (1, -1.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![Expr::Binary(
+            con_nonlinear: vec![NlBody::Tree(Expr::Binary(
                 BinOp::Add,
                 Box::new(pow2(0)),
                 Box::new(pow2(1)),
-            )],
+            ))],
             con_linear: vec![vec![]],
             x_l: vec![-2e19, -2e19],
             x_u: vec![2e19, 2e19],
@@ -846,14 +849,16 @@ mod tests {
             Box::new(Expr::Const(2.0)),
         );
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 1,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![con],
+            con_nonlinear: vec![NlBody::Tree(con)],
             con_linear: vec![vec![]],
             x_l: vec![-2e19],
             x_u: vec![2e19],
@@ -888,14 +893,20 @@ mod tests {
             )
         };
         NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(i, -1.0), (j, -1.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![Expr::Binary(BinOp::Add, Box::new(sq(i)), Box::new(sq(j)))],
+            con_nonlinear: vec![NlBody::Tree(Expr::Binary(
+                BinOp::Add,
+                Box::new(sq(i)),
+                Box::new(sq(j)),
+            ))],
             con_linear: vec![vec![]],
             x_l: vec![-10.0; n],
             x_u: vec![10.0; n],
@@ -962,7 +973,7 @@ mod tests {
             Box::new(Expr::Const(2.0)),
         );
         let mut prob = wide_ball(40, 11, 37);
-        prob.con_nonlinear = vec![con];
+        prob.con_nonlinear = vec![NlBody::Tree(con)];
 
         let (qp, _con_map, _obj_const, cones) = extract_socp_with_map(&prob).expect("extract");
         assert_eq!(cones, vec![ConeSpec::SecondOrder(3)], "rank 1 + 2");
@@ -1095,14 +1106,20 @@ mod tests {
     #[test]
     fn extract_and_solve_equality_qp() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Binary(BinOp::Add, Box::new(pow2(0)), Box::new(pow2(1))),
+            obj_nonlinear: NlBody::Tree(Expr::Binary(
+                BinOp::Add,
+                Box::new(pow2(0)),
+                Box::new(pow2(1)),
+            )),
             obj_linear: vec![],
             obj_constant: 0.0,
-            con_nonlinear: vec![Expr::Const(0.0)],
+            con_nonlinear: vec![NlBody::Tree(Expr::Const(0.0))],
             con_linear: vec![vec![(0, 1.0), (1, 1.0)]],
             x_l: vec![-2e19, -2e19],
             x_u: vec![2e19, 2e19],
@@ -1158,11 +1175,13 @@ mod tests {
             Box::new(Expr::Const(2.0)),
         );
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 1,
             m: 0,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: obj,
+            obj_nonlinear: NlBody::Tree(obj),
             obj_linear: vec![],
             obj_constant: 0.0,
             con_nonlinear: vec![],
@@ -1207,14 +1226,16 @@ mod tests {
     #[test]
     fn inequality_dual_recovered() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 1,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: pow2(0),
+            obj_nonlinear: NlBody::Tree(pow2(0)),
             obj_linear: vec![],
             obj_constant: 0.0,
-            con_nonlinear: vec![Expr::Const(0.0)],
+            con_nonlinear: vec![NlBody::Tree(Expr::Const(0.0))],
             con_linear: vec![vec![(0, 1.0)]], // g(x) = x0
             x_l: vec![-2e19],
             x_u: vec![2e19],
@@ -1264,14 +1285,16 @@ mod tests {
             Box::new(Expr::Const(3.0)),
         );
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 1,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![con],
+            con_nonlinear: vec![NlBody::Tree(con)],
             con_linear: vec![vec![]], // the `+x0` lives in the TREE
             x_l: vec![-2e19],
             x_u: vec![2e19],
@@ -1319,11 +1342,13 @@ mod tests {
             Box::new(Expr::Const(2.0)),
         );
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 1,
             m: 0,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: obj,
+            obj_nonlinear: NlBody::Tree(obj),
             obj_linear: vec![],
             obj_constant: 0.0, // the +9 is in the TREE, not here
             con_nonlinear: vec![],
@@ -1360,11 +1385,13 @@ mod tests {
     #[test]
     fn extract_and_solve_bounded_qp() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 1,
             m: 0,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: pow2(0),
+            obj_nonlinear: NlBody::Tree(pow2(0)),
             obj_linear: vec![(0, -6.0)],
             obj_constant: 9.0,
             con_nonlinear: vec![],
@@ -1395,11 +1422,13 @@ mod tests {
     #[test]
     fn extract_and_solve_lp() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 0,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, -1.0), (1, -1.0)],
             obj_constant: 0.0,
             con_nonlinear: vec![],
@@ -1433,11 +1462,13 @@ mod tests {
     #[test]
     fn extract_maximize_negates() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 1,
             m: 0,
             num_obj: 1,
             minimize: false,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0)],
             obj_constant: 0.0,
             con_nonlinear: vec![],
@@ -1473,11 +1504,13 @@ mod tests {
     #[test]
     fn variable_bound_past_the_opposite_sentinel_is_kept() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 1,
             m: 0,
             num_obj: 1,
             minimize: false, // maximize x0, so the -5e20 upper bound binds
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0)],
             obj_constant: 0.0,
             con_nonlinear: vec![],
@@ -1524,14 +1557,16 @@ mod tests {
     #[test]
     fn a_row_with_equal_bounds_past_the_sentinel_does_not_vanish() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![Expr::Const(0.0)],
+            con_nonlinear: vec![NlBody::Tree(Expr::Const(0.0))],
             con_linear: vec![vec![(0, 1.0), (1, 1.0)]],
             x_l: vec![-2e19, -2e19],
             x_u: vec![2e19, 2e19],
@@ -1573,11 +1608,13 @@ mod tests {
     #[test]
     fn the_box_is_built_with_the_directional_bound_test() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 0,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0), (1, 1.0)],
             obj_constant: 0.0,
             con_nonlinear: vec![],
@@ -1614,11 +1651,13 @@ mod tests {
     #[test]
     fn bound_multipliers_come_back_per_variable() {
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 0,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(0, 1.0), (1, 1.0)],
             obj_constant: 0.0,
             con_nonlinear: vec![],

--- a/crates/pounce-cli/tests/nl_header_counts.rs
+++ b/crates/pounce-cli/tests/nl_header_counts.rs
@@ -34,7 +34,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use pounce_cli::nl_reader::{Expr, NlProblem, collect_vars, read_nl_file};
+use pounce_cli::nl_reader::{NlProblem, read_nl_file};
 
 /// Fixtures whose header line 5 (`nlvc nlvo nlvb`) carries fewer than the
 /// three documented fields, so no census is recorded. All three are
@@ -90,16 +90,12 @@ fn base_name(p: &Path) -> String {
     p.file_name().unwrap_or_default().to_string_lossy().into()
 }
 
-fn is_trivially_zero(e: &Expr) -> bool {
-    matches!(e, Expr::Const(c) if *c == 0.0)
-}
-
 /// Rows whose nonlinear part survived parsing.
 fn nonlinear_rows(prob: &NlProblem) -> Vec<usize> {
     prob.con_nonlinear
         .iter()
         .enumerate()
-        .filter(|(_, e)| !is_trivially_zero(e))
+        .filter(|(_, b)| !b.is_trivially_zero())
         .map(|(i, _)| i)
         .collect()
 }
@@ -108,9 +104,9 @@ fn nonlinear_rows(prob: &NlProblem) -> Vec<usize> {
 /// `NlTnlp::get_variables_linearity` publishes.
 fn walked_nonlinear_vars(prob: &NlProblem) -> BTreeSet<usize> {
     let mut s = BTreeSet::new();
-    collect_vars(&prob.obj_nonlinear, &mut s);
+    prob.obj_nonlinear.collect_vars(&mut s);
     for row in &prob.con_nonlinear {
-        collect_vars(row, &mut s);
+        row.collect_vars(&mut s);
     }
     s
 }

--- a/crates/pounce-cli/tests/quad_parse_differential.rs
+++ b/crates/pounce-cli/tests/quad_parse_differential.rs
@@ -1,0 +1,578 @@
+//! The Q5 parse-time recognizer against the parse it replaces (gh #588).
+//!
+//! Q5 reads a degree-2 `C`/`O` body off the `.nl` token stream as
+//! coefficients and never builds its `Expr` tree — that tree is what sets
+//! peak RSS on a quadratic model. Two things therefore have to be true, and
+//! neither is the sort of claim a fixture sweep can settle:
+//!
+//! 1. **The recognizers agree.** What the parser stores must be, bit for
+//!    bit, what `recognize_expr` returns for the tree those same bytes parse
+//!    to — and the *set* of bodies it recognizes must be exactly the set
+//!    `is_expanded_quadratic` admits, restricted to degree 2. A parse-time
+//!    recognizer that admitted one body more would put a form on Q4's
+//!    constant-matrix path that Q4's accuracy gate refuses; `airport.nl`
+//!    measured what that costs (16 iterations to the 300-iteration cap).
+//!    A coefficient one ulp out would be a wrong Hessian on a model no
+//!    fixture solves.
+//! 2. **The tree is still available, unchanged.** Everything that genuinely
+//!    needs an `Expr` — the `POUNCE_DBG_NO_QUAD` tape reference, FBBT, the
+//!    debugger's renderer — gets one back from `con_expr`/`obj_expr`. It has
+//!    to be *the* tree, not an equivalent one: a re-derived tree would be
+//!    taped differently and this phase would stop being invisible from
+//!    outside.
+//!
+//! So every `.nl` file in the repository is parsed **twice**, with
+//! recognition on and off, and the two problems are compared body by body.
+//! The design note (§9, Q5) says to assert this directly instead of running
+//! a sweep; the sweep is run as well, but this is the artefact that covers
+//! rows no fixture's solve reaches.
+//!
+//! Everything here is compared on **bit patterns**, never with a tolerance.
+//! Q1's 2-ulp line is why: a one-ulp coefficient difference moved a fixture
+//! from 17 to 12 conic iterations, and only a differential check saw it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use pounce_cli::nl_reader::{
+    Expr, FuncallArg, NlBody, NlProblem, collect_vars, parse_nl_text_with_quadratic,
+};
+use pounce_nl::nl_quadratic::{is_expanded_quadratic, recognize_expr};
+
+fn all_fixtures() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().is_some_and(|x| x == "nl") {
+                out.push(p);
+            }
+        }
+    }
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut out = Vec::new();
+    walk(&base.join("fixtures"), &mut out);
+    walk(&base.join("fixtures_issue_49"), &mut out);
+    out.sort();
+    out
+}
+
+/// Structural equality on `Expr`, with every constant compared as a **bit
+/// pattern**: `0.0 == -0.0` and `NaN != NaN` are both wrong answers for a
+/// test whose whole job is to notice that a coefficient moved.
+fn same_expr(a: &Expr, b: &Expr) -> bool {
+    match (a, b) {
+        (Expr::Const(x), Expr::Const(y)) => x.to_bits() == y.to_bits(),
+        (Expr::Var(i), Expr::Var(j)) => i == j,
+        (Expr::Binary(o1, a1, b1), Expr::Binary(o2, a2, b2)) => {
+            o1 == o2 && same_expr(a1, a2) && same_expr(b1, b2)
+        }
+        (Expr::Unary(o1, a1), Expr::Unary(o2, a2)) => o1 == o2 && same_expr(a1, a2),
+        (Expr::Sum(x), Expr::Sum(y))
+        | (Expr::MinList(x), Expr::MinList(y))
+        | (Expr::MaxList(x), Expr::MaxList(y)) => {
+            x.len() == y.len() && x.iter().zip(y).all(|(p, q)| same_expr(p, q))
+        }
+        // Structural, because the two sides come from two independent
+        // parses and no `Arc` is shared between them. That a *rebuilt* body
+        // reuses its own parse's `Arc`s — which is what `HybridTape` keys
+        // CSE sharing on — is a separate assertion, `rebuilt_cses_are_the_parses_own`.
+        (Expr::Cse(x), Expr::Cse(y)) => same_expr(x, y),
+        (Expr::Compare(o1, a1, b1), Expr::Compare(o2, a2, b2)) => {
+            o1 == o2 && same_expr(a1, a2) && same_expr(b1, b2)
+        }
+        (Expr::And(a1, b1), Expr::And(a2, b2)) | (Expr::Or(a1, b1), Expr::Or(a2, b2)) => {
+            same_expr(a1, a2) && same_expr(b1, b2)
+        }
+        (Expr::Not(a1), Expr::Not(a2)) => same_expr(a1, a2),
+        (
+            Expr::Cond {
+                cond: c1,
+                then_: t1,
+                else_: e1,
+            },
+            Expr::Cond {
+                cond: c2,
+                then_: t2,
+                else_: e2,
+            },
+        ) => same_expr(c1, c2) && same_expr(t1, t2) && same_expr(e1, e2),
+        (Expr::Funcall { id: i1, args: a1 }, Expr::Funcall { id: i2, args: a2 }) => {
+            i1 == i2
+                && a1.len() == a2.len()
+                && a1.iter().zip(a2).all(|(p, q)| match (p, q) {
+                    (FuncallArg::Real(x), FuncallArg::Real(y)) => same_expr(x, y),
+                    (FuncallArg::Str(x), FuncallArg::Str(y)) => x == y,
+                    _ => false,
+                })
+        }
+        _ => false,
+    }
+}
+
+/// Compare two recognized forms on the bit patterns of every coefficient.
+fn same_form(a: &pounce_nl::nl_quadratic::Quad2, b: &pounce_nl::nl_quadratic::Quad2) -> bool {
+    let bits = |x: &f64| x.to_bits();
+    a.constant().to_bits() == b.constant().to_bits()
+        && a.linear().len() == b.linear().len()
+        && a.linear()
+            .iter()
+            .zip(b.linear())
+            .all(|((i, x), (j, y))| i == j && bits(x) == bits(y))
+        && a.quadratic().len() == b.quadratic().len()
+        && a.quadratic()
+            .iter()
+            .zip(b.quadratic())
+            .all(|((i, x), (j, y))| i == j && bits(x) == bits(y))
+}
+
+#[derive(Default)]
+struct Report {
+    files: usize,
+    bodies: usize,
+    recognized: usize,
+    rebuilt_nodes: usize,
+}
+
+/// One body, both ways.
+fn check_body(prob_q: &NlProblem, prob_t: &NlProblem, body: usize, name: &str, rep: &mut Report) {
+    let (q_body, tree, q_expr) = if body == usize::MAX {
+        (&prob_q.obj_nonlinear, prob_t.obj_expr(), prob_q.obj_expr())
+    } else {
+        (
+            &prob_q.con_nonlinear[body],
+            prob_t.con_expr(body),
+            prob_q.con_expr(body),
+        )
+    };
+    rep.bodies += 1;
+
+    // (2) The tree survives, byte for byte, whether it was kept or rebuilt.
+    assert!(
+        same_expr(&q_expr, &tree),
+        "{name}: the rebuilt tree is not the tree a non-recognizing parse builds"
+    );
+
+    // The no-quad parse must keep every body as a tree — that is what
+    // `POUNCE_DBG_NO_QUAD=1` promises the gh #540 guard.
+    assert!(
+        prob_t
+            .con_nonlinear
+            .iter()
+            .chain(std::iter::once(&prob_t.obj_nonlinear))
+            .all(|b| b.tree().is_some()),
+        "{name}: recognition leaked into the POUNCE_DBG_NO_QUAD parse"
+    );
+
+    // (1) The recognized set, and the coefficients in it.
+    let want = recognize_expr(&tree)
+        .filter(|f| !f.quadratic().is_empty())
+        .filter(|_| is_expanded_quadratic(&tree));
+    match (q_body.quad(), &want) {
+        (Some(got), Some(want)) => {
+            assert!(
+                same_form(got, want),
+                "{name}: the parse-time form is not bit-identical to the tree's"
+            );
+            rep.recognized += 1;
+        }
+        (None, None) => {}
+        (Some(_), None) => panic!(
+            "{name}: the parser recognized a body the tree walk refuses — \
+             this is the direction that puts a factored form on Q4's \
+             constant-matrix path"
+        ),
+        (None, Some(_)) => panic!(
+            "{name}: the parser rewound a body the tree walk admits — reach \
+             lost, and Q4 would pick it up anyway, so the two are out of step"
+        ),
+    }
+
+    if let NlBody::Quad(q) = q_body {
+        // The stored support is the tree's, including a variable whose
+        // coefficient cancelled to zero (which the form necessarily drops).
+        let mut want_vars: BTreeSet<usize> = BTreeSet::new();
+        collect_vars(&tree, &mut want_vars);
+        let got_vars: BTreeSet<usize> = q.vars.iter().map(|&v| v as usize).collect();
+        assert_eq!(got_vars, want_vars, "{name}: variable support");
+        assert_eq!(expr_depth(&tree), q.depth, "{name}: recorded tree depth");
+        rep.rebuilt_nodes += node_count(&tree);
+    }
+}
+
+fn expr_depth(e: &Expr) -> u32 {
+    let deepest = |kids: &mut dyn Iterator<Item = &Expr>| kids.fold(0, |a, k| a.max(expr_depth(k)));
+    1 + match e {
+        Expr::Const(_) | Expr::Var(_) => 0,
+        Expr::Binary(_, a, b) | Expr::Compare(_, a, b) | Expr::And(a, b) | Expr::Or(a, b) => {
+            deepest(&mut [&**a, &**b].into_iter())
+        }
+        Expr::Unary(_, a) | Expr::Not(a) => expr_depth(a),
+        Expr::Sum(v) | Expr::MinList(v) | Expr::MaxList(v) => deepest(&mut v.iter()),
+        Expr::Cond { cond, then_, else_ } => {
+            deepest(&mut [&**cond, &**then_, &**else_].into_iter())
+        }
+        Expr::Funcall { args, .. } => deepest(&mut args.iter().filter_map(|a| match a {
+            FuncallArg::Real(x) => Some(x),
+            FuncallArg::Str(_) => None,
+        })),
+        Expr::Cse(b) => expr_depth(b),
+    }
+}
+
+fn node_count(e: &Expr) -> usize {
+    1 + match e {
+        Expr::Const(_) | Expr::Var(_) => 0,
+        Expr::Binary(_, a, b) | Expr::Compare(_, a, b) | Expr::And(a, b) | Expr::Or(a, b) => {
+            node_count(a) + node_count(b)
+        }
+        Expr::Unary(_, a) | Expr::Not(a) => node_count(a),
+        Expr::Cse(a) => node_count(a),
+        Expr::Sum(v) | Expr::MinList(v) | Expr::MaxList(v) => v.iter().map(node_count).sum(),
+        Expr::Cond { cond, then_, else_ } => {
+            node_count(cond) + node_count(then_) + node_count(else_)
+        }
+        Expr::Funcall { args, .. } => args
+            .iter()
+            .map(|a| match a {
+                FuncallArg::Real(x) => node_count(x),
+                FuncallArg::Str(_) => 0,
+            })
+            .sum(),
+    }
+}
+
+#[test]
+fn every_fixture_parses_identically_with_and_without_recognition() {
+    let fixtures = all_fixtures();
+    assert!(
+        fixtures.len() >= 50,
+        "expected the fixture corpus, found {} files",
+        fixtures.len()
+    );
+    let mut rep = Report::default();
+    for f in &fixtures {
+        let Ok(txt) = std::fs::read_to_string(f) else {
+            continue;
+        };
+        let (Ok(prob_q), Ok(prob_t)) = (
+            parse_nl_text_with_quadratic(&txt, true),
+            parse_nl_text_with_quadratic(&txt, false),
+        ) else {
+            continue;
+        };
+        let name = f.display().to_string();
+        rep.files += 1;
+
+        // Everything outside the bodies is untouched, and that includes the
+        // constant-row fold (gh #492), which shifts row bounds during the
+        // parse and must not see a different set of bodies.
+        assert_eq!(prob_q.n, prob_t.n, "{name}: n");
+        assert_eq!(prob_q.m, prob_t.m, "{name}: m");
+        assert_eq!(prob_q.minimize, prob_t.minimize, "{name}: sense");
+        for (i, (x, y)) in prob_q.g_l.iter().zip(&prob_t.g_l).enumerate() {
+            assert_eq!(x.to_bits(), y.to_bits(), "{name}: g_l[{i}]");
+        }
+        for (i, (x, y)) in prob_q.g_u.iter().zip(&prob_t.g_u).enumerate() {
+            assert_eq!(x.to_bits(), y.to_bits(), "{name}: g_u[{i}]");
+        }
+        assert_eq!(prob_q.con_linear, prob_t.con_linear, "{name}: con_linear");
+        assert_eq!(prob_q.obj_linear, prob_t.obj_linear, "{name}: obj_linear");
+
+        check_body(
+            &prob_q,
+            &prob_t,
+            usize::MAX,
+            &format!("{name}: obj"),
+            &mut rep,
+        );
+        for k in 0..prob_q.m {
+            check_body(&prob_q, &prob_t, k, &format!("{name}: row {k}"), &mut rep);
+        }
+    }
+
+    // Floors, not targets: a refactor that leaves this test walking a
+    // handful of bodies, or recognizing none of them, should fail rather
+    // than pass vacuously.
+    assert!(rep.files >= 50, "files walked: {}", rep.files);
+    assert!(rep.bodies >= 1000, "bodies walked: {}", rep.bodies);
+    assert!(
+        rep.recognized >= 200,
+        "bodies recognized at parse time: {}",
+        rep.recognized
+    );
+    eprintln!(
+        "[quad parse differential] {} files, {} bodies, {} recognized, \
+         {} Expr nodes not built",
+        rep.files, rep.bodies, rep.recognized, rep.rebuilt_nodes
+    );
+}
+
+/// A model with nothing recognized is the pre-Q5 problem in every respect,
+/// including keeping no source: that is what makes the blast radius
+/// statable as "exactly the degree-2 bodies".
+#[test]
+fn a_model_with_nothing_recognized_keeps_no_source() {
+    // `min sin(x0) + sin(x1)` — transcendental, so nothing is degree 2.
+    let nl = "g3 0 1 0\n2 0 1 0 0\n0 1\n0 0\n0 2 0\n0 0 0 1\n0 0 0 0 0\n0 0\n0 0\n\
+              0 0 0 0 0\nO0 0\no0\no41\nv0\no41\nv1\nb\n3\n3\n";
+    let p = parse_nl_text_with_quadratic(nl, true).expect("parse");
+    assert!(
+        p.src.is_none(),
+        "no body was recognized, so no text is kept"
+    );
+    assert!(p.obj_nonlinear.tree().is_some());
+}
+
+/// A rebuilt body resolves its `v<i>` (`i >= n`) references to the `Arc`s
+/// **this** parse produced, not to fresh allocations.
+///
+/// That is not cosmetic: `HybridTape::build_multi` keys CSE sharing on
+/// pointer identity, so a rebuilt row whose bodies were freshly allocated
+/// would be taped as if nothing were shared — a different tape for the same
+/// model, on the `POUNCE_DBG_NO_QUAD` path that exists to be the reference.
+#[test]
+fn rebuilt_cses_are_the_parses_own() {
+    let mut checked = 0usize;
+    for f in all_fixtures() {
+        let Ok(txt) = std::fs::read_to_string(&f) else {
+            continue;
+        };
+        let Ok(p) = parse_nl_text_with_quadratic(&txt, true) else {
+            continue;
+        };
+        if p.cse_bodies.is_empty() {
+            continue;
+        }
+        let own: BTreeSet<usize> = p
+            .cse_bodies
+            .iter()
+            .map(|b| std::sync::Arc::as_ptr(b) as usize)
+            .collect();
+        for k in 0..p.m {
+            if p.con_nonlinear[k].quad().is_none() {
+                continue;
+            }
+            let mut seen: Vec<usize> = Vec::new();
+            collect_cse_ptrs(&p.con_expr(k), &mut seen);
+            for ptr in seen {
+                assert!(
+                    own.contains(&ptr),
+                    "{}: row {k} rebuilt a CSE body instead of reusing the parse's",
+                    f.display()
+                );
+                checked += 1;
+            }
+        }
+    }
+    eprintln!("[quad parse differential] {checked} rebuilt CSE references checked");
+}
+
+fn collect_cse_ptrs(e: &Expr, out: &mut Vec<usize>) {
+    match e {
+        Expr::Const(_) | Expr::Var(_) => {}
+        Expr::Binary(_, a, b) | Expr::Compare(_, a, b) | Expr::And(a, b) | Expr::Or(a, b) => {
+            collect_cse_ptrs(a, out);
+            collect_cse_ptrs(b, out);
+        }
+        Expr::Unary(_, a) | Expr::Not(a) => collect_cse_ptrs(a, out),
+        Expr::Sum(v) | Expr::MinList(v) | Expr::MaxList(v) => {
+            v.iter().for_each(|k| collect_cse_ptrs(k, out))
+        }
+        Expr::Cond { cond, then_, else_ } => {
+            collect_cse_ptrs(cond, out);
+            collect_cse_ptrs(then_, out);
+            collect_cse_ptrs(else_, out);
+        }
+        Expr::Funcall { args, .. } => args.iter().for_each(|a| {
+            if let FuncallArg::Real(x) = a {
+                collect_cse_ptrs(x, out)
+            }
+        }),
+        Expr::Cse(b) => out.push(std::sync::Arc::as_ptr(b) as usize),
+    }
+}
+
+/// A `V`-segment quadratic, referenced **twice** — the case Q4 had to
+/// refuse and Q5's memoization is what makes affordable.
+///
+/// `V1 = x0·x0`, row `C0 = v1 + v1`. Both references sit on the sum spine
+/// and each is a flat monomial, so the body is an expanded quadratic and the
+/// row is `2·x0²`. Q4's gate ended the walk at the second reference and the
+/// row kept its tape; here it is recognized, from the token stream, with the
+/// same coefficients the tree walk produces.
+///
+/// This also makes `rebuilt_cses_are_the_parses_own` non-vacuous — no
+/// fixture in the repository has a recognized body that references a CSE at
+/// all, which is worth knowing about the corpus.
+const CSE_QUAD: &str = "g3 0 1 0
+1 1 1 0 0
+1 0
+0 0
+1 0 0
+0 0 0 1
+0 0 0 0 0
+0 0
+0 0
+0 1 0 0 0
+V1 0 0
+o2
+v0
+v0
+C0
+o0
+v1
+v1
+O0 0
+n0
+r
+1 5.0
+b
+3
+k0
+";
+
+#[test]
+fn a_twice_referenced_cse_quadratic_is_recognized() {
+    let q = parse_nl_text_with_quadratic(CSE_QUAD, true).expect("parse");
+    let t = parse_nl_text_with_quadratic(CSE_QUAD, false).expect("parse");
+    let form = q.con_nonlinear[0]
+        .quad()
+        .expect("v1 + v1 with v1 = x0² is an expanded quadratic");
+    assert_eq!(
+        form.quadratic().get(&(0, 0)).map(|c| c.to_bits()),
+        Some(2.0_f64.to_bits()),
+        "x0² + x0² = 2·x0²"
+    );
+    let want = recognize_expr(&t.con_expr(0)).expect("the tree walk agrees");
+    assert!(same_form(form, &want), "parse-time form vs tree walk");
+    assert!(
+        is_expanded_quadratic(&t.con_expr(0)),
+        "and the exactness gate admits it — which it did not before Q5"
+    );
+    assert!(
+        same_expr(&q.con_expr(0), &t.con_expr(0)),
+        "the rebuilt tree is the tree"
+    );
+    // The rebuilt body reuses this parse's CSE body rather than a fresh one.
+    let mut ptrs = Vec::new();
+    collect_cse_ptrs(&q.con_expr(0), &mut ptrs);
+    assert_eq!(ptrs.len(), 2, "both references survive the rebuild");
+    let own = std::sync::Arc::as_ptr(&q.cse_bodies[0]) as usize;
+    assert!(ptrs.iter().all(|p| *p == own));
+}
+
+/// A `Pow` whose base is a defined variable stays on the tape, because
+/// `(x0 + x1)²` is a *factored* form and expanding it cancels — the rule
+/// Q4 paid `airport.nl` 16 → 300 iterations to learn. The parse-time
+/// recognizer has to enforce it at the point where it is cheapest to get
+/// wrong, since there is no tree left to re-check afterwards.
+const CSE_FACTORED: &str = "g3 0 1 0
+2 1 1 0 0
+1 0
+0 0
+2 0 0
+0 0 0 1
+0 0 0 0 0
+0 0
+0 0
+0 1 0 0 0
+V2 0 0
+o0
+v0
+v1
+C0
+o5
+v2
+n2
+O0 0
+n0
+r
+1 5.0
+b
+3
+3
+k1
+0
+";
+
+#[test]
+fn a_factored_defined_variable_is_not_recognized() {
+    let q = parse_nl_text_with_quadratic(CSE_FACTORED, true).expect("parse");
+    let t = parse_nl_text_with_quadratic(CSE_FACTORED, false).expect("parse");
+    assert!(
+        q.con_nonlinear[0].quad().is_none(),
+        "(x0 + x1)² must keep its tree — expanding it is the gh #544 defect"
+    );
+    assert!(!is_expanded_quadratic(&t.con_expr(0)));
+    // And it *is* algebraically quadratic, so the refusal is the gate
+    // talking and not the recognizer giving up.
+    assert!(recognize_expr(&t.con_expr(0)).is_some());
+}
+
+/// Summation order is observable, so the parse-time fold has to be the one
+/// `recognize_expr` performs — which is **last operand first**, because its
+/// work stack lowers a sumlist in reverse and then folds in `drain` order.
+///
+/// The row is `1e16·x0² + 1·x0² + 1·x0²`. Folding front to back gives
+/// `1e16` (each `+1` is lost below the ulp); folding back to front gives
+/// `1e16 + 2`. One of those is what the tape-free path stores and the other
+/// is a silent one-ulp lie about a coefficient.
+const SUM_ORDER: &str = "g3 0 1 0
+1 1 1 0 0
+1 0
+0 0
+1 0 0
+0 0 0 1
+0 0 0 0 0
+0 0
+0 0
+0 0 0 0 0
+C0
+o54
+3
+o2
+n1e16
+o2
+v0
+v0
+o2
+n1
+o2
+v0
+v0
+o2
+n1
+o2
+v0
+v0
+O0 0
+n0
+r
+1 5.0
+b
+3
+k0
+";
+
+#[test]
+fn a_sumlist_folds_in_the_order_the_tree_walk_folds() {
+    let q = parse_nl_text_with_quadratic(SUM_ORDER, true).expect("parse");
+    let t = parse_nl_text_with_quadratic(SUM_ORDER, false).expect("parse");
+    let form = q.con_nonlinear[0].quad().expect("expanded quadratic");
+    let want = recognize_expr(&t.con_expr(0)).expect("tree walk");
+    assert!(same_form(form, &want), "fold order");
+    // Pinned as a number as well as differentially, so that a change to
+    // *both* sides at once still has to be argued for.
+    let got = form.quadratic()[&(0, 0)];
+    assert_eq!(
+        got.to_bits(),
+        (1.0e16_f64 + 2.0).to_bits(),
+        "expected the back-to-front fold, got {got:e}"
+    );
+    assert_ne!(got.to_bits(), 1.0e16_f64.to_bits());
+}

--- a/crates/pounce-cli/tests/quad_recognizer_differential.rs
+++ b/crates/pounce-cli/tests/quad_recognizer_differential.rs
@@ -303,15 +303,22 @@ fn every_fixture_row_reads_identically_under_both_recognizers() {
     for f in &fixtures {
         let Ok(prob) = read_nl_file(f) else { continue };
         let name = f.display();
-        check(&prob.obj_nonlinear, &format!("{name}: objective"));
+        // `obj_expr`/`con_expr` rather than the stored bodies: since
+        // gh #588 Q5 the parser recognizes a degree-2 body from the token
+        // stream and keeps no tree for it, and this test is about trees.
+        // The rebuilt tree is the one the parser would have built — which
+        // this test then also happens to exercise, on every corpus row.
+        let obj = prob.obj_expr();
+        check(&obj, &format!("{name}: objective"));
         rows += 1;
-        if analyze_quadratic_full(&prob.obj_nonlinear).is_some() {
+        if analyze_quadratic_full(&obj).is_some() {
             quadratic += 1;
         }
-        for (i, c) in prob.con_nonlinear.iter().enumerate() {
-            check(c, &format!("{name}: row {i}"));
+        for i in 0..prob.m {
+            let c = prob.con_expr(i);
+            check(&c, &format!("{name}: row {i}"));
             rows += 1;
-            if analyze_quadratic_full(c).is_some() {
+            if analyze_quadratic_full(&c).is_some() {
                 quadratic += 1;
             }
         }

--- a/crates/pounce-nl/src/nl_quadratic.rs
+++ b/crates/pounce-nl/src/nl_quadratic.rs
@@ -96,7 +96,7 @@ impl Quad2 {
         &self.quadratic
     }
 
-    fn of_constant(c: f64) -> Self {
+    pub(crate) fn of_constant(c: f64) -> Self {
         Quad2 {
             // `-0.0` and `0.0` alike mean "no constant term"; normalizing
             // here keeps `Neg(Const(0.0))` from reporting `-0.0`.
@@ -105,14 +105,14 @@ impl Quad2 {
         }
     }
 
-    fn of_var(i: usize) -> Self {
+    pub(crate) fn of_var(i: usize) -> Self {
         let mut q = Quad2::default();
         q.linear.insert(i, 1.0);
         q
     }
 
     /// Total degree: 0, 1, or 2.
-    fn degree(&self) -> usize {
+    pub(crate) fn degree(&self) -> usize {
         if !self.quadratic.is_empty() {
             2
         } else if !self.linear.is_empty() {
@@ -123,7 +123,7 @@ impl Quad2 {
     }
 
     /// The value, when this form has no variables in it.
-    fn as_constant(&self) -> Option<f64> {
+    pub(crate) fn as_constant(&self) -> Option<f64> {
         (self.degree() == 0).then_some(self.constant)
     }
 
@@ -143,7 +143,7 @@ impl Quad2 {
     /// either way rather than only when it leans left. Choosing the direction
     /// is free of arithmetic consequence: IEEE addition is commutative bit
     /// for bit, `-0.0` included.
-    fn add(a: Quad2, b: Quad2) -> Quad2 {
+    pub(crate) fn add(a: Quad2, b: Quad2) -> Quad2 {
         let (mut acc, small) = if a.width() >= b.width() {
             (a, b)
         } else {
@@ -161,7 +161,7 @@ impl Quad2 {
         acc
     }
 
-    fn neg(mut self) -> Quad2 {
+    pub(crate) fn neg(mut self) -> Quad2 {
         self.constant = -self.constant;
         for c in self.linear.values_mut() {
             *c = -*c;
@@ -172,7 +172,7 @@ impl Quad2 {
         self
     }
 
-    fn scale(mut self, s: f64) -> Quad2 {
+    pub(crate) fn scale(mut self, s: f64) -> Quad2 {
         if s == 0.0 {
             return Quad2::default();
         }
@@ -189,7 +189,7 @@ impl Quad2 {
     /// `self · other`, or `None` when the product would exceed total
     /// degree 2 — past that the recognizer gives up and the caller routes
     /// to the general NLP path.
-    fn mul(&self, other: &Quad2) -> Option<Quad2> {
+    pub(crate) fn mul(&self, other: &Quad2) -> Option<Quad2> {
         if self.degree() + other.degree() > 2 {
             return None;
         }
@@ -272,6 +272,9 @@ enum Op {
     Pow,
     /// n-ary sum over the top `n` values.
     Sum(usize),
+    /// Not an operation: the value now on top of the stack is the lowering
+    /// of the `Cse` body with this address, so record it before moving on.
+    CacheCse(*const Expr),
 }
 
 /// Lower an [`Expr`] to a [`Quad2`], or `None` if it contains anything the
@@ -281,23 +284,40 @@ enum Op {
 /// …). `None` ⇒ treat as general nonlinear.
 ///
 /// `Cse` nodes are inlined: a reference is mathematically its body, and
-/// every reference is an independent occurrence. A body reached `r` times
-/// is therefore lowered `r` times, exactly as the recursive predecessor did
-/// — memoizing on the `Arc` identity is a pure win still on the table for
-/// Q5, not a behaviour change made here.
+/// every reference is an independent occurrence. A body is nevertheless
+/// lowered **once**, and its [`Quad2`] reused at every later reference
+/// (keyed on `Arc` identity). That is what makes the walk `Θ(nodes)` on a
+/// shared DAG instead of `Θ(2^depth)`; Q4 had to refuse a re-referenced
+/// body outright to bound the cost, and this is the memoization that
+/// refusal was waiting for (gh #588, Q5). It is bitwise neutral — the
+/// lowering of a body is a function of the body, so the reused value is
+/// the one a second lowering would have produced, bit for bit.
 ///
 /// The walk is iterative. See the module docs for why that is a
 /// correctness property and not a style choice.
 pub fn recognize_expr(e: &Expr) -> Option<Quad2> {
     let mut work: Vec<Step<'_>> = vec![Step::Visit(e)];
     let mut vals: Vec<Quad2> = Vec::new();
+    // Lowered `Cse` bodies, by address. Only successes land here: a body
+    // that fails aborts the whole walk, so there is no negative result to
+    // remember.
+    let mut cse: std::collections::HashMap<*const Expr, Quad2> = std::collections::HashMap::new();
 
     while let Some(step) = work.pop() {
         match step {
             Step::Visit(e) => match e {
                 Expr::Const(c) => vals.push(Quad2::of_constant(*c)),
                 Expr::Var(i) => vals.push(Quad2::of_var(*i)),
-                Expr::Cse(body) => work.push(Step::Visit(body)),
+                Expr::Cse(body) => {
+                    let key = std::sync::Arc::as_ptr(body);
+                    match cse.get(&key) {
+                        Some(q) => vals.push(q.clone()),
+                        None => {
+                            work.push(Step::Apply(Op::CacheCse(key)));
+                            work.push(Step::Visit(body));
+                        }
+                    }
+                }
                 Expr::Sum(items) => {
                     work.push(Step::Apply(Op::Sum(items.len())));
                     // Pushed forward, so they pop back to front and land on
@@ -334,8 +354,14 @@ pub fn recognize_expr(e: &Expr) -> Option<Quad2> {
                 // opcodes. None is provably polynomial ⇒ route to NLP.
                 _ => return None,
             },
+            Step::Apply(Op::CacheCse(key)) => {
+                // The body's value is already on the stack and stays there;
+                // this only records it for the next reference.
+                cse.insert(key, vals.last()?.clone());
+            }
             Step::Apply(op) => {
                 let combined = match op {
+                    Op::CacheCse(_) => unreachable!("handled above"),
                     Op::Sum(n) => {
                         // The items are the top `n` values, item 0 on top.
                         let at = vals.len().checked_sub(n)?;
@@ -426,7 +452,15 @@ pub fn analyze_quadratic(e: &Expr) -> Option<QuadHessian> {
 /// value*; dropping it makes the convex solve report an objective off by
 /// that constant versus the NLP path.
 pub fn analyze_quadratic_full(e: &Expr) -> Option<QuadForm> {
-    let q = recognize_expr(e)?;
+    Some(quad_form_readout(&recognize_expr(e)?))
+}
+
+/// The `(Hessian, linear, constant)` read-out of an already-recognized
+/// form — the second half of [`analyze_quadratic_full`], split out so a
+/// caller holding a [`Quad2`] the *parser* produced (gh #588, Q5) reaches
+/// the identical numbers by the identical route. There is exactly one
+/// conversion in the crate; a second one is a second thing to keep in step.
+pub fn quad_form_readout(q: &Quad2) -> QuadForm {
     // ∂²(c·xᵢxⱼ)/∂xᵢ∂xⱼ = c for i≠j; ∂²(c·xᵢ²)/∂xᵢ² = 2c.
     let mut h: QuadHessian = q
         .quadratic
@@ -437,7 +471,7 @@ pub fn analyze_quadratic_full(e: &Expr) -> Option<QuadForm> {
     h.retain(|_, v| v.abs() > 0.0);
     let lin: Vec<(usize, f64)> = q.linear.iter().map(|(i, c)| (*i, *c)).collect();
     // `0.0 +` normalizes `-0.0`, which is how this form spells "absent".
-    Some((h, lin, 0.0 + q.constant))
+    (h, lin, 0.0 + q.constant)
 }
 
 /// Is this expression **already** a flat sum of monomials — that is, would
@@ -467,29 +501,34 @@ pub fn analyze_quadratic_full(e: &Expr) -> Option<QuadForm> {
 /// carrying a shift (a vertex, or the writer's own grouping), which is a
 /// larger change than this phase.
 ///
-/// ## A re-referenced `Cse` body is refused, and that is about cost
+/// ## A re-referenced `Cse` body is *skipped*, not refused
 ///
 /// This walk and [`recognize_expr`] behind it both inline a `Cse` body at
-/// **every** reference, so a DAG whose bodies are shared costs `Θ(2^depth)`
-/// rather than `Θ(nodes)`. `nl_reader`'s
+/// **every** reference, so a DAG whose bodies are shared cost `Θ(2^depth)`
+/// rather than `Θ(nodes)` before either was memoized. `nl_reader`'s
 /// `shared_dag_walks_are_memoized_not_exponential` builds exactly that shape
 /// — 30 levels, each a `Cse` referenced twice — and taking it through this
-/// gate ungated measured **0.00 s → 172 s** on a model the tape path loads
-/// instantly. At depth 40 it would not return at all.
+/// gate in Q4 measured **0.00 s → 172 s** on a model the tape path loads
+/// instantly. At depth 40 it would not have returned at all.
 ///
-/// So a body reached a second time ends the walk with `false`: the model
-/// keeps its tape, which handles sharing properly (that is what `ConHybrid`
-/// is for), and nothing hangs. Memoizing instead — on `Arc` identity, which
-/// is a pure and bitwise-neutral win — would fix this walk and leave
-/// `recognize_expr` exponential behind it, so it belongs with that change in
-/// Q5 rather than half-done here. The target family is unaffected: the
-/// `qcqp*` files declare no common expressions at all.
+/// Q4 bounded that by ending the walk in `false` at the second reference,
+/// which cost reach to buy termination and was explicitly left for Q5 to
+/// replace. It is replaced here: a body reached a second time in the same
+/// mode is **skipped**, which is sound for exactly the reason
+/// `nl_reader::validate_expr` documents for the same trick — this walk
+/// aborts on the first violation, so reaching a body a second time proves
+/// the first visit found none. The verdict is unchanged for every DAG that
+/// is a tree, and a shared DAG that *is* an expanded quadratic is now
+/// admitted instead of refused. The mode is part of the key: a body is
+/// legal on the sum spine if it is a sum of monomials, and legal inside a
+/// monomial only if it is itself a monomial, so the two answers are cached
+/// apart.
 ///
 /// Iterative for the same reason [`recognize_expr`] is.
 pub fn is_expanded_quadratic(e: &Expr) -> bool {
     // The sum spine: `Add`/`Sub`/`Neg`/`Sum` may nest freely, and every
     // leaf of that spine must be a monomial.
-    let mut seen: BTreeSet<*const Expr> = BTreeSet::new();
+    let mut seen: BTreeSet<(*const Expr, bool)> = BTreeSet::new();
     let mut spine: Vec<&Expr> = vec![e];
     while let Some(e) = spine.pop() {
         match e {
@@ -500,10 +539,9 @@ pub fn is_expanded_quadratic(e: &Expr) -> bool {
             }
             Expr::Unary(UnaryOp::Neg, a) => spine.push(a),
             Expr::Cse(body) => {
-                if !seen.insert(std::sync::Arc::as_ptr(body)) {
-                    return false;
+                if seen.insert((std::sync::Arc::as_ptr(body), false)) {
+                    spine.push(body);
                 }
-                spine.push(body);
             }
             other => {
                 if !is_monomial(other, &mut seen) {
@@ -515,6 +553,17 @@ pub fn is_expanded_quadratic(e: &Expr) -> bool {
     true
 }
 
+/// Is this expression a single monomial — the leaf shape
+/// [`is_expanded_quadratic`] admits on its sum spine?
+///
+/// Public because the parse-time recognizer has to answer the same
+/// question about a `V`-segment body it has already parsed, and must
+/// answer it with *this* code rather than a second copy of the rule.
+pub fn is_monomial_expr(e: &Expr) -> bool {
+    let mut seen: BTreeSet<(*const Expr, bool)> = BTreeSet::new();
+    is_monomial(e, &mut seen)
+}
+
 /// A single product term: constants and variables multiplied together, with
 /// no addition anywhere inside it. `xᵢxⱼ`, `0.5·c·xᵢ·xⱼ`, `xᵢ²` and `xᵢ/3`
 /// all qualify; `(xᵢ − xⱼ)²` and `(xᵢ + 1)·xⱼ` do not.
@@ -522,18 +571,19 @@ pub fn is_expanded_quadratic(e: &Expr) -> bool {
 /// Degree is not checked here — [`recognize_expr`] already refused anything
 /// past 2 by the time this runs, and duplicating the rule would only give
 /// the two a way to disagree.
-fn is_monomial(e: &Expr, seen: &mut BTreeSet<*const Expr>) -> bool {
+fn is_monomial(e: &Expr, seen: &mut BTreeSet<(*const Expr, bool)>) -> bool {
     let mut work: Vec<&Expr> = vec![e];
     while let Some(e) = work.pop() {
         match e {
             Expr::Const(_) | Expr::Var(_) => {}
-            // Shared with the spine walk, and refused for the same reason —
-            // see [`is_expanded_quadratic`].
+            // Shared with the spine walk, and skipped on revisit for the
+            // same reason — see [`is_expanded_quadratic`]. The `true` in the
+            // key is "seen in monomial mode": a body cleared on the spine
+            // has not been cleared here.
             Expr::Cse(body) => {
-                if !seen.insert(std::sync::Arc::as_ptr(body)) {
-                    return false;
+                if seen.insert((std::sync::Arc::as_ptr(body), true)) {
+                    work.push(body);
                 }
-                work.push(body);
             }
             Expr::Unary(UnaryOp::Neg, a) => work.push(a),
             Expr::Binary(BinOp::Mul | BinOp::Div, a, b) => {
@@ -742,14 +792,20 @@ mod tests {
         assert!(is_expanded_quadratic(&once));
     }
 
-    /// A `Cse` body reached twice is refused, and the reason is cost rather
-    /// than algebra: this walk and `recognize_expr` behind it both inline a
-    /// body per reference, so a shared DAG is `Θ(2^depth)`. The shape below
-    /// is `nl_reader`'s `shared_dag_walks_are_memoized_not_exponential`
-    /// scaled up — at depth 60 an exponential walk does not return in the
-    /// lifetime of the test run, so this passing at all is the assertion.
+    /// A `Cse` body reached twice is walked once, not `2^depth` times, and
+    /// is **admitted** rather than refused.
+    ///
+    /// Q4 refused it, and refused it for cost rather than algebra — this
+    /// walk and `recognize_expr` behind it both inline a body per
+    /// reference, so a shared DAG was `Θ(2^depth)`. Q5's memoization is
+    /// what makes admitting it affordable, so both halves are asserted
+    /// here: the verdict, and the fact that the test returns at all. The
+    /// shape is `nl_reader`'s `shared_dag_walks_are_memoized_not_exponential`
+    /// scaled up; at depth 60 an exponential walk does not finish inside
+    /// the lifetime of this test run, and `2^60` sums do not fit in an
+    /// `f64` count either.
     #[test]
-    fn a_shared_cse_body_is_refused_rather_than_walked_exponentially() {
+    fn a_shared_cse_body_is_walked_once_and_admitted() {
         let mut e = Expr::Var(0);
         for _ in 0..60 {
             let shared = std::sync::Arc::new(e);
@@ -759,7 +815,44 @@ mod tests {
                 Box::new(Expr::Cse(shared)),
             );
         }
-        assert!(!is_expanded_quadratic(&e));
+        assert!(is_expanded_quadratic(&e));
+        // And the algebra agrees: `x + x` sixty times over is `2^60 · x`.
+        let q = recognize_expr(&e).expect("a sum of one monomial is degree 1");
+        assert_eq!(q.linear().get(&0).copied(), Some(2.0_f64.powi(60)));
+        std::mem::forget(e);
+    }
+
+    /// The same shape inside a *monomial*, which is a different question
+    /// with a different answer and therefore a separately keyed memo: a
+    /// body that is a sum of monomials is legal on the spine and illegal
+    /// under a `*`.
+    #[test]
+    fn a_shared_body_is_judged_per_context_not_once_and_for_all() {
+        let sum = std::sync::Arc::new(Expr::Binary(
+            BinOp::Add,
+            Box::new(Expr::Var(0)),
+            Box::new(Expr::Var(1)),
+        ));
+        // On the spine, twice: fine.
+        let spine = Expr::Binary(
+            BinOp::Add,
+            Box::new(Expr::Cse(std::sync::Arc::clone(&sum))),
+            Box::new(Expr::Cse(std::sync::Arc::clone(&sum))),
+        );
+        assert!(is_expanded_quadratic(&spine));
+        // The same body on the spine and then under a product: the product
+        // is `(x0 + x1) · x1`, a factored form, and the earlier clean visit
+        // on the spine must not clear it.
+        let mixed = Expr::Binary(
+            BinOp::Add,
+            Box::new(Expr::Cse(std::sync::Arc::clone(&sum))),
+            Box::new(Expr::Binary(
+                BinOp::Mul,
+                Box::new(Expr::Cse(sum)),
+                Box::new(Expr::Var(1)),
+            )),
+        );
+        assert!(!is_expanded_quadratic(&mixed));
     }
 
     /// Deep, and on a default-sized test thread, for the same reason

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -32,7 +32,10 @@
 //! * `ref/Ipopt/test/mytoy.nl` — annotated example used for the unit
 //!   tests in this module.
 
-use crate::nl_quadratic::{analyze_quadratic_full, is_expanded_quadratic, is_trivially_zero};
+use crate::nl_quadratic::{
+    Quad2, QuadForm, QuadHessian, analyze_quadratic_full, is_expanded_quadratic, is_trivially_zero,
+    quad_form_readout,
+};
 use crate::nl_tape::{HybridTape, Tape, hybrid_supported};
 use pounce_common::types::{Index, Number, lower_bound_present, upper_bound_present};
 use pounce_nlp::quadratic::QuadraticStructure;
@@ -263,6 +266,145 @@ impl NlCounts {
     }
 }
 
+/// The nonlinear body of the objective, or of one constraint row, as the
+/// parser left it.
+///
+/// Before gh #588 Q5 this was always an [`Expr`], and for most bodies it
+/// still is. The second variant exists because the `Expr` DAG is what sets
+/// peak RSS on a quadratic model — 2.32 M nodes for a ten-row
+/// `qcqp500-3c` — and every consumer of a *recognized* body wants the
+/// degree-≤2 coefficients rather than the tree they would have to walk to
+/// recover them. So the parser recognizes those bodies from the token
+/// stream and never builds the tree at all.
+///
+/// The distinction is deliberately impossible to ignore. Nine consumers
+/// read these bodies (§5.3 of `dev-notes/quadratic-structure-exploitation.md`
+/// enumerates them) and several would read a *missing* tree as "this row is
+/// linear" — a silent wrong answer. An enum makes every one of them a
+/// compile error until it says which reading it wants.
+#[derive(Debug, Clone)]
+pub enum NlBody {
+    /// The expression tree.
+    Tree(Expr),
+    /// A degree-2 form recognized while the token stream was consumed. The
+    /// tree was never built; [`NlProblem::con_expr`] rebuilds it on demand,
+    /// byte for byte, by re-parsing the same bytes with the same parser.
+    Quad(Box<QuadBody>),
+}
+
+/// A body the parser recognized as an already-expanded quadratic.
+#[derive(Debug, Clone)]
+pub struct QuadBody {
+    /// The recognized form. Bit-for-bit what
+    /// [`crate::nl_quadratic::recognize_expr`] returns for the tree these
+    /// same bytes parse to — asserted directly, over the whole corpus, by
+    /// `pounce-cli/tests/quad_parse_differential.rs`.
+    pub form: Quad2,
+    /// Every variable the body's token stream mentions, ascending and
+    /// deduplicated — exactly the set [`collect_vars`] reports for the tree,
+    /// **including** variables whose coefficient cancelled to zero (which
+    /// `form` necessarily drops). Structural consumers want this one; the
+    /// linearity contract is over-stating-is-safe, and a support taken from
+    /// `form` would under-state.
+    pub vars: Vec<u32>,
+    /// Byte range of this body's token stream inside [`NlProblem::src`].
+    pub src: std::ops::Range<usize>,
+    /// Nesting depth of the tree these tokens would have built, on the same
+    /// convention as a leaf counting 1.
+    ///
+    /// Recorded because the streaming recognizer is iterative and the tree
+    /// parser is not: a body deep enough to overflow the parser's stack now
+    /// *loads*, and the depth guard that used to be enforced implicitly by
+    /// the parse failing has to be enforced by something. `pounce-py`'s
+    /// `checked_depth` reads it (pounce #472). Rebuilding such a body with
+    /// [`NlProblem::con_expr`] would still recurse, which is the same
+    /// ceiling Q3 recorded and Q5 does not lift.
+    pub depth: u32,
+}
+
+impl NlBody {
+    /// The identity zero — "this row has no nonlinear part". A recognized
+    /// body is degree 2 by construction, so it is never trivially zero;
+    /// the question still has to be asked through here rather than by
+    /// matching on a tree that may not exist.
+    pub fn is_trivially_zero(&self) -> bool {
+        match self {
+            NlBody::Tree(e) => matches!(e, Expr::Const(c) if *c == 0.0),
+            NlBody::Quad(_) => false,
+        }
+    }
+
+    /// The recognized degree-2 form, when the parser produced one.
+    pub fn quad(&self) -> Option<&Quad2> {
+        match self {
+            NlBody::Tree(_) => None,
+            NlBody::Quad(q) => Some(&q.form),
+        }
+    }
+
+    /// The tree, when there is one resident. `None` for a recognized body —
+    /// use [`NlProblem::con_expr`] / [`NlProblem::obj_expr`] to rebuild it.
+    pub fn tree(&self) -> Option<&Expr> {
+        match self {
+            NlBody::Tree(e) => Some(e),
+            NlBody::Quad(_) => None,
+        }
+    }
+
+    /// This body as a degree-≤2 Hessian, or `None` if it is not provably
+    /// quadratic — [`crate::nl_quadratic::analyze_quadratic`] for a tree,
+    /// and the form the parser already proved for a recognized body. The
+    /// two answers are the same by construction and asserted to be so bit
+    /// for bit; this is the accessor that keeps the corpus from being
+    /// re-recognized once per consumer.
+    pub fn analyze_quadratic(&self) -> Option<QuadHessian> {
+        self.analyze_quadratic_full().map(|(h, _, _)| h)
+    }
+
+    /// [`Self::analyze_quadratic`] with the linear and constant parts.
+    pub fn analyze_quadratic_full(&self) -> Option<QuadForm> {
+        match self {
+            NlBody::Tree(e) => analyze_quadratic_full(e),
+            NlBody::Quad(q) => Some(quad_form_readout(&q.form)),
+        }
+    }
+
+    /// The form the constant-structure evaluator is allowed to use — i.e.
+    /// [`Self::analyze_quadratic_full`] behind the *exactness* gate.
+    ///
+    /// A recognized body has already passed that gate: the parser admits
+    /// only a flat sum of monomials, which is the same rule
+    /// [`crate::nl_quadratic::is_expanded_quadratic`] applies to a tree.
+    /// Reading a factored form out of stored coefficients cancels — five
+    /// digits on `(x − 500000)²` — so the gate is on both arms or on
+    /// neither (gh #588, Q4; gh #673).
+    pub fn admitted_quad_form(&self) -> Option<QuadForm> {
+        match self {
+            NlBody::Tree(e) => {
+                if is_trivially_zero(e) || !is_expanded_quadratic(e) {
+                    return None;
+                }
+                analyze_quadratic_full(e)
+            }
+            NlBody::Quad(q) => Some(quad_form_readout(&q.form)),
+        }
+    }
+
+    /// Add this body's structural variable support to `out`.
+    pub fn collect_vars(&self, out: &mut BTreeSet<usize>) {
+        match self {
+            NlBody::Tree(e) => collect_vars(e, out),
+            NlBody::Quad(q) => out.extend(q.vars.iter().map(|&v| v as usize)),
+        }
+    }
+}
+
+impl From<Expr> for NlBody {
+    fn from(e: Expr) -> Self {
+        NlBody::Tree(e)
+    }
+}
+
 /// Parsed `.nl` problem in the form needed by `NlTnlp`.
 #[derive(Debug, Clone)]
 pub struct NlProblem {
@@ -270,11 +412,11 @@ pub struct NlProblem {
     pub m: usize,
     pub num_obj: usize,
     pub minimize: bool,
-    pub obj_nonlinear: Expr,
+    pub obj_nonlinear: NlBody,
     pub obj_linear: Vec<(usize, Number)>,
     pub obj_constant: Number,
     /// Per-constraint nonlinear part (length m).
-    pub con_nonlinear: Vec<Expr>,
+    pub con_nonlinear: Vec<NlBody>,
     /// Per-constraint linear part (length m), each a list of (var, coef).
     pub con_linear: Vec<Vec<(usize, Number)>>,
     pub x_l: Vec<Number>,
@@ -321,6 +463,23 @@ pub struct NlProblem {
     /// (one name per line, row order). Empty when no `.row` file was found.
     /// See [`NlProblem::var_names`] for why names are captured.
     pub con_names: Vec<String>,
+    /// The `.nl` text this problem was parsed from, kept only when some
+    /// body was recognized as a quadratic and therefore has no tree of its
+    /// own. It is what makes [`NlProblem::con_expr`] able to hand back the
+    /// *exact* tree rather than a re-derived one: same bytes, same parser,
+    /// same `Expr`. `None` for [`NlProblem::from_expressions`] models and
+    /// for a parse that recognized nothing.
+    ///
+    /// The text is resident during parsing either way, so keeping it costs
+    /// nothing at the peak this is all in aid of — see
+    /// `dev-notes/quadratic-structure-exploitation.md` §0f.
+    pub src: Option<Arc<String>>,
+    /// The `V`-segment common subexpressions, by CSE-local index. Held so a
+    /// re-parse resolves `v<i>` (`i >= n`) to the *same* `Arc` the original
+    /// parse did — `HybridTape::build_multi` keys sharing on pointer
+    /// identity, so a rebuilt body that allocated fresh bodies would look
+    /// unshared.
+    pub cse_bodies: Vec<Arc<Expr>>,
 }
 
 /// The pieces of a model built in memory, as handed to
@@ -438,10 +597,10 @@ impl NlProblem {
             m,
             num_obj: 1,
             minimize,
-            obj_nonlinear: objective,
+            obj_nonlinear: NlBody::Tree(objective),
             obj_linear: Vec::new(),
             obj_constant,
-            con_nonlinear: constraints,
+            con_nonlinear: constraints.into_iter().map(NlBody::Tree).collect(),
             con_linear: vec![Vec::new(); m],
             x_l,
             x_u,
@@ -458,7 +617,54 @@ impl NlProblem {
             nl_counts: None,
             var_names,
             con_names,
+            // Built from trees, so every body has one and there is nothing
+            // to rebuild from.
+            src: None,
+            cse_bodies: Vec::new(),
         })
+    }
+
+    /// The objective's nonlinear body as an [`Expr`].
+    ///
+    /// Borrowed when the tree is resident, rebuilt when the parser
+    /// recognized the body and skipped building it. The rebuild re-parses
+    /// the body's own bytes with the same parser that produced the rest of
+    /// the model, so the result is the tree a non-recognizing parse would
+    /// have produced — structurally identical, coefficient bit patterns
+    /// included, and sharing the same `Cse` allocations.
+    ///
+    /// It is not free: it allocates the nodes the recognizer avoided. Reach
+    /// for [`NlBody::quad`] first if the coefficients are what you want.
+    pub fn obj_expr(&self) -> std::borrow::Cow<'_, Expr> {
+        self.body_expr(&self.obj_nonlinear, "objective")
+    }
+
+    /// Row `k`'s nonlinear body as an [`Expr`]. See [`Self::obj_expr`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `k >= m`, or if re-parsing a recognized body fails — the
+    /// latter cannot happen for a problem this crate produced (the bytes
+    /// parsed once already, by this code) and means the `NlProblem` was
+    /// assembled by hand with a `src` that does not match its bodies.
+    pub fn con_expr(&self, k: usize) -> std::borrow::Cow<'_, Expr> {
+        self.body_expr(&self.con_nonlinear[k], "constraint")
+    }
+
+    fn body_expr<'a>(&'a self, body: &'a NlBody, what: &str) -> std::borrow::Cow<'a, Expr> {
+        match body {
+            NlBody::Tree(e) => std::borrow::Cow::Borrowed(e),
+            NlBody::Quad(q) => {
+                let src = self
+                    .src
+                    .as_deref()
+                    .unwrap_or_else(|| panic!("{what} body was recognized but no source is kept"));
+                std::borrow::Cow::Owned(
+                    parse_body_fragment(&src[q.src.clone()], self.n, &self.cse_bodies)
+                        .unwrap_or_else(|e| panic!("re-parsing a recognized {what} body: {e}")),
+                )
+            }
+        }
     }
 }
 
@@ -583,7 +789,9 @@ pub fn read_nl_file(path: &Path) -> Result<NlProblem, String> {
     };
     let txt = std::fs::read_to_string(&resolved)
         .map_err(|e| format!("could not read {}: {}", resolved.display(), e))?;
-    let mut prob = parse_nl_text(&txt)?;
+    // By value: a recognized body keeps a byte range into this text rather
+    // than a tree, so it is moved into the problem instead of copied.
+    let mut prob = parse_nl_string(txt, std::env::var("POUNCE_DBG_NO_QUAD").is_err())?;
     prob.var_names = read_name_file(&resolved.with_extension("col"), prob.n);
     prob.con_names = read_name_file(&resolved.with_extension("row"), prob.m);
     Ok(prob)
@@ -661,15 +869,44 @@ fn row_constant_value(e: &Expr) -> Option<Number> {
 }
 
 /// Parse `.nl` text content. Public so tests can use string literals.
+///
+/// Degree-2 bodies are recognized as the token stream is read, so their
+/// `Expr` trees are never built (gh #588, Q5); `POUNCE_DBG_NO_QUAD=1`
+/// turns that off and restores the pre-Q5 parse exactly, which is what the
+/// A/B reference and gh #540's guard test need. See
+/// [`parse_nl_text_with_quadratic`] for the same switch as a parameter.
 pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
-    let mut p = Parser::new(txt);
+    parse_nl_text_with_quadratic(txt, std::env::var("POUNCE_DBG_NO_QUAD").is_err())
+}
+
+/// [`parse_nl_text`] with parse-time quadratic recognition explicitly on
+/// or off.
+///
+/// The env var the plain entry point reads is process-global, which is
+/// exactly wrong for a differential test that has to parse the *same* text
+/// both ways in one process and compare the results — so the knob is a
+/// parameter here, mirroring [`NlTnlp::try_new_with_quadratic`].
+pub fn parse_nl_text_with_quadratic(txt: &str, use_quadratic: bool) -> Result<NlProblem, String> {
+    parse_nl_string(txt.to_string(), use_quadratic)
+}
+
+/// [`parse_nl_text_with_quadratic`], taking the text by value.
+///
+/// A recognized body keeps a byte range into the source rather than a tree,
+/// so the source outlives the parse. Taking ownership means the file
+/// [`read_nl_file`] already read is *moved* into the problem instead of
+/// copied: the text is resident during parsing either way, so this costs
+/// nothing at the peak the phase is about.
+pub fn parse_nl_string(txt: String, use_quadratic: bool) -> Result<NlProblem, String> {
+    let src = Arc::new(txt);
+    let mut p = Parser::new(&src, use_quadratic);
     p.parse_header()?;
     let n = p.n;
     let m = p.m;
     let num_obj = p.num_obj;
 
-    let mut con_nonlinear: Vec<Expr> = (0..m).map(|_| Expr::Const(0.0)).collect();
-    let mut obj_nonlinear = Expr::Const(0.0);
+    let mut con_nonlinear: Vec<NlBody> = (0..m).map(|_| NlBody::Tree(Expr::Const(0.0))).collect();
+    let mut obj_nonlinear = NlBody::Tree(Expr::Const(0.0));
     let mut minimize = true;
     let mut obj_linear: Vec<(usize, Number)> = Vec::new();
     let mut con_linear: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m];
@@ -696,7 +933,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                 if idx >= m {
                     return Err(format!("C{idx} out of range; m={m}"));
                 }
-                con_nonlinear[idx] = p.parse_expr()?;
+                con_nonlinear[idx] = p.parse_body()?;
             }
             'O' => {
                 let (hdr, _rest) = p.eat_segment_header()?;
@@ -708,7 +945,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                 let kind: i32 = parts[1].parse().map_err(|e| format!("O kind: {e}"))?;
                 if idx == 0 {
                     minimize = kind == 0;
-                    obj_nonlinear = p.parse_expr()?;
+                    obj_nonlinear = p.parse_body()?;
                 } else {
                     // Extra objectives are read but ignored.
                     let _ = p.parse_expr()?;
@@ -900,7 +1137,12 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
     // normalization `qp_extract::analyze_quadratic_full` already performs
     // ad hoc via `const_shift`, promoted to the parse boundary.
     for i in 0..m {
-        let Some(c) = row_constant_value(&con_nonlinear[i]) else {
+        // A recognized body is degree 2, so it is not a constant row and
+        // this fold has nothing to do with it.
+        let Some(tree) = con_nonlinear[i].tree() else {
+            continue;
+        };
+        let Some(c) = row_constant_value(tree) else {
             continue;
         };
         // Presence is directional (gh #401): shifting an *absent* bound
@@ -913,8 +1155,15 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
         if upper_bound_present(g_u[i]) {
             g_u[i] -= c;
         }
-        con_nonlinear[i] = Expr::Const(0.0);
+        con_nonlinear[i] = NlBody::Tree(Expr::Const(0.0));
     }
+
+    // The source is kept only when something in it has no tree of its own.
+    // A model with nothing recognized is byte-for-byte the pre-Q5 problem,
+    // extra field included.
+    let any_recognized =
+        obj_nonlinear.quad().is_some() || con_nonlinear.iter().any(|b| b.quad().is_some());
+    let kept_src = any_recognized.then(|| Arc::clone(&src));
 
     Ok(NlProblem {
         n,
@@ -940,6 +1189,8 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
         // sibling `.col`/`.row` files when present.
         var_names: Vec::new(),
         con_names: Vec::new(),
+        src: kept_src,
+        cse_bodies: p.cses.clone(),
     })
 }
 
@@ -1181,6 +1432,17 @@ fn parse_nl_counts(line3: &str, line5: &str) -> Option<NlCounts> {
 
 struct Parser<'a> {
     lines: Vec<&'a str>,
+    /// Start address and length of the source text. A recognized body
+    /// records the byte *range* it consumed so it can be re-parsed later
+    /// (see [`QuadBody::src`]), and every line borrows from this buffer, so
+    /// one subtraction per line recovers its offset.
+    ///
+    /// Deliberately not a per-line offset table: on a 119 MB generated
+    /// `qcqp500-3c` the file is ~17 M lines, and a `Vec<usize>` beside the
+    /// existing `Vec<&str>` would add 136 MB to the peak this phase exists
+    /// to reduce.
+    txt_base: usize,
+    txt_len: usize,
     pos: usize,
     n: usize,
     m: usize,
@@ -1193,13 +1455,60 @@ struct Parser<'a> {
     /// Common subexpressions (`V` segments). Index in this vec is the
     /// CSE-local index, i.e. the global `.nl` index minus `n`.
     cses: Vec<Arc<Expr>>,
+    /// Recognize degree-2 bodies from the token stream instead of building
+    /// their trees (gh #588, Q5). Off restores the pre-Q5 parse exactly.
+    quad_enabled: bool,
+    /// Per-CSE answers the streaming recognizer needs about a `V` body it
+    /// may be handed a reference to, all keyed by CSE-local index: the
+    /// body's own degree-≤2 form, whether it is legal on a sum spine,
+    /// whether it is legal *inside* a monomial, and its variable support.
+    ///
+    /// These are computed from the built `V` body with the same functions
+    /// `NlTnlp` would apply to a whole row, so a reference costs a lookup
+    /// and cannot drift from what the tree walk would have said. `V` bodies
+    /// keep their trees regardless — they are shared, so the memory is
+    /// amortized over every reference, and dropping them would mean
+    /// rebuilding them for the rows that are *not* recognized.
+    cse_quad: Vec<Option<Quad2>>,
+    cse_sum_ok: Vec<bool>,
+    cse_mono_ok: Vec<bool>,
+    cse_vars: Vec<Vec<u32>>,
+    cse_depth: Vec<u32>,
+}
+
+/// One pending operator on the streaming recognizer's stack.
+struct QFrame {
+    op: QOp,
+    /// Operands still to be read.
+    remaining: usize,
+    /// Read this frame's operands in monomial mode — no `+`/`-` may appear
+    /// below it. See [`crate::nl_quadratic::is_expanded_quadratic`].
+    mono: bool,
+}
+
+/// The operators the streaming recognizer accepts. One variant per shape
+/// that [`crate::nl_quadratic::recognize_expr`] handles; everything else
+/// makes it bail.
+enum QOp {
+    Neg,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    /// `o5`/`o81`/`o83`: base and exponent both read.
+    Pow,
+    /// `o82`: square, exponent implicit.
+    Square,
+    Sum(usize),
 }
 
 impl<'a> Parser<'a> {
-    fn new(txt: &'a str) -> Self {
+    fn new(txt: &'a str, quad_enabled: bool) -> Self {
         let lines: Vec<&str> = txt.lines().collect();
         Self {
             lines,
+            txt_base: txt.as_ptr() as usize,
+            txt_len: txt.len(),
             pos: 0,
             n: 0,
             m: 0,
@@ -1208,6 +1517,25 @@ impl<'a> Parser<'a> {
             nl_counts: None,
             ampl_options: Vec::new(),
             cses: Vec::new(),
+            quad_enabled,
+            cse_quad: Vec::new(),
+            cse_sum_ok: Vec::new(),
+            cse_mono_ok: Vec::new(),
+            cse_vars: Vec::new(),
+            cse_depth: Vec::new(),
+        }
+    }
+
+    /// Byte offset in the source text of the start of line `line`, or the
+    /// end of the text when the cursor has run off it.
+    ///
+    /// Pointer arithmetic against the same allocation, never a deref: every
+    /// line in `lines` borrows from the source buffer, so the difference is
+    /// its offset.
+    fn byte_at(&self, line: usize) -> usize {
+        match self.lines.get(line) {
+            Some(l) => l.as_ptr() as usize - self.txt_base,
+            None => self.txt_len,
         }
     }
 
@@ -1315,6 +1643,207 @@ impl<'a> Parser<'a> {
             .ok_or_else(|| "expected segment header".to_string())?;
         let (hdr, comment) = split_comment(raw);
         Ok((hdr.trim(), comment.trim()))
+    }
+
+    /// Parse one `C`/`O` body, recognizing it from the token stream when
+    /// that is possible instead of building its tree (gh #588, Q5).
+    ///
+    /// The cursor is the whole mechanism. `Parser` is line-based, so a
+    /// failed recognition costs one assignment to rewind — the same trick
+    /// `parse_funcall_arg` already uses to route a Hollerith literal — and
+    /// the fallback then produces exactly the tree this file has always
+    /// produced. Nothing downstream can tell which arm ran except by
+    /// measuring memory.
+    ///
+    /// Only **degree-2** forms are kept. A body that recognizes as constant
+    /// or linear is re-parsed as a tree and stored as one: the constant-row
+    /// fold (gh #492), the linearity contract and the classifier's LP fast
+    /// path all key on the identity zero and on trees, they are cheap
+    /// already, and the memory that motivates this phase is entirely in
+    /// degree-2 rows. Refusing to touch them keeps the change confined to
+    /// the rows it is for.
+    fn parse_body(&mut self) -> Result<NlBody, String> {
+        if !self.quad_enabled {
+            return Ok(NlBody::Tree(self.parse_expr()?));
+        }
+        let saved = self.pos;
+        if let Some((form, vars, depth)) = self.parse_expr_quadratic() {
+            if !form.quadratic().is_empty() {
+                let src = self.byte_at(saved)..self.byte_at(self.pos);
+                return Ok(NlBody::Quad(Box::new(QuadBody {
+                    form,
+                    vars,
+                    src,
+                    depth,
+                })));
+            }
+        }
+        self.pos = saved;
+        Ok(NlBody::Tree(self.parse_expr()?))
+    }
+
+    /// Read one expression off the token stream as a degree-≤2 form,
+    /// **without building it**, or give up.
+    ///
+    /// This is the same computation as
+    /// `is_expanded_quadratic(e) && recognize_expr(e)` run on the tree these
+    /// tokens parse to — the accuracy gate and the algebra, interleaved so
+    /// neither needs the tree. That equivalence is the phase's correctness
+    /// claim and is asserted directly, bit for bit, over every body of every
+    /// `.nl` file in the repository by
+    /// `pounce-cli/tests/quad_parse_differential.rs`.
+    ///
+    /// Two things it must reproduce and not merely approximate:
+    ///
+    /// * **The exactness rule.** `is_expanded_quadratic` admits a body only
+    ///   when reading it as `½xᵀHx + aᵀx + c` repeats the additions the
+    ///   writer already wrote — expanding a *factored* form cancels, which
+    ///   is what took `airport.nl` from 16 to 300 iterations in Q4. Here
+    ///   that rule is structural rather than a separate pass: `+`/`-` are
+    ///   the spine, everything under a `*`, `/` or `^` is read in monomial
+    ///   mode, and a `+` seen in monomial mode gives up.
+    /// * **The association.** `recognize_expr` folds an `o54` sumlist from
+    ///   the *last* operand to the first (its work stack lowers them in
+    ///   reverse, and `drain` then hands them back in that order), so this
+    ///   folds the same way. Summation order is not observable on distinct
+    ///   monomials and is exactly observable on repeated ones.
+    ///
+    /// On `None` the cursor is left wherever it stopped; the caller rewinds.
+    fn parse_expr_quadratic(&mut self) -> Option<(Quad2, Vec<u32>, u32)> {
+        let mut frames: Vec<QFrame> = Vec::new();
+        let mut vals: Vec<Quad2> = Vec::new();
+        let mut vars: Vec<u32> = Vec::new();
+        // Deepest node of the tree these tokens describe. A leaf sits under
+        // `frames.len()` operators, and a CSE reference carries its body's
+        // depth under it — the same convention `pounce-py`'s `expr_depth`
+        // uses, because that is who reads the answer.
+        let mut depth: u32 = 0;
+        let note_leaf = |frames: &[QFrame], depth: &mut u32, below: u32| {
+            let d = u32::try_from(frames.len()).unwrap_or(u32::MAX);
+            *depth = (*depth).max(d.saturating_add(1).saturating_add(below));
+        };
+
+        loop {
+            let mono = frames.last().is_some_and(|f| f.mono);
+            // A `^` base must be atomic — `Const`, `Var` or a `Neg` — or the
+            // body is a factored form dressed as a monomial. `is_monomial`
+            // applies the same test to `Pow`'s left operand.
+            let pow_base = matches!(
+                frames.last(),
+                Some(QFrame {
+                    op: QOp::Pow,
+                    remaining: 2,
+                    ..
+                }) | Some(QFrame {
+                    op: QOp::Square,
+                    remaining: 1,
+                    ..
+                })
+            );
+
+            let raw = self.next_line()?;
+            let tok = strip_comment(raw).trim();
+            let first = tok.chars().next()?;
+            match first {
+                'n' => {
+                    // A constant base is atomic; `is_monomial` accepts it.
+                    let v: Number = tok[1..].trim().parse().ok()?;
+                    note_leaf(&frames, &mut depth, 0);
+                    vals.push(Quad2::of_constant(v));
+                }
+                'v' => {
+                    let i: usize = tok[1..].trim().parse().ok()?;
+                    if i < self.n {
+                        note_leaf(&frames, &mut depth, 0);
+                        vars.push(u32::try_from(i).ok()?);
+                        vals.push(Quad2::of_var(i));
+                    } else {
+                        // A CSE reference lowers to `Expr::Cse`, which is
+                        // *not* one of the shapes `is_monomial` accepts as a
+                        // power's base.
+                        if pow_base {
+                            return None;
+                        }
+                        let local = i.checked_sub(self.n)?;
+                        let ok = if mono {
+                            *self.cse_mono_ok.get(local)?
+                        } else {
+                            *self.cse_sum_ok.get(local)?
+                        };
+                        if !ok {
+                            return None;
+                        }
+                        let form = self.cse_quad.get(local)?.clone()?;
+                        note_leaf(&frames, &mut depth, *self.cse_depth.get(local)?);
+                        vars.extend_from_slice(self.cse_vars.get(local)?);
+                        vals.push(form);
+                    }
+                }
+                'o' => {
+                    let code: i32 = tok[1..].trim().parse().ok()?;
+                    if pow_base && code != 16 {
+                        return None;
+                    }
+                    let (op, arity, child_mono) = match code {
+                        // The sum spine. Inside a monomial there is no such
+                        // thing, and the body is a factored form.
+                        0 if !mono => (QOp::Add, 2, false),
+                        1 if !mono => (QOp::Sub, 2, false),
+                        16 => (QOp::Neg, 1, mono),
+                        54 if !mono => {
+                            let count_line = self.next_data_line().ok()?;
+                            let count: usize =
+                                count_line.split_whitespace().next()?.parse().ok()?;
+                            (QOp::Sum(count), count, false)
+                        }
+                        // Monomial operators: everything below them is read
+                        // in monomial mode.
+                        2 => (QOp::Mul, 2, true),
+                        3 => (QOp::Div, 2, true),
+                        5 | 81 | 83 => (QOp::Pow, 2, true),
+                        82 => (QOp::Square, 1, true),
+                        // Transcendentals, comparisons, conditionals,
+                        // min/max lists, and `+`/`-` under a monomial.
+                        _ => return None,
+                    };
+                    if arity == 0 {
+                        // An empty `o54` is the empty sum: zero.
+                        note_leaf(&frames, &mut depth, 0);
+                        vals.push(Quad2::default());
+                    } else {
+                        frames.push(QFrame {
+                            op,
+                            remaining: arity,
+                            mono: child_mono,
+                        });
+                        continue;
+                    }
+                }
+                // `f` (imported function call), `h`, and anything else.
+                _ => return None,
+            }
+
+            // A value has just been produced. Close every frame it completes.
+            while let Some(f) = frames.last_mut() {
+                f.remaining -= 1;
+                if f.remaining > 0 {
+                    break;
+                }
+                let f = frames.pop()?;
+                let combined = apply_quad_op(f.op, &mut vals)?;
+                vals.push(combined);
+            }
+            if frames.is_empty() {
+                break;
+            }
+        }
+
+        if vals.len() != 1 {
+            return None;
+        }
+        vars.sort_unstable();
+        vars.dedup();
+        Some((vals.pop()?, vars, depth))
     }
 
     fn parse_expr(&mut self) -> Result<Expr, String> {
@@ -1654,9 +2183,142 @@ impl<'a> Parser<'a> {
                 self.n + self.cses.len()
             ));
         }
+        // What a reference to this body would mean to the streaming
+        // recognizer, answered once here rather than per reference. The
+        // `V` tree exists at this point, so these are the *same* functions
+        // `NlTnlp` applies to a whole row — the parse-time recognizer never
+        // gets a second opinion about a CSE.
+        if self.quad_enabled {
+            self.cse_quad
+                .push(crate::nl_quadratic::recognize_expr(&combined));
+            self.cse_sum_ok
+                .push(crate::nl_quadratic::is_expanded_quadratic(&combined));
+            self.cse_mono_ok
+                .push(crate::nl_quadratic::is_monomial_expr(&combined));
+            let mut vars: BTreeSet<usize> = BTreeSet::new();
+            collect_vars(&combined, &mut vars);
+            self.cse_vars
+                .push(vars.into_iter().map(|v| v as u32).collect());
+            self.cse_depth.push(expr_tree_depth(&combined));
+        }
         self.cses.push(Arc::new(combined));
         Ok(())
     }
+}
+
+/// Combine the operands of one recognized operator, mirroring
+/// [`crate::nl_quadratic::recognize_expr`]'s `Apply` arm term for term.
+///
+/// Every difference from that function is a difference in the coefficients
+/// this parser stores, so there is nothing here that is "equivalent but
+/// tidier": the division scales by the reciprocal because that is what the
+/// tree walk does, and the sumlist folds back to front for the same reason.
+/// Nesting depth of a `V`-segment body, leaf = 1, a `Cse` reference
+/// counting one level above its body — the convention `pounce-py`'s
+/// `expr_depth` uses, since that is the guard the answer feeds.
+///
+/// Recursive, and safe to be: this only ever runs on a tree
+/// [`Parser::parse_expr`] has just built *recursively* on this same stack,
+/// so a frame that fits the parser fits this.
+fn expr_tree_depth(e: &Expr) -> u32 {
+    let deepest = |kids: &mut dyn Iterator<Item = &Expr>| {
+        kids.fold(0u32, |acc, k| acc.max(expr_tree_depth(k)))
+    };
+    1 + match e {
+        Expr::Const(_) | Expr::Var(_) => 0,
+        Expr::Binary(_, a, b) | Expr::Compare(_, a, b) | Expr::And(a, b) | Expr::Or(a, b) => {
+            deepest(&mut [&**a, &**b].into_iter())
+        }
+        Expr::Unary(_, a) | Expr::Not(a) => expr_tree_depth(a),
+        Expr::Sum(args) | Expr::MinList(args) | Expr::MaxList(args) => deepest(&mut args.iter()),
+        Expr::Cond { cond, then_, else_ } => {
+            deepest(&mut [&**cond, &**then_, &**else_].into_iter())
+        }
+        Expr::Funcall { args, .. } => deepest(&mut args.iter().filter_map(|a| match a {
+            FuncallArg::Real(inner) => Some(inner),
+            FuncallArg::Str(_) => None,
+        })),
+        Expr::Cse(body) => expr_tree_depth(body),
+    }
+}
+
+fn apply_quad_op(op: QOp, vals: &mut Vec<Quad2>) -> Option<Quad2> {
+    let pop2 = |vals: &mut Vec<Quad2>| -> Option<(Quad2, Quad2)> {
+        let b = vals.pop()?;
+        let a = vals.pop()?;
+        Some((a, b))
+    };
+    Some(match op {
+        QOp::Sum(n) => {
+            let at = vals.len().checked_sub(n)?;
+            let mut acc = Quad2::default();
+            // `recognize_expr` lowers a sumlist's operands in reverse and
+            // then folds them in the order `drain` yields, which is last
+            // operand first. Here they arrive in file order, so the fold is
+            // reversed to match. On repeated monomials the two orders do not
+            // agree bit for bit.
+            for p in vals.drain(at..).rev() {
+                acc = Quad2::add(acc, p);
+            }
+            acc
+        }
+        QOp::Neg => vals.pop()?.neg(),
+        QOp::Add => {
+            let (a, b) = pop2(vals)?;
+            Quad2::add(a, b)
+        }
+        QOp::Sub => {
+            let (a, b) = pop2(vals)?;
+            Quad2::add(a, b.neg())
+        }
+        QOp::Mul => {
+            let (a, b) = pop2(vals)?;
+            a.mul(&b)?
+        }
+        QOp::Div => {
+            let (a, b) = pop2(vals)?;
+            let d = b.as_constant()?;
+            if d == 0.0 {
+                return None;
+            }
+            a.scale(1.0 / d)
+        }
+        QOp::Pow => {
+            let (a, b) = pop2(vals)?;
+            let exp = b.as_constant()?;
+            if exp == 0.0 {
+                Quad2::of_constant(1.0)
+            } else if exp == 1.0 {
+                a
+            } else if exp == 2.0 {
+                a.mul(&a)?
+            } else {
+                return None;
+            }
+        }
+        // `o82` is `Pow(base, Const(2.0))` with the exponent left implicit,
+        // so it takes the `exp == 2.0` branch above.
+        QOp::Square => {
+            let a = vals.pop()?;
+            a.mul(&a)?
+        }
+    })
+}
+
+/// Re-parse one recognized body from the bytes it was recognized from.
+///
+/// The point is that this is the *same* function the original parse ran, on
+/// the *same* bytes, with the same `n` and the same `V`-segment bodies — so
+/// the tree it returns is the tree that parse would have built, down to the
+/// `Arc` identities that `HybridTape::build_multi` keys CSE sharing on.
+/// Deriving an equivalent tree from the stored coefficients instead would
+/// be a different tree, evaluated by a different tape, and this phase would
+/// stop being invisible from outside.
+fn parse_body_fragment(txt: &str, n: usize, cses: &[Arc<Expr>]) -> Result<Expr, String> {
+    let mut p = Parser::new(txt, false);
+    p.n = n;
+    p.cses = cses.to_vec();
+    p.parse_expr()
 }
 
 fn strip_comment(s: &str) -> &str {
@@ -2564,7 +3226,9 @@ fn render_body(linear: &[(usize, Number)], nonlinear: &Expr, prob: &NlProblem) -
 /// or `0 <= T_reactor <= 500`. Bounds outside ±1e19 are treated as
 /// infinite (AMPL's convention), matching [`TNLPAdapter`]'s classifier.
 pub fn render_constraint_equation(prob: &NlProblem, k: usize) -> String {
-    let body = render_body(&prob.con_linear[k], &prob.con_nonlinear[k], prob);
+    // Diagnostic path: a recognized body has no tree, so this is one of
+    // the places that pays to rebuild one. It runs once per rendered row.
+    let body = render_body(&prob.con_linear[k], &prob.con_expr(k), prob);
     let lo = prob.g_l[k];
     let hi = prob.g_u[k];
     const INF: Number = 1.0e19;
@@ -2609,7 +3273,7 @@ pub fn constraint_jacobian_sparsity(prob: &NlProblem) -> (Vec<Index>, Vec<Index>
         for &(j, _coef) in &prob.con_linear[k] {
             support.insert(j);
         }
-        collect_vars(&prob.con_nonlinear[k], &mut support);
+        prob.con_nonlinear[k].collect_vars(&mut support);
         for &j in &support {
             irow.push(k as Index);
             jcol.push(j as Index);
@@ -3246,9 +3910,12 @@ impl NlTnlp {
         // each id to its (library, registered-name) pair so the tape
         // builder can emit live `TapeOp::Funcall` ops.
         let mut referenced: BTreeSet<usize> = BTreeSet::new();
-        super::nl_external::collect_funcall_ids(&prob.obj_nonlinear, &mut referenced);
-        for c in &prob.con_nonlinear {
-            super::nl_external::collect_funcall_ids(c, &mut referenced);
+        // Only trees can carry a `Funcall`: the recognizer refuses one, so
+        // a recognized body provably contains none.
+        for body in std::iter::once(&prob.obj_nonlinear).chain(prob.con_nonlinear.iter()) {
+            if let Some(e) = body.tree() {
+                super::nl_external::collect_funcall_ids(e, &mut referenced);
+            }
         }
         let resolver = if referenced.is_empty() {
             super::nl_external::ExternalResolver::default()
@@ -3277,19 +3944,17 @@ impl NlTnlp {
             // additions the `.nl` writer already wrote. See its docs — and
             // note it is checked *before* recognition, so a factored form
             // costs one cheap structural walk rather than a full expansion.
-            if !is_trivially_zero(&prob.obj_nonlinear) && is_expanded_quadratic(&prob.obj_nonlinear)
-            {
-                if let Some((h, lin, c)) = analyze_quadratic_full(&prob.obj_nonlinear) {
-                    let f = quad.push_form(&h, &lin, c);
-                    quad.assign_objective(f);
-                }
+            // Recognition is the parser's job now (gh #588, Q5) for the
+            // bodies it could reach; `admitted_quad_form` reads its answer
+            // back, and still walks a tree for the bodies that kept one —
+            // a `from_expressions` model, a factored row rewound by the
+            // parser, or any body at all under `POUNCE_DBG_NO_QUAD`.
+            if let Some((h, lin, c)) = prob.obj_nonlinear.admitted_quad_form() {
+                let f = quad.push_form(&h, &lin, c);
+                quad.assign_objective(f);
             }
             for k in 0..prob.m {
-                let row = &prob.con_nonlinear[k];
-                if is_trivially_zero(row) || !is_expanded_quadratic(row) {
-                    continue;
-                }
-                if let Some((h, lin, c)) = analyze_quadratic_full(row) {
+                if let Some((h, lin, c)) = prob.con_nonlinear[k].admitted_quad_form() {
                     let f = quad.push_form(&h, &lin, c);
                     quad.assign_row(k, f);
                 }
@@ -3304,7 +3969,7 @@ impl NlTnlp {
         let obj_tapes: Vec<Tape> = if quad.objective_form().is_some() {
             Vec::new()
         } else {
-            split_top_sums(&prob.obj_nonlinear)
+            split_top_sums(&prob.obj_expr())
                 .iter()
                 .map(|e| Tape::build_with_externals(e, &resolver))
                 .collect()
@@ -3322,7 +3987,7 @@ impl NlTnlp {
                 con_tapes.push(Vec::new());
                 continue;
             }
-            let summands = split_top_sums(&prob.con_nonlinear[k]);
+            let summands = split_top_sums(&prob.con_expr(k));
             con_tapes.push(
                 summands
                     .iter()
@@ -3576,8 +4241,16 @@ impl NlTnlp {
             // `forms` counts the objective too, which is why it can exceed
             // the row count by one.
             let quad_rows = (0..prob.m).filter(|&i| quad.row_form(i).is_some()).count();
+            // How many of those forms the *parser* produced, i.e. how many
+            // never cost an `Expr` (gh #588, Q5). The rest were recognized
+            // from a tree that was built: a `from_expressions` model, or a
+            // body the parser rewound because it was not degree 2.
+            let parsed = std::iter::once(&prob.obj_nonlinear)
+                .chain(prob.con_nonlinear.iter())
+                .filter(|b| b.quad().is_some())
+                .count();
             eprintln!(
-                "[quad stats] forms={} rows={quad_rows}/{} obj={} \
+                "[quad stats] forms={} (parse-time {parsed}) rows={quad_rows}/{} obj={} \
                  stored_h_entries={} colored_pairs={}/{}",
                 quad.len(),
                 prob.m,
@@ -3836,9 +4509,9 @@ impl NlTnlp {
     /// list below so the two can never disagree.
     fn nonlinear_var_set(&self) -> BTreeSet<usize> {
         let mut nonlinear: BTreeSet<usize> = BTreeSet::new();
-        collect_vars(&self.prob.obj_nonlinear, &mut nonlinear);
+        self.prob.obj_nonlinear.collect_vars(&mut nonlinear);
         for row in &self.prob.con_nonlinear {
-            collect_vars(row, &mut nonlinear);
+            row.collect_vars(&mut nonlinear);
         }
         nonlinear
     }
@@ -4168,14 +4841,23 @@ impl pounce_nlp::expression_provider::ExpressionProvider for NlTnlp {
     /// neither a nonlinear expression nor any linear coefficients
     /// (so FBBT skips them — there's nothing to tighten).
     fn constraint_expression(&self, i: usize) -> Option<pounce_nlp::FbbtTape> {
-        let nonlinear = self.prob.con_nonlinear.get(i)?;
+        if i >= self.prob.con_nonlinear.len() {
+            return None;
+        }
+        let nonlinear = self.prob.con_expr(i);
         let linear = self
             .prob
             .con_linear
             .get(i)
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
-        crate::nl_fbbt_translate::translate_constraint(nonlinear, linear)
+        // FBBT needs the tree, so a recognized body is rebuilt here. It is
+        // rebuilt once per row per presolve pass and dropped again, so the
+        // DAG never all exists at once — which is the property the phase is
+        // actually about. Translating the stored coefficients instead would
+        // propagate bounds through a different association and change the
+        // tightening; that is not a trade this phase makes.
+        crate::nl_fbbt_translate::translate_constraint(&nonlinear, linear)
     }
 
     /// Variable name from the sibling `.col` file, if one was loaded.
@@ -4738,9 +5420,10 @@ impl TNLP for NlTnlp {
         // that this test is a genuine linearity test and not just an
         // identity check (`gh #492`).
         for (i, t) in types.iter_mut().enumerate() {
-            *t = match &self.prob.con_nonlinear[i] {
-                Expr::Const(c) if *c == 0.0 => Linearity::Linear,
-                _ => Linearity::NonLinear,
+            *t = if self.prob.con_nonlinear[i].is_trivially_zero() {
+                Linearity::Linear
+            } else {
+                Linearity::NonLinear
             };
         }
         true
@@ -4779,7 +5462,7 @@ impl TNLP for NlTnlp {
         // the guard does not block legitimate eliminations of
         // objective-free equality blocks (the gas-network case).
         let mut nonlinear: BTreeSet<usize> = BTreeSet::new();
-        collect_vars(&self.prob.obj_nonlinear, &mut nonlinear);
+        self.prob.obj_nonlinear.collect_vars(&mut nonlinear);
         for (i, t) in types.iter_mut().enumerate() {
             *t = if nonlinear.contains(&i) {
                 Linearity::NonLinear
@@ -4926,10 +5609,10 @@ b
         assert_eq!(p.m, 0);
         assert_eq!(p.num_obj, 1);
         // f(0,0) = 1 + 4 = 5
-        let f = eval_expr(&p.obj_nonlinear, &[0.0, 0.0]);
+        let f = eval_expr(&p.obj_expr(), &[0.0, 0.0]);
         assert!((f - 5.0).abs() < 1e-12);
         // f(1,2) = 0
-        let f = eval_expr(&p.obj_nonlinear, &[1.0, 2.0]);
+        let f = eval_expr(&p.obj_expr(), &[1.0, 2.0]);
         assert!(f.abs() < 1e-12);
     }
 
@@ -4938,7 +5621,7 @@ b
         let p = parse_nl_text(SIMPLE).expect("parse");
         let x = [0.5, 1.0];
         let mut g = [0.0_f64; 2];
-        grad_expr(&p.obj_nonlinear, &x, 1.0, &mut g);
+        grad_expr(&p.obj_expr(), &x, 1.0, &mut g);
         // d/dx0 = 2*(x0-1) = -1.0
         // d/dx1 = 2*(x1-2) = -2.0
         assert!((g[0] - (-1.0)).abs() < 1e-12);
@@ -4968,11 +5651,13 @@ b
             Box::new(Expr::Const(2.0)),
         );
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 0,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: obj_nl,
+            obj_nonlinear: NlBody::Tree(obj_nl),
             obj_linear: vec![(1, 3.0)],
             obj_constant: 0.0,
             con_nonlinear: vec![],
@@ -5024,14 +5709,16 @@ b
             Box::new(Expr::Const(2.0)),
         );
         let prob = NlProblem {
+            src: None,
+            cse_bodies: Vec::new(),
             n: 2,
             m: 1,
             num_obj: 1,
             minimize: true,
-            obj_nonlinear: Expr::Const(0.0),
+            obj_nonlinear: NlBody::Tree(Expr::Const(0.0)),
             obj_linear: vec![(1, 3.0)],
             obj_constant: 0.0,
-            con_nonlinear: vec![con_nl],
+            con_nonlinear: vec![NlBody::Tree(con_nl)],
             con_linear: vec![vec![]],
             x_l: vec![f64::NEG_INFINITY; 2],
             x_u: vec![f64::INFINITY; 2],
@@ -5286,7 +5973,7 @@ J0 2
         let p = parse_nl_text(&nl).expect("parse");
 
         assert!(
-            matches!(p.con_nonlinear[0], Expr::Const(c) if c == 0.0),
+            p.con_nonlinear[0].is_trivially_zero(),
             "the constant body must be replaced by the identity zero, got {:?}",
             p.con_nonlinear[0]
         );
@@ -5336,7 +6023,7 @@ J0 2
         let nl = EQ_LIN.replace("C0\nn0\n", "C0\no0\nn1\nn2\n");
         assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
         let p = parse_nl_text(&nl).expect("parse");
-        assert!(matches!(p.con_nonlinear[0], Expr::Const(c) if c == 0.0));
+        assert!(p.con_nonlinear[0].is_trivially_zero());
         assert!((p.g_l[0] - (-2.0)).abs() < 1e-12, "g_l = {}", p.g_l[0]);
         assert!((p.g_u[0] - (-2.0)).abs() < 1e-12, "g_u = {}", p.g_u[0]);
     }
@@ -5388,7 +6075,7 @@ J0 2
         assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
         let p = parse_nl_text(&nl).expect("parse");
         assert!(
-            !matches!(p.con_nonlinear[0], Expr::Const(_)),
+            !matches!(p.con_nonlinear[0].tree(), Some(Expr::Const(_))),
             "a row in x0 was folded away: {:?}",
             p.con_nonlinear[0]
         );
@@ -5408,7 +6095,7 @@ J0 2
         assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
         let p = parse_nl_text(&nl).expect("parse");
         assert!(
-            !matches!(p.con_nonlinear[0], Expr::Const(c) if c == 0.0),
+            !p.con_nonlinear[0].is_trivially_zero(),
             "a NaN body was folded into the bounds"
         );
         assert!(p.g_l[0].is_finite() && p.g_u[0].is_finite());
@@ -5426,7 +6113,7 @@ J0 2
         assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
         let p = parse_nl_text(&nl).expect("parse");
         assert!(
-            matches!(p.con_nonlinear[0], Expr::Funcall { .. }),
+            matches!(p.con_nonlinear[0].tree(), Some(Expr::Funcall { .. })),
             "expected the funcall to survive the fold, got {:?}",
             p.con_nonlinear[0]
         );
@@ -6377,16 +7064,16 @@ b
         let p = parse_nl_text(CSE_OBJ).expect("parse");
         assert_eq!(p.n, 2);
         // f(1,2) = 9 + 3 = 12
-        let f = eval_expr(&p.obj_nonlinear, &[1.0, 2.0]);
+        let f = eval_expr(&p.obj_expr(), &[1.0, 2.0]);
         assert!((f - 12.0).abs() < 1e-12, "got {f}");
         // d/dx0 = 2*(x0+x1) + 1 = 7 at (1,2). Same for x1.
         let mut g = [0.0_f64; 2];
-        grad_expr(&p.obj_nonlinear, &[1.0, 2.0], 1.0, &mut g);
+        grad_expr(&p.obj_expr(), &[1.0, 2.0], 1.0, &mut g);
         assert!((g[0] - 7.0).abs() < 1e-12, "g[0]={}", g[0]);
         assert!((g[1] - 7.0).abs() < 1e-12, "g[1]={}", g[1]);
         // collect_vars reaches into the CSE body and finds {0, 1}.
         let mut vs = BTreeSet::new();
-        collect_vars(&p.obj_nonlinear, &mut vs);
+        p.obj_nonlinear.collect_vars(&mut vs);
         assert_eq!(vs.into_iter().collect::<Vec<_>>(), vec![0, 1]);
     }
 
@@ -6811,7 +7498,10 @@ S1 2 sens_init_constr
             vec![(0, 1.0), (1, -1.0)], // mass_in - mass_out
             vec![(0, 1.0)],            // mass_in
         ];
-        prob.con_nonlinear = vec![Expr::Const(0.0), Expr::Const(0.0)];
+        prob.con_nonlinear = vec![
+            NlBody::Tree(Expr::Const(0.0)),
+            NlBody::Tree(Expr::Const(0.0)),
+        ];
         prob.g_l = vec![0.0, 0.0];
         prob.g_u = vec![0.0, 500.0];
 
@@ -6835,8 +7525,12 @@ S1 2 sens_init_constr
         // Row 1: linear in x2 only → support {2}.
         prob.con_linear = vec![vec![(1, 4.0)], vec![(2, 1.0)]];
         prob.con_nonlinear = vec![
-            Expr::Binary(BinOp::Mul, Box::new(Expr::Var(0)), Box::new(Expr::Var(2))),
-            Expr::Const(0.0),
+            NlBody::Tree(Expr::Binary(
+                BinOp::Mul,
+                Box::new(Expr::Var(0)),
+                Box::new(Expr::Var(2)),
+            )),
+            NlBody::Tree(Expr::Const(0.0)),
         ];
         prob.g_l = vec![0.0, 0.0];
         prob.g_u = vec![0.0, 0.0];
@@ -6854,7 +7548,7 @@ S1 2 sens_init_constr
         // legitimately contain '#' (e.g. a parameters-directory path). The
         // old parser ran strip_comment() over the line first, truncating
         // the content at the '#'. Here `h3:a#b` must round-trip to "a#b".
-        let mut p = Parser::new("h3:a#b\n");
+        let mut p = Parser::new("h3:a#b\n", false);
         match p.parse_funcall_arg().expect("parse hollerith arg") {
             FuncallArg::Str(s) => assert_eq!(s, "a#b"),
             other => panic!("expected Str, got {other:?}"),
@@ -6866,7 +7560,7 @@ S1 2 sens_init_constr
         // The declared `<len>` is authoritative: exactly that many bytes
         // after the ':' form the string; trailing content (here a real
         // ` # comment`) is not part of it.
-        let mut p = Parser::new("h3:abc # trailing comment\n");
+        let mut p = Parser::new("h3:abc # trailing comment\n", false);
         match p.parse_funcall_arg().expect("parse hollerith arg") {
             FuncallArg::Str(s) => assert_eq!(s, "abc"),
             other => panic!("expected Str, got {other:?}"),
@@ -6885,7 +7579,7 @@ S1 2 sens_init_constr
     /// Parse a single expression `expr_src` with `n` variables in scope,
     /// driving the real `parse_opcode` path through `parse_expr`.
     fn parse_one_expr(n: usize, expr_src: &str) -> Expr {
-        let mut p = Parser::new(expr_src);
+        let mut p = Parser::new(expr_src, false);
         p.n = n;
         p.parse_expr().expect("parse expression")
     }
@@ -7004,8 +7698,8 @@ S1 2 sens_init_constr
         assert_ne!(nl, SIMPLE, "fixture substitution must apply");
         let p = parse_nl_text(&nl).expect("parse o82 objective");
         // f(3,4) = 9 + 16 = 25; both bases negative still real: f(-3,-4)=25.
-        assert!((eval_expr(&p.obj_nonlinear, &[3.0, 4.0]) - 25.0).abs() < 1e-12);
-        assert!((eval_expr(&p.obj_nonlinear, &[-3.0, -4.0]) - 25.0).abs() < 1e-12);
+        assert!((eval_expr(&p.obj_expr(), &[3.0, 4.0]) - 25.0).abs() < 1e-12);
+        assert!((eval_expr(&p.obj_expr(), &[-3.0, -4.0]) - 25.0).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/pounce-py/src/nl_problem.rs
+++ b/crates/pounce-py/src/nl_problem.rs
@@ -35,7 +35,7 @@ use pyo3::prelude::*;
 
 use pounce_common::types::{Index, Number};
 use pounce_nl::nl_reader::{
-    Expr, NlProblem, NlTnlp, NlVariation, parse_nl_text as parse_nl_text_rs, read_nl_file,
+    Expr, NlBody, NlProblem, NlTnlp, NlVariation, parse_nl_text as parse_nl_text_rs, read_nl_file,
 };
 use pounce_nlp::tnlp::{SparsityRequest, TNLP};
 
@@ -652,9 +652,12 @@ impl Drop for PyNlProblem {
         }
         let prob = self.tnlp.get_mut().problem_mut();
         let mut doomed = Vec::with_capacity(prob.con_nonlinear.len() + 1);
-        doomed.push(std::mem::replace(&mut prob.obj_nonlinear, Expr::Const(0.0)));
+        doomed.push(std::mem::replace(
+            &mut prob.obj_nonlinear,
+            NlBody::Tree(Expr::Const(0.0)),
+        ));
         for c in &mut prob.con_nonlinear {
-            doomed.push(std::mem::replace(c, Expr::Const(0.0)));
+            doomed.push(std::mem::replace(c, NlBody::Tree(Expr::Const(0.0))));
         }
         on_deep_stack(self.expr_depth, move || drop(doomed));
     }
@@ -669,11 +672,19 @@ impl Drop for PyNlProblem {
 /// anything else walks the result (pounce#472).
 fn checked_depth(prob: &NlProblem) -> Result<u32, String> {
     let mut memo = std::collections::HashMap::new();
+    // A body the `.nl` parser recognized as a quadratic has no tree to
+    // walk — it carries the depth the tree *would* have had instead, which
+    // is what this guard is about (gh #588, Q5). Skipping it would report a
+    // shallow model for one whose bodies are anything but.
+    let body_depth = |b: &NlBody, memo: &mut std::collections::HashMap<_, _>| match b {
+        NlBody::Tree(e) => expr_depth(e, memo),
+        NlBody::Quad(q) => q.depth,
+    };
     let depth = prob
         .con_nonlinear
         .iter()
-        .fold(expr_depth(&prob.obj_nonlinear, &mut memo), |acc, c| {
-            acc.max(expr_depth(c, &mut memo))
+        .fold(body_depth(&prob.obj_nonlinear, &mut memo), |acc, c| {
+            acc.max(body_depth(c, &mut memo))
         });
     if depth > MAX_DEPTH {
         return Err(format!(

--- a/dev-notes/quadratic-structure-exploitation.md
+++ b/dev-notes/quadratic-structure-exploitation.md
@@ -32,7 +32,7 @@ describes.
 | Q2 — `.nl` header nonlinearity counts | **done** | (this commit) | census kept; `get_number_of_nonlinear_variables` implemented (60/60 fixtures answer, was `-1`); the LP-fast-path forecast was wrong and was **not** shipped — see §0c |
 | Q3 — recognizer to `pounce-nl`, `Poly` → `Quad2` | **done** | (this commit) | recognizer iterative and allocation-free per monomial; classification of an `o0` chain was `O(k²)` and is now linear (k=16 000: 0.77 s → 0.020 s); the crash Q1 reported is real but unreachable through the CLI — see §0d |
 | Q4 — `QuadraticStructure` + `NlTnlp` fast path | **done** | (this commit) | `qcqp1000-2c` (**real**) 131.4 s → 97.6–103.3 s (1.27–1.35×), 100 → 100 iterations, `eval_h` 19.58 s → 0.20 s (~95×); the ≈1.4× forecast was at or above this machine's Amdahl ceiling; the fast path had to be gated on *already-expanded*, *unshared* forms after it cost `airport.nl` 16 → 300 iterations and a shared-DAG model 0.00 s → 172 s — see §0e |
-| Q5 — parse-time recognition | pending | — | — |
+| Q5 — parse-time recognition | **done** | (this commit) | peak RSS on a **generated** `qcqp500-3c` shape 1253 → 586 MB (2.14×), on the **real** `qcqp1000-2c` 577 → 445 MB, and its load 0.98 → 0.71 s; the two recognizers agree bitwise over 1 631 corpus bodies and both instances solve bit-identically; the forecast's `~0.4 GB` floor is not reached and what is left is the file text and the parser's line index, not the `Expr` DAG — see §0f |
 | Q6 — the four constant-derivative hints | pending | — | — |
 | Q7 — `QcqpProblem` extraction | pending | — | — |
 | Q8 — native QCQP barrier driver | pending | — | — |
@@ -786,6 +786,262 @@ new test file are the ones every integration test here produces).
 
 ---
 
+## 0f. Q5 — parse-time recognition (measured 2026-08-18)
+
+### What shipped
+
+1. **`Parser::parse_expr_quadratic`.** A degree-2 `C`/`O` body is read off the
+   `.nl` token stream as a [`Quad2`] and its `Expr` tree is **never built**.
+   The parser is line-cursor based, so a failed recognition costs one
+   assignment to rewind (`self.pos = saved`) and `parse_expr` then produces
+   exactly the tree this file has always produced — the same trick
+   `parse_funcall_arg` already used for Hollerith literals. The design note
+   got this part exactly right.
+
+2. **`NlBody::{Tree, Quad}`** replaces `Expr` as the type of
+   `NlProblem::obj_nonlinear` / `con_nonlinear`. This is the part §9 does not
+   mention and it is most of the diff: not building the tree means the nine
+   consumers §5.3 enumerates need somewhere to look, and several of them
+   would read a *missing* tree as "this row is linear" — a silent wrong
+   answer, not a crash. An enum makes every one of them a compile error until
+   it says which reading it wants.
+
+3. **The tree is still available, and it is *the* tree.** A recognized body
+   keeps the byte range it was recognized from, and `NlProblem::con_expr` /
+   `obj_expr` re-parse those bytes with the same parser, resolving `v<i>`
+   against the same `V`-segment `Arc`s. So `POUNCE_DBG_NO_QUAD`'s tape
+   reference, FBBT, the debugger's renderer and `pounce-py` all get back a
+   structurally identical tree with the same `Cse` pointer identities —
+   which matters because `HybridTape::build_multi` keys sharing on them.
+   Deriving an equivalent tree from the stored coefficients instead would be
+   a different tree, taped differently, and the phase would stop being
+   invisible from outside.
+
+4. **`recognize_expr` and `is_expanded_quadratic` are memoized on `Arc`
+   identity**, so Q4's refusal of a re-referenced `Cse` body is dropped. The
+   fix in the gate is one line — a repeat visit `continue`s instead of
+   returning `false`, sound for exactly the reason `validate_expr` documents
+   for the same trick: the walk aborts on the first violation, so reaching a
+   body twice proves the first visit found none. The memo is keyed on
+   *(body, mode)*: a body is legal on the sum spine if it is a sum of
+   monomials and legal inside a monomial only if it is itself a monomial, and
+   conflating the two would clear a factored product because it had been seen
+   somewhere safe.
+
+5. **`parse_nl_text_with_quadratic` / `parse_nl_string`**, the parse-time twin
+   of `try_new_with_quadratic`, and `POUNCE_DBG_NO_QUAD=1` now turns
+   recognition off at the parse as well as at the tape — so the env var means
+   one thing, and gh #540's guard keeps the pre-Q4 arithmetic *and* the
+   pre-Q4 memory.
+
+### The measurement: peak RSS, which is what this phase is for
+
+Two probes per instance. `pounce check-x0` is parse + build + one evaluation,
+which isolates what Q5 changes; the full solve is what a user sees. Peak RSS
+is far less noisy than wall clock, which is fortunate given the claim.
+
+**The real `qcqp1000-2c`** — the one Mittelmann instance on this machine:
+
+| | Q4 (`947b3aa3`) | Q5 | |
+|---|---|---|---|
+| `check-x0` peak RSS | 183.8 MB | **102.2 MB** | **1.80×** |
+| `check-x0` wall | 0.98 s | **0.71 s** | 1.38× |
+| full-solve peak RSS | 576.9 MB | **444.5 MB** | 1.30× |
+| full-solve wall | 98.61 s | 100.23 s | noise (§10) |
+| iterations | 100 | 100 | unchanged |
+| objective | 738127.4263173543 | 738127.4263173543 | **every digit** |
+| final dual inf | 2.467359649926948e-12 | 2.467359649926948e-12 | **every digit** |
+| final constraint violation | 1.0186340659856796e-10 | 1.0186340659856796e-10 | **every digit** |
+| recognized forms | 8 | 8, **all parse-time** | |
+
+The solve is bit-identical, which is the phase's correctness claim measured
+rather than argued. `POUNCE_DBG_TAPE_STATS` reports
+`[quad stats] forms=8 (parse-time 8) rows=7/5107 obj=quadratic` — all seven
+quadratic rows and the objective now cost no `Expr` at all.
+
+**A generated `qcqp500-3c` shape** — the evaluation-bound, memory-heavy
+regime, and **generated, not the Mittelmann instance**. §0e's calibration
+applies and cuts the right way here: the generator overstates *wall-clock*
+wins, but it reproduced Q4's peak RSS closely (3855 MB against the note's
+3.3 GB), so for a *memory* claim it is on much firmer ground than it was for a
+timer. This run reproduces Q4's own figure to within a megabyte:
+
+| **generated `qcqp500-3c` shape** | Q4 | Q5 | |
+|---|---|---|---|
+| `check-x0` peak RSS | 1365.7 MB | **698.8 MB** | 1.95× |
+| `check-x0` wall | 6.92 s | 5.66 s | 1.22× |
+| full-solve peak RSS | 1253.4 MB | **586.2 MB** | **2.14×** |
+| full-solve wall | 17.43 s | 12.72 s | |
+| solve timer (`total_wallclock`) | 7.50 s | 7.25 s | unchanged, as designed |
+| iterations | 75 | 75 | unchanged |
+| objective | 24779.69029930317 | 24779.69029930317 | every digit |
+
+The whole series on that shape, for the record: **3855 MB → 1253 MB (Q4) →
+586 MB (Q5)**. The wall-clock difference is entirely the parse — the solve
+timer does not move, and it should not.
+
+### The forecast, and where it is wrong
+
+**"Peak RSS ~2 GB → ~0.4 GB" is wrong at both ends, in opposite
+directions.** The starting point after Q4 is **1.25 GB**, not 2 GB, and the
+finish is **0.59 GB**, not 0.4 GB. Q5 takes 2.14× on the shape the claim is
+about and 1.30× on the real instance.
+
+**And the residue is no longer the `Expr` DAG.** On the generated shape the
+`.nl` text is 119 MB and the file is ~17 M lines, so `Parser`'s existing
+`lines: Vec<&str>` index is ~280 MB — together about 400 MB of the remaining
+586 MB. Getting the next factor means a parser that does not materialize a
+line index, not a better recognizer. That is a different phase and this note
+should not be read as promising it.
+
+That number also came with a lesson inside the phase. The first cut recorded a
+per-line byte-offset table beside `lines` so a recognized body could name its
+byte range; on this model that `Vec<usize>` cost **136 MB** — measured, 845.7
+against 698.8 MB on `check-x0` — to save memory. It is one base-pointer
+subtraction now. A data structure proportional to the input is not free just
+because it is small per element.
+
+**"Plus a faster parse" holds.** 0.98 s → 0.71 s loading the real instance,
+and 4.7 s off the generated model's wall with its solve timer unchanged. This
+is *net* of the rewind: every body that is not an admitted degree-2 form is
+read twice, and on the real instance that is 5 100 rows — each one token, so
+the cost is real and invisible.
+
+**"Handles `V`-segment CSEs via a parallel `cse_quad`, which matters because
+Pyomo/AMPL routinely emit quadratics that way" — the mechanism is there and
+tested, and the premise is mostly wrong.** A defined variable is emitted as
+`v<k>` and *used* as `v<k>^2` or `v<k>·v<j>`, i.e. a `Pow`/`Mul` over a
+non-atomic operand — which is precisely the **factored** shape
+`is_expanded_quadratic` refuses, and must refuse, because expanding it is the
+gh #544 failure mode Q4 measured on `airport.nl` (§0e). So `cse_quad` pays only
+where a `V` body is *itself* a flat sum of monomials referenced on the sum
+spine. That case is real, is what Q4 had to refuse outright, and is now
+recognized — pinned by `a_twice_referenced_cse_quadratic_is_recognized`, which
+had to be hand-written because **no `.nl` file in this repository has a
+recognized body that references a CSE at all**. The Pyomo defined-variable
+case is blocked by [#673](https://github.com/jkitchin/pounce/issues/673), not
+by the recognizer's CSE handling, and Q5 does not move it.
+
+### Dropping Q4's `Cse` refusal cost no reach and gained a little
+
+Q4 refused a re-referenced `Cse` body to bound cost and said the memoization
+was Q5's. Measured after the memoization:
+
+* `nl_quadratic`'s own shared-DAG test now runs at depth **60** — `2^60`
+  inlinings — and returns instantly, admitting the body and reporting the
+  right coefficient (`2^60 · x`). Q4 refused the same shape at depth 30 after
+  172 s.
+* Corpus reach is **unchanged**: `quad_evaluator_differential` reports the
+  identical 27 models, 251 quadratic rows, 26 846 of 26 848 Hessian entries
+  bit-identical and worst `g`/`∇g`/`f`/`∇f` deviation 4.13e-15 that Q4
+  recorded. Nothing in the corpus was being refused for sharing, exactly as
+  Q4 measured.
+
+### The exactness rule survives the move, by construction
+
+This was the phase's biggest hazard: a parse-time recognizer that admitted one
+body more than `is_expanded_quadratic` would put a factored form on Q4's
+constant-matrix path at a stage the sweep is even less likely to see.
+
+It is not enforced by a second copy of the rule but by the shape of the
+streaming walk: `+`/`-`/`o54` are the sum spine, everything under a `*`, `/`
+or `^` is read in *monomial mode*, a `+` seen in monomial mode gives up, and a
+`^` whose base token is not `n`/`v<i (i < n)`/`o16` gives up. A `v<i>` with
+`i ≥ n` is an `Expr::Cse`, which `is_monomial` does not accept as a power's
+base, so it gives up there too. The differential test then checks the
+*outcome* rather than trusting the argument: over the corpus the parse-time
+recognized set is exactly `is_expanded_quadratic ∧ recognize_expr ∧ degree 2`,
+with a named panic for each direction of disagreement.
+
+One detail was found by writing the test rather than by reading the code, and
+it is the kind of thing that decides whether "bitwise" means anything.
+`recognize_expr` folds an `o54` sumlist **last operand first** — its work
+stack lowers the items in reverse and `drain` then hands them back in that
+order — while a streaming parser naturally accumulates front to back. On
+distinct monomials the two agree; on a *repeated* monomial they do not.
+`a_sumlist_folds_in_the_order_the_tree_walk_folds` pins it with coefficients
+`[1e16, 1, 1]` on the same `x₀²`: front to back gives `1e16`, back to front
+gives `1e16 + 2`, and only one of those is what the tape-free path must store.
+
+### Correctness: the differential test, and the sweep as well
+
+`crates/pounce-cli/tests/quad_parse_differential.rs` parses every `.nl` file in
+the repository **twice**, with recognition on and off, and compares:
+
+| comparison | result |
+|---|---|
+| files / bodies walked | 61 / **1 631** |
+| bodies recognized at parse time | **260** |
+| recognized form vs `recognize_expr` on the tree | **bit-identical**, coefficient bit patterns, on all 260 |
+| recognized *set* vs `is_expanded_quadratic ∧ degree 2` | **identical**, both directions checked |
+| rebuilt tree vs the non-recognizing parse's tree | **structurally identical**, constants compared as bit patterns, on all 1 631 |
+| rebuilt `Cse` references | resolve to this parse's own `Arc`s |
+| stored variable support vs `collect_vars` | identical, including variables whose coefficient cancelled |
+| bounds, `con_linear`, `obj_linear` (i.e. the gh #492 fold) | bit-identical |
+
+§9 says to assert this instead of running a sweep. The sweep was run anyway,
+on the argument that a "this cannot change anything" claim is exactly what
+Q1's 2-ulp line and Q4's `infeasible_equalities` line each defeated:
+
+* `scripts/sweep-fixtures.sh`, 57 models: **diff empty**.
+* `Problem class:` over all 61 `.nl` files in the repository: **diff empty**.
+* Both measured instances solve to **every digit** of objective, dual
+  infeasibility and constraint violation (table above).
+
+`POUNCE_DBG_NO_QUAD=1` gives **487.7 MB** on `check-x0` for the real instance
+from *both* binaries — the switch restores the pre-Q4 parse exactly, memory
+included.
+
+### A ceiling Q3 handed to Q5, retired for degree-2 bodies
+
+Q3 recorded that after its own fix "the recursive parser is now the lowest
+ceiling on this shape, which is Q5's to fix". Half of it is fixed, and the
+half is worth naming precisely. A left-deep `o0` chain of `k` monomials —
+what a writer that emits binary `+` for a long sum produces — as a `C` body:
+
+| `k` | Q4 | Q5 |
+|---|---|---|
+| 5 000 | loads | loads |
+| 20 000 | **abort (rc 134, stack overflow)** | **loads, and solves** |
+| 100 000 | abort | **loads** |
+
+because the streaming recognizer is iterative where `parse_expr` recurses. The
+same chain with `o41` (sin) leaves still aborts on both binaries: a body that
+is not an admitted degree-2 form is rewound and parsed recursively, exactly as
+before. And `con_expr` re-parses recursively too, so *rebuilding* such a body
+would abort — which is why a recognized body records the depth its tree would
+have had, and `pounce-py`'s `checked_depth` (pounce #472) reads that instead of
+walking a tree that is not there.
+
+### What Q5 did not do
+
+* **`V`-segment bodies keep their trees.** They are shared, so the memory is
+  amortized over every reference, and dropping them would mean rebuilding them
+  for the rows that are *not* recognized. A model whose bulk lives in `V`
+  segments gains nothing here.
+* **Only degree-2 bodies are recognized at parse time.** A body that reads as
+  constant or linear is rewound and stored as a tree on purpose: the
+  constant-row fold (gh #492), the linearity contract and the classifier's LP
+  fast path all key on the identity zero and on trees, they are cheap already,
+  and the memory this phase is about is entirely in degree-2 rows.
+* **FBBT, the debugger's renderer and `pounce-py` rebuild a body when they
+  need one**, one at a time — so the DAG never all exists at once, which is
+  the property that matters, but those paths do allocate. Translating the
+  stored coefficients into an `FbbtTape` directly would propagate bounds
+  through a different association; that is a trajectory change and not one
+  this phase makes.
+
+### Gates
+
+`cargo test --workspace --exclude pounce-hsl`: **2995 passed, 0 failed**
+(2988 at Q4; the 7 new ones are this phase's — six in
+`quad_parse_differential`, and Q4's `a_shared_cse_body_is_refused…` becomes
+two tests that assert the opposite verdict and the per-context memo key).
+`cargo fmt --check` clean; `cargo clippy --workspace --exclude pounce-hsl
+--all-targets` exit 0, no new lint class.
+
+---
+
 ## 1. Summary
 
 Three findings reframe the issue.
@@ -1206,8 +1462,8 @@ inversion the win requires. It would also add entries to the 20-crate
 topological publish list guarded by `scripts/check-release-consistency.sh`.
 
 - **`crates/pounce-nl/src/quadratic.rs`** — recognition. `Quad2` (a flat
-  degree-≤2 accumulator), `recognize_expr`, `canonicalize`,
-  `parse_expr_quadratic`.
+  degree-≤2 accumulator), `recognize_expr`, `canonicalize`.
+  *(Q5: `parse_expr_quadratic` went to `nl_reader.rs` — it reads the `.nl` token stream, so it is a parser method that calls this module's arithmetic, not a member of it.)*
 - **`crates/pounce-nlp/src/quadratic.rs`** — data structure and kernels.
   `QuadForm`, `QuadraticStructure`, `QuadScratch`, `ConstantDerivatives`. Pure
   sparse linear algebra; no `Expr`, no `feral`. `pounce-nlp` is where `TNLP`
@@ -1715,6 +1971,58 @@ matters because Pyomo/AMPL routinely emit quadratics that way. **Win: peak RSS
 ~2 GB → ~0.4 GB**, plus a faster parse. **No trajectory change** if the two
 recognizers agree bitwise — assert that directly instead of running a sweep.
 
+**Done — the mechanism is exactly as described, the memory forecast is wrong
+at both ends, and one premise about `V` segments does not survive contact
+with Q4's accuracy gate; §0f has the measurement.** Shipped:
+`Parser::parse_expr_quadratic` with the rewind this paragraph describes,
+`NlBody::{Tree, Quad}` on `NlProblem`, `NlProblem::con_expr`/`obj_expr` to
+rebuild a recognized body from its own bytes, `Arc`-identity memoization in
+`recognize_expr` and `is_expanded_quadratic` (which retires Q4's `Cse`
+refusal), and `parse_nl_text_with_quadratic` as the A/B switch.
+Corrections, in ascending order of how much they change the phase:
+
+1. **The `Expr`-free parse is real and the rewind is free**, as written. On
+   the real `qcqp1000-2c` all eight recognized forms — seven rows and the
+   objective — now cost no `Expr` at all, and the load goes 0.98 s → 0.71 s
+   *net* of re-reading the 5 100 bodies that are rewound.
+2. **"Peak RSS ~2 GB → ~0.4 GB" is wrong at both ends.** After Q4 the
+   starting point is 1.25 GB, not 2 GB, and Q5 reaches 0.59 GB, not 0.4 GB
+   (generated `qcqp500-3c` shape, full solve: 1253 → 586 MB, 2.14×; real
+   `qcqp1000-2c`: 577 → 445 MB). **What is left is no longer the `Expr`
+   DAG**: about 400 MB of that 586 MB is the `.nl` text plus `Parser`'s
+   existing `lines: Vec<&str>` index over a 17 M-line file. The next factor
+   belongs to a parser that does not materialize a line index, and is not
+   this phase.
+3. **The `V`-segment premise is mostly wrong.** `cse_quad` works and is
+   tested, but a Pyomo defined variable is *used* as `v<k>^2` or `v<k>·v<j>`
+   — a power or product over a non-atomic operand, which is exactly the
+   factored shape `is_expanded_quadratic` must refuse (gh #544, §0e). So this
+   pays only where a `V` body is itself a flat sum of monomials referenced on
+   the sum spine — the case Q4 refused outright, now admitted. No `.nl` file
+   in this repository has a recognized body that references a CSE at all. The
+   Pyomo case is blocked by
+   [#673](https://github.com/jkitchin/pounce/issues/673), not here.
+4. **The paragraph does not mention the part that is most of the diff.** Not
+   building a tree means the nine consumers §5.3 enumerates need somewhere
+   else to look, and several of them read a *missing* tree as "this row is
+   linear". `NlBody` makes each one a compile error; `con_expr` re-parses the
+   body's own bytes, with the same `V`-segment `Arc`s, so everything that
+   genuinely needs a tree gets the one a non-recognizing parse would have
+   built.
+5. **"No trajectory change if the two recognizers agree bitwise" — they do,
+   and the sweep was run anyway.** 1 631 corpus bodies compared both ways,
+   260 recognized, forms bit-identical and the recognized *set* identical in
+   both directions; `sweep-fixtures.sh` and the `Problem class:` line both
+   diff-empty; and both measured instances solve to every digit of objective,
+   dual infeasibility and constraint violation. Asserting it was the right
+   call and running the sweep cost one run.
+6. **A side effect worth recording:** because the streaming recognizer is
+   iterative where `parse_expr` recurses, a left-deep `o0` chain of 20 000 or
+   100 000 monomials now *loads and solves* where it aborted with a stack
+   overflow before — half of the ceiling Q3 handed to Q5. The other half
+   stands: a body that is not an admitted degree-2 form is still parsed
+   recursively, and so is a rebuild.
+
 **Q6 — honour the four constant-derivative hints.** Auto-detect
 `ConstantDerivatives` from the structure; reconcile with the user's option and
 **warn-and-ignore a hint that contradicts proof** — a deliberate divergence from
@@ -1973,7 +2281,7 @@ line is individually explained.
 
 | file | role |
 |---|---|
-| `crates/pounce-nl/src/nl_quadratic.rs` *(new, landed in Q3)* | `Quad2`, `recognize_expr`, `analyze_quadratic{,_full}`, `is_trivially_zero`; `parse_expr_quadratic` is Q5's. Named for the crate's `nl_*` module convention, not the bare `quadratic.rs` this row first guessed |
+| `crates/pounce-nl/src/nl_quadratic.rs` *(new, landed in Q3)* | `Quad2`, `recognize_expr`, `analyze_quadratic{,_full}`, `is_trivially_zero`. `parse_expr_quadratic` turned out to belong in `nl_reader.rs` instead — it consumes the token stream, so it is a parser method; what it borrows from here is `Quad2`'s arithmetic (landed in Q5). Named for the crate's `nl_*` module convention, not the bare `quadratic.rs` this row first guessed |
 | `crates/pounce-nlp/src/quadratic.rs` *(new)* | `QuadForm`, `QuadraticStructure`, `QuadScratch`, `ConstantDerivatives`, kernels |
 | `crates/pounce-convex/src/qcqp.rs` *(new)* | `QuadRow`, `QcqpProblem`, `QuadJacobian`, `to_socp` |
 | `crates/pounce-convex/src/qcqp_ipm.rs` *(new)* | `QcqpKkt`, `solve_qcqp_ipm` |


### PR DESCRIPTION
**Review-only. Do not merge.** This PR exists so Q5 of the #588 series can be read as a self-contained diff against Q4; the series PR is **#603** and that is where the work actually lands. Base branch `review/588-q4-base` is Q4's commit `947b3aa3`, so the diff here is exactly one phase.

## Problem

Peak RSS on a quadratic model is set during *parsing*, by the `.nl` text and the `Expr` DAG. Q4 removed what is built from that DAG — the AD tapes — and recorded that the DAG itself was Q5's to remove:

| generated `qcqp500-3c` shape, full solve | peak RSS |
|---|---|
| before Q4 | 3855 MB |
| after Q4 | 1253 MB |
| **after Q5 (this PR)** | **586 MB** |

The CLI also recognized every row twice — once in `classify_problem`, once in `NlTnlp::try_new` — and `recognize_expr` was still `Θ(2^depth)` on a shared `Cse` DAG, which Q4 had to work around by refusing a re-referenced body outright.

## Cause

`Parser::parse_expr` allocates one `Expr` node per token, and `NlProblem` held the result for the life of the solve. For an AMPL-emitted quadratic row that is `n²` nodes describing `n²/2` distinct coefficients — the recognizer then walks all of them to recover a matrix the token stream already spelled out.

## Fix

`Parser::parse_expr_quadratic` reads a degree-2 body off the token stream as a `Quad2` and never builds the tree. The parser is line-cursor based, so a body it cannot prove costs one assignment to rewind (`self.pos = saved`) and `parse_expr` then produces exactly the tree it always produced — the same trick `parse_funcall_arg` already used for Hollerith literals.

- **`NlBody::{Tree, Quad}`** on `NlProblem` is most of the diff. Nine consumers read these bodies and several would read a *missing* tree as "this row is linear" — a silent wrong answer, not a crash. An enum makes each one a compile error until it says which reading it wants.
- **The tree is still available, and it is *the* tree.** A recognized body keeps the byte range it came from; `NlProblem::con_expr`/`obj_expr` re-parse those bytes with the same parser and the same `V`-segment `Arc`s. Rebuilding from the stored *coefficients* was rejected: that is a different tree, taped differently, and the `POUNCE_DBG_NO_QUAD` reference and gh#540's guard depend on the tape path being byte-for-byte what it was.
- **The exactness rule is structural, not a second copy of `is_expanded_quadratic`.** `+`/`-`/`o54` are the sum spine; everything under `*`, `/` or `^` is read in monomial mode; a `+` in monomial mode gives up; a `^` whose base token is not `n` / `v<i (i < n)` / `o16` gives up. Getting this wrong would put a *factored* form on Q4's constant-matrix path — the gh#544 failure mode that cost `airport.nl` 16 → 300 iterations.
- **`recognize_expr` and `is_expanded_quadratic` are memoized on `Arc` identity**, so Q4's `Cse` refusal is dropped. In the gate that is one line — a repeat visit `continue`s instead of returning `false`, sound for the reason `validate_expr` already documents — with the memo keyed on *(body, mode)*, because a body legal on the sum spine is not thereby legal inside a monomial.

A per-line byte-offset table was tried first for the byte ranges and rejected by measurement: on the generated model it cost **136 MB** (845.7 vs 698.8 MB) to save memory. It is one base-pointer subtraction now.

## Blast radius

**Bit-identical except for memory.** Both instances available here solve to every digit:

| | Q4 | Q5 |
|---|---|---|
| `qcqp1000-2c` (**real**) iterations / objective | 100 / 738127.4263173543 | 100 / 738127.4263173543 |
| …final dual inf / constraint violation | 2.467359649926948e-12 / 1.0186340659856796e-10 | identical |
| …load peak RSS, wall | 183.8 MB, 0.98 s | **102.2 MB, 0.71 s** |
| …full-solve peak RSS | 576.9 MB | **444.5 MB** |
| generated `qcqp500-3c` iterations / objective | 75 / 24779.69029930317 | 75 / 24779.69029930317 |
| …full-solve peak RSS | 1253.4 MB | **586.2 MB** (2.14×) |

- `scripts/sweep-fixtures.sh`, 57 models, against `947b3aa3`: **diff empty**.
- `Problem class:` over all 61 `.nl` files: **diff empty**.
- `quad_evaluator_differential` (Q4's): identical 27 models, 251 quadratic rows, 26 846 of 26 848 Hessian entries bit-identical, worst deviation 4.13e-15 — so dropping the `Cse` refusal cost no reach and gained none on this corpus.
- `POUNCE_DBG_NO_QUAD=1` now disables recognition at the parse as well as at the tape, and gives 487.7 MB from *both* binaries.
- Incidental: a left-deep `o0` chain of 20 000 or 100 000 monomials now loads and solves where it aborted with a stack overflow, because the streaming recognizer is iterative where `parse_expr` recurses.

## Tests

`crates/pounce-cli/tests/quad_parse_differential.rs` parses every `.nl` file in the repository twice, recognition on and off — 61 files, 1 631 bodies, 260 recognized at parse time — and asserts, on bit patterns and never a tolerance:

- every recognized form is bit-identical to `recognize_expr` on the tree;
- the recognized *set* is exactly `is_expanded_quadratic ∧ degree 2`, with a named failure for each direction of disagreement;
- every rebuilt tree is structurally identical to the non-recognizing parse's, constants compared as bits;
- rebuilt `Cse` references resolve to this parse's own `Arc`s;
- the stored variable support matches `collect_vars`, including variables whose coefficient cancelled to zero;
- the bounds the gh#492 constant-row fold writes are bit-identical.

Three hand-written models pin what the corpus does not reach: a twice-referenced `V`-segment quadratic (which Q4 refused and this admits — no fixture in the repo has a recognized body that references a CSE at all), a factored defined variable that must *not* be recognized, and `a_sumlist_folds_in_the_order_the_tree_walk_folds`. That last one exists because `recognize_expr` folds an `o54` sumlist **last operand first** while a streaming parser naturally accumulates front to back; with `[1e16, 1, 1]` on the same `x₀²` the two orders give `1e16` and `1e16 + 2`. It was found by writing the test, and it fails on the natural implementation.

`a_shared_cse_body_is_refused_rather_than_walked_exponentially` is replaced by two tests asserting the opposite verdict at depth 60 and the per-context memo key; it fails on the parent commit, for the stated reason — that is the behaviour change.

Deliberately not pinned: the memory numbers themselves. Peak RSS is measured, reported in the note (§0f) and reproducible with `scripts/gen-qcqp-nl.py`, but a test that asserts an RSS figure would be a flake on any other machine.

---

- [x] Tests fail on the parent commit for the stated reason
- [ ] `CHANGELOG.md` `[Unreleased]` entry — the series PR #603 carries it; this branch is review-only
- [ ] Book page under `docs/src/` — no user-facing surface changes
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean (2995 passed, 0 failed; 2988 at Q4)
- [x] Every claim in this body is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZTh36oN4JK9t6fN2CzXC9)_