### PR TITLE
Q6 review copy: prove the four constant-derivative hints instead of trusting them

### DIFF
--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1296,6 +1296,51 @@ impl IpoptApplication {
         crate::unimplemented_options::hint_warnings(&self.options, &self.reg_options)
     }
 
+    /// Resolve the four constant-derivative hints for this solve and
+    /// install the result on the NLP (gh #588, phase Q6).
+    ///
+    /// `grad_f_constant` / `hessian_constant` / `jac_c_constant` /
+    /// `jac_d_constant` are, upstream, unchecked user assertions: Ipopt
+    /// reuses the derivative and returns a wrong answer if the assertion
+    /// was false. pounce asks the model first. Where the model *proves*
+    /// the derivative constant, the reuse happens whether or not the
+    /// option was set — the hint is redundant. Where the model proves it
+    /// **varies** and the option was set anyway, the option is refused
+    /// with a warning, which is the deliberate divergence. Where the
+    /// model can prove nothing — every callback front end, both GAMS
+    /// links — the user's assertion is honoured on trust, exactly as
+    /// upstream, because "unproved" is not "disproved" and silently
+    /// overriding the caller there would be its own wrong answer.
+    fn install_constant_derivative_hints(&self, orig_nlp: &mut OrigIpoptNlp) {
+        use pounce_common::journalist::JournalCategory;
+        use pounce_nlp::constant_derivatives::{HINT_OPTIONS, reconcile};
+
+        let asserted = HINT_OPTIONS
+            .map(|name| matches!(self.options.get_bool_value(name, ""), Ok((true, true))));
+        let proofs = orig_nlp.derivative_proofs();
+        let (outcomes, enabled) = reconcile(proofs, asserted);
+
+        for outcome in &outcomes {
+            if let Some(warning) = outcome.warning() {
+                eprintln!("{warning}");
+                self.journalist.print(
+                    JournalLevel::J_STRONGWARNING,
+                    JournalCategory::J_MAIN,
+                    &format!("{warning}\n"),
+                );
+            }
+        }
+        if std::env::var("POUNCE_DBG_CONSTDERIV").is_ok() {
+            for outcome in &outcomes {
+                eprintln!(
+                    "[const deriv] {:<15} proof={:?} asserted={} reused={}",
+                    outcome.name, outcome.proof, outcome.asserted, outcome.honoured,
+                );
+            }
+        }
+        orig_nlp.set_constant_derivatives(enabled);
+    }
+
     /// Resolve the five registered `derivative_test*` knobs. Every one
     /// of them was registered and never read, so `derivative_test=
     /// first-order` ran no test and printed nothing — a checker that
@@ -1432,13 +1477,16 @@ impl IpoptApplication {
             .ok()
             .and_then(|(v, f)| f.then_some(v))
             .unwrap_or(1.0);
-        let orig_nlp = match OrigIpoptNlp::new(
+        let mut orig_nlp = match OrigIpoptNlp::new(
             Rc::clone(&adapter),
             Rc::new(ConstObjScaling(obj_scaling_factor)),
         ) {
             Ok(n) => n,
             Err(_) => return ApplicationReturnStatus::InternalError,
         };
+        // Same Q6 reconciliation as the IPM route: the SQP driver
+        // evaluates the same derivatives through the same NLP object.
+        self.install_constant_derivative_hints(&mut orig_nlp);
         let nlp_rc: Rc<RefCell<dyn IpoptNlp>> = Rc::new(RefCell::new(orig_nlp));
 
         let mut sqp_adapter = crate::sqp::IpoptNlpAdapter::new(Rc::clone(&nlp_rc));
@@ -2262,6 +2310,9 @@ impl IpoptApplication {
             }
         };
         orig_nlp.set_timing_stats(Rc::clone(&timing));
+        // Q6: decide which derivatives may be reused across iterates,
+        // before anything is evaluated (gh #588).
+        self.install_constant_derivative_hints(&mut orig_nlp);
 
         // Mirror upstream `OrigIpoptNLP::InitializeStructures` (IpOrigIpoptNLP.cpp:299):
         // bail out with NotEnoughDegreesOfFreedom when there are fewer free

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -237,12 +237,22 @@ pub const UNIMPLEMENTED_VALUES: &[UnimplementedValue] = &[UnimplementedValue {
 /// unaffected — but whose performance hint pounce does not exploit.
 /// These warn rather than fail: refusing them would stop a solve that
 /// returns the right result today, only a little slower.
-pub const UNEXPLOITED_HINTS: &[&str] = &[
-    "grad_f_constant",
-    "hessian_constant",
-    "jac_c_constant",
-    "jac_d_constant",
-];
+///
+/// **Empty since gh #588 phase Q6.** The four constant-derivative hints
+/// (`grad_f_constant`, `hessian_constant`, `jac_c_constant`,
+/// `jac_d_constant`) lived here and are now exploited:
+/// [`pounce_nlp::constant_derivatives`] reconciles each one against what
+/// the model can prove about its own algebra, and
+/// `OrigIpoptNlp` reuses the derivative across iterates when the answer
+/// is yes. A hint the model *disproves* still produces a warning — but a
+/// louder one, from that module, saying the hint was refused rather than
+/// merely unused.
+///
+/// The table stays because the shape is right for the next hint that
+/// arrives registered-but-unexploited, and because
+/// [`hint_warnings`] and its two membership tests are the mechanism that
+/// keeps such an option from going silent again.
+pub const UNEXPLOITED_HINTS: &[&str] = &[];
 
 /// An option set to something the registry says is not its default.
 ///
@@ -446,18 +456,29 @@ mod tests {
         assert!(msg.contains("CG-penalty"), "{msg}");
     }
 
-    /// Hints warn instead of failing: the answer is the same either way,
-    /// so blocking the solve would cost the user more than the silence
-    /// did.
+    /// The four constant-derivative hints left this table in gh #588 Q6.
+    /// They must not block a solve — that was never in question — and
+    /// they must no longer produce the "pounce does not exploit this"
+    /// warning, because pounce now does. What they earn instead (a
+    /// proof-backed refusal, or silent reuse) is asserted where it is
+    /// decided: `pounce_nlp::constant_derivatives` and
+    /// `pounce-cli/tests/unimplemented_options.rs`.
     #[test]
-    fn caching_hints_warn_but_do_not_refuse() {
+    fn the_constant_derivative_hints_are_no_longer_unexploited() {
         let (mut opts, reg) = fixture();
         opts.set_string_value("hessian_constant", "yes", true, false)
             .unwrap();
         assert_eq!(refusal(&opts, &reg), None, "a hint must not block a solve");
-        let warnings = hint_warnings(&opts, &reg);
-        assert_eq!(warnings.len(), 1, "{warnings:?}");
-        assert!(warnings[0].contains("hessian_constant"));
+        assert!(
+            hint_warnings(&opts, &reg).is_empty(),
+            "`hessian_constant` is exploited now; the unexploited-hint \
+             warning would contradict the reuse the solver actually does",
+        );
+        assert!(
+            UNEXPLOITED_HINTS.is_empty(),
+            "gh #588 Q6 emptied this table; an entry added back needs its \
+             own warning text and a test that the option is really unused",
+        );
     }
 
     /// `fast_step_computation` was in the refusal table for one commit,

--- a/crates/pounce-algorithm/tests/constant_derivative_hints.rs
+++ b/crates/pounce-algorithm/tests/constant_derivative_hints.rs
@@ -1,0 +1,202 @@
+//! The third state: a hint POUNCE can neither prove nor disprove
+//! (gh #588, phase Q6).
+//!
+//! `pounce-cli`'s corpus tests cover the two states an `.nl` model can
+//! reach — a proof of constancy (reuse without being asked) and a proof of
+//! variation (a warning, and the user's option refused). Neither is
+//! reachable from a *callback* TNLP: the C interface, the Python bridge and
+//! both GAMS links hand POUNCE numbers, so every proof comes back
+//! `Unknown`, and what the user asserts is all there is.
+//!
+//! Upstream Ipopt behaves this way for every model. POUNCE behaves this way
+//! only here, which makes this the one place the divergence *does not*
+//! apply — and therefore the one worth an end-to-end test, because
+//! "unproved" quietly turning into "refused" would break every front end
+//! the note says the win is actually on.
+//!
+//! The model below is a QP written as callbacks: a quadratic objective over
+//! a linear equality and a linear inequality. `∇²L` really is constant, so
+//! the assertion is true, and the counter proves POUNCE stopped asking for
+//! it — with the answer unchanged.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// `min x0² + 2x1² + x2²  s.t.  x0 + x1 + x2 == 3,  x0 − x1 <= 1`, as
+/// callbacks and nothing else. POUNCE sees no algebra here, so
+/// `derivative_proofs` keeps its declining default.
+#[derive(Default)]
+struct CallbackQp {
+    h_calls: usize,
+    jac_calls: usize,
+    final_obj: Option<Number>,
+    final_x: Option<Vec<Number>>,
+}
+
+impl TNLP for CallbackQp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 3,
+            m: 2,
+            nnz_jac_g: 5,
+            nnz_h_lag: 3,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-10.0; 3]);
+        b.x_u.copy_from_slice(&[10.0; 3]);
+        b.g_l.copy_from_slice(&[3.0, -2.0e19]);
+        b.g_u.copy_from_slice(&[3.0, 1.0]);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.0, 0.0, 0.0]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _: bool) -> Option<Number> {
+        Some(x[0] * x[0] + 2.0 * x[1] * x[1] + x[2] * x[2])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * x[0];
+        g[1] = 4.0 * x[1];
+        g[2] = 2.0 * x[2];
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] + x[1] + x[2];
+        g[1] = x[0] - x[1];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0, 0, 1, 1]);
+                jcol.copy_from_slice(&[0, 1, 2, 0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                self.jac_calls += 1;
+                values.copy_from_slice(&[1.0, 1.0, 1.0, 1.0, -1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 2]);
+                jcol.copy_from_slice(&[0, 1, 2]);
+            }
+            SparsityRequest::Values { values } => {
+                self.h_calls += 1;
+                values.copy_from_slice(&[2.0 * obj_factor, 4.0 * obj_factor, 2.0 * obj_factor]);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _: &IpoptData, _: &IpoptCq) {
+        self.final_obj = Some(sol.obj_value);
+        self.final_x = Some(sol.x.to_vec());
+    }
+}
+
+fn solve(hints: &[(&str, &str)]) -> (ApplicationReturnStatus, usize, usize, Number, Vec<Number>) {
+    let tnlp = Rc::new(RefCell::new(CallbackQp::default()));
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .expect("print_level");
+    for (k, v) in hints {
+        app.options_mut()
+            .set_string_value(k, v, true, false)
+            .unwrap_or_else(|_| panic!("set {k}"));
+    }
+    let status = app.optimize_tnlp(Rc::clone(&tnlp) as Rc<RefCell<dyn TNLP>>);
+    let t = tnlp.borrow();
+    (
+        status,
+        t.h_calls,
+        t.jac_calls,
+        t.final_obj.expect("objective"),
+        t.final_x.clone().expect("x"),
+    )
+}
+
+/// Baseline: no hint, no proof, so every iterate asks for `∇²L` and the
+/// Jacobian again. This is the number the assertion below has to beat, and
+/// pinning it here means the test cannot pass vacuously on a model that
+/// happened to converge in one step.
+#[test]
+fn without_a_hint_a_callback_model_is_re_evaluated_every_iterate() {
+    let (status, h, jac, _, _) = solve(&[]);
+    assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);
+    assert!(h > 1, "expected repeated Hessian evaluations, got {h}");
+    assert!(jac > 1, "expected repeated Jacobian evaluations, got {jac}");
+}
+
+/// The divergence does **not** apply where there is no proof. POUNCE has no
+/// way to check this model's algebra, so the user's assertion stands and the
+/// derivative is evaluated once — upstream's contract, and the case the
+/// design note says the win is actually on.
+#[test]
+fn an_unprovable_hint_is_honoured_on_trust() {
+    let (base_status, base_h, base_jac, base_obj, base_x) = solve(&[]);
+    let (status, h, jac, obj, x) = solve(&[
+        ("hessian_constant", "yes"),
+        ("jac_c_constant", "yes"),
+        ("jac_d_constant", "yes"),
+    ]);
+    assert_eq!(status, base_status);
+    assert_eq!(h, 1, "`hessian_constant=yes` must stop the re-evaluation");
+    // Two, not one: gradient-based scaling (the default
+    // `nlp_scaling_method`) asks the user TNLP for `∇g` at the starting
+    // point directly, before the NLP object and its caches exist. That
+    // probe is outside anything Q6 touches; the *algorithm* then evaluates
+    // once and reuses it for every iterate.
+    assert_eq!(jac, 2, "`jac_*_constant=yes` must stop the re-evaluation");
+    assert!(
+        base_h > h && base_jac > jac,
+        "hint made no difference: {base_h}/{base_jac} -> {h}/{jac}"
+    );
+
+    // The hint is true for this model, so honouring it must not move the
+    // answer by a single bit — a reused derivative is the *same* matrix,
+    // not an approximation of it.
+    assert_eq!(obj.to_bits(), base_obj.to_bits(), "objective moved");
+    for (a, b) in x.iter().zip(base_x.iter()) {
+        assert_eq!(a.to_bits(), b.to_bits(), "solution moved");
+    }
+}
+
+/// A hint set to its registered default asks for nothing and must not
+/// engage the reuse — the same rule the refusal table follows for every
+/// other option (`unimplemented_options::set_to_a_non_default`).
+#[test]
+fn writing_the_default_explicitly_asserts_nothing() {
+    let (_, h, jac, _, _) = solve(&[("hessian_constant", "no"), ("jac_c_constant", "no")]);
+    assert!(h > 1, "an explicit `no` must not enable reuse, got {h}");
+    assert!(jac > 1, "an explicit `no` must not enable reuse, got {jac}");
+}

--- a/crates/pounce-cli/src/counting_tnlp.rs
+++ b/crates/pounce-cli/src/counting_tnlp.rs
@@ -145,6 +145,16 @@ impl TNLP for CountingTnlp {
         self.inner.borrow_mut().get_number_of_nonlinear_variables()
     }
 
+    /// Transparent decorator: forward the constant-derivative proofs, or
+    /// `OrigIpoptNlp` asks this wrapper — which knows no algebra — and
+    /// gets the declining default, so gh #588 Q6's reuse never engages on
+    /// any model the CLI solves. Neither wrapper changes a row, a
+    /// variable or a derivative's value, so both directions of the proof
+    /// carry through unchanged.
+    fn derivative_proofs(&mut self) -> pounce_nlp::constant_derivatives::DerivativeProofs {
+        self.inner.borrow_mut().derivative_proofs()
+    }
+
     fn get_list_of_nonlinear_variables(&mut self, pos: &mut [Index]) -> bool {
         self.inner.borrow_mut().get_list_of_nonlinear_variables(pos)
     }

--- a/crates/pounce-cli/src/seeded_tnlp.rs
+++ b/crates/pounce-cli/src/seeded_tnlp.rs
@@ -99,6 +99,16 @@ impl TNLP for SeededTnlp {
     fn get_number_of_nonlinear_variables(&mut self) -> Index {
         self.inner.borrow_mut().get_number_of_nonlinear_variables()
     }
+
+    /// Transparent decorator: forward the constant-derivative proofs, or
+    /// `OrigIpoptNlp` asks this wrapper — which knows no algebra — and
+    /// gets the declining default, so gh #588 Q6's reuse never engages on
+    /// any model the CLI solves. Neither wrapper changes a row, a
+    /// variable or a derivative's value, so both directions of the proof
+    /// carry through unchanged.
+    fn derivative_proofs(&mut self) -> pounce_nlp::constant_derivatives::DerivativeProofs {
+        self.inner.borrow_mut().derivative_proofs()
+    }
     fn get_list_of_nonlinear_variables(&mut self, pos: &mut [Index]) -> bool {
         self.inner.borrow_mut().get_list_of_nonlinear_variables(pos)
     }

--- a/crates/pounce-cli/tests/constant_derivative_proofs.rs
+++ b/crates/pounce-cli/tests/constant_derivative_proofs.rs
@@ -1,0 +1,426 @@
+//! Q6's proofs, checked against the derivatives they are proofs *about*
+//! (gh #588).
+//!
+//! Q6 lets POUNCE evaluate a derivative once and reuse the answer for the
+//! rest of the solve, on the strength of a claim about the model's algebra:
+//! a body the recognizer proves is degree ≤ 1 has a gradient that does not
+//! move, and a model whose rows are all degree ≤ 1 has a `∇²L` that does not
+//! move either. If that claim is ever wrong, POUNCE hands the algorithm a
+//! stale matrix and converges somewhere else — silently, on a model no
+//! fixture asserts iteration counts for. That is precisely the failure mode
+//! upstream Ipopt ships by trusting the user, and the whole point of the
+//! phase is not to ship it ourselves.
+//!
+//! So the proofs are not argued here, they are **measured**, in the shape of
+//! Q3's, Q4's and Q5's differentials: every `.nl` file in the repository is
+//! loaded, asked what it can prove, and then the derivative it made a claim
+//! about is evaluated at several points — and, for `∇²L`, at several
+//! multiplier vectors, because `∇²L = σ∇²f + Σᵢλᵢ∇²gᵢ` depends on `λ` and a
+//! proof that ignored that would be a proof of the wrong thing.
+//!
+//! Both directions are checked, because both are load-bearing:
+//!
+//! * a `Constant` proof must hold **bit for bit** — a tolerance would be
+//!   meaningless when the shipped behaviour is literally to return the same
+//!   `Rc` again;
+//! * a `Varying` proof must be **witnessed** — some pair of probe points
+//!   where the derivative really does move. A spurious `Varying` is not a
+//!   wrong answer, but it makes POUNCE refuse a user's true hint with a
+//!   warning that says the model disproves it, which is its own way of
+//!   lying.
+//!
+//! `Unknown` is deliberately unchecked: it asserts nothing, which is the
+//! whole reason it exists as a third state.
+//!
+//! ### Why the proof is *not* gated on `is_expanded_quadratic`
+//!
+//! Q4's fast path is gated on already-expanded forms because *evaluating* a
+//! factored quadratic from stored coefficients cancels — `(x − 500000)²`
+//! loses five digits (gh #544). Q6 evaluates nothing from coefficients: it
+//! reuses the number the model's own tape produced. So the question here is
+//! only about the body's *degree*, and a factored `(x − a)²` answers it as
+//! well as an expanded one. `airport.nl`, the model that forced Q4's gate,
+//! is one of the models Q6 reaches — and this test is what turns that
+//! argument into evidence.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use pounce_cli::nl_reader::{NlProblem, NlTnlp, parse_nl_text_with_quadratic, read_nl_file};
+use pounce_nlp::constant_derivatives::{DerivativeProof, DerivativeProofs};
+use pounce_nlp::tnlp::{SparsityRequest, TNLP};
+
+// ---------------------------------------------------------------------
+// Probing
+// ---------------------------------------------------------------------
+
+/// A deterministic xorshift, so a failure is reproducible from its seed.
+struct Rng(u64);
+
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        (self.0 >> 11) as f64 / (1u64 << 52) as f64 * 4.0 - 2.0
+    }
+    fn vec(&mut self, n: usize) -> Vec<f64> {
+        (0..n).map(|_| self.next_f64()).collect()
+    }
+}
+
+/// Probe points: the model's own starting point plus perturbations. `x0`
+/// alone is not enough — a quadratic row probed where half its variables are
+/// zero hides half its coefficients.
+fn probe_points(prob: &NlProblem, k: usize, rng: &mut Rng) -> Vec<Vec<f64>> {
+    let mut out = vec![prob.x0.clone()];
+    for _ in 0..k {
+        out.push(prob.x0.iter().map(|&v| v + rng.next_f64()).collect());
+    }
+    out
+}
+
+fn bit_equal(a: f64, b: f64) -> bool {
+    if a.is_nan() || b.is_nan() {
+        return a.is_nan() && b.is_nan();
+    }
+    a.to_bits() == b.to_bits()
+}
+
+fn jac_structure(t: &mut NlTnlp, nnz: usize) -> (Vec<i32>, Vec<i32>) {
+    let (mut irow, mut jcol) = (vec![0i32; nnz], vec![0i32; nnz]);
+    assert!(t.eval_jac_g(
+        None,
+        true,
+        SparsityRequest::Structure {
+            irow: &mut irow,
+            jcol: &mut jcol,
+        },
+    ));
+    (irow, jcol)
+}
+
+fn all_fixtures() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().is_some_and(|x| x == "nl") {
+                out.push(p);
+            }
+        }
+    }
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut out = Vec::new();
+    walk(&base.join("fixtures"), &mut out);
+    walk(&base.join("fixtures_issue_49"), &mut out);
+    out.sort();
+    out
+}
+
+/// Corpus-wide census, printed so the reach of the phase is a number in the
+/// log rather than a claim in a commit message.
+#[derive(Default)]
+struct Census {
+    models: usize,
+    grad_f_constant: usize,
+    grad_f_varying: usize,
+    grad_f_unknown: usize,
+    hessian_constant: usize,
+    hessian_varying: usize,
+    hessian_unknown: usize,
+    rows_constant: usize,
+    rows_varying: usize,
+    rows_unknown: usize,
+    /// Derivative values compared across probe points.
+    values_compared: usize,
+    /// `Varying` proofs for which a witness was found, and the ones for
+    /// which the probe grid happened not to separate two points.
+    witnessed: usize,
+    unwitnessed: usize,
+}
+
+/// The whole phase, over the whole corpus: every `Constant` proof holds bit
+/// for bit at every probe point, and every `Varying` proof is witnessed.
+#[test]
+fn every_proof_holds_over_the_fixture_corpus() {
+    let mut census = Census::default();
+    for path in all_fixtures() {
+        check_model(&path, &mut census);
+    }
+
+    println!(
+        "constant-derivative proofs over {} models:\n  \
+         grad_f  constant {:>4}  varying {:>4}  unknown {:>4}\n  \
+         hessian constant {:>4}  varying {:>4}  unknown {:>4}\n  \
+         rows    constant {:>4}  varying {:>4}  unknown {:>4}\n  \
+         {} derivative values compared across probe points; \
+         {} varying proofs witnessed, {} not separated by the probe grid",
+        census.models,
+        census.grad_f_constant,
+        census.grad_f_varying,
+        census.grad_f_unknown,
+        census.hessian_constant,
+        census.hessian_varying,
+        census.hessian_unknown,
+        census.rows_constant,
+        census.rows_varying,
+        census.rows_unknown,
+        census.values_compared,
+        census.witnessed,
+        census.unwitnessed,
+    );
+
+    // Reach floors. Not the point of the test, but a proof set that
+    // silently collapsed to "everything Unknown" would still pass every
+    // assertion above, and the phase would be a no-op nobody noticed.
+    assert!(
+        census.models >= 40,
+        "corpus shrank: {} models",
+        census.models
+    );
+    assert!(
+        census.grad_f_constant + census.hessian_constant >= 10,
+        "the objective-side proofs went quiet: {} + {}",
+        census.grad_f_constant,
+        census.hessian_constant
+    );
+    assert!(
+        census.rows_constant >= 100,
+        "row proofs went quiet: {}",
+        census.rows_constant
+    );
+    assert!(
+        census.values_compared >= 10_000,
+        "not enough was actually compared: {}",
+        census.values_compared
+    );
+}
+
+fn check_model(path: &Path, census: &mut Census) {
+    let Ok(prob) = read_nl_file(path) else { return };
+    let (n, m) = (prob.n, prob.m);
+    if n == 0 {
+        return;
+    }
+    let Ok(mut t) = NlTnlp::try_new(prob.clone()) else {
+        return;
+    };
+    let Some(info) = t.get_nlp_info() else { return };
+    let proofs = t.derivative_proofs();
+    census.models += 1;
+    let name = path.display();
+
+    let mut rng = Rng(0x9e37_79b9_5eed_1234);
+    let points = probe_points(&prob, 4, &mut rng);
+    // Multiplier vectors, so the `∇²L` claim is tested against the `λ` it
+    // actually depends on and not only against `x`.
+    let lambdas: Vec<Vec<f64>> = (0..points.len()).map(|_| rng.vec(m)).collect();
+
+    match proofs.grad_f {
+        DerivativeProof::Constant => census.grad_f_constant += 1,
+        DerivativeProof::Varying => census.grad_f_varying += 1,
+        DerivativeProof::Unknown => census.grad_f_unknown += 1,
+    }
+    match proofs.hessian {
+        DerivativeProof::Constant => census.hessian_constant += 1,
+        DerivativeProof::Varying => census.hessian_varying += 1,
+        DerivativeProof::Unknown => census.hessian_unknown += 1,
+    }
+    for i in 0..m {
+        match proofs.row(i) {
+            DerivativeProof::Constant => census.rows_constant += 1,
+            DerivativeProof::Varying => census.rows_varying += 1,
+            DerivativeProof::Unknown => census.rows_unknown += 1,
+        }
+    }
+
+    // ---- ∇f ----
+    let grads: Vec<Vec<f64>> = points
+        .iter()
+        .map(|x| {
+            let mut g = vec![0.0; n];
+            assert!(t.eval_grad_f(x, true, &mut g), "{name}: eval_grad_f");
+            g
+        })
+        .collect();
+    check_claim(&format!("{name}: ∇f"), proofs.grad_f, &grads, census);
+
+    // ---- ∇g, per row ----
+    if m > 0 && info.nnz_jac_g > 0 {
+        let (irow, _) = jac_structure(&mut t, info.nnz_jac_g as usize);
+        let jacs: Vec<Vec<f64>> = points
+            .iter()
+            .map(|x| {
+                let mut v = vec![0.0; info.nnz_jac_g as usize];
+                assert!(
+                    t.eval_jac_g(Some(x), true, SparsityRequest::Values { values: &mut v }),
+                    "{name}: eval_jac_g"
+                );
+                v
+            })
+            .collect();
+        // Group the flat triplet values by row once, then compare per row:
+        // a per-row proof is only about that row's entries.
+        let mut by_row: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+        for (k, &r) in irow.iter().enumerate() {
+            by_row.entry(r).or_default().push(k);
+        }
+        for (row, slots) in &by_row {
+            // `NlTnlp` reports `IndexStyle::C`, so the triplet rows are
+            // already the model's own 0-based row numbers.
+            let i = *row as usize;
+            if i >= m {
+                continue;
+            }
+            let series: Vec<Vec<f64>> = jacs
+                .iter()
+                .map(|v| slots.iter().map(|&k| v[k]).collect())
+                .collect();
+            check_claim(
+                &format!("{name}: ∇g row {i}"),
+                proofs.row(i),
+                &series,
+                census,
+            );
+        }
+    }
+
+    // ---- ∇²L ----
+    if info.nnz_h_lag > 0 {
+        let nnz = info.nnz_h_lag as usize;
+        let mut hs: Vec<Vec<f64>> = Vec::new();
+        let mut ok = true;
+        for (p, x) in points.iter().enumerate() {
+            let mut v = vec![0.0; nnz];
+            let lam = &lambdas[p];
+            if !t.eval_h(
+                Some(x),
+                true,
+                1.0,
+                Some(lam),
+                true,
+                SparsityRequest::Values { values: &mut v },
+            ) {
+                ok = false;
+                break;
+            }
+            hs.push(v);
+        }
+        if ok {
+            check_claim(&format!("{name}: ∇²L"), proofs.hessian, &hs, census);
+        }
+    }
+}
+
+/// One claim against one series of evaluations, one entry per probe point.
+fn check_claim(what: &str, proof: DerivativeProof, series: &[Vec<f64>], census: &mut Census) {
+    if series.len() < 2 || series[0].is_empty() {
+        return;
+    }
+    let mut moved = false;
+    for later in &series[1..] {
+        for (k, (&a, &b)) in series[0].iter().zip(later.iter()).enumerate() {
+            census.values_compared += 1;
+            if bit_equal(a, b) {
+                continue;
+            }
+            moved = true;
+            assert_ne!(
+                proof,
+                DerivativeProof::Constant,
+                "{what}: proved constant, but entry {k} moved between probe \
+                 points: {a:?} -> {b:?}. Q6 would have reused the first value \
+                 for the whole solve.",
+            );
+        }
+    }
+    match proof {
+        DerivativeProof::Varying if moved => census.witnessed += 1,
+        // Not a failure: a genuinely quadratic row whose only free
+        // variables happen to be fixed at these probe points, or a `∇²L`
+        // whose moving entries all cancel, will not separate. It is
+        // recorded so the number is visible rather than assumed.
+        DerivativeProof::Varying => census.unwitnessed += 1,
+        _ => {}
+    }
+}
+
+/// A `Varying` proof is what makes POUNCE refuse a user's hint, so at least
+/// some of them have to be real, and demonstrably so. The corpus-wide test
+/// counts them; this one fails if that count ever drops to nothing, which is
+/// the state in which the divergence from upstream would be theatre.
+#[test]
+fn varying_proofs_are_witnessed_by_the_corpus() {
+    let mut census = Census::default();
+    for path in all_fixtures() {
+        check_model(&path, &mut census);
+    }
+    assert!(
+        census.witnessed >= 20,
+        "only {} varying proofs were witnessed by a derivative that actually \
+         moved; a warn-and-ignore that never fires on real algebra is not a \
+         feature",
+        census.witnessed
+    );
+}
+
+/// The proofs must not depend on whether the parser recognized a body at
+/// parse time — that is a memory optimization (Q5), not a change of algebra.
+/// If the two disagreed, `POUNCE_DBG_NO_QUAD=1` would silently change how
+/// often derivatives are evaluated, and the A/B switch every phase of this
+/// series is measured with would stop being an A/B.
+#[test]
+fn parse_time_recognition_does_not_move_a_single_proof() {
+    let mut checked = 0usize;
+    for path in all_fixtures() {
+        let Ok(txt) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let (Ok(pq), Ok(pt)) = (
+            parse_nl_text_with_quadratic(&txt, true),
+            parse_nl_text_with_quadratic(&txt, false),
+        ) else {
+            continue;
+        };
+        if pq.n == 0 {
+            continue;
+        }
+        let (Ok(mut a), Ok(mut b)) = (NlTnlp::try_new(pq), NlTnlp::try_new(pt)) else {
+            continue;
+        };
+        let (pa, pb): (DerivativeProofs, DerivativeProofs) =
+            (a.derivative_proofs(), b.derivative_proofs());
+        assert_eq!(
+            pa,
+            pb,
+            "{}: proofs moved with parse-time recognition",
+            path.display()
+        );
+        checked += 1;
+    }
+    assert!(checked >= 40, "only {checked} models compared");
+}
+
+/// The three states, spelled out on models small enough to read.
+///
+/// These are the cases the reconciliation table in
+/// `pounce_nlp::constant_derivatives` is written against, so they are pinned
+/// against the actual recognizer rather than against a mock of it.
+#[test]
+fn the_three_states_on_hand_written_models() {
+    // `min x0` s.t. `x0·x1 = 1` — affine objective (constant ∇f), a
+    // genuinely bilinear row (∇g varies, so ∇²L varies).
+    let bilinear = "g3 0 1 0\n 2 1 1 0 1\n 1 1\n 0 1\n 2 2 2\n 0 0 0 1\n 0 0 0 0 0\n 2 1\n 0 0\n 0 0\n\
+                    C0\no2\nv0\nv1\nO0 0\nn0\nx2\n0 1.0\n1 1.0\nr\n4 1\nb\n3\n3\nk1\n2\nJ0 2\n0 0\n1 0\nG0 2\n0 1\n1 0\n";
+    let p = parse_nl_text_with_quadratic(bilinear, true).expect("parse bilinear");
+    let mut t = NlTnlp::try_new(p).expect("build bilinear");
+    let pr = t.derivative_proofs();
+    assert_eq!(pr.grad_f, DerivativeProof::Constant, "affine objective");
+    assert_eq!(pr.row(0), DerivativeProof::Varying, "bilinear row");
+    assert_eq!(pr.hessian, DerivativeProof::Varying, "λ-dependent ∇²L");
+}

--- a/crates/pounce-cli/tests/unimplemented_options.rs
+++ b/crates/pounce-cli/tests/unimplemented_options.rs
@@ -121,15 +121,92 @@ fn knobs_on_implemented_features_still_solve() {
     }
 }
 
-/// A caching hint warns and solves: ignoring it costs evaluations, never
-/// correctness, so blocking the run would be a worse trade than the
-/// silence was.
+/// The four constant-derivative hints used to warn "pounce does not
+/// exploit this" and re-evaluate anyway. gh #588 Q6 exploits them, and
+/// this pin flips with it: what a hint earns now is decided by the
+/// model's own algebra, and what it earns is *measured in evaluations*
+/// rather than asserted from a warning string.
+///
+/// `user_scaling_suffix.nl` has a `∇²L` POUNCE proves is not constant,
+/// so asserting `hessian_constant=yes` on it is the case upstream Ipopt
+/// honours — reusing a Hessian that genuinely moves — and the case
+/// POUNCE refuses. The solve must still succeed: the option is ignored,
+/// not fatal.
 #[test]
-fn a_caching_hint_warns_but_solves() {
+fn a_disproved_caching_hint_is_refused_with_a_warning() {
     let (code, err) = run("user_scaling_suffix.nl", "hint", &["hessian_constant=yes"]);
     assert_eq!(code, Some(0), "stderr:\n{err}");
     assert!(err.contains("warning"), "stderr:\n{err}");
     assert!(err.contains("hessian_constant"), "stderr:\n{err}");
+    assert!(
+        err.contains("ignoring"),
+        "the warning must say the hint was refused, not merely unused; \
+         stderr:\n{err}"
+    );
+}
+
+/// The other half of the flip, and the half a string match cannot reach:
+/// a model whose `∇²L` and Jacobian POUNCE *proves* constant is evaluated
+/// **once**, with no option set at all.
+///
+/// `nonconvex_qp.nl` is a quadratic objective over linear rows forced
+/// down the NLP path (the convex-QP route would not exercise this), so
+/// `∇²L = σ∇²f` and every row's gradient is a constant vector. The
+/// assertion is `num_hess_evals == 1` against an iteration count well
+/// above 1 — before Q6 both counters tracked the iterations.
+#[test]
+fn a_proved_constant_hessian_is_evaluated_once() {
+    let dir = std::env::temp_dir().join("pounce_unimplopt_constderiv");
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join("nonconvex_qp.nl");
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures/nonconvex_qp.nl");
+    std::fs::copy(&fixture, &nl).expect("copy fixture");
+    let json = dir.join("out.json");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .arg("--json-output")
+        .arg(&json)
+        .arg("print_level=0")
+        .output()
+        .expect("run pounce");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = std::fs::read_to_string(&json).expect("json report");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    // Small, flat JSON: pull the three integers out without a parser
+    // dependency this test crate does not otherwise have.
+    fn field(text: &str, key: &str) -> i64 {
+        let at = text
+            .find(&format!("\"{key}\""))
+            .unwrap_or_else(|| panic!("`{key}` missing from report:\n{text}"));
+        let rest = &text[at + key.len() + 2..];
+        let start = rest.find(':').expect("colon") + 1;
+        let end = rest[start..]
+            .find([',', '}'])
+            .map(|e| start + e)
+            .unwrap_or(rest.len());
+        rest[start..end].trim().parse().expect("integer field")
+    }
+    let iters = field(&text, "iteration_count");
+    let hess = field(&text, "num_hess_evals");
+    let jac = field(&text, "num_constr_jac_evals");
+    assert!(iters > 1, "expected a multi-iteration solve, got {iters}");
+    assert_eq!(
+        hess, 1,
+        "`∇²L` is provably constant on this model; it must be evaluated \
+         once and reused for all {iters} iterations"
+    );
+    assert_eq!(
+        jac, 1,
+        "every row is linear; the Jacobian must be evaluated once (got \
+         {jac} over {iters} iterations)"
+    );
 }
 
 /// The guard runs before routing: a convex-QP model dispatches to

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -34,10 +34,11 @@
 
 use crate::nl_quadratic::{
     Quad2, QuadForm, QuadHessian, analyze_quadratic_full, is_expanded_quadratic, is_trivially_zero,
-    quad_form_readout,
+    quad_form_readout, recognize_expr,
 };
 use crate::nl_tape::{HybridTape, Tape, hybrid_supported};
 use pounce_common::types::{Index, Number, lower_bound_present, upper_bound_present};
+use pounce_nlp::constant_derivatives::{DerivativeProof, DerivativeProofs};
 use pounce_nlp::quadratic::QuadraticStructure;
 use pounce_nlp::tnlp::{
     BoundsInfo, IDX_NAMES, IndexStyle, IpoptCq, IpoptData, Linearity, MetaData, NlpInfo,
@@ -387,6 +388,41 @@ impl NlBody {
                 analyze_quadratic_full(e)
             }
             NlBody::Quad(q) => Some(quad_form_readout(&q.form)),
+        }
+    }
+
+    /// Whether this body is provably **affine** — degree ≤ 1 — as a
+    /// three-valued answer: `Some(true)` proved affine, `Some(false)`
+    /// proved to have a nonzero second derivative, `None` no proof
+    /// either way.
+    ///
+    /// This is the degree question *without* the exactness gate
+    /// [`Self::admitted_quad_form`] applies, and the difference is the
+    /// point (gh #588, Q6). That gate exists because reading a value out
+    /// of stored coefficients cancels for a factored form; nothing is
+    /// read out here. The answer is used to decide whether a derivative
+    /// may be **reused** across iterates — a question about the
+    /// *degree* of the body, which a factored `(x − a)²` answers just as
+    /// well as an expanded one.
+    ///
+    /// `None` is not evidence of nonlinearity: the recognizer refuses
+    /// `2·(x + 1)`, which is affine. Consumers must treat it as "not
+    /// established".
+    ///
+    /// Deliberately answers from the term maps rather than from
+    /// [`Self::analyze_quadratic_full`]'s triplets: on `qssp180` that is
+    /// 65 341 recognized rows, and materializing a `QuadHessian` per row
+    /// to ask whether it is empty is the allocation-per-object cost Q3
+    /// removed from the recognizer in the first place.
+    pub fn provably_affine(&self) -> Option<bool> {
+        match self {
+            NlBody::Tree(e) => {
+                if is_trivially_zero(e) {
+                    return Some(true);
+                }
+                recognize_expr(e).map(|q| q.quadratic().is_empty())
+            }
+            NlBody::Quad(q) => Some(q.form.quadratic().is_empty()),
         }
     }
 
@@ -5484,6 +5520,51 @@ impl TNLP for NlTnlp {
         }
         pos_nonlin_vars[..list.len()].copy_from_slice(&list);
         true
+    }
+
+    fn derivative_proofs(&mut self) -> DerivativeProofs {
+        // Degree is the whole argument (gh #588, Q6). A body proved
+        // degree ≤ 1 has a constant gradient and no second derivative; a
+        // body proved degree 2 has a nonzero second derivative, hence a
+        // gradient that moves. A body the recognizer refuses is
+        // `Unknown` — and `Unknown` must stay `Unknown`, because the
+        // refusal is structural, not a finding of nonlinearity.
+        fn proof(affine: Option<bool>) -> DerivativeProof {
+            match affine {
+                Some(true) => DerivativeProof::Constant,
+                Some(false) => DerivativeProof::Varying,
+                None => DerivativeProof::Unknown,
+            }
+        }
+        let obj_affine = self.prob.obj_nonlinear.provably_affine();
+        let jac: Vec<DerivativeProof> = self
+            .prob
+            .con_nonlinear
+            .iter()
+            .map(|b| proof(b.provably_affine()))
+            .collect();
+
+        // `∇²L = σ·∇²f + Σᵢ λᵢ·∇²gᵢ`. One row proved genuinely quadratic
+        // makes `∇²L` a non-constant function of `λ` — this is the QCQP
+        // case, and it is exactly the assertion Ipopt would honour and
+        // get wrong (§4 Lever 2). Otherwise every row must be *proved*
+        // affine and the objective *proved* degree ≤ 2, at which point
+        // `∇²L = σ·∇²f`, constant for a given `σ`; the caller keys its
+        // reuse on `σ` because the restoration phase passes a different
+        // one.
+        let hessian = if jac.iter().any(|&p| p == DerivativeProof::Varying) {
+            DerivativeProof::Varying
+        } else if obj_affine.is_some() && jac.iter().all(|&p| p == DerivativeProof::Constant) {
+            DerivativeProof::Constant
+        } else {
+            DerivativeProof::Unknown
+        };
+
+        DerivativeProofs {
+            grad_f: proof(obj_affine),
+            hessian,
+            jac,
+        }
     }
 }
 

--- a/crates/pounce-nlp/src/constant_derivatives.rs
+++ b/crates/pounce-nlp/src/constant_derivatives.rs
@@ -1,0 +1,348 @@
+//! The four upstream constant-derivative hints, and what pounce can
+//! *prove* about them.
+//!
+//! Ipopt registers `grad_f_constant`, `hessian_constant`,
+//! `jac_c_constant` and `jac_d_constant` as unchecked user assertions:
+//! setting one makes the solver evaluate that derivative once and reuse
+//! it forever, and if the assertion is false the answer is silently
+//! wrong — a Hessian frozen at the starting point is still *a* matrix,
+//! and the algorithm converges to something with it. pounce until now
+//! did the opposite and equally unhelpful thing: it warned that the hint
+//! was ignored and re-evaluated regardless (gh #483,
+//! `unimplemented_options::UNEXPLOITED_HINTS`).
+//!
+//! This module is the middle road, and it is a deliberate divergence
+//! from upstream (gh #588, phase Q6). A model that knows its own algebra
+//! — an `.nl` file, whose bodies the degree-≤2 recognizer reads exactly —
+//! can *prove* the hint, and then the hint needs no user at all. It can
+//! also prove the hint **false**, and then honouring it would produce
+//! the wrong Hessian on purpose.
+//!
+//! # Three states, not two
+//!
+//! The reconciliation is over [`DerivativeProof`], which is three-valued,
+//! because the two-valued reading is a bug in each direction:
+//!
+//! | proof | user asserted | pounce does |
+//! |---|---|---|
+//! | `Constant` | yes or no | **reuses** the derivative — the option is not needed |
+//! | `Varying` | no | evaluates every iterate |
+//! | `Varying` | yes | **warns and ignores** — the divergence |
+//! | `Unknown` | no | evaluates every iterate |
+//! | `Unknown` | yes | **honours it on trust** — upstream's contract |
+//!
+//! The last row is the one that keeps this honest. A callback TNLP, the
+//! C interface and both GAMS links hand pounce numbers, not algebra:
+//! there is nothing to read a proof off, and `Unknown` is the truthful
+//! answer. Overriding a user there — refusing a hint pounce merely
+//! cannot confirm — would be its own silent wrong answer, one level up.
+//! `Unknown` is emphatically **not** "varies"; it is "not established".
+//!
+//! # What counts as proof
+//!
+//! Degree. A body the recognizer proves is degree ≤ 1 has a constant
+//! gradient and a zero Hessian; one it proves is degree 2 has a Hessian
+//! that is nonzero, hence a gradient that genuinely moves. A body it
+//! refuses is `Unknown` — the refusal is not evidence of nonlinearity
+//! (`is_expanded_quadratic` refuses `2·(x + 1)`, which is affine).
+//!
+//! Note which gate this is. Q4's `is_expanded_quadratic` gate exists
+//! because *evaluating* a factored form from stored coefficients cancels
+//! (`(x − 500000)²` loses five digits, gh #544). Q6 evaluates nothing
+//! from coefficients: it reuses the value the model's own tape produced
+//! at the first call. So the gate that applies here is the weaker,
+//! ungated degree question — which is why `airport.nl`, a factored
+//! model Q4 must refuse, is one of the models Q6 reaches.
+
+use pounce_common::types::Index;
+
+/// What a model can prove about one derivative's constancy.
+///
+/// Three-valued on purpose; see the module docs. `Unknown` is the
+/// default because it is what a model that has not been asked, or
+/// cannot answer, truthfully reports.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DerivativeProof {
+    /// No proof either way. **Not** a claim that the derivative varies.
+    #[default]
+    Unknown,
+    /// Proved to be the same function value at every point pounce will
+    /// evaluate it at.
+    Constant,
+    /// Proved to depend on its arguments.
+    Varying,
+}
+
+impl DerivativeProof {
+    /// The proof for a derivative assembled from several independent
+    /// pieces — a Jacobian block over its rows, or `∇²L` over the
+    /// objective and the rows it sums.
+    ///
+    /// One proved-varying piece proves the whole thing varies, whatever
+    /// the others say; otherwise every piece must be proved constant,
+    /// because a single `Unknown` leaves the sum unestablished.
+    pub fn all(pieces: impl IntoIterator<Item = DerivativeProof>) -> DerivativeProof {
+        let mut out = DerivativeProof::Constant;
+        for p in pieces {
+            match p {
+                DerivativeProof::Varying => return DerivativeProof::Varying,
+                DerivativeProof::Unknown => out = DerivativeProof::Unknown,
+                DerivativeProof::Constant => {}
+            }
+        }
+        out
+    }
+
+    /// Weaken a `Varying` proof to `Unknown`, keeping the other two.
+    ///
+    /// Used where a transformation below the proof can only *remove*
+    /// variation — fixed-variable elimination is the case that matters:
+    /// a row `x·y` with `y` fixed to a parameter has a constant gradient
+    /// in the reduced space the algorithm actually sees, so the
+    /// full-space proof that it varies no longer holds. Constancy
+    /// survives such a transformation; a proof of variation does not.
+    pub fn forget_variation(self) -> DerivativeProof {
+        match self {
+            DerivativeProof::Varying => DerivativeProof::Unknown,
+            other => other,
+        }
+    }
+}
+
+/// What one model proves about its own derivatives, in the model's own
+/// (full, pre-split) row order.
+///
+/// Returned by [`crate::tnlp::TNLP::derivative_proofs`]. The default —
+/// everything `Unknown`, no rows — is what a TNLP that has only
+/// callbacks to offer honestly reports, and is what every TNLP reports
+/// until it overrides the method.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DerivativeProofs {
+    /// Proof for `∇f`. The `grad_f_constant` hint.
+    pub grad_f: DerivativeProof,
+    /// Proof for `∇²L` **as a whole** — objective and rows together.
+    /// The `hessian_constant` hint.
+    pub hessian: DerivativeProof,
+    /// Proof for `∇gᵢ`, one entry per constraint row in the TNLP's own
+    /// row order. Empty means "declined", which is the same answer as
+    /// `m` `Unknown`s and costs no allocation.
+    pub jac: Vec<DerivativeProof>,
+}
+
+impl DerivativeProofs {
+    /// The proof for row `i`, treating an empty [`Self::jac`] as
+    /// `Unknown`.
+    pub fn row(&self, i: usize) -> DerivativeProof {
+        self.jac.get(i).copied().unwrap_or_default()
+    }
+}
+
+/// Which derivatives one solve will reuse across iterates.
+///
+/// This is the *resolved* answer — proof reconciled with the user's four
+/// options — and the only thing [`crate::orig_ipopt_nlp::OrigIpoptNlp`]
+/// reads. Default: reuse nothing, i.e. exactly the behaviour every
+/// pounce release before gh #588 Q6 had.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ConstantDerivatives {
+    pub grad_f: bool,
+    pub hessian: bool,
+    pub jac_c: bool,
+    pub jac_d: bool,
+}
+
+impl ConstantDerivatives {
+    /// True when nothing is reused — the pre-Q6 behaviour, and the case
+    /// every hot path can skip.
+    pub fn is_empty(&self) -> bool {
+        !(self.grad_f || self.hessian || self.jac_c || self.jac_d)
+    }
+}
+
+/// The registered option names, in the order [`reconcile`] takes and
+/// returns them.
+pub const HINT_OPTIONS: [&str; 4] = [
+    "grad_f_constant",
+    "hessian_constant",
+    "jac_c_constant",
+    "jac_d_constant",
+];
+
+/// What became of one hint, for reporting to the user.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HintOutcome {
+    /// The registered option name.
+    pub name: &'static str,
+    /// Whether the user set it to a non-default (i.e. asserted it).
+    pub asserted: bool,
+    /// What the model proved.
+    pub proof: DerivativeProof,
+    /// Whether pounce will reuse the derivative.
+    pub honoured: bool,
+}
+
+impl HintOutcome {
+    /// The user asserted a hint the model disproves. This is the case
+    /// upstream honours silently and pounce refuses.
+    pub fn contradicted(&self) -> bool {
+        self.asserted && self.proof == DerivativeProof::Varying
+    }
+
+    /// The user asserted a hint pounce can neither confirm nor refute,
+    /// and it is being taken on trust.
+    pub fn trusted(&self) -> bool {
+        self.asserted && self.proof == DerivativeProof::Unknown
+    }
+
+    /// pounce proved the hint without being asked. Nothing to report to
+    /// the user; worth a debug line.
+    pub fn auto_detected(&self) -> bool {
+        !self.asserted && self.proof == DerivativeProof::Constant
+    }
+
+    /// The message a contradicted hint earns, or `None`.
+    pub fn warning(&self) -> Option<String> {
+        if !self.contradicted() {
+            return None;
+        }
+        Some(format!(
+            "pounce: warning: ignoring `{}=yes` — pounce proved from the \
+             model's own algebra that this derivative is not constant, so \
+             reusing it would return a wrong answer rather than a slow one. \
+             Ipopt honours this hint without checking it. Remove the option; \
+             pounce detects a genuinely constant derivative on its own and \
+             needs no hint to reuse it. (gh#588)",
+            self.name
+        ))
+    }
+}
+
+/// Reconcile what the model proved with what the user asserted.
+///
+/// `proofs` and `asserted` are both in [`HINT_OPTIONS`] order. The rule
+/// is the table in the module docs: proof wins in both directions where
+/// there is one, and the user's assertion decides only where there is
+/// none.
+pub fn reconcile(
+    proofs: [DerivativeProof; 4],
+    asserted: [bool; 4],
+) -> ([HintOutcome; 4], ConstantDerivatives) {
+    let mut outcomes = [HintOutcome {
+        name: "",
+        asserted: false,
+        proof: DerivativeProof::Unknown,
+        honoured: false,
+    }; 4];
+    for k in 0..4 {
+        let honoured = match proofs[k] {
+            DerivativeProof::Constant => true,
+            DerivativeProof::Varying => false,
+            DerivativeProof::Unknown => asserted[k],
+        };
+        outcomes[k] = HintOutcome {
+            name: HINT_OPTIONS[k],
+            asserted: asserted[k],
+            proof: proofs[k],
+            honoured,
+        };
+    }
+    let enabled = ConstantDerivatives {
+        grad_f: outcomes[0].honoured,
+        hessian: outcomes[1].honoured,
+        jac_c: outcomes[2].honoured,
+        jac_d: outcomes[3].honoured,
+    };
+    (outcomes, enabled)
+}
+
+/// Fold per-row proofs into the equality / inequality split the
+/// algorithm actually evaluates.
+///
+/// `rows` are indices into the model's own row order — `c_map` or
+/// `d_map` from the bound classification. An empty subsystem is
+/// vacuously constant: there is no Jacobian block to re-evaluate.
+pub fn subsystem_proof(proofs: &DerivativeProofs, rows: &[Index]) -> DerivativeProof {
+    DerivativeProof::all(rows.iter().map(|&i| proofs.row(i as usize)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_is_dominated_by_a_proof_of_variation() {
+        use DerivativeProof::*;
+        assert_eq!(DerivativeProof::all([Constant, Constant]), Constant);
+        assert_eq!(DerivativeProof::all([Constant, Unknown]), Unknown);
+        assert_eq!(DerivativeProof::all([Unknown, Varying]), Varying);
+        assert_eq!(DerivativeProof::all([Varying, Unknown]), Varying);
+        // Vacuous: nothing to re-evaluate.
+        assert_eq!(DerivativeProof::all([]), Constant);
+    }
+
+    #[test]
+    fn forgetting_variation_keeps_the_other_two() {
+        use DerivativeProof::*;
+        assert_eq!(Varying.forget_variation(), Unknown);
+        assert_eq!(Constant.forget_variation(), Constant);
+        assert_eq!(Unknown.forget_variation(), Unknown);
+    }
+
+    /// The heart of the phase: a proof beats the user in both
+    /// directions, and only where there is no proof does the user decide.
+    #[test]
+    fn proof_beats_the_user_in_both_directions() {
+        use DerivativeProof::*;
+        let (out, en) = reconcile(
+            [Constant, Varying, Unknown, Unknown],
+            [false, true, true, false],
+        );
+        // Proved constant without being asked: reused anyway.
+        assert!(out[0].honoured && out[0].auto_detected());
+        // Proved varying and asserted: refused, and it warns.
+        assert!(!out[1].honoured);
+        assert!(out[1].contradicted());
+        assert!(
+            out[1]
+                .warning()
+                .is_some_and(|w| w.contains("hessian_constant"))
+        );
+        // Unknown and asserted: honoured on trust, silently.
+        assert!(out[2].honoured && out[2].trusted());
+        assert!(out[2].warning().is_none());
+        // Unknown and not asserted: nothing happens.
+        assert!(!out[3].honoured);
+        assert_eq!(
+            en,
+            ConstantDerivatives {
+                grad_f: true,
+                hessian: false,
+                jac_c: true,
+                jac_d: false,
+            }
+        );
+        assert!(!en.is_empty());
+    }
+
+    #[test]
+    fn a_default_options_list_over_a_silent_model_reuses_nothing() {
+        let (out, en) = reconcile([DerivativeProof::Unknown; 4], [false; 4]);
+        assert!(en.is_empty());
+        assert!(out.iter().all(|o| o.warning().is_none()));
+    }
+
+    #[test]
+    fn an_empty_subsystem_is_vacuously_constant() {
+        let p = DerivativeProofs {
+            jac: vec![DerivativeProof::Varying, DerivativeProof::Constant],
+            ..Default::default()
+        };
+        assert_eq!(subsystem_proof(&p, &[]), DerivativeProof::Constant);
+        assert_eq!(subsystem_proof(&p, &[1]), DerivativeProof::Constant);
+        assert_eq!(subsystem_proof(&p, &[0, 1]), DerivativeProof::Varying);
+        // Out of range reads as Unknown rather than panicking: a model
+        // that answered for fewer rows than it has has declined for the
+        // rest.
+        assert_eq!(subsystem_proof(&p, &[5]), DerivativeProof::Unknown);
+    }
+}

--- a/crates/pounce-nlp/src/lib.rs
+++ b/crates/pounce-nlp/src/lib.rs
@@ -22,6 +22,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod alg_types;
+pub mod constant_derivatives;
 pub mod derivative_test;
 pub mod expression_provider;
 pub mod ipopt_nlp;
@@ -34,6 +35,9 @@ pub mod tnlp;
 pub mod tnlp_adapter;
 
 pub use alg_types::SolverReturn;
+pub use constant_derivatives::{
+    ConstantDerivatives, DerivativeProof, DerivativeProofs, HintOutcome,
+};
 pub use expression_provider::{ExpressionProvider, FbbtOp, FbbtTape};
 pub use ipopt_nlp::{IpoptNlp, Nlp};
 pub use orig_ipopt_nlp::{ConstObjScaling, NlpScaling, NoScaling, OrigIpoptNlp};

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -57,6 +57,9 @@
 //!   `fixed_variable_treatment` knob lands when the option machinery
 //!   does.
 
+use crate::constant_derivatives::{
+    ConstantDerivatives, DerivativeProof, DerivativeProofs, subsystem_proof,
+};
 use crate::ipopt_nlp::{IpoptNlp, Nlp, SplitNames};
 use crate::tnlp::{IDX_NAMES, MetaData, NlpInfo, ScalingRequest, SparsityRequest, StartingPoint};
 use crate::tnlp_adapter::{BoundClassification, TNLPAdapter};
@@ -279,6 +282,19 @@ pub struct OrigIpoptNlp {
     /// [`Self::set_timing_stats`]; when `None`, all `eval_*` entry
     /// points skip the timing overhead.
     timing: RefCell<Option<Rc<TimingStatistics>>>,
+
+    /// Which derivatives this solve reuses across iterates — the four
+    /// upstream `*_constant` hints, resolved against what the model
+    /// could prove (gh #588, Q6). Default: reuse nothing, which is the
+    /// behaviour every path had before this field existed.
+    ///
+    /// A reused derivative is stored in its ordinary cache with an
+    /// **empty** dependency list instead of the iterate's tag, so the
+    /// lookup that already runs on every call finds it at every point.
+    /// That is upstream's own mechanism (`IpOrigIpoptNLP.cpp` nulls the
+    /// dependency); what pounce does differently is decide *when* it is
+    /// allowed to (see [`crate::constant_derivatives`]).
+    const_deriv: ConstantDerivatives,
 }
 
 #[derive(Clone)]
@@ -620,6 +636,7 @@ impl OrigIpoptNlp {
             h_evals: RefCell::new(0),
             info,
             timing: RefCell::new(None),
+            const_deriv: ConstantDerivatives::default(),
         })
     }
 
@@ -656,6 +673,68 @@ impl OrigIpoptNlp {
                 f()
             }
         }
+    }
+
+    // ---- constant-derivative hints (gh #588, Q6) ----
+
+    /// Ask the model what it can prove about its own derivatives, and
+    /// fold the per-row answers into the four hints the algorithm's
+    /// evaluation sites are actually about.
+    ///
+    /// Returned in [`crate::constant_derivatives::HINT_OPTIONS`] order:
+    /// `grad_f`, `hessian`, `jac_c`, `jac_d`. Two translations happen
+    /// here and nowhere else, because this is the only layer that knows
+    /// both the model's row order and the algorithm's:
+    ///
+    /// 1. **The c/d split.** The model proves things about *its* rows;
+    ///    the algorithm evaluates an equality block and an inequality
+    ///    block. `c_map` / `d_map` are the authoritative split — deriving
+    ///    it a second time from `g_l == g_u` inside the model would be a
+    ///    second rule that could disagree with this one.
+    /// 2. **Fixed variables.** Under `fixed_variable_treatment =
+    ///    make_parameter` a variable with `x_l == x_u` leaves the space
+    ///    the algorithm differentiates in, so a row like `x·y` with `y`
+    ///    fixed has a *constant* gradient here while the model correctly
+    ///    proved it varies. A proof of variation therefore does not
+    ///    survive fixing and is weakened to `Unknown`; a proof of
+    ///    constancy does survive, since dropping variables cannot
+    ///    introduce dependence. Getting this backwards would make pounce
+    ///    refuse a hint that is true — the same kind of silent wrong
+    ///    answer the phase exists to prevent, pointed the other way.
+    pub fn derivative_proofs(&self) -> [DerivativeProof; 4] {
+        let proofs: DerivativeProofs = {
+            let a = self.adapter.borrow();
+            let mut t = a.tnlp().borrow_mut();
+            t.derivative_proofs()
+        };
+        let cls = self.adapter.borrow().classification().clone();
+        let out = [
+            proofs.grad_f,
+            proofs.hessian,
+            subsystem_proof(&proofs, &cls.c_map),
+            subsystem_proof(&proofs, &cls.d_map),
+        ];
+        if cls.n_x_fixed == 0 {
+            return out;
+        }
+        out.map(DerivativeProof::forget_variation)
+    }
+
+    /// Install the resolved hints. Called once, before the first
+    /// evaluation; calling it later would leave point-keyed entries in
+    /// the caches, which is harmless (they simply never match again) but
+    /// means the first reused value is whichever iterate got there
+    /// first.
+    pub fn set_constant_derivatives(&mut self, cd: ConstantDerivatives) {
+        self.const_deriv = cd;
+        // Anything cached against a point was computed before the
+        // decision and must not be mistaken for the constant answer.
+        self.invalidate_eval_caches();
+    }
+
+    /// The hints in force for this solve.
+    pub fn constant_derivatives(&self) -> ConstantDerivatives {
+        self.const_deriv
     }
 
     // ---- accessors used by the algorithm wiring layer ----
@@ -1584,6 +1663,13 @@ impl OrigIpoptNlp {
     }
 
     fn eval_grad_f_internal(&self, x: &dyn Vector) -> Rc<dyn Vector> {
+        // A reused derivative lives in the same cache under an empty
+        // dependency list, so it matches at every point (gh #588, Q6).
+        if self.const_deriv.grad_f
+            && let Some(v) = self.grad_f_cache.borrow().get(&[], &[])
+        {
+            return v;
+        }
         if let Some(v) = self.grad_f_cache.borrow().get_1dep(x.as_tagged()) {
             return v;
         }
@@ -1610,10 +1696,21 @@ impl OrigIpoptNlp {
                 gv[var_idx] = full_g[full_idx as usize] * obj_scal;
             }
         }
+        // A failed evaluation NaN-fills; storing that as *the* constant
+        // answer would poison every remaining iteration instead of
+        // letting the line search back away from a bad point, so the
+        // point-keyed entry is used and the next call tries again.
+        let reuse = self.const_deriv.grad_f && all_finite(g_compressed.values());
         let result: Rc<dyn Vector> = Rc::new(g_compressed);
-        self.grad_f_cache
-            .borrow_mut()
-            .add_1dep(Rc::clone(&result), x.as_tagged());
+        if reuse {
+            self.grad_f_cache
+                .borrow_mut()
+                .add(Rc::clone(&result), &[], &[]);
+        } else {
+            self.grad_f_cache
+                .borrow_mut()
+                .add_1dep(Rc::clone(&result), x.as_tagged());
+        }
         result
     }
 
@@ -1763,6 +1860,11 @@ impl OrigIpoptNlp {
     }
 
     fn eval_jac_c_internal(&self, x: &dyn Vector) -> Rc<dyn Matrix> {
+        if self.const_deriv.jac_c
+            && let Some(m) = self.jac_c_cache.borrow().get(&[], &[])
+        {
+            return m;
+        }
         if let Some(m) = self.jac_c_cache.borrow().get_1dep(x.as_tagged()) {
             return m;
         }
@@ -1785,14 +1887,26 @@ impl OrigIpoptNlp {
                 };
             }
         }
+        let reuse = self.const_deriv.jac_c && all_finite(jac_c.values());
         let result: Rc<dyn Matrix> = Rc::new(jac_c);
-        self.jac_c_cache
-            .borrow_mut()
-            .add_1dep(Rc::clone(&result), x.as_tagged());
+        if reuse {
+            self.jac_c_cache
+                .borrow_mut()
+                .add(Rc::clone(&result), &[], &[]);
+        } else {
+            self.jac_c_cache
+                .borrow_mut()
+                .add_1dep(Rc::clone(&result), x.as_tagged());
+        }
         result
     }
 
     fn eval_jac_d_internal(&self, x: &dyn Vector) -> Rc<dyn Matrix> {
+        if self.const_deriv.jac_d
+            && let Some(m) = self.jac_d_cache.borrow().get(&[], &[])
+        {
+            return m;
+        }
         if let Some(m) = self.jac_d_cache.borrow().get_1dep(x.as_tagged()) {
             return m;
         }
@@ -1813,10 +1927,17 @@ impl OrigIpoptNlp {
                 };
             }
         }
+        let reuse = self.const_deriv.jac_d && all_finite(jac_d.values());
         let result: Rc<dyn Matrix> = Rc::new(jac_d);
-        self.jac_d_cache
-            .borrow_mut()
-            .add_1dep(Rc::clone(&result), x.as_tagged());
+        if reuse {
+            self.jac_d_cache
+                .borrow_mut()
+                .add(Rc::clone(&result), &[], &[]);
+        } else {
+            self.jac_d_cache
+                .borrow_mut()
+                .add_1dep(Rc::clone(&result), x.as_tagged());
+        }
         result
     }
 
@@ -1829,6 +1950,20 @@ impl OrigIpoptNlp {
     ) -> Rc<dyn SymMatrix> {
         // h_cache key: (x, y_c, y_d) tags + obj_factor scalar dep, as
         // upstream `IpOrigIpoptNLP.cpp:786`.
+        //
+        // A reused `∇²L` drops the three tags and keeps `obj_factor`:
+        // the hint's premise is that every row is linear, so `λ` weights
+        // nothing and `∇²L = σ·∇²f` — a function of `σ` alone. Upstream
+        // drops `σ` too, which is safe only because the main algorithm
+        // always passes 1.0; the restoration phase passes 0.0
+        // (`resto_nlp.rs`), and keeping the scalar dependency costs one
+        // float compare and makes that case right by construction rather
+        // than by coincidence.
+        if self.const_deriv.hessian
+            && let Some(m) = self.h_cache.borrow().get(&[], &[obj_factor])
+        {
+            return m;
+        }
         if let Some(m) = self.h_cache.borrow().get(
             &[x.as_tagged(), y_c.as_tagged(), y_d.as_tagged()],
             &[obj_factor],
@@ -1885,17 +2020,32 @@ impl OrigIpoptNlp {
         for (k, &src) in self.h_entry_in_full.iter().enumerate() {
             h_vals[k] = full_vals[src as usize];
         }
+        let reuse = self.const_deriv.hessian && all_finite(h.values());
         let result: Rc<dyn SymMatrix> = Rc::new(h);
-        self.h_cache.borrow_mut().add(
-            Rc::clone(&result),
-            &[x.as_tagged(), y_c.as_tagged(), y_d.as_tagged()],
-            &[obj_factor],
-        );
+        if reuse {
+            self.h_cache
+                .borrow_mut()
+                .add(Rc::clone(&result), &[], &[obj_factor]);
+        } else {
+            self.h_cache.borrow_mut().add(
+                Rc::clone(&result),
+                &[x.as_tagged(), y_c.as_tagged(), y_d.as_tagged()],
+                &[obj_factor],
+            );
+        }
         result
     }
 }
 
 // ---- helpers ----
+
+/// Whether every value is finite. Guards the constant-derivative store:
+/// a failed user evaluation NaN-fills its buffer, and a NaN written into
+/// a cache entry that never expires would fail the rest of the solve
+/// rather than the one trial point that caused it.
+fn all_finite(v: &[Number]) -> bool {
+    v.iter().all(|x| x.is_finite())
+}
 
 fn make_dense_from(
     space: &Rc<DenseVectorSpace>,

--- a/crates/pounce-nlp/src/scaling_tnlp.rs
+++ b/crates/pounce-nlp/src/scaling_tnlp.rs
@@ -623,6 +623,16 @@ impl TNLP for ScalingTnlp {
             .get_objective_variables_linearity(types)
     }
 
+    fn derivative_proofs(&mut self) -> crate::constant_derivatives::DerivativeProofs {
+        // Every transform this wrapper applies is a multiply by a
+        // constant factor (`∇f ÷ d`, `J[i,j] ÷ d[j]`, `H[i,j] ÷
+        // d[i]·d[j]`), and the row order is untouched — so a derivative
+        // that was constant below stays constant above, and one that
+        // was proved to vary still varies. Forwarding is sound in both
+        // directions, which is the condition the trait states.
+        self.inner.borrow_mut().derivative_proofs()
+    }
+
     fn scaling_factors(&self) -> Option<Vec<Number>> {
         Some(self.d.clone())
     }

--- a/crates/pounce-nlp/src/tnlp.rs
+++ b/crates/pounce-nlp/src/tnlp.rs
@@ -254,6 +254,35 @@ pub trait TNLP {
         false
     }
 
+    /// What this model can *prove* about the constancy of its own
+    /// derivatives (gh #588, phase Q6).
+    ///
+    /// This is the auto-detection behind the four upstream hints
+    /// `grad_f_constant` / `hessian_constant` / `jac_c_constant` /
+    /// `jac_d_constant`. Where a model knows its own algebra — an `.nl`
+    /// body the degree-≤2 recognizer reads exactly — it can establish
+    /// the hint without being told, *and* it can establish that the hint
+    /// is false, which is the case upstream honours anyway and pounce
+    /// refuses.
+    ///
+    /// The default declines: everything
+    /// [`DerivativeProof::Unknown`](crate::constant_derivatives::DerivativeProof::Unknown),
+    /// no rows. That is the truthful answer for a TNLP that offers
+    /// callbacks and no algebra — the C interface, the Python bridge,
+    /// both GAMS links — and it is what makes a user's hint on such a
+    /// model still count: `Unknown` means "not established", never
+    /// "varies", and an asserted hint over `Unknown` is honoured on
+    /// trust. See [`crate::constant_derivatives`] for the full table.
+    ///
+    /// A transparent decorator should forward the inner answer only if
+    /// its transformation preserves both directions. Diagonal variable
+    /// scaling does ([`crate::scaling_tnlp::ScalingTnlp`] forwards);
+    /// presolve does not — it changes what the rows *are* — so a
+    /// presolve wrapper must keep the declining default.
+    fn derivative_proofs(&mut self) -> crate::constant_derivatives::DerivativeProofs {
+        crate::constant_derivatives::DerivativeProofs::default()
+    }
+
     /// Per-iteration intermediate callback. Returning false requests
     /// early termination with `User_Requested_Stop`.
     fn intermediate_callback(

--- a/dev-notes/quadratic-structure-exploitation.md
+++ b/dev-notes/quadratic-structure-exploitation.md
@@ -33,7 +33,7 @@ describes.
 | Q3 — recognizer to `pounce-nl`, `Poly` → `Quad2` | **done** | (this commit) | recognizer iterative and allocation-free per monomial; classification of an `o0` chain was `O(k²)` and is now linear (k=16 000: 0.77 s → 0.020 s); the crash Q1 reported is real but unreachable through the CLI — see §0d |
 | Q4 — `QuadraticStructure` + `NlTnlp` fast path | **done** | (this commit) | `qcqp1000-2c` (**real**) 131.4 s → 97.6–103.3 s (1.27–1.35×), 100 → 100 iterations, `eval_h` 19.58 s → 0.20 s (~95×); the ≈1.4× forecast was at or above this machine's Amdahl ceiling; the fast path had to be gated on *already-expanded*, *unshared* forms after it cost `airport.nl` 16 → 300 iterations and a shared-DAG model 0.00 s → 172 s — see §0e |
 | Q5 — parse-time recognition | **done** | (this commit) | peak RSS on a **generated** `qcqp500-3c` shape 1253 → 586 MB (2.14×), on the **real** `qcqp1000-2c` 577 → 445 MB, and its load 0.98 → 0.71 s; the two recognizers agree bitwise over 1 631 corpus bodies and both instances solve bit-identically; the forecast's `~0.4 GB` floor is not reached and what is left is the file text and the parser's line index, not the `Expr` DAG — see §0f |
-| Q6 — the four constant-derivative hints | pending | — | — |
+| Q6 — the four constant-derivative hints | **done** | (this commit) | proofs are three-valued and a hint that contradicts one is **warned and ignored**; `UNEXPLOITED_HINTS` emptied; over 57 fixtures `∇f` evaluations 1729 → 1161 and `∇g` 2005 → 1573 at bit-identical trajectories, `∇²L` only 1880 → 1873; the **real** `qcqp1000-2c` does not move at all, as forecast; the "single-digit % on true QPs" half of the forecast is capped at 2.7% by Q4's own Amdahl share and is unobservable — see §0g |
 | Q7 — `QcqpProblem` extraction | pending | — | — |
 | Q8 — native QCQP barrier driver | pending | — | — |
 | Q9 — Gondzio correctors + QCQP presolve/equilibration | pending (go, revised) | — | Q0(b): corrector-shaped stall confirmed on `qcqp1000-2nc` only |
@@ -1042,6 +1042,258 @@ two tests that assert the opposite verdict and the per-context memo key).
 
 ---
 
+## 0g. Q6 — the four constant-derivative hints (measured 2026-08-18)
+
+### What shipped
+
+1. **`pounce_nlp::constant_derivatives`.** `DerivativeProof` is
+   **three-valued** — `Constant`, `Varying`, `Unknown` — and `reconcile`
+   turns (proof, user assertion) into the four booleans `OrigIpoptNlp`
+   reads. Proof wins in both directions where there is one; the user's
+   assertion decides only where there is none. §9's paragraph describes a
+   two-state design ("auto-detect … reconcile with the user's option"), and
+   two states is a bug in each direction: without `Constant`-without-asking
+   the detection buys nothing, and without a distinct `Unknown` every
+   callback front end — the C interface, the Python bridge, **both GAMS
+   links** — gets its true hint refused on the grounds that pounce could not
+   check it. That third row is where the note itself says the win is.
+
+2. **`TNLP::derivative_proofs`**, declining by default; `NlTnlp` answers it,
+   and `ScalingTnlp`, `CountingTnlp` and `SeededTnlp` forward it. A presolve
+   wrapper deliberately does **not** — it changes what the rows are — and
+   the declining default makes that the free, safe choice.
+
+3. **`NlBody::provably_affine`** — three-valued degree query, and *not*
+   `admitted_quad_form`. See "the fact Q5 handed over is the wrong fact"
+   below; this is the largest single decision in the phase.
+
+4. **Reuse in `OrigIpoptNlp`.** A reused derivative is stored in its
+   existing cache with an **empty dependency list**, so the lookup that
+   already runs on every call finds it at every point. That is upstream's own
+   mechanism; what differs is deciding when it is allowed. Two deviations
+   from upstream, both cheap: `∇²L` keeps `obj_factor` as a scalar dependency
+   (restoration passes `0.0`, and upstream drops it and is right only by
+   coincidence), and a NaN-filled result from a failed user evaluation is
+   never stored as *the* constant answer — otherwise one bad trial point
+   would poison the rest of the solve instead of being backtracked over.
+
+5. **`UNEXPLOITED_HINTS` is empty**, and the CLI pin flipped: the string
+   assertion on "pounce does not exploit this" became
+   `a_disproved_caching_hint_is_refused_with_a_warning` plus
+   `a_proved_constant_hessian_is_evaluated_once`, which asserts
+   `num_hess_evals == 1` and `num_constr_jac_evals == 1` out of
+   `--json-output` on a six-iteration solve.
+
+6. **Both GAMS links now assert what GMO already told them.** When no
+   Jacobian nonzero carries GMO's nonlinear flag, `gams_pounce.c` and
+   `python/pounce/gams/link.py` set `jac_c_constant=yes` / `jac_d_constant=yes`
+   before reading the option file. This is not a new claim: both links
+   *already* rely on it per row, copying cached coefficients for a linear row
+   rather than calling the GMO evaluator. If it were false they would already
+   be returning wrong Jacobians.
+
+### The three states, and what happens in each
+
+| proof | user asserted | pounce | why |
+|---|---|---|---|
+| `Constant` | either | **reuses** | the option is redundant; the model proved it |
+| `Varying` | no | evaluates each iterate | nothing to do |
+| `Varying` | **yes** | **warns and ignores** | the divergence: Ipopt honours this and returns a wrong Hessian |
+| `Unknown` | no | evaluates each iterate | nothing to do |
+| `Unknown` | **yes** | **honours on trust** | upstream's contract; "unproved" is not "disproved" |
+
+The last row is the one that had to be got right. A callback TNLP has no
+algebra to read, so *every* proof comes back `Unknown`; refusing a hint there
+would be the same class of silent wrong answer as honouring a false one,
+pointed the other way. `crates/pounce-algorithm/tests/constant_derivative_hints.rs`
+pins it end to end on a QP written as callbacks: 1 Hessian evaluation with the
+hint against 12 without, bit-identical objective and solution.
+
+Two guards on the proof itself, both in `OrigIpoptNlp::derivative_proofs`:
+the model proves things about *its* rows and the algorithm evaluates a c-block
+and a d-block, so `c_map`/`d_map` do the split (deriving it a second time
+inside the model from `g_l == g_u` would be a second rule that could
+disagree); and under `fixed_variable_treatment = make_parameter` a `Varying`
+proof is weakened to `Unknown`, because a row `x·y` with `y` fixed has a
+constant gradient in the space the algorithm differentiates in. Constancy
+survives fixing; a proof of variation does not. Backwards, that guard would
+make pounce refuse a *true* hint.
+
+### The fact Q5 handed over is the wrong fact
+
+Q5's handoff pointed at `NlBody::admitted_quad_form` as "the single place
+that answers is-this-a-constant-Hessian form". It answers a different
+question. That accessor is behind Q4's **exactness** gate
+(`is_expanded_quadratic`), which exists because *evaluating* a factored
+quadratic from stored coefficients cancels — `(x − 500000)²` loses five
+digits, gh #544, §0e. Q6 evaluates nothing from coefficients: it hands back
+the number the model's own tape produced at the first call. The applicable
+question is therefore only the body's **degree**, which a factored `(x − a)²`
+answers as well as an expanded one, and `NlBody::provably_affine` asks it
+without the gate.
+
+Measured on the fixture corpus, gating it would have cost:
+
+| | ungated (shipped) | gated on `is_expanded_quadratic` |
+|---|---|---|
+| models with `∇²L` proved constant | **29** | 11 |
+| models with `∇f` proved *varying* (i.e. a hint refusable) | **34** | 9 |
+| rows proved varying | **296** | 251 |
+| rows proved constant | 787 | 787 |
+
+So the gate would have thrown away 18 of the 29 constant-Hessian models and
+gone quiet on 25 of the 34 models where a false `grad_f_constant=yes` is
+detectable. `airport.nl` — the very model that forced Q4's gate to exist — is
+one of the models Q6 reaches. Row-level *constancy* is unaffected, because a
+flat affine sum passes the gate anyway; everything the gate costs is on the
+factored side, which is exactly where it was designed to bite.
+
+### Correctness: the differential is the load-bearing artefact
+
+`crates/pounce-cli/tests/constant_derivative_proofs.rs`, in the shape of Q3's,
+Q4's and Q5's. Every `.nl` file in the repository is loaded, asked what it can
+prove, and then the derivative it made a claim about is evaluated at five
+points — and, for `∇²L`, at five *multiplier vectors*, since
+`∇²L = σ∇²f + Σᵢλᵢ∇²gᵢ` depends on `λ` and a proof that ignored that would be
+a proof of the wrong thing.
+
+Over 60 models: `∇f` proved constant on 12, varying on 34, unknown on 14;
+`∇²L` constant on 29, varying on 19, unknown on 12; and 787 / 296 / 484 rows.
+**59 756 derivative values compared across probe points, every `Constant`
+claim bit-identical**, and all **349** `Varying` proofs witnessed by a
+derivative that actually moved — none left unwitnessed. Both directions are
+checked because both are load-bearing: a spurious `Varying` is not a wrong
+answer, but it makes pounce refuse a user's *true* hint with a warning
+claiming the model disproves it, which is its own way of lying.
+
+The index convention was found by the test rather than by reading the code:
+the first draft read the triplet rows as 1-based and compared row *i*'s
+values against row *i+1*'s proof, which fired immediately on
+`linear_eq_aggregation.nl`. `NlTnlp` reports `IndexStyle::C`.
+
+A fourth test pins that the proofs do not move with parse-time recognition
+(`parse_nl_text_with_quadratic` on and off, 44 models): if they did,
+`POUNCE_DBG_NO_QUAD=1` would silently change how often derivatives are
+evaluated and the A/B switch every phase of this series is measured with
+would stop being an A/B.
+
+### The measurement: counts move, wall clock does not
+
+**Real fixtures, 57 models, both binaries.** `scripts/sweep-fixtures.sh` is
+**diff-empty**: status, objective and iteration count identical on every
+model. Evaluation counts, summed over the corpus:
+
+| counter | Q5 | Q6 | |
+|---|---|---|---|
+| iterations | 2082 | 2082 | unchanged, by construction |
+| `eval_f` | 4631 | 4631 | not a derivative |
+| `eval_g` | 4833 | 4833 | not a derivative |
+| **`eval_grad_f`** | 1729 | **1161** | −568 (−33%) |
+| **`eval_jac_g`** | 2005 | **1573** | −432 (−22%) |
+| **`eval_h`** | 1880 | **1873** | −7 (−0.4%) |
+
+13 of 57 models move. The largest: `pooling_rt2stp` `∇f` 304 → 1 (over 298
+iterations), `unbounded_cubic` `∇g` 291 → 1, `deb7` `∇f` 157 → 1,
+`autocorr_bern55-06` `∇f` 73 → 1, `jit1`/`jit1_boxed`/`jit1_node` `∇g` 26 → 1,
+`nonconvex_qp` `∇g` and `∇²L` both 7 → 1.
+
+**And on none of them does a timer move.** `pooling_rt2stp`:
+`ObjectiveGradientEvaluations` 0.006 s either way, `OverallAlgorithm` 0.641 vs
+0.637 s. Removing 303 evaluations of a *linear* objective's gradient is below
+timer resolution, because a linear objective's gradient is the cheapest thing
+in the model. That is the honest shape of this phase on this corpus: it is a
+correctness change with a measurable evaluation-count effect and no
+measurable time effect.
+
+**The real QCQP control behaves exactly as forecast — nothing moves.** On
+`qcqp1000-2c`, the one real Mittelmann instance available here, the proofs are
+`grad_f` **varying**, `hessian` **varying**, `jac_d` **varying**, `jac_c`
+**constant** (its 100 equalities are linear; the 7 quadratic rows are all
+inequalities). 100 iterations both ways, objective 738127.4263173543 to every
+digit, and every reported eval counter identical (`f` 357, `g` 357, `∇f` 105,
+`∇g` 101, `∇²L` 101). `OverallAlgorithm` 105.049 s → 106.326 s, a 1.2%
+difference against a ~1.3× noise floor — i.e. nothing.  Note that
+`num_constr_jac_evals` is `max(jac_c_evals, jac_d_evals)`, so the c-block
+saving that *did* happen is invisible in it; on this instance it is 100 rows
+out of 5107 and worth nothing anyway.
+
+**Generated: a dense true QP forced down the NLP path.** `scripts/gen-qcqp-nl.py
+--quad-rows 0` writes a quadratic objective over linear rows; run with
+`solver_selection=nlp`, because pounce routes a QP to `pounce-qp` /
+`pounce-convex` by default and the note's own `qp` set exists to force it back.
+**Generated, not a Mittelmann instance.** n = 500, dense objective, 140 rows:
+`num_hess_evals` 18 → **1** and `num_constr_jac_evals` 18 → **1** at 17
+unchanged iterations and an objective identical to every digit;
+`LagrangianHessianEvaluations` 0.022 s → 0.001 s and
+`TotalFunctionEvaluations` 0.043 s → 0.021 s (2.1×). Wall clock: 1.3 s either
+way.
+
+### Which forecasts were verified, and which were wrong
+
+1. **"Win ≈0% on the QCQP family" — right, and now measured** on the real
+   instance rather than argued. This is the first forecast in the series that
+   survived contact.
+
+2. **"Single-digit % on true QPs forced down the NLP path" — not reachable,
+   and Q4 is why.** The measurement above removes 51% of
+   `TotalFunctionEvaluations` on exactly that shape, but after Q4 evaluation
+   is **5.3%** of `OverallAlgorithm` there (0.043 s of 0.808 s), so Amdahl
+   caps the whole phase at **2.7%** on that model — under the noise floor,
+   unobservable, and not worth quoting as a speedup. Q4 already made a
+   recognized quadratic's derivatives nearly free; Q6 removes the residue of
+   a residue. The evaluation-count claim is real and the wall-clock claim is
+   not, and this note should not have made the second one without checking
+   the first phase's own Amdahl arithmetic.
+
+3. **"…and on callback/GAMS front ends that assert the hint" — the premise
+   was false.** Neither GAMS link asserted any of the four hints; the pip
+   link and the C link both set `max_iter`, `max_wall_time`,
+   `acceptable_iter` and `hessian_approximation` and nothing else. Q6 makes
+   them assert `jac_c_constant`/`jac_d_constant` from GMO's own linearity
+   census. **Not measured here** — no GAMS licence, no GAMS shared libraries
+   in this container, and `plato.asu.edu` is blocked. The pip link's half is
+   unit-tested against the fake `GmoView` (`python/tests/test_gams_link.py`,
+   five new cases, including that a view which *declines* the question never
+   asserts the hint); the C link's half is code-reviewed against the
+   `row_has_nl` array it already keys its own fast path on, and is untested
+   for the same reason the rest of that file is.
+
+4. **The note names `hessian_constant` first, and it is the hint with the
+   least reach on the NLP path.** It requires a quadratic objective over
+   linear rows — i.e. a QP — and pounce routes QPs to `pounce-qp` /
+   `pounce-convex`, so a model that qualifies has usually already left the
+   NLP path. Corpus-wide `eval_h` falls by 0.4%. The two hints that actually
+   pay are ones §4's Lever 2 never mentions: **`grad_f_constant`** (a linear
+   objective under nonlinear rows — `pooling_rt2stp`, `deb7`, `csfi2`,
+   `autocorr_bern55-06`) and **`jac_c_constant`/`jac_d_constant`** (linear
+   rows under a nonlinear objective — `jit1`, `unbounded_cubic`,
+   `linear_eq_collapsed_box`). Between them they are 1000 removed
+   evaluations on 57 small fixtures.
+
+5. **Q5's handoff pointed at the wrong accessor** — see above; measured cost
+   of following it would have been 18 of 29 constant-Hessian models.
+
+### Gates
+
+`cargo test --workspace --exclude pounce-hsl`: **3008 passed, 0 failed**
+(2995 at Q5; the 13 new ones are this phase's — 4 in
+`constant_derivative_proofs`, 3 in `constant_derivative_hints`, 5 in
+`constant_derivatives`, and one net in the two CLI pins).
+`cargo fmt --check` clean; `cargo clippy --workspace --exclude pounce-hsl
+--all-targets` exit 0, no new lint instance in the new code.
+`scripts/sweep-fixtures.sh` **diff-empty across all 57 models** — status,
+objective and iteration count identical, which is the assertion that matters
+for a phase that changes how often derivatives are evaluated.
+
+### What Q6 did not do
+
+`hessian_constant` is not split into the "the *quadratic model* is constant"
+option §4's Lever 2 asks for. That is a different option with a different
+name, and it belongs with the `QcqpProblem` extraction (Q7) that would give
+it something to name. Nothing here changes what a QCQP does.
+
+---
+
 ## 1. Summary
 
 Three findings reframe the issue.
@@ -1122,6 +1374,11 @@ pub const UNEXPLOITED_HINTS: &[&str] = &[
 Setting `hessian_constant=yes` emits a warning today, asserted by
 `pounce-cli/tests/unimplemented_options.rs:129`. **This gives Q6 a crisp,
 already-testable completion criterion: empty that list and invert the test.**
+
+**Done in Q6 (§0g).** The list is empty, the test is inverted, and the
+criterion turned out to be the easy half: the hard half was that a hint is
+*three*-valued — proved, disproved, and unknown — and only the middle one may
+be refused. See `pounce_nlp::constant_derivatives`.
 
 ---
 
@@ -2031,6 +2288,48 @@ upstream, which trusts the user and silently produces a wrong Hessian. Empty
 **Win ≈0% on the QCQP family** (see the Lever 2 caveat); single-digit % on true
 QPs forced down the NLP path and on callback/GAMS front ends that assert the hint.
 
+**Done — the ≈0% half is right and now measured, the single-digit-% half is
+not reachable after Q4, and the design needed a third state; §0g has the
+measurement.** Shipped: `pounce_nlp::constant_derivatives` with a
+three-valued `DerivativeProof`, `TNLP::derivative_proofs`,
+`NlBody::provably_affine`, reuse in `OrigIpoptNlp`'s existing caches under an
+empty dependency list, an emptied `UNEXPLOITED_HINTS`, and both GAMS links
+asserting the Jacobian hints from GMO's own linearity census. Corrections, in
+ascending order of how much they change the phase:
+
+1. **"Auto-detect … reconcile with the user's option" is two states, and it
+   needs three.** `Constant`, `Varying` and `Unknown` are different answers:
+   a hint over `Unknown` is honoured **on trust**, exactly as upstream,
+   because a callback TNLP has no algebra to read and refusing a true hint
+   there is the same class of silent wrong answer as honouring a false one.
+   The divergence applies only to a hint a model **disproves**.
+2. **"…on callback/GAMS front ends that assert the hint" — none of them
+   did.** Neither GAMS link set any of the four options. Q6 makes both assert
+   `jac_c_constant`/`jac_d_constant` when GMO flags no nonlinear Jacobian
+   nonzero — a fact both links already rely on per row. Unmeasurable here (no
+   GAMS libraries, no licence); the pip half is unit-tested against the fake
+   `GmoView`.
+3. **"Single-digit % on true QPs forced down the NLP path" is capped at 2.7%
+   by Q4.** On a *generated* dense 500-variable QP run with
+   `solver_selection=nlp`, `num_hess_evals` goes 18 → 1 and
+   `TotalFunctionEvaluations` 0.043 s → 0.021 s — but evaluation is only 5.3%
+   of `OverallAlgorithm` there *because Q4 already removed the rest of it*, so
+   the whole phase cannot reach the noise floor. Counts, not stopwatches, are
+   what this phase can claim.
+4. **`hessian_constant` — the hint Lever 2 is written around — has the least
+   reach on the NLP path**, because a model that qualifies for it is a QP and
+   pounce routes QPs elsewhere: corpus-wide `eval_h` falls 0.4%. The hints
+   that pay are `grad_f_constant` (a linear objective under nonlinear rows)
+   and `jac_c/jac_d_constant` (linear rows under a nonlinear objective),
+   neither of which Lever 2 mentions: together, `∇f` 1729 → 1161 and `∇g`
+   2005 → 1573 over 57 fixtures, at bit-identical trajectories.
+5. **The proof must *not* use Q5's `admitted_quad_form`.** That accessor is
+   behind Q4's exactness gate, which exists because evaluating a factored
+   form from coefficients cancels; Q6 reuses the model's own tape output and
+   only needs the *degree*. Measured cost of the gate had it been used: 18 of
+   29 constant-`∇²L` models and 25 of 34 refusable hints, including
+   `airport.nl` — the model that forced Q4's gate in the first place.
+
 **Q7 — `QcqpProblem` extraction** in `pounce-convex`, reusing the classifier's
 already-computed forms. Today `to_poly` expands the same tree **three times** per
 row (classify, convexity check, extract) — on `qcqp500-3c` that is three
@@ -2289,8 +2588,8 @@ line is individually explained.
 | `crates/pounce-nl/src/nl_reader.rs` | header `:1142`, `'C'`/`'O'` arms `:618-641`, `NlProblem:202`, `try_new:3067`, `lower_pairs:3179`, `jac_cols:3222`, `eval_g:3903`, `eval_jac_g:3947`, `eval_h:4046`, linearity/FBBT consumers `:2414,:2480,:3755,:4259,:4276,:4303` |
 | `crates/pounce-cli/src/dispatch.rs` | ~~delete `Poly`/`to_poly`/`analyze_quadratic*`~~ *(done in Q3; the analyzers are re-exported from `pounce-nl` so no call site moved)*; `SOCP_SIZE_BUDGET:65`, `QCQP_SOCP_COUPLED_VARS:90`, `ProblemClass:93-110`, `classify_problem:206-323`, `resolve_solver:333-390` |
 | `crates/pounce-cli/src/qp_extract.rs` | `dense_symmetric:584`, `psd_outer_factor:600`, `extract_socp_with_map:367`; new `extract_qcqp_with_map` |
-| `crates/pounce-nlp/src/orig_ipopt_nlp.rs` | cache keying for the hints: `eval_grad_f:1587`, `eval_jac_c:1766`, `eval_h_internal:1823`, `set_new_problem:1214` |
-| `crates/pounce-algorithm/src/unimplemented_options.rs` | empty `UNEXPLOITED_HINTS:200-206`, paired with `pounce-cli/tests/unimplemented_options.rs:126-133` |
+| `crates/pounce-nlp/src/orig_ipopt_nlp.rs` | ~~cache keying for the hints~~ *(done in Q6: a reused derivative is stored under an empty dependency list in the cache it already had; `derivative_proofs`/`set_constant_derivatives` do the c/d split and the fixed-variable downgrade)* |
+| `crates/pounce-algorithm/src/unimplemented_options.rs` | ~~empty `UNEXPLOITED_HINTS:200-206`, paired with `pounce-cli/tests/unimplemented_options.rs:126-133`~~ *(done in Q6; the reconciliation itself lives in the new `pounce-nlp/src/constant_derivatives.rs`, and `application.rs::install_constant_derivative_hints` is where the two meet)* |
 | `crates/pounce-convex/src/presolve.rs` | `Reduction:408-497`, `protected_row:957-1003`, `presolve_once:1033`, `dedup_rows`/`parallel_signature:2136-2280` |
 | `crates/pounce-convex/src/equilibrate.rs` | `equilibrate:83`, scope note `:44-49`, `Scaling::unscale_solution` |
 | `crates/pounce-cli/src/main.rs` | `run_convex_socp:2857` (wire `presolve_conic`), new `run_convex_qcqp` |

--- a/docs/src/gams.md
+++ b/docs/src/gams.md
@@ -144,6 +144,19 @@ tol        1e-10
 max_iter   500
 ```
 
+Both links set a few defaults before reading the option file, so a
+`pounce.opt` entry always wins. One of them is worth knowing about: when
+GMO reports that **no** Jacobian nonzero is nonlinear — the whole
+constraint matrix is linear — the link asserts `jac_c_constant=yes` and
+`jac_d_constant=yes`, and POUNCE then evaluates the constraint Jacobian
+once for the entire solve instead of once per iteration. This is the same
+flag the links already use to copy cached coefficients for a linear row
+rather than calling the GMO evaluator, so it asserts nothing new. POUNCE
+cannot establish it on its own here — through a callback interface it
+sees numbers, not algebra — which is precisely why the link, which does
+see GMO's linearity census, is the layer that says it. Put
+`jac_c_constant no` in `pounce.opt` to turn it off.
+
 ### Machine-readable solve report
 
 Set `json_output` in `pounce.opt` to also emit a structured

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -139,11 +139,28 @@ Two deliberate exceptions:
   `ipopt.opt` spells out defaults, and `dependency_detector=none` asks for
   nothing. Only a value that differs from the default is a request POUNCE
   cannot honour.
-* **Caching hints warn instead of failing.** `grad_f_constant`,
+* **Caching hints are checked, not trusted.** `grad_f_constant`,
   `hessian_constant`, `jac_c_constant` and `jac_d_constant` tell the
-  solver a quantity does not change between iterations. POUNCE
-  re-evaluates regardless, so ignoring them costs evaluations and never
-  correctness — failing the solve would be a worse trade.
+  solver a derivative does not change between iterations. Ipopt takes
+  such a hint on faith and silently returns a wrong answer if it is
+  false. POUNCE asks the model first, and there are three cases:
+
+  * **POUNCE proves the derivative constant** — from an `.nl` model's own
+    algebra — and reuses it across iterations *whether or not you set the
+    option*. Setting it is harmless and unnecessary.
+  * **POUNCE proves the derivative is not constant** and you set the
+    option anyway: the option is **ignored, with a warning**. A QCQP's
+    `∇²L = σQ₀ + Σᵢλᵢ Qᵢ` genuinely varies with the multipliers, so
+    `hessian_constant=yes` there is not a hint but a false statement, and
+    honouring it would trade a correct answer for a fast wrong one.
+  * **POUNCE cannot tell** — every callback front end (the C interface,
+    the Python `Problem` callbacks, both GAMS links) hands POUNCE numbers
+    rather than algebra — and your assertion is **honoured on trust**,
+    exactly as upstream. "Unproved" is not "disproved"; overriding you
+    here would be its own silent wrong answer.
+
+  `POUNCE_DBG_CONSTDERIV=1` prints which of the three fired for each of
+  the four options.
 
 Options whose *feature* runs and whose value simply is not read yet are
 **not** in this category; they still solve, with the default in effect.

--- a/gams/gams_pounce.c
+++ b/gams/gams_pounce.c
@@ -946,6 +946,29 @@ DllExport int STDCALL pouCallSolver(void *Cptr)
     if (!data->have_hessian)
         AddIpoptStrOption(nlp, "hessian_approximation", "limited-memory");
 
+    /* Every constraint's Jacobian row is a constant vector when GMO flags
+     * no nonlinear nonzero anywhere in the matrix. That is not a new claim:
+     * gams_eval_jac_g already *relies* on it per row, copying
+     * jac_values_init for a row with row_has_nl == 0 instead of calling
+     * gmoEvalGrad. Asserting it to POUNCE lets the solver evaluate the
+     * Jacobian once for the whole solve rather than once per iteration
+     * (pounce #588, phase Q6). POUNCE cannot prove this itself through the
+     * callback interface -- it sees numbers, not algebra -- so the hint is
+     * honored on trust, which is exactly the state it is for.
+     *
+     * Both blocks are asserted together because the equality/inequality
+     * split happens inside POUNCE and this flag is about the whole matrix.
+     * Set before the option-file parse so a user pounce.opt can override. */
+    if (m > 0 && data->nnz_jac > 0) {
+        int any_nl_row = 0;
+        for (int i = 0; i < m; i++)
+            if (data->row_has_nl[i]) { any_nl_row = 1; break; }
+        if (!any_nl_row) {
+            AddIpoptStrOption(nlp, "jac_c_constant", "yes");
+            AddIpoptStrOption(nlp, "jac_d_constant", "yes");
+        }
+    }
+
     /* ---------------------------------------------------------------
      * Read option file (pounce.opt, pounce.op2, ...)
      * --------------------------------------------------------------- */

--- a/python/pounce/gams/gmo_translate.py
+++ b/python/pounce/gams/gmo_translate.py
@@ -72,6 +72,14 @@ class GmoView(Protocol):
     # Lower-triangle Hessian-of-Lagrangian nonzeros (only when has_hessian()).
     def hess_structure(self) -> tuple[Sequence[int], Sequence[int]]: ...
 
+    # True when no Jacobian nonzero is flagged nonlinear, i.e. every
+    # constraint gradient is a constant vector. Optional: a view that does
+    # not define it is read as "not established", which is what
+    # `problem_from_gmo` records. The adapter over the real GMO answers it
+    # from the same `nlflag` array `eval_jac` already keys its
+    # copy-the-cached-coefficients fast path on.
+    def constraints_are_linear(self) -> bool: ...
+
     # --- numerical evaluators (native sense) -----------------------------
     def eval_obj(self, x: np.ndarray) -> float: ...
     def eval_grad_obj(self, x: np.ndarray) -> Sequence[float]: ...
@@ -105,6 +113,12 @@ class GmoProblem:
     x0: np.ndarray
     has_hessian: bool
     obj_sign: float  # +1 minimize, -1 maximize
+    #: Every constraint gradient is a constant vector (GMO flags no
+    #: nonlinear Jacobian nonzero). Drives the `jac_c_constant` /
+    #: `jac_d_constant` hints, which let POUNCE evaluate the Jacobian once
+    #: for the whole solve (pounce#588 Q6). False when the view does not
+    #: report it: an unanswered question is not a "yes".
+    jacobian_is_constant: bool = False
 
 
 class _GmoProblemObj:
@@ -191,6 +205,10 @@ def problem_from_gmo(view: GmoView) -> GmoProblem:
     x0 = np.asarray(view.var_init(), dtype=float)
 
     has_hess = bool(view.has_hessian())
+    # Optional on the protocol, so a view written before this existed (or a
+    # test fake) simply declines rather than failing.
+    linear_rows = getattr(view, "constraints_are_linear", None)
+    jac_const = bool(m) and bool(linear_rows() if callable(linear_rows) else False)
     obj = (
         _GmoProblemObjHess(view, obj_sign)
         if has_hess
@@ -208,4 +226,5 @@ def problem_from_gmo(view: GmoView) -> GmoProblem:
         x0=x0,
         has_hessian=has_hess,
         obj_sign=obj_sign,
+        jacobian_is_constant=jac_const,
     )

--- a/python/pounce/gams/link.py
+++ b/python/pounce/gams/link.py
@@ -287,6 +287,19 @@ def solve_view(
     prob.add_option("acceptable_iter", 0)
     if not gp.has_hessian:
         prob.add_option("hessian_approximation", "limited-memory")
+    # Every Jacobian row is a constant vector when GMO flags no nonlinear
+    # nonzero anywhere in the matrix. `_GmoView.eval_jac` already relies on
+    # exactly this per row -- it copies the cached coefficients for a row
+    # with no nonlinear entry instead of calling the evaluator -- so
+    # asserting it to POUNCE adds no new claim, it just lets the solver
+    # evaluate the Jacobian once for the whole solve instead of once per
+    # iteration (pounce#588, phase Q6). POUNCE cannot prove this through the
+    # callback interface; a hint it can neither confirm nor refute is
+    # honoured on trust, which is what this state is for. Mirrors the C
+    # link, and is set before the option file so a user pounce.opt wins.
+    if gp.jacobian_is_constant:
+        prob.add_option("jac_c_constant", "yes")
+        prob.add_option("jac_d_constant", "yes")
 
     for key, value in (options or {}).items():
         try:
@@ -567,6 +580,15 @@ class _GmoAdapter:  # pragma: no cover - thin wrapper over gamsapi calls
     # --- structure -------------------------------------------------------
     def jac_structure(self):
         return self._jac_rows, self._jac_cols
+
+    def constraints_are_linear(self) -> bool:
+        """True when no Jacobian nonzero is flagged nonlinear by GMO.
+
+        Same `nlflag` array :meth:`eval_jac` keys its copy-the-cached-
+        coefficients path on, so this asserts nothing the link does not
+        already depend on being true.
+        """
+        return self._m > 0 and not any(self._row_has_nl)
 
     def hess_structure(self):
         gmo = self._gmo

--- a/python/tests/test_gams_link.py
+++ b/python/tests/test_gams_link.py
@@ -698,3 +698,123 @@ def test_gams_pi_wyndor_shadow_prices_both_senses():
     lam = [0.0, 1.5, 1.0]  # POUNCE internal multipliers for the Wyndor optimum
     assert link.gams_pi(lam, obj_sign=-1.0) == pytest.approx([0.0, 1.5, 1.0])
     assert link.gams_pi(lam, obj_sign=1.0) == pytest.approx([0.0, -1.5, -1.0])
+
+
+# --- gh #588 Q6: the constant-Jacobian hint the link can prove and POUNCE
+#     cannot ------------------------------------------------------------------
+#
+# POUNCE's own auto-detection reads the algebra of an `.nl` body. Through a
+# callback front end there is no algebra to read, so every proof comes back
+# "unknown" and a hint the *caller* asserts is honoured on trust. GMO hands
+# the link a per-nonzero linearity flag, which the link already relies on
+# (`eval_jac` copies cached coefficients for a row with no nonlinear entry
+# rather than calling the evaluator), so the link is exactly the layer that
+# can assert it.
+
+
+class LinearRowsView(HS071View):
+    """HS071's shape with a linear constraint matrix and no Hessian.
+
+    Only the flag and the Jacobian matter here; nothing in these tests
+    solves this model.
+    """
+
+    def constraints_are_linear(self):
+        return True
+
+
+def test_a_view_that_declines_the_linearity_question_reports_not_constant():
+    """The protocol member is optional, so a view predating it must not
+    accidentally assert the hint. Absence is `False`, never `True`."""
+    gp = problem_from_gmo(HS071View())
+    assert not hasattr(HS071View, "constraints_are_linear")
+    assert gp.jacobian_is_constant is False
+
+
+def test_a_linear_constraint_matrix_is_carried_into_the_problem():
+    gp = problem_from_gmo(LinearRowsView())
+    assert gp.jacobian_is_constant is True
+
+
+def test_a_model_with_no_rows_never_claims_a_constant_jacobian():
+    """`m == 0` has no Jacobian to reuse; claiming the hint there would set
+    an option that describes nothing."""
+
+    class NoRows(LinearRowsView):
+        def num_cons(self):
+            return 0
+
+        def con_lower(self):
+            return []
+
+        def con_upper(self):
+            return []
+
+        def jac_structure(self):
+            return [], []
+
+    assert problem_from_gmo(NoRows()).jacobian_is_constant is False
+
+
+def test_solve_view_sets_the_jacobian_hints_only_when_the_rows_are_linear():
+    """The two options reach `pounce.Problem`, and only for a linear matrix.
+
+    Asserted on the options the link *sets*, not on an evaluation count: a
+    counter would also move if POUNCE changed how it caches, and the claim
+    here is about what this link asserts.
+    """
+    seen = []
+
+    class FakeProblem:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def add_option(self, key, value):
+            seen.append((key, value))
+
+        def solve(self, x0, report_path=None, report_detail=None):
+            return np.asarray(x0, dtype=float), {"status": "Solve_Succeeded"}
+
+    import pounce as pounce_mod
+
+    real = pounce_mod.Problem
+    try:
+        pounce_mod.Problem = FakeProblem
+        seen.clear()
+        link.solve_view(LinearRowsView())
+        assert ("jac_c_constant", "yes") in seen
+        assert ("jac_d_constant", "yes") in seen
+
+        seen.clear()
+        link.solve_view(HS071View())
+        assert not [k for k, _ in seen if k.startswith("jac_")]
+    finally:
+        pounce_mod.Problem = real
+
+
+def test_the_jacobian_hints_precede_the_user_option_file():
+    """A `pounce.opt` must be able to turn the hint back off, which requires
+    the link to set it *before* the user's options are applied."""
+    seen = []
+
+    class FakeProblem:
+        def __init__(self, **kwargs):
+            pass
+
+        def add_option(self, key, value):
+            seen.append((key, value))
+
+        def solve(self, x0, report_path=None, report_detail=None):
+            return np.asarray(x0, dtype=float), {"status": "Solve_Succeeded"}
+
+    import pounce as pounce_mod
+
+    real = pounce_mod.Problem
+    try:
+        pounce_mod.Problem = FakeProblem
+        link.solve_view(LinearRowsView(), options={"jac_c_constant": "no"})
+    finally:
+        pounce_mod.Problem = real
+    keys = [k for k, _ in seen]
+    assert keys.index("jac_c_constant") < len(keys) - 1
+    assert seen[-1] == ("jac_c_constant", "no")


### PR DESCRIPTION
**Review-only. Do not merge.** This PR exists so phase Q6 of the #588 series can be read as a single diff against its parent (Q5, `19340e6c`). The series PR is **#603**; the commit lands there. Mirrors #671 / #674 / #675.

## Problem

Ipopt registers four caching hints — `grad_f_constant`, `hessian_constant`, `jac_c_constant`, `jac_d_constant` — as **unchecked user assertions**. Setting one makes the solver evaluate that derivative once and reuse it for the rest of the solve; if the assertion is false, the answer is silently wrong. A Hessian frozen at the starting point is still *a* matrix, and the algorithm converges to something with it.

POUNCE's position until now was the mirror image, and equally unhelpful: the four names sat in `unimplemented_options::UNEXPLOITED_HINTS`, setting one printed "pounce does not exploit this", and every derivative was re-evaluated every iteration.

Neither is right, and the model usually knows which. Over this repo's 60-model `.nl` corpus, POUNCE can prove `∇²L` constant on **29** of them and prove it *not* constant on **19** more, without asking anyone.

## Cause

The recognizer that Q3–Q5 built already answers the question exactly — it just was not wired to it. What was missing was the reconciliation: what to do when the model's answer and the user's option disagree, and what to do when the model has no answer at all.

## Fix

`pounce_nlp::constant_derivatives`. `DerivativeProof` is **three-valued**, and that is the substance of the phase — the design note describes two states, and two states is a bug in each direction.

| proof | user asserted | POUNCE | why |
|---|---|---|---|
| `Constant` | either | **reuses** | the option is redundant; the model proved it |
| `Varying` | no | evaluates each iterate | nothing to do |
| `Varying` | **yes** | **warns and ignores** | the divergence — Ipopt honours this and returns a wrong Hessian |
| `Unknown` | no | evaluates each iterate | nothing to do |
| `Unknown` | **yes** | **honours on trust** | upstream's contract |

The last row is the one that had to be got right. A callback TNLP — the C interface, the Python bridge, **both GAMS links** — hands POUNCE numbers, not algebra, so *every* proof comes back `Unknown`. Refusing a hint there, on the grounds that POUNCE could not confirm it, would be the same class of silent wrong answer as honouring a false one, pointed the other way. `Unknown` means *not established*, never *varies*.

**The accessor Q5's handoff named is the wrong one, and this is the largest decision in the diff.** Q5 pointed at `NlBody::admitted_quad_form`. That sits behind Q4's *exactness* gate (`is_expanded_quadratic`), which exists because **evaluating** a factored quadratic from stored coefficients cancels — `(x − 500000)²` loses five digits, gh#544. Q6 evaluates nothing from coefficients; it hands back the number the model's own tape produced at the first call. The applicable question is only the body's **degree**, which a factored `(x − a)²` answers as well as an expanded one — so the proof reads a new `NlBody::provably_affine`, same recognizer, no gate.

Measured cost of the gate had it been used (corpus census, run both ways):

| | ungated (shipped) | gated on `is_expanded_quadratic` |
|---|---|---|
| models with `∇²L` proved constant | **29** | 11 |
| models where a false `grad_f_constant` is detectable | **34** | 9 |
| rows proved varying | **296** | 251 |
| rows proved constant | 787 | 787 |

`airport.nl` — the model that forced Q4's gate into existence — is one of the models Q6 reaches. Row-level *constancy* is identical either way; everything the gate costs is on the factored side, which is exactly where it was designed to bite.

**Reuse mechanism.** Upstream's own: the derivative goes into the cache it already had, under an **empty dependency list**, so the lookup that runs on every call finds it at every point. Two deliberate deviations, both cheap:

* `∇²L` keeps `obj_factor` as a scalar dependency. The restoration phase calls `orig.eval_h(x, 0.0, ..)`; upstream drops the scalar and is right only because the main algorithm always passes 1.0.
* A NaN-filled result from a failed user evaluation is **never** stored as *the* constant answer. Otherwise one bad trial point poisons the rest of the solve instead of being backtracked over.

**Two translations in `OrigIpoptNlp`**, because it is the only layer that knows both row orders:

* the model proves things about *its* rows, the algorithm evaluates a c-block and a d-block, so `c_map`/`d_map` do the split — deriving it a second time from `g_l == g_u` inside the model would be a second rule that could disagree with the first;
* under `fixed_variable_treatment = make_parameter` a `Varying` proof is weakened to `Unknown`. A row `x·y` with `y` fixed has a *constant* gradient in the space the algorithm differentiates in. Constancy survives fixing; a proof of variation does not. Backwards, that guard would make POUNCE refuse a hint that is **true**.

**Both GAMS links now assert what GMO already told them.** When no Jacobian nonzero carries GMO's nonlinear flag, `gams/gams_pounce.c` and `python/pounce/gams/link.py` set `jac_c_constant=yes` / `jac_d_constant=yes` before reading the option file, so a `pounce.opt` can still turn it off. This is not a new claim: both links *already* rely on it per row, copying cached coefficients for a linear row rather than calling the GMO evaluator. If it were false they would already be returning wrong Jacobians.

`UNEXPLOITED_HINTS` is now empty. The table and `hint_warnings` stay — the shape is right for the next registered-but-unexploited hint, and the two membership tests are what keeps such an option from going silent again.

## Blast radius

**Sweep: `scripts/sweep-fixtures.sh` is diff-empty across all 57 models** against the parent commit `19340e6c` — status, objective *and iteration count* identical everywhere. That is the assertion that matters for a phase which changes how often derivatives are evaluated.

What does move is evaluation counts, over the same 57 models:

| counter | Q5 | Q6 | |
|---|---|---|---|
| iterations | 2082 | 2082 | unchanged, by construction |
| `eval_grad_f` | 1729 | **1161** | −568 (−33%) |
| `eval_jac_g` | 2005 | **1573** | −432 (−22%) |
| `eval_h` | 1880 | **1873** | −7 (−0.4%) |

13 of 57 models move: `pooling_rt2stp` `∇f` 304 → 1 over 298 iterations, `unbounded_cubic` `∇g` 291 → 1, `deb7` `∇f` 157 → 1, `autocorr_bern55-06` 73 → 1, the three `jit1` variants `∇g` 26 → 1, `nonconvex_qp` `∇g` and `∇²L` both 7 → 1.

**And on none of them does a timer move.** `pooling_rt2stp`: `ObjectiveGradientEvaluations` 0.006 s either way, `OverallAlgorithm` 0.641 vs 0.637 s. A linear objective's gradient is the cheapest thing in the model, so removing 300 of them is below timer resolution. This is a correctness change with a measurable evaluation-count effect and **no measurable time effect**, and it should be read that way.

**Real `qcqp1000-2c` (the one Mittelmann instance available) — the control, and it does not move**, exactly as the ≈0% forecast said. Proofs: `grad_f`/`hessian`/`jac_d` **varying**, `jac_c` **constant** (its 100 equalities are linear; the 7 quadratic rows are all inequalities). 100 iterations both ways, objective `738127.4263173543` to every digit, every reported eval counter identical (357/357/105/101/101), `OverallAlgorithm` 105.049 → 106.326 s — 1.2% against a ~1.3× noise floor, i.e. nothing.

**Forecasts that were wrong**, recorded in note §0g:

* *"single-digit % on true QPs forced down the NLP path"* — capped at **2.7% by Q4**. On a **generated** dense 500-variable QP (`gen-qcqp-nl.py --quad-rows 0`, `solver_selection=nlp`) `num_hess_evals` goes 18 → 1 at 17 unchanged iterations and `TotalFunctionEvaluations` 0.043 → 0.021 s — but evaluation is only 5.3% of `OverallAlgorithm` there *because Q4 already removed the rest of it*. Q6 removes the residue of a residue.
* *"…callback/GAMS front ends that assert the hint"* — false premise. Neither GAMS link asserted any of the four. They do now.
* `hessian_constant`, the hint §4's Lever 2 is written around, has the **least** reach on the NLP path (corpus `eval_h` −0.4%), because a model that qualifies for it is a QP and POUNCE routes QPs to `pounce-qp`/`pounce-convex`. The hints that pay are the two Lever 2 never mentions.

Decorators: `ScalingTnlp`, `CountingTnlp` and `SeededTnlp` forward the proofs (every transform they apply is a multiply by a constant, and neither direction of the proof is affected). Presolve wrappers deliberately do **not** — they change what the rows are — and the declining default makes that the free, safe choice.

## Tests

* **`crates/pounce-cli/tests/constant_derivative_proofs.rs`** — the load-bearing artefact, in the shape of Q3's, Q4's and Q5's differentials. Every `.nl` file in the repository is asked what it can prove, and then the derivative it made a claim about is evaluated at five points — and, for `∇²L`, at five *multiplier vectors*, because `∇²L = σ∇²f + Σᵢλᵢ∇²gᵢ` depends on λ and a proof that ignored that would be a proof of the wrong thing. Over 60 models: **59,756 derivative values compared, every `Constant` claim bit-identical, and all 349 `Varying` proofs witnessed by a derivative that actually moved** (none unwitnessed). Both directions are checked because both bite: a spurious `Varying` is not a wrong answer, but it refuses a user's *true* hint while claiming the model disproves it. A fourth case pins that the proofs do not move with parse-time recognition on/off, so `POUNCE_DBG_NO_QUAD=1` stays a real A/B.

  This test found the phase's one real defect on its own: the first draft read the Jacobian triplet rows as 1-based and compared row *i*'s values against row *i+1*'s proof. `NlTnlp` reports `IndexStyle::C`. It failed on `linear_eq_aggregation.nl` immediately.

* **`crates/pounce-algorithm/tests/constant_derivative_hints.rs`** — the `Unknown` state end to end, on a QP written as callbacks and nothing else: 12 Hessian evaluations without the hint, **1** with it, bit-identical objective and solution. Plus: an explicit `hessian_constant=no` asserts nothing.

* **`crates/pounce-cli/tests/unimplemented_options.rs`** — the pin the note asked to flip. `a_caching_hint_warns_but_solves` (string match on "pounce does not exploit") becomes `a_disproved_caching_hint_is_refused_with_a_warning` and `a_proved_constant_hessian_is_evaluated_once`, the latter asserting `num_hess_evals == 1` and `num_constr_jac_evals == 1` out of `--json-output` on a six-iteration solve.

* **`python/tests/test_gams_link.py`** — five license-free cases over the fake `GmoView`, including that a view which *declines* the linearity question never asserts the hint, and that the link sets it before the user's option file.

**How they bite on the parent commit:** all three Rust files are new or newly-inverted and fail on `19340e6c` for the right reason — `constant_derivative_proofs.rs` and `constant_derivative_hints.rs` do not compile there (`TNLP::derivative_proofs` and `pounce_nlp::constant_derivatives` do not exist), and `a_proved_constant_hessian_is_evaluated_once` fails on the count (`num_hess_evals == 7`, not 1).

**Deliberately not pinned:** the C GAMS link's half of the hint. There is no GAMS licence and no GAMS shared library in any CI runner, so `gams/gams_pounce.c` is untested here for the same reason the rest of that file is; it is code-reviewed against the `row_has_nl` array it already keys its own fast path on. The two `solve_view` Python cases could not be *run* in the container that produced this branch (the native `pounce._pounce` extension is not built there) — they are pure-Python monkeypatch tests and run in CI.

---

- [x] Tests fail on the parent commit for the stated reason
- [ ] `CHANGELOG.md` `[Unreleased]` entry — deliberately omitted, matching Q0–Q5: the series lands one CHANGELOG entry at the end
- [x] Book page under `docs/src/` updated — `options.md` (the three states, with `POUNCE_DBG_CONSTDERIV`) and `gams.md` (the Jacobian hints the links now set)
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude pounce-hsl --all-targets` (exit 0, no new lint instance in the new code), `cargo test --workspace --exclude pounce-hsl` (3008 passed, 0 failed; 2995 at Q5)
- [x] Every claim in this body is true of the code as it stands

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZTh36oN4JK9t6fN2CzXC9)_