### PR TITLE
Wire alpha_red_factor through to the line search (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ changes.
 
 ## [Unreleased]
 
+- **`alpha_red_factor` reaches the line search** (#678).
+
+  The option was registered, range-checked against its bounds `(0,1)`,
+  accepted without complaint — and never read. `LineSearchOptions` had
+  no such field, `application.rs` never asked the `OptionsList` for it,
+  and `alg_builder.rs` never assigned it, so the backtracking line
+  search kept the hard-coded 0.5 it gets from
+  `BacktrackingLineSearch::new` no matter what the user set. Asking it
+  to backtrack by 0.2 produced no error, no warning, and a bit-identical
+  trajectory.
+
+  It was the last unwired field of the ten on `BacktrackingLineSearch`;
+  the nine around it — including the `max_soc` block immediately
+  adjacent, which #191 fixed as its worked example of exactly this bug —
+  were already wired, which is why the block read as finished. The field
+  is genuinely consumed by the algorithm (it scales alpha at every
+  backtracking step) and the option name has eleven hits in
+  `backtracking.rs`, so neither a grep nor the compiler could see the
+  gap; only tracing the assignment path finds it.
+
+  **No default trajectory moves.** The registered default and the
+  hard-coded one are both 0.5, so an unset run is unchanged.
+  `scripts/sweep-fixtures.sh` over all 57 fixtures diffs empty against
+  the parent commit, and an explicit `alpha_red_factor=0.5` sweep also
+  diffs empty against the *pre-fix* binary. The same sweep at 0.2 moves
+  12 fixtures — that is what makes the two empty diffs mean "default
+  preserved" rather than "still unwired".
+
+  Per #551 the deliverable is a test that proves the option changes
+  behaviour, not one that proves the field is assigned:
+  `crates/pounce-cli/tests/issue_678_alpha_red_factor.rs` drives the CLI
+  and pins both halves. Note that `hs71_obj1e8`, the fixture in the
+  report, cannot serve — it accepts nearly every trial step at full
+  alpha, so it reads identical across the whole legal range even after
+  the fix. It demonstrated the bug; it cannot demonstrate the repair.
+  `hs13_bigstart` backtracks hard and does.
+
+  This is one option. The remaining registered names with no located
+  consumer are #551's ongoing work.
+
 - **The CasADi plugin builds against CasADi master again** (#668).
 
   CasADi renamed the runtime helper `convexify_eval` to

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -605,6 +605,11 @@ impl Default for MuOptions {
 /// mirror `IpBacktrackingLineSearch.cpp:RegisterOptions`.
 #[derive(Debug, Clone)]
 pub struct LineSearchOptions {
+    /// `alpha_red_factor` — fractional reduction applied to the trial
+    /// step size at every backtracking step
+    /// (`alpha *= alpha_red_factor`). Mirrors upstream's
+    /// `IpBacktrackingLineSearch::alpha_red_factor_`.
+    pub alpha_red_factor: Number,
     pub watchdog_shortened_iter_trigger: Index,
     pub watchdog_trial_iter_max: Index,
     /// `soft_resto_pderror_reduction_factor` — required relative
@@ -698,6 +703,7 @@ pub struct LineSearchOptions {
 impl Default for LineSearchOptions {
     fn default() -> Self {
         Self {
+            alpha_red_factor: 0.5,
             watchdog_shortened_iter_trigger: 10,
             watchdog_trial_iter_max: 3,
             soft_resto_pderror_reduction_factor: 1.0 - 1e-4,
@@ -1149,6 +1155,7 @@ impl AlgorithmBuilder {
             LineSearchChoice::CgPenalty => Box::new(PenaltyLsAcceptor::default()),
         };
         let mut line_search = BacktrackingLineSearch::new(acceptor);
+        line_search.alpha_red_factor = self.line_search.alpha_red_factor;
         line_search.watchdog_shortened_iter_trigger =
             self.line_search.watchdog_shortened_iter_trigger;
         line_search.watchdog_trial_iter_max = self.line_search.watchdog_trial_iter_max;

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -3710,6 +3710,11 @@ impl IpoptApplication {
         if let Some(v) = read_int("filter_reset_trigger") {
             builder.line_search.filter_reset_trigger = v;
         }
+        // Backtracking reduction factor (#678), consumed by
+        // `BacktrackingLineSearch` to scale alpha on every trial step.
+        if let Some(v) = read_num("alpha_red_factor") {
+            builder.line_search.alpha_red_factor = v;
+        }
         // Second-order-correction constants (#191), consumed by
         // `BacktrackingLineSearch`. `max_soc = 0` disables SOC.
         if let Some(v) = read_int("max_soc") {

--- a/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
@@ -358,3 +358,46 @@ fn dual_inf_scale_kappa_override_flows_through() {
         assert_eq!(b.conv_check.dual_inf_scale_kappa, value);
     }
 }
+
+/// gh#678 — `alpha_red_factor` was registered, range-checked and
+/// accepted, but never copied out of the `OptionsList`, so the line
+/// search always backtracked by the hard-coded 0.5. It was the last
+/// unwired field of the ten on `BacktrackingLineSearch`; the other nine
+/// (including the `max_soc` block right beside it) were already
+/// covered. Note that a name grep does *not* find this class of bug:
+/// `alpha_red_factor` has eleven hits in `backtracking.rs` and a real
+/// read site, so the option looks consumed. Only the assignment path
+/// tells you, which is what these two tests walk.
+#[test]
+fn alpha_red_factor_default_matches_registered() {
+    // Untouched option ⇒ builder carries the registered default 0.5,
+    // which is also `BacktrackingLineSearch::new`'s hard-coded default.
+    // That equality is the whole reason wiring this moves no default
+    // trajectory, so it is asserted rather than assumed.
+    let b = builder_from(|_| {}).line_search;
+    assert_eq!(b.alpha_red_factor, 0.5);
+}
+
+#[test]
+fn alpha_red_factor_override_flows_through() {
+    let b = builder_from(|app| {
+        app.options_mut()
+            .set_numeric_value("alpha_red_factor", 0.2, true, false)
+            .unwrap();
+    })
+    .line_search;
+    assert_eq!(b.alpha_red_factor, 0.2);
+}
+
+/// The option must survive `build()` onto the concrete
+/// `BacktrackingLineSearch` in the assembled bundle. This is the step
+/// that was actually missing in gh#678 — `application.rs` had no read
+/// *and* `alg_builder.rs` had no assignment, so covering only the
+/// option → builder hop above would leave half the gap untested.
+#[test]
+fn alpha_red_factor_reaches_assembled_line_search() {
+    let mut builder = AlgorithmBuilder::new();
+    builder.line_search.alpha_red_factor = 0.2;
+    let bundle = builder.build();
+    assert_eq!(bundle.line_search.alpha_red_factor, 0.2);
+}

--- a/crates/pounce-cli/tests/issue_678_alpha_red_factor.rs
+++ b/crates/pounce-cli/tests/issue_678_alpha_red_factor.rs
@@ -1,0 +1,201 @@
+//! gh#678 — `alpha_red_factor` reaches the line search.
+//!
+//! The option was registered (bounded (0,1), default 0.5), accepted
+//! without complaint, and never read: `LineSearchOptions` had no such
+//! field, `application.rs` never asked the `OptionsList` for it, and
+//! `alg_builder.rs` never assigned it. The field on
+//! `BacktrackingLineSearch` is genuinely consumed — it scales alpha at
+//! every backtracking step — so it just kept its `new()` default of
+//! 0.5 forever. Asking the line search to backtrack by 0.2 got you no
+//! error, no warning, and a bit-identical trajectory.
+//!
+//! Per gh#551 the deliverable for this class of bug is a test that
+//! proves the option *changes behaviour*, not one that proves the field
+//! is assigned — the latter is what the wiring tests in
+//! `pounce-algorithm/tests/algorithm_options_wiring.rs` do, and on its
+//! own it would have passed just as happily against a value nothing
+//! downstream used. So this file drives the real CLI.
+//!
+//! Two claims, and both matter:
+//!
+//! 1. **The option is live.** Distinct values must produce distinct
+//!    trajectories on a fixture that actually backtracks. `hs71_obj1e8`,
+//!    the fixture in the gh#678 report, is *not* such a fixture — it
+//!    accepts nearly every trial step at full alpha (13 objective
+//!    evaluations for 11 iterations), so it reads identical across the
+//!    whole legal range even after the fix. It demonstrated the bug; it
+//!    cannot demonstrate the repair. `hs13_bigstart` backtracks hard
+//!    (85 objective evaluations for 29 iterations at the default).
+//!
+//! 2. **The default did not move.** The registered default (0.5) equals
+//!    the hard-coded one, so wiring the option must leave an unset run
+//!    bit-for-bit where it was. That is the entire safety argument for a
+//!    trajectory change, and CLAUDE.md is explicit that it has to be
+//!    demonstrated rather than asserted. `scripts/sweep-fixtures.sh`
+//!    over all 57 fixtures diffed empty against the parent commit, and
+//!    an explicit `alpha_red_factor=0.5` sweep also diffed empty against
+//!    the *pre-fix* binary. The same sweep at 0.2 moved 12 fixtures,
+//!    which is what says the empty diffs mean "default preserved" rather
+//!    than "still unwired". This test pins the fixture-sized version of
+//!    both halves so a future retune has to notice.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_solve_report::SolveReport;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(format!("{name}.nl"));
+    p
+}
+
+fn tmp_path(tag: &str, ext: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "pounce_gh678_{}_{seq}_{tag}.{ext}",
+        std::process::id()
+    ));
+    p
+}
+
+/// Solve `model`, optionally with an explicit `alpha_red_factor`.
+/// `None` leaves the option unset so the registry default applies.
+fn solve(model: &str, alpha_red_factor: Option<&str>) -> SolveReport {
+    let tag = format!("{model}_{}", alpha_red_factor.unwrap_or("unset"));
+    let json = tmp_path(&tag, "json");
+    // Explicit, so a solved fixture does not drop a `.sol` beside the
+    // `.nl` in the source tree.
+    let sol = tmp_path(&tag, "sol");
+    let mut cmd = Command::new(pounce_exe());
+    cmd.arg(fixture(model))
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("--json-output")
+        .arg(&json)
+        .arg("--json-detail")
+        .arg("summary")
+        .arg("print_level=0");
+    if let Some(v) = alpha_red_factor {
+        cmd.arg(format!("alpha_red_factor={v}"));
+    }
+    let out = cmd.output().expect("spawn pounce");
+    let text = std::fs::read_to_string(&json).unwrap_or_else(|e| {
+        panic!(
+            "no report for {model} @ alpha_red_factor={:?} (exit {:?}, {e}); \
+             stderr:\n{}",
+            alpha_red_factor,
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr),
+        )
+    });
+    let _ = std::fs::remove_file(&json);
+    let _ = std::fs::remove_file(&sol);
+    serde_json::from_str(&text).expect("parse SolveReport JSON")
+}
+
+/// `(iterations, objective evaluations)`. The evaluation count is the
+/// more direct witness of the two: `alpha_red_factor` sets how fast the
+/// backtracking loop shrinks alpha, so it changes how many trial points
+/// get evaluated per iteration whether or not the iteration count moves.
+fn trajectory(r: &SolveReport) -> (usize, usize) {
+    (
+        r.statistics.iteration_count as usize,
+        r.statistics.num_obj_evals as usize,
+    )
+}
+
+/// Claim 1: the option reaches the line search.
+///
+/// No absolute counts are asserted — those are the most
+/// platform-sensitive numbers in a sweep, and nothing here rests on a
+/// particular one. What is asserted is that the trajectories *differ*,
+/// which is exactly the property that was false before gh#678 and is
+/// unfalsifiable by any amount of grepping for the option name.
+#[test]
+fn alpha_red_factor_changes_the_trajectory() {
+    let slow = solve("hs13_bigstart", Some("0.2"));
+    let default = solve("hs13_bigstart", None);
+    let fast = solve("hs13_bigstart", Some("0.8"));
+
+    // Measured on x86_64-unknown-linux-gnu at the fixing commit:
+    // 0.2 -> (31, 64), unset -> (29, 85), 0.8 -> (26, 39).
+    assert_ne!(
+        trajectory(&slow),
+        trajectory(&default),
+        "alpha_red_factor=0.2 produced the default trajectory; the \
+         option is not reaching BacktrackingLineSearch (this is the \
+         gh#678 regression)",
+    );
+    assert_ne!(
+        trajectory(&fast),
+        trajectory(&default),
+        "alpha_red_factor=0.8 produced the default trajectory; the \
+         option is not reaching BacktrackingLineSearch (this is the \
+         gh#678 regression)",
+    );
+    assert_ne!(
+        trajectory(&slow),
+        trajectory(&fast),
+        "alpha_red_factor=0.2 and =0.8 produced the same trajectory",
+    );
+
+    // A knob that only scales the backtracking step must not change
+    // which optimum is found. hs13 violates the constraint
+    // qualification at its solution, so the tolerance is loose on
+    // purpose: the three runs stop at slightly different points on a
+    // flat approach, not at different answers.
+    for (label, r) in [("0.2", &slow), ("unset", &default), ("0.8", &fast)] {
+        assert_eq!(
+            r.solution.status,
+            ApplicationReturnStatus::SolveSucceeded,
+            "hs13_bigstart @ alpha_red_factor={label} did not converge",
+        );
+        let obj = r.solution.objective;
+        assert!(
+            (obj - 1.0).abs() < 2e-2,
+            "hs13_bigstart @ alpha_red_factor={label} reached {obj}, \
+             not the expected optimum near 1.0",
+        );
+    }
+}
+
+/// Claim 2: wiring the option left the default run exactly where it
+/// was.
+///
+/// The registered default and the `BacktrackingLineSearch::new`
+/// default are both 0.5, so an unset run and an explicit `=0.5` run
+/// must be indistinguishable — same iteration count, same evaluation
+/// count, same objective to the last bit. If someone ever changes one
+/// of the two defaults without the other, this fails, and the corpus
+/// sweep that was clean at merge stops meaning anything.
+#[test]
+fn unset_is_bit_identical_to_the_registered_default() {
+    for model in ["hs13_bigstart", "csfi2", "eigenb2"] {
+        let default = solve(model, None);
+        let explicit = solve(model, Some("0.5"));
+        assert_eq!(
+            trajectory(&default),
+            trajectory(&explicit),
+            "{model}: unset and alpha_red_factor=0.5 took different \
+             trajectories, so the registered default no longer matches \
+             the hard-coded one",
+        );
+        assert_eq!(
+            default.solution.objective, explicit.solution.objective,
+            "{model}: unset and alpha_red_factor=0.5 reached different \
+             objectives",
+        );
+        assert_eq!(default.solution.status, explicit.solution.status);
+    }
+}


### PR DESCRIPTION
Fixes #678.

## Problem

`alpha_red_factor` is registered (bounded `(0,1)`, default 0.5), range-checked, accepted without complaint — and never reaches the line search. A user asking the backtracking line search to shrink alpha by 0.2 instead of 0.5 gets no error, no warning, and a bit-identical trajectory.

`hs13_bigstart`, a fixture that actually backtracks:

| `alpha_red_factor` | | status | objective | NLP error | iters | obj evals |
|---|---|---|---|---|---|---|
| unset | before | SolveSucceeded | 0.9849287152 | 6.11e-09 | 29 | 85 |
| `0.2` | before | SolveSucceeded | 0.9849287152 | 6.11e-09 | 29 | 85 |
| `0.8` | before | SolveSucceeded | 0.9849287152 | 6.11e-09 | 29 | 85 |
| unset | after | SolveSucceeded | 0.9849287152 | 6.11e-09 | 29 | 85 |
| `0.2` | after | SolveSucceeded | 0.9834451325 | 7.07e-09 | 31 | 64 |
| `0.8` | after | SolveSucceeded | 1.009360939 | 1.48e-09 | 26 | 39 |

Every "before" row is identical to every other, to the last digit. The oracle here is not an objective — all six rows find the same optimum of a problem whose published solution is 1 — it is the *responsiveness itself*: a knob documented as "at every step of the backtracking line search, the trial step size is reduced by this factor" must change the number of trial steps, and before this PR it did not.

## Cause

The option is unwired at **both** levels, so there was no single missing line:

- `LineSearchOptions` (`alg_builder.rs:607`) has no `alpha_red_factor` field.
- `application.rs` never calls `read_num("alpha_red_factor")`.
- The single construction site (`alg_builder.rs:1151`) copies nine line-search fields across from `self.line_search` and not this one.

The field on `BacktrackingLineSearch` exists and is genuinely consumed — it scales alpha at `backtracking.rs:928`, `:1003`, `:1154` — so it simply kept the 0.5 that `BacktrackingLineSearch::new` hands it, forever.

It was the last unwired field of the ten on `BacktrackingLineSearch`. The nine around it are wired, including the `max_soc`/`kappa_soc`/`soc_method` block immediately adjacent, which #191 fixed as its worked example of exactly this bug — the comment above that block reads *"registered but previously never read"*. That is why this block reads as finished, and it is the "indistinguishable from a real fix by inspection" hazard #551 describes.

Neither available detector fires: the option name has eleven hits in `backtracking.rs`, so a grep says it is consumed; and the field has real read sites, so it is not dead by any compiler measure. Only tracing the assignment path finds it.

## Fix

Add the field to `LineSearchOptions` (default 0.5, matching the registry), read it in `application.rs` alongside the other line-search constants, assign it at `alg_builder.rs:1158`. Three lines of behaviour change, following the established direct-field pattern of the watchdog and SOC knobs beside it rather than inventing a mechanism.

No alternative was seriously entertained and rejected — the surrounding nine fields fix the shape of the answer, and deviating from it would be the surprising choice. Worth recording from the issue's analysis, though, since a future reader will ask: this field is *already* strongly typed, with a typed default and a real read site, and it was still silently broken. Typing does not supply the wiring, so the #649 direction would not have caught this one.

## Blast radius

Bit-identical except for runs that explicitly set the option. Baseline is the parent commit `cda80f8`; sweeps are `scripts/sweep-fixtures.sh` over all 57 CLI fixtures.

| sweep | vs | result |
|---|---|---|
| new binary, option unset | parent commit `cda80f8` | **empty diff** |
| new binary, explicit `alpha_red_factor=0.5` | **pre-fix** binary | **empty diff** |
| new binary, `alpha_red_factor=0.2` | new binary, unset | **12 of 57 fixtures move** |

The registered default (0.5) equals the hard-coded default (0.5), so an unset run cannot move — but per CLAUDE.md that is the whole safety claim and so it is demonstrated rather than asserted.

The third row is the one that gives the first two their meaning. Two empty diffs are equally consistent with "default preserved" and with "still unwired"; the 0.2 sweep is what distinguishes them. Fixtures that move under 0.2: `autocorr_bern55-06`, `cresc4`, `csfi2`, `deb7`, `eigena2`, `eigenb2`, `hs13_bigstart`, `infeasible_equalities`, `issue_508_infeasible_gap_1em2`, `issue_508_infeasible_gap_1em4`, `linear_eq_collapsed_box`, `pooling_rt2stp`. That movement is the feature working, not a regression — no default run reaches it.

## Tests

Per #551 the deliverable is a test proving the option changes behaviour, not one proving the field is assigned. The latter would have passed just as happily against a value nothing downstream used.

**`crates/pounce-cli/tests/issue_678_alpha_red_factor.rs`** (new) drives the real CLI:

- `alpha_red_factor_changes_the_trajectory` — `0.2`, unset, and `0.8` must give three distinct `(iterations, obj evals)` pairs on `hs13_bigstart`, and all three must still converge near the published optimum of 1. **Fails on the parent commit**, and for the stated reason: with the `alg_builder.rs` assignment reverted it fails on the first `assert_ne!`, reporting that `0.2` produced the default trajectory. Verified directly, not assumed.
- `unset_is_bit_identical_to_the_registered_default` — unset vs explicit `=0.5` on three fixtures, same trajectory and same objective bits. This one **passes pre-fix by design**: it pins the safety property, not the bug. If someone later moves one of the two defaults without the other, the clean corpus sweep above quietly stops meaning anything, and this is what notices.

**`crates/pounce-algorithm/tests/algorithm_options_wiring.rs`** (+3) covers both hops — option → builder, and builder → assembled `BacktrackingLineSearch`. Both were missing, so covering only one would leave half the gap untested.

Deliberately **not** pinned: absolute iteration counts. The test asserts relations (`!=`, `==`) only, following the convention `issue_616_ls_init_downgrades.rs` set — absolute counts are the most platform-sensitive numbers in a sweep and nothing here rests on a particular one. The measured x86_64 values are recorded in a comment for future attribution.

One correction to the issue's test suggestion, since it would otherwise be repeated: **`hs71_obj1e8` cannot serve as the witness.** It is the fixture in the report and it does demonstrate the bug, but it accepts nearly every trial step at full alpha (13 objective evaluations for 11 iterations), so it reads bit-identical across the whole legal range *after the fix as well* — see the third block of the measurement above. It demonstrated the bug; it cannot demonstrate the repair. I swept the corpus for fixtures that genuinely backtrack and used `hs13_bigstart` (85 obj evals for 29 iterations at the default).

## Scope

This one option. The remaining registered names with no located consumer are #551's ongoing work and this does not attempt to close it.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new — **n/a**: no book page documents this option's behaviour; the registry description was already accurate, it just was not true of the code. Nothing in `docs/src/` needed revising.
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — `pounce-algorithm` and `pounce-cli` suites pass in full (71 `pounce-cli` test binaries, 0 failures); no new clippy lints beyond the `expect()`-in-tests style the surrounding test files already share
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGE8Une5KFmx3vpD1464sC)_