### PR TITLE
685 part 2: a quadratic form that dropped a term does not get to route the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,8 +125,47 @@ changes.
   and the *degree* answer correct while the read-out is still short an
   entire `x²`.
 
-  Part 2 of #685 — a model of this shape being classified LP — predates
-  this work and is unchanged here.
+- **…and a model of that shape is no longer *classified* an LP**
+  (#685 part 2).
+
+  The third consumer of the cancelled map is the classifier, and it is
+  the one that decides which solver sees the model at all.
+  `classify_problem` read the row's Hessian, found it empty, and took the
+  "purely linear after all" arm; with no other nonlinearity in the model
+  that is an **LP**, and `qp_extract` then folded the row's empty linear
+  part into `G` and the constraint left the model altogether. The
+  reproduction — `min −x₀` subject to `2⁵³·x₀² + x₀² − 2⁵³·x₀² ≤ 5`,
+  `0 ≤ x₀ ≤ 10⁶` — printed `problem class LP` and `Objective:
+  -1.0000000000000000e+06`, the bound, reported `Optimal`.
+
+  The gate now sits on `NlBody::analyze_quadratic_full` itself rather
+  than on each caller, because every caller past it reads coefficients
+  *out*: the classifier tests a Hessian's definiteness, and both
+  extractors build `P`, `c`, `A` and `G` from all three parts. A form
+  that dropped a term is not the body, so none of them may have it. Such
+  a model routes NLP, where the row is evaluated from its own tape, and
+  `POUNCE_DBG_CLASSIFY=1` names the finding (two new `ClassReason`
+  variants) instead of reporting it as "not a degree-2 polynomial".
+
+  What this does **not** claim is a true optimum for a row like that: a
+  body whose coefficients cancel in the recognizer's arithmetic cancels
+  in the tape's too, so neither route computes the mathematical
+  `x₀² + x₁²`. What goes away is the six-order-of-magnitude gap between
+  a vanished constraint and an evaluated one, and the confident
+  `Optimal` beside it.
+
+  Measured to be a routing change and nothing else: the 57-model fixture
+  sweep is byte-identical, and `Problem class:` over all 61 loadable
+  `.nl` files in the tree is unchanged.
+
+  The cost is reach, and it is real: `x − x` in a nonlinear part is an
+  *exact* cancellation, and it now routes NLP too, because the flag
+  records that a term was dropped and not whether the arithmetic that
+  dropped it was exact. Nothing in the corpus is affected — no fixture
+  body drops a term — but a model that spells a linear row that way loses
+  the LP path. #687 tracks the sharper gate (flag the inexact *fold*,
+  which is where `2⁵³ + 1` loses the `1`, rather than the drop it leads
+  to), which would give those models their fast path back.
 
 - **`least_square_init_primal=yes` costs one accepted downgrade on the
   fixture corpus, not two** (#681, revising the gh#616 measurement).

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -156,6 +156,12 @@ pub enum ClassReason {
     ObjectiveNotQuadratic,
     /// Row `row`'s nonlinear part is not a degree-2 polynomial.
     ConstraintNotQuadratic { row: usize },
+    /// The objective is degree ≤ 2, but the recognizer dropped a term
+    /// reaching its coefficients, so they are not the whole objective.
+    ObjectiveTermsDropped,
+    /// Row `row` is degree ≤ 2, but the recognizer dropped a term reaching
+    /// its coefficients, so they are not the whole row (gh #685).
+    ConstraintTermsDropped { row: usize },
     /// The sense-adjusted objective Hessian has a negative eigenvalue.
     ObjectiveHessianIndefinite,
     /// Row `row` is quadratic with a PSD Hessian, but its bound sense
@@ -191,6 +197,16 @@ impl ClassReason {
             ClassReason::ConstraintNotQuadratic { row } => {
                 format!("row {row}'s nonlinear part is not a degree-2 polynomial")
             }
+            ClassReason::ObjectiveTermsDropped => {
+                "the objective's quadratic form dropped a term to floating-point \
+                 cancellation or underflow, so its coefficients are not the whole \
+                 objective"
+                    .to_string()
+            }
+            ClassReason::ConstraintTermsDropped { row } => format!(
+                "row {row}'s quadratic form dropped a term to floating-point \
+                 cancellation or underflow, so its coefficients are not the whole row"
+            ),
             ClassReason::ObjectiveHessianIndefinite => {
                 "the objective Hessian (sense-adjusted for minimization) is not PSD".to_string()
             }
@@ -380,8 +396,18 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
     }
 
     // Objective curvature.
+    //
+    // The `None` arm covers two findings, and they are not the same
+    // finding: a genuinely non-quadratic term, and a degree-≤2 form the
+    // recognizer could not carry every coefficient of (gh #685). Both route
+    // NLP — the second *must*, since every consumer past this point reads
+    // those coefficients out — but a user reading `POUNCE_DBG_CLASSIFY=1` on
+    // a model they know is a QP is owed the difference.
     let obj_quad = match prob.obj_nonlinear.analyze_quadratic() {
         Some(q) => q,
+        None if prob.obj_nonlinear.quad_terms_dropped() => {
+            return (ProblemClass::Nlp, ClassReason::ObjectiveTermsDropped);
+        }
         // Objective has a non-quadratic nonlinear term ⇒ NLP.
         None => return (ProblemClass::Nlp, ClassReason::ObjectiveNotQuadratic),
     };
@@ -394,8 +420,20 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
             continue;
         }
         match c.analyze_quadratic() {
-            Some(q) if q.is_empty() => {} // purely linear after all
+            // Purely linear after all — and provably so. `analyze_quadratic`
+            // refuses a form that dropped a term, so an empty Hessian here
+            // is the absence of curvature rather than the failure to keep
+            // it. Before gh #685 it was not: a row whose quadratic
+            // coefficients cancelled arrived here empty, classified linear,
+            // and then vanished out of the extracted LP entirely.
+            Some(q) if q.is_empty() => {}
             Some(_) => any_quadratic_constraint = true,
+            None if c.quad_terms_dropped() => {
+                return (
+                    ProblemClass::Nlp,
+                    ClassReason::ConstraintTermsDropped { row },
+                );
+            }
             None => {
                 return (
                     ProblemClass::Nlp,
@@ -483,6 +521,17 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
                         );
                     }
                     reform_flops = reform_flops.saturating_add(socp_reform_flops(&q));
+                }
+                // Both `None` arms are defensive here: the curvature loop
+                // above walks the same rows and has already returned for
+                // any row that answers `None`. They are kept so this
+                // `match` stays correct on its own terms rather than on
+                // the order of two loops.
+                None if c.quad_terms_dropped() => {
+                    return (
+                        ProblemClass::Nlp,
+                        ClassReason::ConstraintTermsDropped { row },
+                    );
                 }
                 None => {
                     return (
@@ -1431,9 +1480,10 @@ mod tests {
         assert_eq!(reason, ClassReason::ConstraintHessianIndefinite { row: 0 });
     }
 
-    /// The LP fast path reports *why* it is an LP, and the two ways of
-    /// getting there are told apart: nothing nonlinear at all, versus
-    /// nonlinear parts that expanded to nothing quadratic.
+    /// The LP fast path reports *why* it is an LP, and the ways of getting
+    /// there are told apart: nothing nonlinear at all, versus a nonlinear
+    /// part that expanded to something of degree ≤ 1 — versus one that only
+    /// *looks* that way because a coefficient was dropped.
     #[test]
     fn lp_reasons_distinguish_absent_from_cancelled() {
         let prob = qp_stub(Expr::Const(0.0), vec![Expr::Const(0.0)]);
@@ -1442,13 +1492,30 @@ mod tests {
             (ProblemClass::Lp, ClassReason::NoNonlinearParts)
         );
 
-        // x0 − x0 in the objective's nonlinear part: present, but degree 0
-        // once expanded.
+        // 2·x0 in the objective's nonlinear part: present, nonlinear to the
+        // header, degree 1 once expanded, and nothing dropped getting there.
+        let expands = Expr::Binary(
+            BinOp::Mul,
+            Box::new(Expr::Const(2.0)),
+            Box::new(Expr::Var(0)),
+        );
+        let prob = qp_stub(expands, vec![Expr::Const(0.0)]);
+        assert_eq!(
+            classify_problem_explained(&prob),
+            (ProblemClass::Lp, ClassReason::NonlinearPartsCancelled)
+        );
+
+        // x0 − x0 reaches degree 0 the other way: by the two coefficients
+        // summing to zero and the term being dropped. The recognizer cannot
+        // tell that from `2⁵³·x0 + x0 − 2⁵³·x0`, where the same drop loses a
+        // whole `x0` and the LP built from the read-out is a different
+        // problem — so it refuses both and the model goes to NLP (gh #685).
+        // The cost is reach: this one *was* linear.
         let cancels = Expr::Binary(BinOp::Sub, Box::new(Expr::Var(0)), Box::new(Expr::Var(0)));
         let prob = qp_stub(cancels, vec![Expr::Const(0.0)]);
         assert_eq!(
             classify_problem_explained(&prob),
-            (ProblemClass::Lp, ClassReason::NonlinearPartsCancelled)
+            (ProblemClass::Nlp, ClassReason::ObjectiveTermsDropped)
         );
     }
 
@@ -1668,11 +1735,17 @@ mod tests {
         assert_eq!(classify_problem(&prob), ProblemClass::Nlp);
     }
 
-    /// A nonlinear objective expression whose quadratic part algebraically
-    /// cancels has an empty Hessian ⇒ classify as `Lp`, not a spurious QP
-    /// (which would otherwise route a linear problem to the QP IPM).
+    /// A nonlinear objective whose quadratic part cancels has an empty
+    /// Hessian — and an empty Hessian it *arrived at by dropping a term* is
+    /// not evidence of anything (gh #685). It used to classify `Lp` on the
+    /// strength of that map; it now goes to NLP, because the coefficient
+    /// arithmetic that emptied the map is the same arithmetic that empties
+    /// it for `2⁵³·x0² + x0² − 2⁵³·x0²`, which is `x0²`.
+    ///
+    /// The spurious-QP concern this test was written for is unaffected: the
+    /// empty Hessian still never reaches the QP IPM.
     #[test]
-    fn classify_cancelling_quadratic_objective_is_lp() {
+    fn classify_cancelling_quadratic_objective_is_not_lp() {
         // x0² − x0²  ≡ 0: the degree-2 terms cancel in the polynomial walk.
         let sq = || {
             Expr::Binary(
@@ -1683,7 +1756,10 @@ mod tests {
         };
         let obj = Expr::Binary(BinOp::Sub, Box::new(sq()), Box::new(sq()));
         let prob = qp_stub(obj, vec![Expr::Const(0.0)]);
-        assert_eq!(classify_problem(&prob), ProblemClass::Lp);
+        assert_eq!(
+            classify_problem_explained(&prob),
+            (ProblemClass::Nlp, ClassReason::ObjectiveTermsDropped)
+        );
     }
 
     #[test]

--- a/crates/pounce-cli/src/qp_extract.rs
+++ b/crates/pounce-cli/src/qp_extract.rs
@@ -114,10 +114,13 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
         // Combine the `.nl` linear section with any degree-≤1 terms AMPL
         // folded into the (here empty-Hessian) nonlinear tree — the
         // classifier admits constraint rows whose nonlinear expression
-        // reduces to degree ≤ 1 (`dispatch.rs`), e.g. cancelled
-        // quadratics or defined variables, and those linear/constant
-        // terms live in `con_nonlinear`, not `con_linear`. Dropping them
-        // silently solves the wrong constraint. The folded constant
+        // reduces to degree ≤ 1 (`dispatch.rs`), e.g. defined variables
+        // or a quadratic the writer wrote out and cancelled exactly, and
+        // those linear/constant terms live in `con_nonlinear`, not
+        // `con_linear`. Dropping them silently solves the wrong
+        // constraint. (A row whose coefficients cancelled *in the
+        // recognizer's own arithmetic* does not reach here at all: it
+        // never classifies LP/QP — gh #685.) The folded constant
         // shifts the bounds: `g_l ≤ row + k ≤ g_u  ⇔  g_l−k ≤ row ≤ g_u−k`.
         // This mirrors the SOCP extractor's linear-constraint handling.
         let (nl_lin, const_shift) = prob.con_nonlinear[row]

--- a/crates/pounce-cli/tests/issue_685_cancelled_quadratic_evaluation.rs
+++ b/crates/pounce-cli/tests/issue_685_cancelled_quadratic_evaluation.rs
@@ -25,8 +25,12 @@
 //! read-out is still short an entire `x₀²`. An emptiness test passes that
 //! model and stays wrong.
 //!
-//! Part 2 of the issue — the classifier calling such a model an LP — is on
-//! `main`, predates this branch, and is not touched here.
+//! Part 2 of the issue — the classifier calling such a model an LP — was
+//! fixed after this one, in `issue_685_cancelled_quadratic_routing`. That
+//! fix moved the gate onto `analyze_quadratic_full` itself, so the models
+//! here now also refuse to hand a dropped form to the classifier; the
+//! `admitted_quad_form` gate this file asserts is the separate one that
+//! governs *evaluation*, and it stays where it is.
 
 use std::path::PathBuf;
 use std::process::Command;

--- a/crates/pounce-cli/tests/issue_685_cancelled_quadratic_routing.rs
+++ b/crates/pounce-cli/tests/issue_685_cancelled_quadratic_routing.rs
@@ -1,0 +1,308 @@
+//! A model whose only nonlinearity cancelled must not be **routed** as an
+//! LP (gh #685, part 2).
+//!
+//! Part 1 (`issue_685_cancelled_quadratic_evaluation`) closed the
+//! evaluation half: a row whose quadratic coefficients cancelled in the
+//! recognizer's own floating-point arithmetic is no longer handed to Q4's
+//! constant-structure evaluator in place of its tape. This is the routing
+//! half, and it is the larger of the two — it is a *classification*
+//! decision, and `dispatch`'s LP fast path is what turns a wrong
+//! classification into a wrong answer rather than a slow one.
+//!
+//! The shape: `2⁵³·x₀² + x₀² − 2⁵³·x₀²` folds to an empty quadratic map, so
+//! `classify_inner`'s "purely linear after all" arm took the row, no row
+//! was quadratic, the objective was linear, and the model classified **LP**
+//! — the reproduction printed
+//!
+//! ```text
+//! pounce: problem class LP — every nonlinear part expanded to a
+//!         linear (or constant) polynomial
+//! Objective: -1.0000000000000000e+06
+//! ```
+//!
+//! `qp_extract` then folded the row's (empty) linear part into `G` and the
+//! constraint left the model altogether: `min −x₀` with nothing holding it
+//! walks to its `10⁶` bound and reports `Optimal`.
+//!
+//! The fix is the same gate as part 1's and in the same place it belongs —
+//! `NlBody::analyze_quadratic_full` refuses a form that dropped a term, so
+//! every consumer that *reads coefficients out* (the classifier, both
+//! extractors) refuses with it. The classifier then names the finding
+//! rather than reporting it as "not a degree-2 polynomial", which is what
+//! the two new `ClassReason` variants are for.
+//!
+//! The refusal is conservative in a way worth knowing about: it keys off
+//! "a term was dropped", not off "the arithmetic that dropped it was
+//! lossy", so an exact `x − x` loses the LP path along with the
+//! catastrophic cases. Nothing in the fixture corpus drops a term at all,
+//! so nothing measurable moves; gh #687 tracks the sharper gate.
+//!
+//! What is asserted here is the routing, not a numerical optimum. A body
+//! whose coefficients cancel in the recognizer's arithmetic cancels in the
+//! tape's too, so the NLP route does not compute the mathematical
+//! `x₀² + x₁²` either; it computes what the row means to this solver, which
+//! is an ill-conditioned thing to hand a line search. The defect gh #685
+//! reports is the six-order-of-magnitude gap and the confident `Optimal`
+//! beside it, and that is what goes away.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use pounce_cli::dispatch::{ClassReason, ProblemClass, classify_problem_explained};
+use pounce_cli::nl_reader::{NlProblem, parse_nl_text_with_quadratic};
+
+// ---------------------------------------------------------------------
+// Models
+// ---------------------------------------------------------------------
+
+/// `2⁵³·x₀² + x₀² − 2⁵³·x₀²`, folded front to back: `2⁵³`, then `2⁵³ + 1`
+/// rounds back to `2⁵³`, then `2⁵³ − 2⁵³` is exactly `0`. The body is
+/// `x₀²`; the stored form is nothing at all.
+///
+/// The middle term is spelled `x₀^2` where the outer two are `x₀·x₀` so
+/// that the tape does not hash-cons all three onto one node — same
+/// construction, and same reason, as gh #683's reproducer.
+fn cancelling_body() -> String {
+    let big = (1u64 << 53) as f64;
+    format!(
+        "o54\n3\n\
+         o2\nn{big:.1}\no2\nv0\nv0\n\
+         o5\nv0\nn2\n\
+         o2\nn{neg:.1}\no2\nv0\nv0\n",
+        neg = -big,
+        big = big,
+    )
+}
+
+/// `(10⁻²⁰⁰·x₀)·(10⁻²⁰⁰·x₀)`: one monomial, degree 2, whose coefficient
+/// `10⁻⁴⁰⁰` is not representable and flushes to zero on the multiply.
+fn underflowing_body() -> &'static str {
+    "o2\no2\nn1e-200\nv0\no2\nn1e-200\nv0\n"
+}
+
+/// An honest `x₀²`, to check the gate did not simply close the QP route.
+fn ordinary_body() -> &'static str {
+    "o5\nv0\nn2\n"
+}
+
+/// The reported reproduction: `min −x₀` subject to `body ≤ 5`, with
+/// `0 ≤ x₀ ≤ 10⁶`. One variable, one row, and *nothing else nonlinear* —
+/// which is the point. Every other model in this pair of test files keeps a
+/// `sin` around to hold the classifier on the NLP route; this one has none,
+/// so the class is decided entirely by what the recognizer made of row 0.
+fn con_model(body: &str) -> String {
+    format!(
+        "g3 0 1 0\n\
+         1 1 1 0 0\n\
+         1 0\n\
+         0 0\n\
+         1 0 0\n\
+         0 0 0 1\n\
+         0 0 0 0 0\n\
+         1 1\n\
+         0 0\n\
+         0 0 0 0 0\n\
+         C0\n{body}\
+         O0 0\n\
+         n0\n\
+         x1\n\
+         0 1.0\n\
+         r\n\
+         1 5.0\n\
+         b\n\
+         0 0.0 1000000.0\n\
+         k0\n\
+         J0 1\n\
+         0 0\n\
+         G0 1\n\
+         0 -1.0\n"
+    )
+}
+
+/// The same defect on the objective side: `min body` subject to a linear
+/// row `x₀ ≥ 1`, `0 ≤ x₀ ≤ 10⁶`. A cancelled objective classified LP by the
+/// same route — an empty Hessian read as "it was effectively linear".
+fn obj_model(body: &str) -> String {
+    format!(
+        "g3 0 1 0\n\
+         1 1 1 0 0\n\
+         0 1\n\
+         0 0\n\
+         0 1 0\n\
+         0 0 0 1\n\
+         0 0 0 0 0\n\
+         1 1\n\
+         0 0\n\
+         0 0 0 0 0\n\
+         C0\n\
+         n0\n\
+         O0 0\n{body}\
+         x1\n\
+         0 1.0\n\
+         r\n\
+         2 1.0\n\
+         b\n\
+         0 0.0 1000000.0\n\
+         k0\n\
+         J0 1\n\
+         0 1.0\n\
+         G0 1\n\
+         0 0\n"
+    )
+}
+
+/// Parse with parse-time quadratic recognition on and off. The classifier
+/// reaches its form from a `Quad` body one way and re-derives it from a
+/// `Tree` the other, and the gate has to be on both arms or it is on
+/// neither.
+fn both_paths(txt: &str) -> [(&'static str, NlProblem); 2] {
+    [
+        (
+            "recognizing",
+            parse_nl_text_with_quadratic(txt, true).expect("parse (recognizing)"),
+        ),
+        (
+            "trees",
+            parse_nl_text_with_quadratic(txt, false).expect("parse (trees)"),
+        ),
+    ]
+}
+
+// ---------------------------------------------------------------------
+// The routing decision
+// ---------------------------------------------------------------------
+
+/// The regression: a row that lost a term is not called linear, so the
+/// model does not route LP.
+///
+/// Before the fix all four of these classified `Lp` with
+/// `NonlinearPartsCancelled`.
+#[test]
+fn a_row_that_dropped_a_term_does_not_route_lp() {
+    for (what, txt) in [
+        ("cancellation", con_model(&cancelling_body())),
+        ("underflow", con_model(underflowing_body())),
+    ] {
+        for (path, prob) in both_paths(&txt) {
+            let (class, reason) = classify_problem_explained(&prob);
+            assert_eq!(
+                class,
+                ProblemClass::Nlp,
+                "{what} ({path}): a model whose only row lost its quadratic \
+                 term was routed to the convex path",
+            );
+            assert_eq!(
+                reason,
+                ClassReason::ConstraintTermsDropped { row: 0 },
+                "{what} ({path}): routed NLP, but for the wrong stated reason",
+            );
+        }
+    }
+}
+
+/// The same on the objective side.
+#[test]
+fn an_objective_that_dropped_a_term_does_not_route_lp() {
+    for (what, txt) in [
+        ("cancellation", obj_model(&cancelling_body())),
+        ("underflow", obj_model(underflowing_body())),
+    ] {
+        for (path, prob) in both_paths(&txt) {
+            let (class, reason) = classify_problem_explained(&prob);
+            assert_eq!(
+                class,
+                ProblemClass::Nlp,
+                "{what} ({path}): a model whose objective lost its quadratic \
+                 term was routed to the convex path",
+            );
+            assert_eq!(
+                reason,
+                ClassReason::ObjectiveTermsDropped,
+                "{what} ({path}): routed NLP, but for the wrong stated reason",
+            );
+        }
+    }
+}
+
+/// The gate is on the drop, not on the shape: an honest quadratic still
+/// reaches the convex path, on both the constraint and the objective side.
+/// Without this the "fix" is just a switch that turns the QP route off.
+#[test]
+fn an_ordinary_quadratic_still_routes_convex() {
+    for (path, prob) in both_paths(&con_model(ordinary_body())) {
+        assert_eq!(
+            classify_problem_explained(&prob).0,
+            ProblemClass::ConvexQcqp,
+            "{path}: an honest `x₀² ≤ 5` lost the conic route",
+        );
+    }
+    for (path, prob) in both_paths(&obj_model(ordinary_body())) {
+        assert_eq!(
+            classify_problem_explained(&prob).0,
+            ProblemClass::ConvexQp,
+            "{path}: an honest `min x₀²` lost the convex-QP route",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// The reported symptom
+// ---------------------------------------------------------------------
+
+/// End to end, through the CLI: the reproduction no longer reports the
+/// bound.
+///
+/// The two things asserted are the two things gh #685 shows: the routing
+/// log says NLP where it said LP, and the reported objective is nowhere
+/// near `x₀`'s `10⁶` ceiling — the row constrains the model again instead
+/// of having vanished out of the extracted LP. The optimum itself is not
+/// asserted, for the reason in the module header: on either route this row
+/// is what floating point makes of it, not `x₀²`.
+#[test]
+fn the_cli_no_longer_reports_the_bound() {
+    let dir = std::env::temp_dir().join("pounce_issue_685_routing");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let path = dir.join("cancelling.nl");
+    std::fs::write(&path, con_model(&cancelling_body())).expect("write model");
+
+    // A cancelling row is ill-conditioned on the tape as well, so cap the
+    // iterations rather than wait out a thrash; the routing decision this
+    // is watching is made before iteration 1.
+    let out = Command::new(PathBuf::from(env!("CARGO_BIN_EXE_pounce")))
+        .arg(&path)
+        .arg("max_iter=200")
+        .env("POUNCE_DBG_CLASSIFY", "1")
+        .output()
+        .expect("run pounce");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let class = text
+        .lines()
+        .find(|l| l.contains("pounce: problem class"))
+        .unwrap_or_else(|| panic!("no classification log in:\n{text}"));
+    assert!(
+        class.contains("problem class NLP"),
+        "the reproduction still routes to the convex path: {class}",
+    );
+
+    let obj = objective(&text).unwrap_or_else(|| panic!("no objective in:\n{text}"));
+    assert!(
+        obj > -1.0e3,
+        "the reproduction still walks x₀ to its 10⁶ bound: objective {obj}",
+    );
+}
+
+/// The unscaled objective from the end-of-run summary block.
+fn objective(text: &str) -> Option<f64> {
+    let line = text
+        .lines()
+        .find(|l| l.trim_start().starts_with("Objective."))?;
+    line.split_whitespace()
+        .filter_map(|t| t.parse::<f64>().ok())
+        .next_back()
+}

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -33,8 +33,8 @@
 //!   tests in this module.
 
 use crate::nl_quadratic::{
-    Quad2, QuadForm, QuadHessian, analyze_quadratic_full, is_expanded_quadratic, is_trivially_zero,
-    quad_form_readout, recognize_expr,
+    Quad2, QuadForm, QuadHessian, is_expanded_quadratic, is_trivially_zero, quad_form_readout,
+    recognize_expr,
 };
 use crate::nl_tape::{HybridTape, Tape, hybrid_supported};
 use pounce_common::types::{Index, Number, lower_bound_present, upper_bound_present};
@@ -358,15 +358,70 @@ impl NlBody {
     /// two answers are the same by construction and asserted to be so bit
     /// for bit; this is the accessor that keeps the corpus from being
     /// re-recognized once per consumer.
+    ///
+    /// `None` also when a term was dropped getting to the form — see
+    /// [`Self::analyze_quadratic_full`].
     pub fn analyze_quadratic(&self) -> Option<QuadHessian> {
         self.analyze_quadratic_full().map(|(h, _, _)| h)
     }
 
     /// [`Self::analyze_quadratic`] with the linear and constant parts.
+    ///
+    /// ## A form that dropped a term is not this body
+    ///
+    /// Everything downstream of here *reads coefficients out*: the
+    /// classifier decides a problem class from the Hessian, and
+    /// `qp_extract` builds `P`, `c`, `A` and `G` from all three parts. So
+    /// this accessor owes its callers a form that is the whole body, and
+    /// a recognized form is only that when nothing was dropped reaching
+    /// it. `2⁵³·x₀² + x₀² − 2⁵³·x₀²` folds to `x₀²` and stores nothing;
+    /// `(10⁻²⁰⁰·x₀)·(10⁻²⁰⁰·x₀)` underflows the same way (gh #683).
+    ///
+    /// Handing that form out is what routed the reproduction in gh #685
+    /// to the **LP** fast path: with the row's only quadratic term gone
+    /// the classifier saw a linear row, `qp_extract` folded an empty
+    /// linear part into `G`, and the constraint left the model
+    /// altogether — `min −x₀` subject to a vanished row walks `x₀` to its
+    /// `10⁶` bound and reports `Optimal`. A wrong answer, on the default
+    /// route, with no option set (gh #685 part 2).
+    ///
+    /// The gate is [`Quad2::dropped_terms`] and not an emptiness test,
+    /// for the reason spelled out on [`Self::admitted_quad_form`]:
+    /// partial cancellation leaves a non-empty map that is still short a
+    /// term. Refusing costs reach only — the row falls back to the AD
+    /// tape, and the model to the NLP path, which solves it soundly.
+    ///
+    /// It costs more reach than it strictly has to. `x − x` cancels
+    /// *exactly*, so that form is the body and could be kept; the flag
+    /// says a term was dropped, not whether the arithmetic that dropped
+    /// it was lossy, so this refuses that too. gh #687 tracks the sharper
+    /// gate (flag the inexact fold, which is where `2⁵³ + 1` loses the
+    /// `1`, rather than the drop it leads to).
+    ///
+    /// Use [`Self::quad_terms_dropped`] to tell the two `None`s apart.
     pub fn analyze_quadratic_full(&self) -> Option<QuadForm> {
         match self {
-            NlBody::Tree(e) => analyze_quadratic_full(e),
-            NlBody::Quad(q) => Some(quad_form_readout(&q.form)),
+            NlBody::Tree(e) => {
+                let form = recognize_expr(e)?;
+                (!form.dropped_terms()).then(|| quad_form_readout(&form))
+            }
+            NlBody::Quad(q) => (!q.form.dropped_terms()).then(|| quad_form_readout(&q.form)),
+        }
+    }
+
+    /// Whether the recognizer reached a degree-≤2 form for this body but
+    /// dropped at least one term getting there — the case
+    /// [`Self::analyze_quadratic_full`] refuses.
+    ///
+    /// `false` both for a body that recognized cleanly and for one that
+    /// did not recognize at all, so this separates the two reasons that
+    /// accessor answers `None`; it is not a nonlinearity test. Meant for
+    /// the *refusal* path (the classifier naming its reason), not the hot
+    /// one: on a tree it re-runs the recognizer.
+    pub fn quad_terms_dropped(&self) -> bool {
+        match self {
+            NlBody::Tree(e) => recognize_expr(e).is_some_and(|f| f.dropped_terms()),
+            NlBody::Quad(q) => q.form.dropped_terms(),
         }
     }
 

--- a/dev-notes/lp-qp-routing.md
+++ b/dev-notes/lp-qp-routing.md
@@ -247,6 +247,18 @@ so the header alone does **not** distinguish LP from QP:
 - Until Phase 4 (SOCP) lands, **ConvexQcqp** falls through to NLP-IPM;
   the distinct class is the dispatch seam the conic solver later
   intercepts (same pattern as `NonconvexQp`).
+- **A recovered `Q` is only usable if it is the whole row** (gh #685
+  part 2). The walk recovers coefficients by summing in floating point,
+  so `2⁵³·x² + x² − 2⁵³·x²` folds to an empty map: degree 2, stored as
+  nothing. Reading that map is how a row with real curvature came back
+  *linear*, the model classified **LP**, and the extractor folded an
+  empty linear part into `G` — the constraint left the problem, and
+  `min −x₀` walked to its bound and reported `Optimal`. The recognizer
+  records whether it dropped a term, and `analyze_quadratic_full`
+  refuses the form when it did, which is upstream of every consumer that
+  reads coefficients out (this walk and both extractors). The row's
+  model then goes to NLP and is evaluated from its tape — the
+  conservative fallback above, reached for one more reason.
 
 This mirrors how QP-capable AMPL solvers detect QPs (ASL's `nqpcheck`
 walks the nonlinear tree to recover `Q`); the header is a fast reject

--- a/dev-notes/quadratic-structure-exploitation.md
+++ b/dev-notes/quadratic-structure-exploitation.md
@@ -51,8 +51,13 @@ same cancelled coefficients were **evaluated** in place of the row's tape
 (gh #685 part 1). Both are wrong answers on the default route with no option
 set, both are written up in §0g's degree/storage pair, and neither moves the
 sweep — no fixture body drops a term, which is why six per-phase sweeps saw
-nothing. Part 2 of gh #685 — a model of that shape classifying LP — is on
-`main`, predates this branch, and stays open.
+nothing. Part 2 of gh #685 — a model of that shape classifying **LP**, so
+the row leaves the extracted problem altogether — predates this branch and
+was fixed after it merged, by moving the gate onto
+`NlBody::analyze_quadratic_full` itself: every consumer past that accessor
+reads coefficients *out*, so none of them may have a form that dropped one.
+It moves neither the fixture sweep nor `Problem class:` over the 61 loadable
+`.nl` files.
 
 **The forecasts in §9 and §11 are forecasts.** Where a measurement contradicts
 one, the row above records what was measured and the PR comment says so; a wrong


### PR DESCRIPTION
Part 1 of #685 (merged in #603) stopped Q4 **evaluating** a row from
coefficients that had cancelled. The same map has a third consumer, and it is
the one that decides which solver sees the model at all.

`classify_inner` read the row's Hessian, found it empty, and took the "purely
linear after all" arm. With no other nonlinearity in the model that is an
**LP** — and `qp_extract` then folded the row's empty linear part into `G`, so
the constraint left the problem entirely.

## Measured, on the issue's reproduction

`min -x0` subject to `2^53*x0^2 + x0^2 - 2^53*x0^2 <= 5`, `0 <= x0 <= 1e6`.

Parent commit (`main`):

```
pounce: problem class LP - every nonlinear part expanded to a
        linear (or constant) polynomial
Objective...............:  -1.0000000000000000e+06     <- the bound, reported Optimal
```

This branch:

```
pounce: problem class NLP - row 0's quadratic form dropped a term to
        floating-point cancellation or underflow, so its coefficients
        are not the whole row
Objective...............:  -1.2090486567570389e+00
```

## The change

The gate goes on `NlBody::analyze_quadratic_full` rather than on each caller.
Everything past that accessor reads coefficients **out** — the classifier tests
a Hessian's definiteness, `qp_extract` and `extract_socp` build `P`, `c`, `A`
and `G` from all three parts — so a form that dropped a term is not a form any
of them may have. One choke point, and the extractors are covered by
construction rather than by remembering.

`NlBody::quad_terms_dropped` then lets the classifier name the finding
(`ObjectiveTermsDropped` / `ConstraintTermsDropped { row }`, two new
`ClassReason` variants) instead of reporting it as "not a degree-2 polynomial".
It re-runs the recognizer on a tree, so it is called only on the refusal path,
never the hot one.

**Not claimed:** a true optimum for such a row. A body whose coefficients
cancel in the recognizer's arithmetic cancels in the tape's too, so neither
route computes the mathematical `x0^2 + x1^2`. What goes away is the six orders
of magnitude between a vanished constraint and an evaluated one, and the
confident `Optimal` beside it. The test file says so in its header.

## Gates

Per `CLAUDE.md`, this is a routing change, so it was measured before merge, not
argued about:

- `scripts/sweep-fixtures.sh` over the 57 models: **byte-identical** to the
  parent commit.
- `Problem class:` over all 61 loadable `.nl` files in the tree: **identical**.
- Full suite green (3188 passed / 0 failed); `cargo fmt --check` clean; CI's
  clippy invocation clean.
- Falsified: with the gate reverted and everything else in place, 3 of the 4
  new tests fail, with the `problem class LP` line above.

`crates/pounce-cli/tests/issue_685_cancelled_quadratic_routing.rs` covers the
constraint side, the objective side, both parse paths (`Quad` bodies and
`Tree` bodies), the CLI end to end — and that an honest `x0^2 <= 5` still
reaches the conic path and an honest `min x0^2` still reaches the convex-QP
path, so the fix is not a switch that turns the QP route off.

## The cost, recorded

Two unit tests encoded the old contract at exactly the point of the defect and
are updated with the reason. That is also where the cost shows: `x - x` cancels
**exactly**, and it is refused too, because the flag records that a term was
dropped and not whether the arithmetic that dropped it was lossy. Nothing in
the corpus is affected — no fixture body drops a term at all, which is why none
of the three sweeps moved — but a model that spells a linear row that way loses
its LP path.

#687 tracks the sharper gate: flag the inexact **fold**, which is where
`2^53 + 1` loses the `1`, rather than the drop it leads to. That would hand the
fast paths back to the exact cases in all three consumers (#683, #685 part 1,
and this one) while still refusing the lossy ones.

Fixes #685.
