### PR TITLE
nl: flag the inexact fold, not the drop (#687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,9 +163,9 @@ changes.
   records that a term was dropped and not whether the arithmetic that
   dropped it was exact. Nothing in the corpus is affected — no fixture
   body drops a term — but a model that spells a linear row that way loses
-  the LP path. #687 tracks the sharper gate (flag the inexact *fold*,
-  which is where `2⁵³ + 1` loses the `1`, rather than the drop it leads
-  to), which would give those models their fast path back.
+  the LP path. #687 is the sharper gate (flag the inexact *fold*, which
+  is where `2⁵³ + 1` loses the `1`, rather than the drop it leads to);
+  the next entry lands it and hands those models their fast path back.
 
 - **…and a row whose coefficients cancel *exactly* keeps both fast paths**
   (#687, sharpening the two above).
@@ -177,8 +177,8 @@ changes.
   coefficient map is a lower bound. `2⁵³·x² + x² − 2⁵³·x²` loses its `x²`
   at `fl(2⁵³ + 1) = 2⁵³`, an inexact add, and only then cancels. Both set
   the same flag, so both were refused, and the first one paid a proved
-  degree, a matrix evaluation, and (once the classifier gates on it) the
-  convex route for arithmetic that never rounded.
+  degree, a matrix evaluation, and — once the classifier gated on it too
+  — the LP/QP route, all for arithmetic that never rounded.
 
   The gate is now the **fold** rather than the drop: a form records
   whether its arithmetic rounded — a two-sum on every coefficient add, an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,34 @@ changes.
   Part 2 of #685 — a model of this shape being classified LP — predates
   this work and is unchanged here.
 
+- **…and a row whose coefficients cancel *exactly* keeps both fast paths**
+  (#687, sharpening the two above).
+
+  The flag those two fixes read said a coefficient had been **dropped**,
+  which is a different question from whether anything was lost. `x − x`
+  folds `fl(1) + fl(−1)` to zero and that add is exact — the term really
+  is absent, the body really is degree 0, and nothing about the
+  coefficient map is a lower bound. `2⁵³·x² + x² − 2⁵³·x²` loses its `x²`
+  at `fl(2⁵³ + 1) = 2⁵³`, an inexact add, and only then cancels. Both set
+  the same flag, so both were refused, and the first one paid a proved
+  degree, a matrix evaluation, and (once the classifier gates on it) the
+  convex route for arithmetic that never rounded.
+
+  The gate is now the **fold** rather than the drop: a form records
+  whether its arithmetic rounded — a two-sum on every coefficient add, an
+  FMA check on every product, and one on the reciprocal a `Div` scales by
+  — and a dropped term counts as missing only when something behind it
+  did. An underflowed or `NaN` coefficient still counts on its own; there
+  is no exact case to spare there.
+
+  No model in the corpus changes: the 57-fixture sweep and the
+  `Problem class:` line over every loadable `.nl` are both byte-identical
+  to the parent build, because no fixture body drops a term at all. What
+  moves is synthetic material that does: 197 rows of the ill-scaled
+  degree battery get their proof back, and the quadratic evaluator's
+  differential compares 197 more generated problems against their tapes
+  (bit-identical Hessians, worst `g`/Jacobian deviation `4.8e-15`).
+
 - **`least_square_init_primal=yes` costs one accepted downgrade on the
   fixture corpus, not two** (#681, revising the gh#616 measurement).
 

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -156,11 +156,14 @@ pub enum ClassReason {
     ObjectiveNotQuadratic,
     /// Row `row`'s nonlinear part is not a degree-2 polynomial.
     ConstraintNotQuadratic { row: usize },
-    /// The objective is degree ≤ 2, but the recognizer dropped a term
+    /// The objective is degree ≤ 2, but the recognizer *lost* a term
     /// reaching its coefficients, so they are not the whole objective.
     ObjectiveTermsDropped,
-    /// Row `row` is degree ≤ 2, but the recognizer dropped a term reaching
+    /// Row `row` is degree ≤ 2, but the recognizer *lost* a term reaching
     /// its coefficients, so they are not the whole row (gh #685).
+    ///
+    /// "Lost", not merely "dropped": a term that cancels exactly is not
+    /// missing from the form, so those rows keep the fast path (gh #687).
     ConstraintTermsDropped { row: usize },
     /// The sense-adjusted objective Hessian has a negative eigenvalue.
     ObjectiveHessianIndefinite,
@@ -198,14 +201,15 @@ impl ClassReason {
                 format!("row {row}'s nonlinear part is not a degree-2 polynomial")
             }
             ClassReason::ObjectiveTermsDropped => {
-                "the objective's quadratic form dropped a term to floating-point \
-                 cancellation or underflow, so its coefficients are not the whole \
-                 objective"
+                "the objective's quadratic form lost a term to an inexact \
+                 floating-point fold or a flush to zero, so its coefficients are \
+                 not the whole objective"
                     .to_string()
             }
             ClassReason::ConstraintTermsDropped { row } => format!(
-                "row {row}'s quadratic form dropped a term to floating-point \
-                 cancellation or underflow, so its coefficients are not the whole row"
+                "row {row}'s quadratic form lost a term to an inexact \
+                 floating-point fold or a flush to zero, so its coefficients are \
+                 not the whole row"
             ),
             ClassReason::ObjectiveHessianIndefinite => {
                 "the objective Hessian (sense-adjusted for minimization) is not PSD".to_string()
@@ -1506,13 +1510,42 @@ mod tests {
         );
 
         // x0 − x0 reaches degree 0 the other way: by the two coefficients
-        // summing to zero and the term being dropped. The recognizer cannot
-        // tell that from `2⁵³·x0 + x0 − 2⁵³·x0`, where the same drop loses a
-        // whole `x0` and the LP built from the read-out is a different
-        // problem — so it refuses both and the model goes to NLP (gh #685).
-        // The cost is reach: this one *was* linear.
+        // summing to zero and the term being dropped. That sum is *exact*
+        // — `fl(1) + fl(−1)` loses nothing — so the empty form really is
+        // the objective, and this stays LP. (gh #685 sent it to NLP; gh
+        // #687 sharpened the gate to the inexact fold and handed the reach
+        // back.)
         let cancels = Expr::Binary(BinOp::Sub, Box::new(Expr::Var(0)), Box::new(Expr::Var(0)));
         let prob = qp_stub(cancels, vec![Expr::Const(0.0)]);
+        assert_eq!(
+            classify_problem_explained(&prob),
+            (ProblemClass::Lp, ClassReason::NonlinearPartsCancelled)
+        );
+
+        // 2⁵³·x0 + x0 − 2⁵³·x0 empties the same map, but the `x0` was lost
+        // at `fl(2⁵³ + 1) = 2⁵³` — an inexact add — so the read-out is a
+        // whole `x0` short of the objective and the LP built from it would
+        // be a different problem. This is the case that must not route LP
+        // (gh #685).
+        let big = 9007199254740992.0_f64; // 2⁵³
+        let loses = Expr::Binary(
+            BinOp::Sub,
+            Box::new(Expr::Binary(
+                BinOp::Add,
+                Box::new(Expr::Binary(
+                    BinOp::Mul,
+                    Box::new(Expr::Const(big)),
+                    Box::new(Expr::Var(0)),
+                )),
+                Box::new(Expr::Var(0)),
+            )),
+            Box::new(Expr::Binary(
+                BinOp::Mul,
+                Box::new(Expr::Const(big)),
+                Box::new(Expr::Var(0)),
+            )),
+        );
+        let prob = qp_stub(loses, vec![Expr::Const(0.0)]);
         assert_eq!(
             classify_problem_explained(&prob),
             (ProblemClass::Nlp, ClassReason::ObjectiveTermsDropped)
@@ -1736,25 +1769,49 @@ mod tests {
     }
 
     /// A nonlinear objective whose quadratic part cancels has an empty
-    /// Hessian — and an empty Hessian it *arrived at by dropping a term* is
-    /// not evidence of anything (gh #685). It used to classify `Lp` on the
-    /// strength of that map; it now goes to NLP, because the coefficient
-    /// arithmetic that emptied the map is the same arithmetic that empties
-    /// it for `2⁵³·x0² + x0² − 2⁵³·x0²`, which is `x0²`.
+    /// Hessian — and whether that empty map is evidence depends on how it
+    /// got empty. `x0² − x0²` cancels exactly, so the map is the whole
+    /// objective and the model is an LP. `2⁵³·x0² + x0² − 2⁵³·x0²` empties
+    /// the same map having lost an entire `x0²` at `fl(2⁵³ + 1)`, so the
+    /// read-out is not the objective and the model must go to NLP (gh
+    /// #685, gated on the inexact fold per gh #687).
     ///
-    /// The spurious-QP concern this test was written for is unaffected: the
-    /// empty Hessian still never reaches the QP IPM.
+    /// The spurious-QP concern this test was written for is unaffected in
+    /// either case: an empty Hessian never reaches the QP IPM.
     #[test]
-    fn classify_cancelling_quadratic_objective_is_not_lp() {
-        // x0² − x0²  ≡ 0: the degree-2 terms cancel in the polynomial walk.
-        let sq = || {
-            Expr::Binary(
+    fn classify_cancelling_quadratic_objective_routes_on_exactness() {
+        // x0² − x0²  ≡ 0: the degree-2 terms cancel in the polynomial walk,
+        // and the sum that cancels them is exact.
+        let sq = |c: f64| {
+            let p = Expr::Binary(
                 BinOp::Pow,
                 Box::new(Expr::Var(0)),
                 Box::new(Expr::Const(2.0)),
-            )
+            );
+            if c == 1.0 {
+                p
+            } else {
+                Expr::Binary(BinOp::Mul, Box::new(Expr::Const(c)), Box::new(p))
+            }
         };
-        let obj = Expr::Binary(BinOp::Sub, Box::new(sq()), Box::new(sq()));
+        let obj = Expr::Binary(BinOp::Sub, Box::new(sq(1.0)), Box::new(sq(1.0)));
+        let prob = qp_stub(obj, vec![Expr::Const(0.0)]);
+        assert_eq!(
+            classify_problem_explained(&prob),
+            (ProblemClass::Lp, ClassReason::NonlinearPartsCancelled)
+        );
+
+        // 2⁵³·x0² + x0² − 2⁵³·x0² ≡ x0²: same empty map, one lost term.
+        let big = 9007199254740992.0_f64; // 2⁵³
+        let obj = Expr::Binary(
+            BinOp::Sub,
+            Box::new(Expr::Binary(
+                BinOp::Add,
+                Box::new(sq(big)),
+                Box::new(sq(1.0)),
+            )),
+            Box::new(sq(big)),
+        );
         let prob = qp_stub(obj, vec![Expr::Const(0.0)]);
         assert_eq!(
             classify_problem_explained(&prob),

--- a/crates/pounce-cli/tests/issue_683_cancelled_quadratic_degree.rs
+++ b/crates/pounce-cli/tests/issue_683_cancelled_quadratic_degree.rs
@@ -153,6 +153,41 @@ fn a_cancelled_quadratic_row_is_never_proved_affine() {
     }
 }
 
+/// The other side of the demotion, sharpened in gh #687: a row whose terms
+/// cancel **exactly** keeps its proof. `x₀² − x₀²` is degree 0 — the add
+/// `fl(1) + fl(−1)` loses nothing — and the tape agrees, so demoting it to
+/// "not established" would give up a whole solve's worth of frozen
+/// Jacobian for arithmetic that never rounded.
+///
+/// This is what separates the gh #687 gate from the drop-based one it
+/// replaces: on the pre-#687 code every assertion below reads `None`.
+#[test]
+fn an_exactly_cancelled_quadratic_row_is_still_proved_affine() {
+    // `x₀·x₀ − x₀^2`, the two spellings, so the tape does not hash-cons the
+    // pair into one node and cancel the comparison away with them.
+    let body = "o1\no2\nv0\nv0\no5\nv0\nn2\n";
+    for (path, prob) in ["recognizing", "trees"]
+        .iter()
+        .zip(both_paths(&model(body)))
+    {
+        assert_eq!(
+            prob.con_nonlinear[0].provably_affine(),
+            Some(true),
+            "{path}: an exactly cancelling row lost its degree proof",
+        );
+    }
+
+    // And the claim is true of the body: the tape's ∂g₀/∂x really does hold
+    // still, because `2x₀ − 2x₀` is `0` at every `x₀`.
+    let prob = parse_nl_text_with_quadratic(&model(body), true).expect("parse");
+    let mut t = NlTnlp::try_new(prob).expect("build TNLP");
+    assert_eq!(
+        t.derivative_proofs().row(0),
+        DerivativeProof::Constant,
+        "the row's Jacobian was not proved constant",
+    );
+}
+
 /// A row the recognizer has nothing to say about is still `None` and not
 /// `Some(false)` — the demotion must not have turned into "everything is
 /// suspicious", which would be correct and useless.
@@ -278,6 +313,17 @@ fn the_cli_does_not_reuse_the_inequality_jacobian() {
 // whose repeated monomials hash-cons into one node can have one of exactly
 // zero); `None` asserts nothing by construction.
 
+/// How far a proved-affine row's tape Jacobian may drift between probes
+/// before this battery calls it a moving derivative.
+///
+/// Bitwise equality is what almost every row gives, and what every row gave
+/// before gh #687 admitted the exactly-cancelling ones. Exactly one body in
+/// 3 000 seeds drifts at all — seed 1293, whose adjoint accumulation sums
+/// `±10³⁰⁸` against `−10³⁰⁰` — and it drifts by `4.5e-12`. This is three
+/// orders above that and eleven below the smallest change a *degree* defect
+/// produces (those move a derivative off zero, or by factors of `x`).
+const TAPE_WOBBLE_REL: f64 = 1e-9;
+
 /// A deterministic xorshift, so a failure names a reproducible seed.
 struct Rng(u64);
 
@@ -359,9 +405,13 @@ fn a_proved_affine_body_has_a_jacobian_its_own_tape_holds_still() {
         [1e-8, 2.0, 1e8],
     ];
     let (mut affine, mut quadratic, mut refused) = (0usize, 0usize, 0usize);
+    // Probe entries skipped because the tape itself overflowed — see the
+    // comment at the comparison.
+    let mut non_finite = 0usize;
+    let mut worst_rel = 0.0f64;
     // Of the refusals, how many are this fix talking — a form the recognizer
-    // *did* lower, demoted because it dropped a term — as opposed to a body
-    // it never lowered at all (a degree-3 product).
+    // *did* lower, demoted because a term went missing — as opposed to a
+    // body it never lowered at all (a degree-3 product).
     let mut demoted = 0usize;
 
     for seed in 1..=3_000u64 {
@@ -396,7 +446,7 @@ fn a_proved_affine_body_has_a_jacobian_its_own_tape_holds_still() {
                     refused += 1;
                     if b.tree()
                         .and_then(recognize_expr)
-                        .is_some_and(|q| q.dropped_terms())
+                        .is_some_and(|q| q.lost_terms())
                     {
                         demoted += 1;
                     }
@@ -435,11 +485,44 @@ fn a_proved_affine_body_has_a_jacobian_its_own_tape_holds_still() {
                 if claims[row] != Some(true) {
                     continue;
                 }
-                assert_eq!(
-                    first[k].to_bits(),
-                    here[k].to_bits(),
+                // A probe where the *tape* overflowed is not evidence about
+                // the body. Seed 565 is the case: `x₀²·((x₁ − x₁)·x₁)·10³⁰⁰`
+                // is identically zero, and the recognizer proves it — the
+                // `x₁ − x₁` cancels exactly and annihilates the product. Its
+                // tape multiplies before it sums, so at `x₀ = 10⁸` the
+                // adjoint reaches `10³⁰⁰ · 10¹⁶ = ∞` and then `∞ · 0 = NaN`,
+                // where every finite probe reads `0`. A `NaN` is not a
+                // derivative that moved; it is a derivative the tape could
+                // not compute, and the frozen `0` is the value it gives
+                // wherever it gives a number at all. Both directions of the
+                // comparison have to be numbers for the comparison to mean
+                // anything (gh #687 admitted these rows; before it they were
+                // refused for the cancellation and never reached here).
+                if !first[k].is_finite() || !here[k].is_finite() {
+                    non_finite += 1;
+                    continue;
+                }
+                if first[k].to_bits() == here[k].to_bits() {
+                    continue;
+                }
+                // Bitwise is the assertion; this is the one escape, and it
+                // is about the *tape's* conditioning rather than the claim.
+                // Since gh #687 an exactly cancelling row is proved affine,
+                // and the tape re-does that cancellation with `x`-scaled
+                // adjoints: seed 1293's row sums `±10³⁰⁸` contributions that
+                // cancel mathematically into a running total of `−10³⁰⁰`, so
+                // the constant it lands on drifts a few ulps with `x`. The
+                // *body* is affine, and the frozen derivative is the value
+                // the drift is around. What this rules out is a derivative
+                // that genuinely moves, which is orders of magnitude, not
+                // parts in 10¹²: the gh #683 reproductions move from `0`.
+                let rel = (first[k] - here[k]).abs()
+                    / first[k].abs().max(here[k].abs()).max(f64::MIN_POSITIVE);
+                worst_rel = worst_rel.max(rel);
+                assert!(
+                    rel <= TAPE_WOBBLE_REL,
                     "seed {seed}: row {row} was proved affine, but ∂g/∂x[{}] moved \
-                     from {} to {} between {:?} and {x:?}",
+                     from {} to {} (rel {rel:e}) between {:?} and {x:?}",
                     jcol[k],
                     first[k],
                     here[k],
@@ -451,7 +534,9 @@ fn a_proved_affine_body_has_a_jacobian_its_own_tape_holds_still() {
 
     eprintln!(
         "[gh683 battery] {affine} rows proved affine, {quadratic} proved degree 2, \
-         {refused} not established ({demoted} of them demoted for a dropped term)"
+         {refused} not established ({demoted} of them demoted for a lost term); \
+         {non_finite} probe entries skipped as non-finite on the tape; \
+         worst surviving Jacobian drift {worst_rel:e}"
     );
     // All three verdicts have to be represented, or the battery is asserting
     // something about a set it never reached. `refused` in particular is the

--- a/crates/pounce-cli/tests/issue_685_cancelled_quadratic_evaluation.rs
+++ b/crates/pounce-cli/tests/issue_685_cancelled_quadratic_evaluation.rs
@@ -18,7 +18,7 @@
 //! end of it — an objective of `-1.0e6` against a true optimum a couple of
 //! units away, reported `Optimal`.
 //!
-//! The fix keys off [`Quad2::dropped_terms`] and not off the map being
+//! The fix keys off [`Quad2::lost_terms`] and not off the map being
 //! empty, and the difference is the whole of `partial_cancellation` below:
 //! `2⁵³·x₀² + x₀² − 2⁵³·x₀² + x₁²` keeps `x₁²`, so the map is *not* empty
 //! and `provably_affine` says `Some(false)` quite correctly — while the
@@ -105,7 +105,7 @@ fn cancelling_body() -> String {
 /// `2⁵³·x₀² + x₀² − 2⁵³·x₀² + x₁²` — the same cancellation with a live term
 /// beside it. The map keeps `x₁²`, so it is not empty, and the degree
 /// answer is a correct `Some(false)`; the read-out is nonetheless missing
-/// `x₀²` entirely. This is the model that separates a `dropped_terms` gate
+/// `x₀²` entirely. This is the model that separates a `lost_terms` gate
 /// from an emptiness gate.
 fn partially_cancelling_body() -> String {
     let big = (1u64 << 53) as f64;
@@ -129,6 +129,14 @@ fn underflowing_body() -> &'static str {
 /// An honest degree-2 body, to check the gate did not simply close.
 fn ordinary_body() -> &'static str {
     "o54\n2\no2\nv0\nv0\no5\nv1\nn2\n"
+}
+
+/// `x₀·x₀ − x₀^2 + x₁²`: a term that cancels **exactly**, beside a live one.
+/// `fl(1) + fl(−1)` is `0` with nothing rounded away, so the read-out is the
+/// whole body and the row keeps its matrix evaluation (gh #687). The two
+/// spellings of `x₀²` keep the tape from hash-consing the pair.
+fn exactly_cancelling_body() -> &'static str {
+    "o54\n3\no2\nv0\nv0\no16\no5\nv0\nn2\no5\nv1\nn2\n"
 }
 
 /// Parse with parse-time quadratic recognition on and off — the two arms of
@@ -191,6 +199,37 @@ fn partial_cancellation_is_not_caught_by_looking_for_an_empty_form() {
             "{path}: a non-empty but incomplete form was admitted",
         );
     }
+}
+
+/// The gate is on the *loss*, not on the drop (gh #687): a row whose term
+/// cancelled exactly is admitted, because its read-out is the whole body.
+/// On the pre-#687 code this row was refused along with the absorbing one,
+/// and the row went back to the tape for nothing.
+#[test]
+fn an_exactly_cancelled_row_is_still_admitted_for_evaluation() {
+    for (path, prob) in both_paths(&model(exactly_cancelling_body())) {
+        let form = prob.con_nonlinear[0]
+            .admitted_quad_form()
+            .unwrap_or_else(|| panic!("{path}: an exactly cancelling row lost its fast path"));
+        let (h, _lin, _c) = form;
+        // The cancelled `x₀²` is absent because it is absent, and `x₁²` is
+        // there because it is there.
+        assert_eq!(h.get(&(0, 0)), None, "{path}");
+        assert_eq!(h.get(&(1, 1)), Some(&2.0), "{path}");
+    }
+
+    // And the fast path it keeps agrees with the tape it replaces.
+    let x = [3.0, 1.0];
+    let g = |quad: bool| -> f64 {
+        let prob =
+            parse_nl_text_with_quadratic(&model(exactly_cancelling_body()), true).expect("parse");
+        let mut t = NlTnlp::try_new_with_quadratic(prob, quad).expect("build TNLP");
+        let m = t.get_nlp_info().expect("nlp info").m as usize;
+        let mut out = vec![0.0; m];
+        assert!(t.eval_g(&x, true, &mut out), "eval_g failed");
+        out[0]
+    };
+    assert_eq!(g(true), g(false), "the admitted form is not the row");
 }
 
 /// The gate is on the drop, not on the shape: an ordinary `x₀² + x₁²` is

--- a/crates/pounce-cli/tests/issue_685_cancelled_quadratic_routing.rs
+++ b/crates/pounce-cli/tests/issue_685_cancelled_quadratic_routing.rs
@@ -31,11 +31,12 @@
 //! rather than reporting it as "not a degree-2 polynomial", which is what
 //! the two new `ClassReason` variants are for.
 //!
-//! The refusal is conservative in a way worth knowing about: it keys off
-//! "a term was dropped", not off "the arithmetic that dropped it was
-//! lossy", so an exact `x − x` loses the LP path along with the
-//! catastrophic cases. Nothing in the fixture corpus drops a term at all,
-//! so nothing measurable moves; gh #687 tracks the sharper gate.
+//! The refusal was at first conservative in a way worth knowing about: it
+//! keyed off "a term was dropped", not off "the arithmetic that dropped
+//! it was lossy", so an exact `x − x` lost the LP path along with the
+//! catastrophic cases. gh #687 sharpened the flag to the inexact *fold*,
+//! so exact cancellations keep their fast path and only the lossy ones —
+//! the shape asserted below — route NLP.
 //!
 //! What is asserted here is the routing, not a numerical optimum. A body
 //! whose coefficients cancel in the recognizer's arithmetic cancels in the

--- a/crates/pounce-cli/tests/quad_evaluator_differential.rs
+++ b/crates/pounce-cli/tests/quad_evaluator_differential.rs
@@ -573,7 +573,7 @@ const BATTERY_WORST_REL: f64 = 1e-14;
 /// Coefficients stay within a few orders of magnitude on purpose. The
 /// ill-scaled case — where the sum of a row's coefficients is catastrophic
 /// and the two paths part company by more than any tolerance — is a real
-/// defect on the *storage* side (see the `dropped_terms` skip below), not
+/// defect on the *storage* side (see the `lost_terms` skip below), not
 /// something for this battery to rediscover once per seed.
 fn battery_monomial(rng: &mut Rng2) -> Expr {
     fn c(rng: &mut Rng2) -> Expr {
@@ -660,14 +660,23 @@ fn rng_below(rng: &mut Rng2, n: u64) -> u64 {
 /// The fast path and the tape, over expressions no `.nl` writer emitted.
 ///
 /// A body whose recognized form has
-/// [`dropped_terms`](pounce_cli::nl_quadratic::Quad2::dropped_terms) set is
+/// [`lost_terms`](pounce_cli::nl_quadratic::Quad2::lost_terms) set is
 /// **skipped**, and the skip is the honest part of this test. Such a body's
-/// coefficients cancelled or underflowed on the way into the form, so the
-/// fast path is evaluating a different function from the tape — by design,
-/// and wrongly: `2⁵³·x² + x² − 2⁵³·x²` reads out as the zero form while its
-/// own tape gives 16 at `x = 3`. That is the storage-side half of gh #683,
-/// filed as gh #685; a battery that did not skip it would be reporting that
-/// defect once per seed instead of guarding this one.
+/// coefficients were rounded and then cancelled, or underflowed, on the way
+/// into the form, so the fast path is evaluating a different function from
+/// the tape — by design, and wrongly: `2⁵³·x² + x² − 2⁵³·x²` reads out as
+/// the zero form while its own tape gives 16 at `x = 3`. That is the
+/// storage-side half of gh #683, filed as gh #685; a battery that did not
+/// skip it would be reporting that defect once per seed instead of guarding
+/// this one.
+///
+/// The skip used to fire on any drop, which took **204 of 1 500** seeds out
+/// of the comparison — most of them for cancellations that lost nothing
+/// (`c·xᵢxⱼ − c·xᵢxⱼ` is a shape this battery emits readily, and every
+/// coefficient it draws from is a power of two or a small integer). Since
+/// gh #687 it fires on the *loss*, 7 seeds remain skipped, and the 197
+/// problems that came back are compared like any other — at the same
+/// tolerance, which they meet.
 #[test]
 fn a_synthetic_battery_evaluates_the_same_both_ways() {
     let mut rep = Report::default();
@@ -682,8 +691,8 @@ fn a_synthetic_battery_evaluates_the_same_both_ways() {
 
         // The skip. Asked of the same recognizer the evaluator asks, so it
         // cannot drift out of step with what the fast path admits.
-        let dropped = |e: &Expr| recognize_expr(e).is_some_and(|q| q.dropped_terms());
-        if dropped(&objective) || rows.iter().any(dropped) {
+        let lost = |e: &Expr| recognize_expr(e).is_some_and(|q| q.lost_terms());
+        if lost(&objective) || rows.iter().any(lost) {
             skipped += 1;
             continue;
         }
@@ -712,7 +721,7 @@ fn a_synthetic_battery_evaluates_the_same_both_ways() {
 
     eprintln!(
         "[quad differential] battery: {seeds_used} problems built ({skipped} skipped for \
-         dropped terms), {} reached the fast path, {} quadratic rows, {} hessian entries \
+         lost terms), {} reached the fast path, {} quadratic rows, {} hessian entries \
          ({} not bit-identical, worst {} ulp at {}), worst g/jac rel deviation {:.3e}",
         rep.models_with_quadratic,
         rep.quadratic_rows,

--- a/crates/pounce-nl/src/nl_quadratic.rs
+++ b/crates/pounce-nl/src/nl_quadratic.rs
@@ -72,26 +72,50 @@ pub type QuadForm = (QuadHessian, Vec<(usize, f64)>, f64);
 /// consumer guards on `!= 0.0`, and [`analyze_quadratic_full`] normalizes
 /// the sign on the way out.
 ///
-/// ### …and what dropping one costs
+/// ### …and when dropping one loses something
 ///
-/// Dropping is right for the *storage* question and wrong for the *degree*
-/// question, and [`dropped_terms`](Quad2::dropped_terms) is the difference
-/// (gh #683). A coefficient that reaches zero is a coefficient that was
-/// **summed**, not one that was proven absent: `2⁵³·x² + x² − 2⁵³·x²` folds
-/// to an empty `quadratic` map even though the body is degree 2, and so
-/// does `(10⁻²⁰⁰·x)·(10⁻²⁰⁰·x)`, whose one coefficient underflows. The maps
-/// therefore record a *lower bound* on the degree, and the flag records
-/// whether that bound is tight.
+/// Dropping is right for the *storage* question and can be wrong for the
+/// *degree* question, and [`lost_terms`](Quad2::lost_terms) is the
+/// difference (gh #683, sharpened by gh #687). A coefficient that reaches
+/// zero is a coefficient that was **summed**, and it is the arithmetic of
+/// that sum — not the drop — that decides whether anything went missing:
+///
+/// * `x − x` folds `fl(1) + fl(−1)` to `0.0`, and that add is **exact**.
+///   The term really is absent, the body really is degree 0, and the maps
+///   are not a lower bound on anything.
+/// * `2⁵³·x² + x² − 2⁵³·x²` loses the `x²` at `fl(2⁵³ + 1) = 2⁵³`, which is
+///   an **inexact** add, and only then does `2⁵³ − 2⁵³` drop the survivor.
+///   The body is `x²`; the maps say degree 0.
+///
+/// The loss happens at the inexact fold; the drop is only where it becomes
+/// visible. So the flag is set from the *fold*: a form whose arithmetic
+/// never rounded — and never flushed a live coefficient to zero — carries
+/// coefficients that are exactly what real arithmetic on the writer's own
+/// literals would give, and a term missing from its maps is a term that is
+/// genuinely absent. Flagging the drop instead refused both of the above
+/// alike, which was sound and cost reach on the first (gh #687).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Quad2 {
     constant: f64,
     linear: BTreeMap<usize, f64>,
     quadratic: QuadHessian,
-    /// Set when a term was dropped as exactly zero (or as `NaN`) rather
-    /// than proven absent — see the type docs. Sticky: it survives every
-    /// operation the form takes part in, because a term that cancelled
-    /// three additions ago is no less missing now.
-    dropped_terms: bool,
+    /// Set when a term may be **missing** from the maps — see the type
+    /// docs and [`lost_terms`](Quad2::lost_terms). Sticky: it survives
+    /// every operation the form takes part in, because a term that went
+    /// missing three additions ago is no less missing now.
+    lost_terms: bool,
+    /// Set when some arithmetic in this form's construction **rounded**:
+    /// an add that could not represent its sum, or a product that could
+    /// not represent itself. Sticky, and for the same reason.
+    ///
+    /// Clear ⇒ every stored coefficient is exactly the real-arithmetic
+    /// value of the terms folded into it, so a coefficient that reached
+    /// zero reached it because the real value is zero. That is the whole
+    /// warrant for `lost_terms` staying clear across a cancellation, and
+    /// it is why an inexact *fold* sets this bit even when the coefficient
+    /// it produced is nonzero and stays stored: what it rounded away can
+    /// be cancelled out of sight later, by an add that is itself exact.
+    inexact: bool,
 }
 
 impl Quad2 {
@@ -112,8 +136,10 @@ impl Quad2 {
         &self.quadratic
     }
 
-    /// Whether some term of this form was **dropped as zero** (or as `NaN`)
-    /// on the way here, rather than shown to be absent.
+    /// Whether a term may be **missing** from this form's maps: something
+    /// was dropped on the way here *and* the arithmetic that produced it
+    /// had already rounded, or a live coefficient was flushed to zero (or
+    /// to `NaN`) outright.
     ///
     /// This is what turns the term maps from an answer about degree into a
     /// lower bound on it (gh #683). When it is set, an empty
@@ -125,19 +151,45 @@ impl Quad2 {
     /// reported as proved affine and had its Jacobian frozen for a whole
     /// solve.
     ///
+    /// It was originally set by the **drop** alone, which conflated an
+    /// exact cancellation with a lossy one and refused both (gh #687):
+    /// `x − x` is degree 0 by an exact add, and a consumer that treats it
+    /// as "not established" gives up a proved degree, a matrix evaluation
+    /// and — once the classifier gates on this too — the convex route, for
+    /// a body that lost nothing. The gate is now the fold, so the exact
+    /// case keeps its fast paths and the lossy one is refused for the
+    /// reason it deserves. [`inexact`](Quad2::inexact) is the other half of
+    /// that answer.
+    ///
     /// It is deliberately one bit for the whole form rather than a record
     /// per monomial: the consumer's question is about the form, and Q3's
     /// point was that a `Quad2` allocates nothing per term (gh #588, Q3).
+    /// Two bits, now, and still nothing per term — the cost of a per-key
+    /// provenance record is what keeps this a *conservative* answer: an
+    /// inexact fold on one monomial makes a cancellation on an unrelated
+    /// one count as lossy.
     ///
-    /// A *linear* or constant term that dropped sets it too, even though
-    /// dropping one cannot understate an affine body's degree by itself: it
-    /// can once the form is **multiplied**, because
+    /// A *linear* or constant term that goes missing sets it too, even
+    /// though losing one cannot understate an affine body's degree by
+    /// itself: it can once the form is **multiplied**, because
     /// [`mul`](Quad2::mul)'s degree guard reads the same maps —
     /// `(2⁵³ + 1 − 2⁵³)·x · x²` is degree 3 and folds to an apparent
-    /// degree 0. Distinguishing the two would take a second flag to buy
+    /// degree 0. Distinguishing the two would take a third flag to buy
     /// back reach that the corpus does not contain.
-    pub fn dropped_terms(&self) -> bool {
-        self.dropped_terms
+    pub fn lost_terms(&self) -> bool {
+        self.lost_terms
+    }
+
+    /// Whether any arithmetic behind this form's coefficients **rounded**.
+    ///
+    /// Clear means every stored coefficient is exact, which is what makes a
+    /// coefficient of zero a proof of absence rather than a lower bound —
+    /// see [`lost_terms`](Quad2::lost_terms), which is this bit read at the
+    /// moment a term is dropped. Public because it is the thing a test
+    /// about the sharpened gate has to be able to see; no consumer routes
+    /// on it.
+    pub fn inexact(&self) -> bool {
+        self.inexact
     }
 
     pub(crate) fn of_constant(c: f64) -> Self {
@@ -193,24 +245,40 @@ impl Quad2 {
         } else {
             (b, a)
         };
-        let mut dropped = small.dropped_terms;
+        // Whether anything either side already knew it had rounded. Read
+        // once, before any merge, so the verdict below does not depend on
+        // the order the maps happen to iterate in.
+        let carried_inexact = acc.inexact || small.inexact;
+        let (mut dropped, mut inexact) = (false, false);
         if small.constant != 0.0 {
             let was = acc.constant;
             acc.constant += small.constant;
             // Same rule as a coefficient, for the same reason: the degree-0
             // term is exempt from the "no stored zeros" invariant but not
             // from arithmetic, and `mul` reads `constant == 0.0` as
-            // *annihilates*. A constant that cancelled is not one that was
-            // proven absent (gh #683).
+            // *annihilates*. A constant that cancelled *inexactly* is not
+            // one that was proven absent (gh #683); one that cancelled
+            // exactly is (gh #687).
+            inexact |= !add_is_exact(was, small.constant, acc.constant);
             dropped |= was != 0.0 && acc.constant == 0.0;
         }
         for (i, c) in &small.linear {
-            dropped |= merge(&mut acc.linear, *i, *c);
+            let m = merge(&mut acc.linear, *i, *c);
+            dropped |= m.dropped;
+            inexact |= m.inexact;
         }
         for (k, c) in &small.quadratic {
-            dropped |= merge(&mut acc.quadratic, *k, *c);
+            let m = merge(&mut acc.quadratic, *k, *c);
+            dropped |= m.dropped;
+            inexact |= m.inexact;
         }
-        acc.dropped_terms |= dropped;
+        // A term is only *lost* if something was dropped and some fold on
+        // the way here could not represent itself. Neither half is enough
+        // alone: an exact cancellation drops a term that was really zero,
+        // and an inexact fold that keeps its coefficient has hidden
+        // nothing — yet.
+        acc.lost_terms |= small.lost_terms || (dropped && (carried_inexact || inexact));
+        acc.inexact = carried_inexact || inexact;
         acc
     }
 
@@ -230,49 +298,100 @@ impl Quad2 {
     /// The `prune` is not decoration, and neither is the flag it sets. A
     /// nonzero coefficient times a nonzero `s` can still land on zero by
     /// underflow — `1e-300 x0²` divided by `1e300` is reachable from a real
-    /// `.nl` body, through [`Op::Div`]'s `scale(1.0 / d)` — so this is the
+    /// `.nl` body, through [`Op::Div`]'s reciprocal — so this is the
     /// gh #683 shape again, arrived at by scaling rather than by summing.
     /// Leaving the flushed entry stored would make an arithmetically
     /// constant form report degree 2 to [`Quad2::degree`] and be refused as
     /// degree 3 the moment anything multiplied it; dropping it without
-    /// recording the drop would make a genuinely degree-2 body look affine
-    /// to [`Quad2::dropped_terms`]'s consumers. `prune` does both.
-    /// (`neg` needs neither: negation cannot reach zero from a coefficient
-    /// that was not already there.)
+    /// recording the loss would make a genuinely degree-2 body look affine
+    /// to [`Quad2::lost_terms`]'s consumers. `prune` does the first and
+    /// this does the second. (`neg` needs neither: negation cannot reach
+    /// zero from a coefficient that was not already there, and it never
+    /// rounds.)
+    ///
+    /// A coefficient here can only reach zero by **underflow** — both
+    /// factors are nonzero — so unlike a cancelling sum there is no exact
+    /// case to spare (gh #687): `10⁻³⁰⁰ · 10⁻³⁰⁰` is a term the form can no
+    /// longer see, whatever the flags said before.
     pub(crate) fn scale(mut self, s: f64) -> Quad2 {
         if s == 0.0 {
             // An exact zero annihilates every term, so this is a proof of
-            // degree 0 rather than a drop — nothing is being discarded that
-            // survived the multiplication. The flag still rides along: the
-            // one route here is division by an infinity, and `0 · NaN` is
-            // not zero.
+            // degree 0 rather than a loss — nothing is being discarded that
+            // survived the multiplication, and `x · 0` is exact. The flags
+            // still ride along: the one route here is division by an
+            // infinity, and `0 · NaN` is not zero.
             return Quad2 {
-                dropped_terms: self.dropped_terms,
+                lost_terms: self.lost_terms,
+                inexact: self.inexact,
                 ..Quad2::default()
             };
         }
         let was = self.constant;
         self.constant *= s;
-        self.dropped_terms |= was != 0.0 && self.constant == 0.0;
+        if was != 0.0 {
+            self.lost_terms |= self.constant == 0.0;
+            self.inexact |= !mul_is_exact(was, s, self.constant);
+        }
+        let mut inexact = false;
         for c in self.linear.values_mut() {
+            let was = *c;
             *c *= s;
+            inexact |= !mul_is_exact(was, s, *c);
         }
         for c in self.quadratic.values_mut() {
+            let was = *c;
             *c *= s;
+            inexact |= !mul_is_exact(was, s, *c);
         }
-        // A scale can underflow a live coefficient to zero, which is a
-        // dropped term like any other and used to be stored as a zero.
-        self.prune();
+        self.inexact |= inexact;
+        // A scale can underflow a live coefficient to zero, which is a lost
+        // term and used to be stored as a zero.
+        self.lost_terms |= self.prune();
         self
     }
 
     /// Restore the "no stored zeros" invariant after an operation wrote
-    /// coefficients in bulk, recording that something was dropped.
-    fn prune(&mut self) {
+    /// coefficients in bulk. Returns whether anything was dropped; what
+    /// that *means* is the caller's to say, because it depends on how the
+    /// coefficients got there (see [`scale`](Quad2::scale) and
+    /// [`mul`](Quad2::mul)).
+    fn prune(&mut self) -> bool {
         let before = self.width();
         self.linear.retain(|_, c| is_live(*c));
         self.quadratic.retain(|_, c| is_live(*c));
-        self.dropped_terms |= self.width() != before;
+        self.width() != before
+    }
+
+    /// `self / d`, for a constant `d` the caller has already checked is
+    /// nonzero.
+    ///
+    /// Scales by the **reciprocal** (not `c / d`) so the arithmetic matches
+    /// what the recursive predecessor produced bit for bit; what is new is
+    /// that `fl(1/d)` is the reciprocal only when `d` is a power of two,
+    /// and `fma(r, d, −1) == 0` says so exactly. Recording it matters
+    /// because a coefficient no real arithmetic produced can still cancel
+    /// *exactly* against another one later — and that cancellation would
+    /// otherwise be read as a proof of absence (gh #687).
+    pub(crate) fn div_by_constant(self, d: f64) -> Quad2 {
+        let r = 1.0 / d;
+        let exact = r.is_normal() && d.is_normal() && r.mul_add(d, -1.0) == 0.0;
+        let mut out = self.scale(r);
+        out.inexact |= !exact;
+        out
+    }
+
+    /// Take on another form's [`lost_terms`](Quad2::lost_terms) and
+    /// [`inexact`](Quad2::inexact) history.
+    ///
+    /// The operand a `Div` or a `Pow` reads as a *constant* is a [`Quad2`]
+    /// like any other, and its arithmetic is part of this form's: dividing
+    /// by `fl(10²⁰⁰ · 10²⁰⁰)` is dividing by an infinity, and dividing by a
+    /// constant that swallowed a variable term is worse than that. The
+    /// value is read out through [`as_constant`](Quad2::as_constant), which
+    /// keeps neither fact, so the caller hands the form itself over here.
+    pub(crate) fn absorb_flags(&mut self, other: &Quad2) {
+        self.lost_terms |= other.lost_terms;
+        self.inexact |= other.inexact;
     }
 
     /// `self · other`, or `None` when the product would exceed total
@@ -283,23 +402,45 @@ impl Quad2 {
             return None;
         }
         let mut out = Quad2::default();
+        // Either operand's missing term is missing from the product too,
+        // and so is either operand's rounding.
+        let mut lost = self.lost_terms || other.lost_terms;
+        let carried_inexact = self.inexact || other.inexact;
+        let mut inexact = false;
+        // A product of two live coefficients that lands on zero underflowed
+        // — `(10⁻²⁰⁰·x)·(10⁻²⁰⁰·x)` is one monomial whose coefficient is not
+        // representable (gh #683) — and unlike a cancelling *sum* there is
+        // no exact case to spare, so `lost` is set on the spot rather than
+        // left to the cancellation rule below.
+        let product = |a: f64, b: f64, lost: &mut bool, inexact: &mut bool| -> f64 {
+            let t = a * b;
+            *lost |= !is_live(t);
+            *inexact |= !mul_is_exact(a, b, t);
+            t
+        };
         if self.constant != 0.0 && other.constant != 0.0 {
-            out.constant = self.constant * other.constant;
             // `10⁻²⁰⁰ · 10⁻²⁰⁰` is not zero, and the branches below read a
             // zero constant as an annihilating one — which would take a
             // degree-2 product down to nothing without a trace (gh #683).
-            out.dropped_terms = out.constant == 0.0;
+            out.constant = product(self.constant, other.constant, &mut lost, &mut inexact);
         }
+        let mut dropped = false;
         // constant × (linear, quadratic), both ways round.
         for (a, b) in [(self, other), (other, self)] {
             if a.constant == 0.0 {
                 continue;
             }
             for (i, c) in &b.linear {
-                *out.linear.entry(*i).or_insert(0.0) += a.constant * c;
+                let t = product(a.constant, *c, &mut lost, &mut inexact);
+                let m = accumulate(&mut out.linear, *i, t);
+                dropped |= m.dropped;
+                inexact |= m.inexact;
             }
             for (k, c) in &b.quadratic {
-                *out.quadratic.entry(*k).or_insert(0.0) += a.constant * c;
+                let t = product(a.constant, *c, &mut lost, &mut inexact);
+                let m = accumulate(&mut out.quadratic, *k, t);
+                dropped |= m.dropped;
+                inexact |= m.inexact;
             }
         }
         // linear × linear. The degree guard above means at most one of the
@@ -308,46 +449,142 @@ impl Quad2 {
         for (i, a) in &self.linear {
             for (j, b) in &other.linear {
                 let key = (*i.min(j), *i.max(j));
-                *out.quadratic.entry(key).or_insert(0.0) += a * b;
+                let t = product(*a, *b, &mut lost, &mut inexact);
+                let m = accumulate(&mut out.quadratic, key, t);
+                dropped |= m.dropped;
+                inexact |= m.inexact;
             }
         }
-        // Either operand's missing term is missing from the product too,
-        // and a product of two live coefficients can underflow to zero —
-        // `(10⁻²⁰⁰·x)·(10⁻²⁰⁰·x)` is one monomial whose coefficient is not
-        // representable (gh #683).
-        out.dropped_terms |= self.dropped_terms || other.dropped_terms;
-        out.prune();
+        // What `prune` drops here that `accumulate` did not already see is a
+        // key whose *first* contribution was a zero — an underflowed product,
+        // and `lost` is set for it above. So the cancellation rule is the
+        // same one `add` applies: a drop counts as a loss only when some fold
+        // behind it rounded.
+        dropped |= out.prune();
+        out.lost_terms = lost || (dropped && (carried_inexact || inexact));
+        out.inexact = carried_inexact || inexact;
         Some(out)
     }
 }
 
+/// What folding one coefficient into a map did — the two facts
+/// [`Quad2::lost_terms`] is decided from.
+#[derive(Clone, Copy)]
+struct Merged {
+    /// The key is no longer stored: the fold reached exactly zero, or
+    /// `NaN`.
+    dropped: bool,
+    /// The fold **rounded**: what is stored (or what cancelled) is not what
+    /// exact arithmetic on the same two numbers would have left.
+    inexact: bool,
+}
+
 /// Add `c` to `map[key]`, keeping the "no stored zeros" invariant. Returns
-/// whether a term was **dropped** doing so.
+/// what that did, as [`Merged`].
 ///
 /// Only the touched key can have become zero, which is what keeps a merge
 /// proportional to what it merged rather than to what it merged *into*.
-fn merge<K: Ord>(map: &mut BTreeMap<K, f64>, key: K, c: f64) -> bool {
+fn merge<K: Ord>(map: &mut BTreeMap<K, f64>, key: K, c: f64) -> Merged {
     use std::collections::btree_map::Entry;
     match map.entry(key) {
         Entry::Occupied(mut e) => {
-            let v = *e.get() + c;
+            let a = *e.get();
+            let v = a + c;
+            let inexact = !add_is_exact(a, c, v);
             if is_live(v) {
                 e.insert(v);
-                false
+                Merged {
+                    dropped: false,
+                    inexact,
+                }
             } else {
                 e.remove();
-                true
+                Merged {
+                    dropped: true,
+                    inexact,
+                }
             }
         }
+        // Nothing was added to anything: a live `c` is stored as it stands,
+        // and a dead one is only reachable from a caller that already knows
+        // what its own zero means (`mul`'s underflowed products; `add` only
+        // ever passes stored — hence live — coefficients).
         Entry::Vacant(e) => {
             if is_live(c) {
                 e.insert(c);
-                false
+                Merged {
+                    dropped: false,
+                    inexact: false,
+                }
             } else {
-                true
+                Merged {
+                    dropped: true,
+                    inexact: c.is_nan(),
+                }
             }
         }
     }
+}
+
+/// Accumulate `t` into `map[key]`, the way [`Quad2::mul`] builds a product
+/// up term by term, and report what the fold did.
+///
+/// Unlike [`merge`] this leaves a zero stored — `mul` prunes once at the
+/// end — because a key it lands on twice must see the first contribution as
+/// a plain `0.0 + t`, bit for bit what the `+=` this replaced produced.
+/// Only a key that was already nonzero can be said to have *dropped*
+/// anything.
+fn accumulate<K: Ord>(map: &mut BTreeMap<K, f64>, key: K, t: f64) -> Merged {
+    let slot = map.entry(key).or_insert(0.0);
+    let was = *slot;
+    *slot = was + t;
+    Merged {
+        dropped: was != 0.0 && !is_live(*slot),
+        inexact: !add_is_exact(was, t, *slot),
+    }
+}
+
+/// Was `a + b`, which came out as `s`, computed **exactly**?
+///
+/// Knuth's two-sum: `err` below is the part of the true sum that `s` could
+/// not represent, and it is itself exact for every finite pair — no
+/// tolerance, no magnitude test. Two extra flops per merge, which is the
+/// whole cost of telling `x − x` (exact, degree really 0) apart from
+/// `2⁵³·x + x − 2⁵³·x` (the `x` was absorbed by the first add, and the
+/// second only made it visible). See gh #687.
+///
+/// A non-finite operand — or a sum that overflowed — makes `err` a `NaN`,
+/// which answers *inexact*: the conservative direction, and the right one,
+/// since an infinity has lost every term it swallowed.
+fn add_is_exact(a: f64, b: f64, s: f64) -> bool {
+    let bb = s - a;
+    let err = (a - (s - bb)) + (b - bb);
+    err == 0.0
+}
+
+/// Was `a · b`, which came out as `p`, computed **exactly**?
+///
+/// `fma(a, b, −p)` is the multiply's rounding error, exactly, and `p` is
+/// exact iff that error is zero. The `±1` shortcut is not micro-optimizing
+/// for its own sake: every variable enters the recognizer with a
+/// coefficient of `1.0` (see [`Quad2::of_var`]), so it is the common case
+/// by a wide margin, and `f64::mul_add` is a libm call on targets without a
+/// hardware FMA.
+///
+/// A product that overflowed to an infinity answers *inexact* for the same
+/// reason a sum that did.
+fn mul_is_exact(a: f64, b: f64, p: f64) -> bool {
+    if a == 1.0 || a == -1.0 || b == 1.0 || b == -1.0 || a == 0.0 || b == 0.0 {
+        // Multiplying by ±1 or by an exact zero cannot round.
+        return true;
+    }
+    // A product that is not *normal* is one the exponent range could not
+    // hold: zero (`10⁻²⁰⁰ · 10⁻²⁰⁰`, from two nonzero factors), a subnormal
+    // that gave up bits at the bottom, or an infinity from overflow. The
+    // `fma` below cannot be asked about those — it rounds onto the same
+    // grid, and answers `0` for the underflowed product as readily as for
+    // an exact one — so they are answered here, inexact.
+    p.is_normal() && a.mul_add(b, -p) == 0.0
 }
 
 /// Is this coefficient worth **storing**? Exact zeros are dropped so that
@@ -361,8 +598,9 @@ fn merge<K: Ord>(map: &mut BTreeMap<K, f64>, key: K, c: f64) -> bool {
 /// applied to a **sum** of coefficients, so a degree-2 body whose
 /// coefficients cancel — or whose one coefficient underflows — stores
 /// nothing and looks affine. That is gh #683, and it is why every caller
-/// records the drop in [`Quad2::dropped_terms`]; the degree question is
-/// answered from *that*, not from this predicate.
+/// weighs the drop against the arithmetic that led to it and records the
+/// verdict in [`Quad2::lost_terms`]; the degree question is answered from
+/// *that*, not from this predicate.
 fn is_live(c: f64) -> bool {
     c.abs() > 0.0
 }
@@ -515,13 +753,18 @@ pub fn recognize_expr(e: &Expr) -> Option<Quad2> {
                         if d == 0.0 {
                             return None;
                         }
-                        a.scale(1.0 / d)
+                        let mut out = a.div_by_constant(d);
+                        // The divisor's own history comes along: `as_constant`
+                        // reads a number out of a form and leaves the flags
+                        // behind.
+                        out.absorb_flags(&b);
+                        out
                     }
                     Op::Pow => {
                         // Polynomial only for constant exponents in {0, 1, 2}.
                         let (a, b) = pop2(&mut vals)?;
                         let exp = b.as_constant()?;
-                        if exp == 0.0 {
+                        let mut out = if exp == 0.0 {
                             Quad2::of_constant(1.0)
                         } else if exp == 1.0 {
                             a
@@ -529,7 +772,12 @@ pub fn recognize_expr(e: &Expr) -> Option<Quad2> {
                             a.mul(&a)?
                         } else {
                             return None;
-                        }
+                        };
+                        // Same as `Div`: the exponent is read out of a form,
+                        // and one that lost a term is not the exponent it
+                        // looks like.
+                        out.absorb_flags(&b);
+                        out
                     }
                 };
                 vals.push(combined);
@@ -820,7 +1068,7 @@ mod tests {
         // "not established" rather than "yes".
         let q = recognize_expr(&flushed).expect("degree-2 at worst");
         assert!(
-            q.dropped_terms(),
+            q.lost_terms(),
             "a coefficient that underflowed in `scale` was dropped silently"
         );
         // And the degree has to go with it for the *storage* question:
@@ -843,6 +1091,183 @@ mod tests {
         assert!(h.is_empty());
         let times_x1 = Expr::Binary(BinOp::Mul, Box::new(zero), Box::new(Expr::Var(1)));
         assert!(analyze_quadratic(&times_x1).is_some());
+    }
+
+    /// The gh #687 distinction, at the level it is made: an **exact**
+    /// cancellation leaves the form complete, and an absorbed term does
+    /// not. Both bodies drop a coefficient; only one of them lost anything
+    /// doing it.
+    #[test]
+    fn an_exact_cancellation_is_not_a_lost_term() {
+        // x0² − x0²: `fl(1) + fl(−1)` is exactly `0`, so the body really is
+        // degree 0 and the maps say so with nothing held back.
+        let zero = Expr::Binary(BinOp::Sub, Box::new(sq(0)), Box::new(sq(0)));
+        let q = recognize_expr(&zero).expect("degree-2 at worst");
+        assert!(q.quadratic().is_empty());
+        assert!(!q.inexact(), "an exact fold reported rounding");
+        assert!(
+            !q.lost_terms(),
+            "x0² − x0² was refused a fast path it is entitled to",
+        );
+
+        // 2⁵³·x0² + x0² − 2⁵³·x0², front to back: the `x0²` is absorbed by
+        // `fl(2⁵³ + 1) = 2⁵³` — an inexact add — and the exact `− 2⁵³` only
+        // makes the loss visible.
+        let big = (1u64 << 53) as f64;
+        let scaled = |c: f64| Expr::Binary(BinOp::Mul, Box::new(Expr::Const(c)), Box::new(sq(0)));
+        let absorbing = Expr::Sum(vec![scaled(big), sq(0), scaled(-big)]);
+        let q = recognize_expr(&absorbing).expect("degree-2 at worst");
+        assert!(q.quadratic().is_empty());
+        assert!(q.inexact(), "the absorbing add was not seen to round");
+        assert!(
+            q.lost_terms(),
+            "a body whose x0² was absorbed was reported complete",
+        );
+    }
+
+    /// The absorption is recorded where it happens, which is the point of
+    /// the sharpened gate: `2⁵³·x0² + x0²` has lost the `x0²` already, and
+    /// the form says so before anything cancels — while its coefficient is
+    /// still stored and its degree is still 2.
+    #[test]
+    fn the_inexact_fold_is_flagged_before_anything_drops() {
+        let big = (1u64 << 53) as f64;
+        let scaled = |c: f64| Expr::Binary(BinOp::Mul, Box::new(Expr::Const(c)), Box::new(sq(0)));
+        let e = Expr::Binary(BinOp::Add, Box::new(scaled(big)), Box::new(sq(0)));
+        let q = recognize_expr(&e).expect("degree-2");
+        assert_eq!(q.quadratic().get(&(0, 0)), Some(&big));
+        assert!(q.inexact(), "fl(2⁵³ + 1) = 2⁵³ was called exact");
+        // Nothing is missing from the maps *yet*, so the consumers keep
+        // their fast paths: the degree is not in question here.
+        assert!(!q.lost_terms());
+    }
+
+    /// The sticky half of the same rule. The rounding and the drop are in
+    /// different subexpressions — `(2⁵³·x0 + x0)` absorbs, `− 2⁵³·x0`
+    /// cancels — and the verdict has to survive the trip between them.
+    #[test]
+    fn rounding_carried_from_a_subexpression_makes_a_later_drop_a_loss() {
+        let big = (1u64 << 53) as f64;
+        let scaled =
+            |c: f64| Expr::Binary(BinOp::Mul, Box::new(Expr::Const(c)), Box::new(Expr::Var(0)));
+        let absorbed = Expr::Binary(BinOp::Add, Box::new(scaled(big)), Box::new(Expr::Var(0)));
+        let e = Expr::Binary(BinOp::Sub, Box::new(absorbed), Box::new(scaled(big)));
+        let q = recognize_expr(&e).expect("degree-1 at worst");
+        assert!(q.linear().is_empty());
+        assert!(
+            q.lost_terms(),
+            "the x0 absorbed two additions ago is no less missing now",
+        );
+    }
+
+    /// Cancellation *inside a product*: `(x0 + x1)·(x0 − x1)` accumulates
+    /// `+x0x1` and `−x0x1` onto one key and they cancel exactly. The body
+    /// really has no cross term, so the form must not be demoted for
+    /// noticing.
+    #[test]
+    fn an_exact_cancellation_in_a_product_is_not_a_lost_term() {
+        let add = |a: Expr, b: Expr| Expr::Binary(BinOp::Add, Box::new(a), Box::new(b));
+        let sub = |a: Expr, b: Expr| Expr::Binary(BinOp::Sub, Box::new(a), Box::new(b));
+        let e = Expr::Binary(
+            BinOp::Mul,
+            Box::new(add(Expr::Var(0), Expr::Var(1))),
+            Box::new(sub(Expr::Var(0), Expr::Var(1))),
+        );
+        let q = recognize_expr(&e).expect("degree-2");
+        assert_eq!(q.quadratic().get(&(0, 0)), Some(&1.0));
+        assert_eq!(q.quadratic().get(&(1, 1)), Some(&-1.0));
+        assert_eq!(q.quadratic().get(&(0, 1)), None);
+        assert!(!q.lost_terms(), "x0² − x1² was reported incomplete");
+    }
+
+    /// An underflowing **multiply** has no exact case to spare: both
+    /// factors are nonzero and the product is a monomial the form can no
+    /// longer see. `(10⁻²⁰⁰·x0)·(10⁻²⁰⁰·x0)` stays refused, which is gh
+    /// #683's second reproduction and gh #687's second acceptance case.
+    #[test]
+    fn an_underflowing_product_is_still_a_lost_term() {
+        let tiny = |i: usize| {
+            Expr::Binary(
+                BinOp::Mul,
+                Box::new(Expr::Const(1e-200)),
+                Box::new(Expr::Var(i)),
+            )
+        };
+        let e = Expr::Binary(BinOp::Mul, Box::new(tiny(0)), Box::new(tiny(0)));
+        let q = recognize_expr(&e).expect("degree-2 at worst");
+        assert!(q.quadratic().is_empty());
+        assert!(
+            q.lost_terms(),
+            "a coefficient that underflowed on the multiply was reported absent",
+        );
+    }
+
+    /// A constant folded away exactly is degree 0 for real — and `mul`
+    /// reads a zero constant as annihilating, so this is the one drop whose
+    /// verdict a *product* depends on.
+    #[test]
+    fn an_exactly_cancelled_constant_is_not_a_lost_term() {
+        let e = Expr::Binary(
+            BinOp::Sub,
+            Box::new(Expr::Const(3.0)),
+            Box::new(Expr::Const(3.0)),
+        );
+        let q = recognize_expr(&e).expect("degree 0");
+        assert_eq!(q.as_constant(), Some(0.0));
+        assert!(!q.lost_terms());
+
+        // The same shape one ulp off: `fl(2⁵³ + 1) − 2⁵³` is `0.0` where the
+        // real value is `1`.
+        let big = (1u64 << 53) as f64;
+        let absorbed = Expr::Binary(
+            BinOp::Add,
+            Box::new(Expr::Const(big)),
+            Box::new(Expr::Const(1.0)),
+        );
+        let e = Expr::Binary(BinOp::Sub, Box::new(absorbed), Box::new(Expr::Const(big)));
+        let q = recognize_expr(&e).expect("degree 0");
+        assert_eq!(q.as_constant(), Some(0.0));
+        assert!(q.lost_terms(), "an absorbed constant was reported absent");
+    }
+
+    /// Rounding a coefficient is recorded even when nothing is dropped,
+    /// because that is what a later exact cancellation would be hiding:
+    /// `x0²/3` cannot be represented, and the form has to remember it.
+    #[test]
+    fn a_rounded_scale_is_inexact_but_loses_nothing() {
+        let e = Expr::Binary(BinOp::Div, Box::new(sq(0)), Box::new(Expr::Const(3.0)));
+        let q = recognize_expr(&e).expect("degree-2");
+        assert_eq!(q.quadratic().get(&(0, 0)), Some(&(1.0 / 3.0)));
+        assert!(q.inexact(), "1 · (1/3) was called exact");
+        assert!(
+            !q.lost_terms(),
+            "a rounded coefficient is not a missing one"
+        );
+
+        // Halving is exact, so the same shape by a power of two is not.
+        let e = Expr::Binary(BinOp::Div, Box::new(sq(0)), Box::new(Expr::Const(2.0)));
+        let q = recognize_expr(&e).expect("degree-2");
+        assert!(!q.inexact(), "x0²/2 rounds nothing");
+    }
+
+    /// The two-sum and the two-product, against the cases the recognizer
+    /// actually meets. Exactness is not a tolerance, so these are `==`.
+    #[test]
+    fn the_exactness_tests_agree_with_the_arithmetic() {
+        let big = (1u64 << 53) as f64;
+        assert!(add_is_exact(big, -big, big + -big));
+        assert!(add_is_exact(1.0, 2.0, 3.0));
+        assert!(!add_is_exact(big, 1.0, big + 1.0), "2⁵³ + 1 loses the 1");
+        assert!(!add_is_exact(0.1, 0.2, 0.1 + 0.2));
+        assert!(!add_is_exact(f64::INFINITY, 1.0, f64::INFINITY));
+        assert!(!add_is_exact(f64::NAN, 1.0, f64::NAN + 1.0));
+
+        assert!(mul_is_exact(3.0, 1.0, 3.0), "the ±1 shortcut");
+        assert!(mul_is_exact(3.0, 0.5, 1.5));
+        assert!(mul_is_exact(0.1, 4.0, 0.4));
+        assert!(!mul_is_exact(3.0, 1.0 / 3.0, 3.0 * (1.0 / 3.0)));
+        assert!(!mul_is_exact(1e-200, 1e-200, 1e-200 * 1e-200), "underflow");
+        assert!(!mul_is_exact(1e300, 1e300, 1e300 * 1e300), "overflow");
     }
 
     #[test]

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -385,32 +385,31 @@ impl NlBody {
     /// `10⁶` bound and reports `Optimal`. A wrong answer, on the default
     /// route, with no option set (gh #685 part 2).
     ///
-    /// The gate is [`Quad2::dropped_terms`] and not an emptiness test,
-    /// for the reason spelled out on [`Self::admitted_quad_form`]:
-    /// partial cancellation leaves a non-empty map that is still short a
-    /// term. Refusing costs reach only — the row falls back to the AD
-    /// tape, and the model to the NLP path, which solves it soundly.
+    /// The gate is [`Quad2::lost_terms`] and not an emptiness test, for
+    /// the reason spelled out on [`Self::admitted_quad_form`]: partial
+    /// cancellation leaves a non-empty map that is still short a term.
+    /// Refusing costs reach only — the row falls back to the AD tape,
+    /// and the model to the NLP path, which solves it soundly.
     ///
-    /// It costs more reach than it strictly has to. `x − x` cancels
-    /// *exactly*, so that form is the body and could be kept; the flag
-    /// says a term was dropped, not whether the arithmetic that dropped
-    /// it was lossy, so this refuses that too. gh #687 tracks the sharper
-    /// gate (flag the inexact fold, which is where `2⁵³ + 1` loses the
-    /// `1`, rather than the drop it leads to).
+    /// `lost_terms` is the *inexact fold* and not the drop it leads to
+    /// (gh #687), so the reach given up here is only the reach that has
+    /// to be. `x − x` cancels exactly — nothing was lost, the form is
+    /// the body, and it is still handed out; `2⁵³·x + x − 2⁵³·x` loses
+    /// the `x` at `fl(2⁵³ + 1)`, and that is what this refuses.
     ///
     /// Use [`Self::quad_terms_dropped`] to tell the two `None`s apart.
     pub fn analyze_quadratic_full(&self) -> Option<QuadForm> {
         match self {
             NlBody::Tree(e) => {
                 let form = recognize_expr(e)?;
-                (!form.dropped_terms()).then(|| quad_form_readout(&form))
+                (!form.lost_terms()).then(|| quad_form_readout(&form))
             }
-            NlBody::Quad(q) => (!q.form.dropped_terms()).then(|| quad_form_readout(&q.form)),
+            NlBody::Quad(q) => (!q.form.lost_terms()).then(|| quad_form_readout(&q.form)),
         }
     }
 
     /// Whether the recognizer reached a degree-≤2 form for this body but
-    /// dropped at least one term getting there — the case
+    /// lost at least one term getting there — the case
     /// [`Self::analyze_quadratic_full`] refuses.
     ///
     /// `false` both for a body that recognized cleanly and for one that
@@ -420,8 +419,8 @@ impl NlBody {
     /// one: on a tree it re-runs the recognizer.
     pub fn quad_terms_dropped(&self) -> bool {
         match self {
-            NlBody::Tree(e) => recognize_expr(e).is_some_and(|f| f.dropped_terms()),
-            NlBody::Quad(q) => q.form.dropped_terms(),
+            NlBody::Tree(e) => recognize_expr(e).is_some_and(|f| f.lost_terms()),
+            NlBody::Quad(q) => q.form.lost_terms(),
         }
     }
 

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -380,7 +380,7 @@ impl NlBody {
     /// digits on `(x − 500000)²` — so the gate is on both arms or on
     /// neither (gh #588, Q4; gh #673).
     ///
-    /// ## The second gate: a term that was dropped is a term that is missing
+    /// ## The second gate: a term that was *lost* is a term that is missing
     ///
     /// `is_expanded_quadratic` is a gate on the *shape* the coefficients
     /// were derived from. It says nothing about whether the derivation kept
@@ -397,7 +397,7 @@ impl NlBody {
     /// then walks the objective variable to its `-10⁶` floor and reports
     /// `Optimal`, where the same bytes down the tape stop at `-0.281`. On
     /// the default route, with no option set. So the form is admitted only
-    /// when [`Quad2::dropped_terms`] is clear (gh #685 part 1).
+    /// when [`Quad2::lost_terms`] is clear (gh #685 part 1).
     ///
     /// It has to be that flag and not an emptiness test. Partial
     /// cancellation is the same defect wearing a different face:
@@ -406,7 +406,13 @@ impl NlBody {
     /// while the read-out is still short an entire `x₀²`. A gate that looked
     /// at emptiness would pass this and stay wrong.
     ///
-    /// The cost is reach, not correctness: a dropped term sends the row back
+    /// And it is the *loss*, not the drop. `x₀² − x₀²` folds through
+    /// `fl(1) + fl(−1) = 0` with nothing rounded away, so its read-out is
+    /// the whole body and it keeps this fast path; gating on the drop
+    /// refused it alongside the absorbing row above, for arithmetic that
+    /// lost nothing (gh #687).
+    ///
+    /// The cost is reach, not correctness: a row that lost a term goes back
     /// to the AD tape, which is where it was before Q4.
     pub fn admitted_quad_form(&self) -> Option<QuadForm> {
         match self {
@@ -415,9 +421,9 @@ impl NlBody {
                     return None;
                 }
                 let form = recognize_expr(e)?;
-                (!form.dropped_terms()).then(|| quad_form_readout(&form))
+                (!form.lost_terms()).then(|| quad_form_readout(&form))
             }
-            NlBody::Quad(q) => (!q.form.dropped_terms()).then(|| quad_form_readout(&q.form)),
+            NlBody::Quad(q) => (!q.form.lost_terms()).then(|| quad_form_readout(&q.form)),
         }
     }
 
@@ -451,11 +457,17 @@ impl NlBody {
     /// froze those rows' Jacobians for the whole solve (gh #683).
     ///
     /// So an empty quadratic map is a proof of degree ≤ 1 only when no term
-    /// was dropped getting there, which is what
-    /// [`Quad2::dropped_terms`](crate::nl_quadratic::Quad2::dropped_terms)
-    /// records. When one was, this answers `None` — the state the contract
+    /// went missing getting there, which is what
+    /// [`Quad2::lost_terms`](crate::nl_quadratic::Quad2::lost_terms)
+    /// records. When one did, this answers `None` — the state the contract
     /// already reserved for "not established", which is why the fix needs
     /// nothing of its consumer.
+    ///
+    /// A term that cancelled **exactly** did not go missing, and gh #687 is
+    /// where that stopped costing a proof: `x₀² − x₀²` is degree 0 by an
+    /// add that rounded nothing, its tape holds `∂g/∂x` at zero for every
+    /// `x`, and answering `None` for it gave up a whole solve of frozen
+    /// Jacobian to be safe from arithmetic that never happened.
     ///
     /// Deliberately answers from the term maps rather than from
     /// [`Self::analyze_quadratic_full`]'s triplets: on `qssp180` that is
@@ -487,11 +499,11 @@ impl NlBody {
 /// form, in one place so both arms answer it the same way.
 ///
 /// A stored quadratic coefficient is a witness that the body is degree 2.
-/// An *absent* one is only a witness of the opposite when nothing was
-/// dropped on the way — see [`Quad2::dropped_terms`] and gh #683.
+/// An *absent* one is only a witness of the opposite when nothing went
+/// missing on the way — see [`Quad2::lost_terms`], gh #683 and gh #687.
 fn affine_from_form(q: &Quad2) -> Option<bool> {
     if q.quadratic().is_empty() {
-        (!q.dropped_terms()).then_some(true)
+        (!q.lost_terms()).then_some(true)
     } else {
         Some(false)
     }
@@ -2380,12 +2392,14 @@ fn apply_quad_op(op: QOp, vals: &mut Vec<Quad2>) -> Option<Quad2> {
             if d == 0.0 {
                 return None;
             }
-            a.scale(1.0 / d)
+            let mut out = a.div_by_constant(d);
+            out.absorb_flags(&b);
+            out
         }
         QOp::Pow => {
             let (a, b) = pop2(vals)?;
             let exp = b.as_constant()?;
-            if exp == 0.0 {
+            let mut out = if exp == 0.0 {
                 Quad2::of_constant(1.0)
             } else if exp == 1.0 {
                 a
@@ -2393,7 +2407,11 @@ fn apply_quad_op(op: QOp, vals: &mut Vec<Quad2>) -> Option<Quad2> {
                 a.mul(&a)?
             } else {
                 return None;
-            }
+            };
+            // The exponent is read out of a form with `as_constant`, which
+            // leaves its flags behind; `Div` above does the same.
+            out.absorb_flags(&b);
+            out
         }
         // `o82` is `Pow(base, Const(2.0))` with the exponent left implicit,
         // so it takes the `exp == 2.0` branch above.

--- a/dev-notes/lp-qp-routing.md
+++ b/dev-notes/lp-qp-routing.md
@@ -254,11 +254,14 @@ so the header alone does **not** distinguish LP from QP:
   *linear*, the model classified **LP**, and the extractor folded an
   empty linear part into `G` — the constraint left the problem, and
   `min −x₀` walked to its bound and reported `Optimal`. The recognizer
-  records whether it dropped a term, and `analyze_quadratic_full`
+  records whether it *lost* a term — a drop behind arithmetic that
+  rounded (gh #687), not a drop as such — and `analyze_quadratic_full`
   refuses the form when it did, which is upstream of every consumer that
   reads coefficients out (this walk and both extractors). The row's
   model then goes to NLP and is evaluated from its tape — the
-  conservative fallback above, reached for one more reason.
+  conservative fallback above, reached for one more reason. An exactly
+  cancelling row (`x − x`) lost nothing, so the empty map really is the
+  row and it keeps the LP/QP route.
 
 This mirrors how QP-capable AMPL solvers detect QPs (ASL's `nqpcheck`
 walks the nonlinear tree to recover `Q`); the header is a fast reject

--- a/dev-notes/quadratic-structure-exploitation.md
+++ b/dev-notes/quadratic-structure-exploitation.md
@@ -1295,9 +1295,9 @@ is a coefficient that was *summed*, and there are two ways to sum to zero:
 Flagging the drop refused both. That was the right first move and it closed two
 wrong-answer defects; what it cost is reach, on every consumer at once. An
 exactly cancelling row was not provably affine (gh #683's gate), was not
-evaluated from its own — correct, empty — matrices (gh #685 part 1), and once
-the classifier gates on the same bit (gh #685 part 2, still open) would lose
-the convex route as well.
+evaluated from its own — correct, empty — matrices (gh #685 part 1), and — once
+the classifier gated on the same bit too (gh #685 part 2) — lost the LP/QP
+route as well.
 
 **The loss happens at the inexact fold, not at the drop.** So that is what is
 recorded now. `Quad2` carries two bits instead of one:
@@ -1307,7 +1307,9 @@ recorded now. `Quad2` carries two bits instead of one:
   literals gives.
 * `lost_terms` — a term may be missing: something was dropped *while* `inexact`
   was set, or a live coefficient was flushed to zero (or to `NaN`) outright.
-  This is the bit the consumers read, under its old contract.
+  This is the bit all three consumers read — the degree gate, the evaluator's
+  admission, and `analyze_quadratic_full`'s (the classifier's and both
+  extractors') — under its old contract.
 
 Three exactness tests feed the first bit, and none of them is a tolerance:
 
@@ -1326,7 +1328,7 @@ constant.
 **Why not simply flag every inexact add**, which is what gh #687 proposes? It
 is sound, and it gives back less than it costs: `0.1·x² + 0.2·x²` rounds, drops
 nothing, and has complete maps — under that rule it would lose the matrix
-evaluation and (part 2) the QP route, for a form that is missing nothing. The
+evaluation and the LP/QP route, for a form that is missing nothing. The
 drop is still necessary; what changed is that it is no longer sufficient.
 
 The conservatism that is left is the one Q3 bought: two bits per *form*, not a

--- a/dev-notes/quadratic-structure-exploitation.md
+++ b/dev-notes/quadratic-structure-exploitation.md
@@ -1276,6 +1276,129 @@ still classifies as linear and a model made of such rows still routes **LP**.
 Pre-existing on `main`, unchanged by this fix, filed with the storage defect
 as gh #685.
 
+### The gate is the fold, not the drop (gh #687)
+
+The bit both fixes above key off recorded that a coefficient was **dropped**,
+and that is not the question either consumer has. A coefficient reaching zero
+is a coefficient that was *summed*, and there are two ways to sum to zero:
+
+* `x − x` folds `fl(1) + fl(−1)` to `0.0`, and that add is **exact**. The term
+  really is absent. The body really is degree 0. Nothing is a lower bound.
+* `2⁵³·x² + x² − 2⁵³·x²` loses the `x²` at `fl(2⁵³ + 1) = 2⁵³` — an **inexact**
+  add — and the exact `2⁵³ − 2⁵³` that follows only makes the loss visible.
+
+Flagging the drop refused both. That was the right first move and it closed two
+wrong-answer defects; what it cost is reach, on every consumer at once. An
+exactly cancelling row was not provably affine (gh #683's gate), was not
+evaluated from its own — correct, empty — matrices (gh #685 part 1), and once
+the classifier gates on the same bit (gh #685 part 2, still open) would lose
+the convex route as well.
+
+**The loss happens at the inexact fold, not at the drop.** So that is what is
+recorded now. `Quad2` carries two bits instead of one:
+
+* `inexact` — some arithmetic behind these coefficients rounded. Clear means
+  every stored coefficient is exactly what real arithmetic on the writer's own
+  literals gives.
+* `lost_terms` — a term may be missing: something was dropped *while* `inexact`
+  was set, or a live coefficient was flushed to zero (or to `NaN`) outright.
+  This is the bit the consumers read, under its old contract.
+
+Three exactness tests feed the first bit, and none of them is a tolerance:
+
+| operation | test | cost |
+|---|---|---|
+| `a + b` | Knuth two-sum: `err = (a − (s − bb)) + (b − bb)`, exact for every finite pair | 4 flops per merge |
+| `a · b` | `fma(a, b, −p) == 0`, with `±1`/`0` answered directly (every variable enters with coefficient `1.0`) and a non-normal product — underflow, subnormal, overflow — answered *inexact* | an `fma`, usually skipped |
+| `a / d` | the recognizer scales by `fl(1/d)`, which is the reciprocal only for a power of two: `fma(r, d, −1) == 0` | one `fma` per `Div` node |
+
+Two smaller holes closed on the way, both from `as_constant` reading a number
+out of a form and leaving its flags behind: a `Div`'s divisor and a `Pow`'s
+exponent now hand their `lost_terms`/`inexact` to the result (`absorb_flags`).
+Dividing by a constant that swallowed a variable term is not dividing by a
+constant.
+
+**Why not simply flag every inexact add**, which is what gh #687 proposes? It
+is sound, and it gives back less than it costs: `0.1·x² + 0.2·x²` rounds, drops
+nothing, and has complete maps — under that rule it would lose the matrix
+evaluation and (part 2) the QP route, for a form that is missing nothing. The
+drop is still necessary; what changed is that it is no longer sufficient.
+
+The conservatism that is left is the one Q3 bought: two bits per *form*, not a
+provenance record per monomial, so an inexact fold on one coefficient makes an
+exact cancellation on an unrelated one count as lost. That is a reach question
+only, and per-monomial provenance is an allocation per term.
+
+*What the extra flops cost.* gh #687 asks for the recognizer's own timings, and
+the benchmark corpus (`$POUNCE_BENCH_DATA`) is not on this machine, so `qssp180`
+— the 65 341-row instance the merge path runs hottest on — could not be
+re-measured. What was measured is the worst case the change has, on two
+synthetic bodies, release build, 200 recognitions each, three runs per side:
+
+| body | parent | with the gate |
+|---|---|---|
+| 20 000 monomials folding onto 64 keys (**every term a merge**) | 7.00 / 7.04 / 7.15 ms | 7.72 / 7.79 / 7.80 ms (**+10%**) |
+| `(Σ⁶⁴ xᵢ)²` — 4 096 product accumulations | 354 / 349 / 350 µs | 332 / 334 / 341 µs (noise) |
+
+The two-sum is 4 flops on a path whose other cost is a B-tree lookup, and 10%
+of that path is the ceiling: no fixture is a 20 000-term collision. The product
+side does not move because every variable enters with a coefficient of `1.0`,
+which the `±1` shortcut answers without an `fma`. `sweep-fixtures.sh`'s
+wall-clock over the 57 fixtures shows no change outside run-to-run noise.
+
+*Reach handed back, measured on the ill-scaled battery* (3 000 seeds,
+9 000 bodies, `issue_683_cancelled_quadratic_degree`): **499 → 302** rows
+demoted for a lost term, so **197 rows regained the degree proof**; rows proved
+affine 5 500 → 5 697, rows proved degree 2 unchanged at 1 812. On the
+`quad_evaluator_differential` battery the skip falls from **204 of 1 500**
+seeds to **7**, so 197 more problems are evaluated from their matrices and
+compared against their tapes — 4 479 quadratic rows and 54 132 Hessian
+entries, **0 not bit-identical**, worst `g`/Jacobian relative deviation
+`4.774e-15` against `4.385e-15` before (the pinned tolerance is `1e-14`).
+
+On the corpus: nothing, in either direction. `scripts/sweep-fixtures.sh` over
+the 57 fixtures is **diff-empty** against the parent binary, and so is the
+`Problem class:` line over the 61 loadable `.nl` files in the repository (4 LP,
+24 convex QP, 2 convex QCQP, 1 nonconvex QP, 30 NLP; the 62nd,
+`idaes_helmholtz.nl`, wants `AMPLFUNC` and does not load here, as before). No
+fixture body drops a term at all, which is the same reason gh #683's and
+gh #685's own reach costs measured zero — this change is visible only where
+those were.
+
+#### What the sharper gate turned up in the battery
+
+Admitting exactly cancelling rows put a class of body in front of the gh #683
+battery that had never reached it, and it found two things the assertion had to
+be honest about — neither a defect in the claim, both in the *tape*:
+
+* **Seed 565** — `x₀²·((x₁ − x₁)·x₁)·10³⁰⁰` is identically zero, and the
+  recognizer proves it. Its tape multiplies before it sums, so at `x₀ = 10⁸`
+  the adjoint reaches `10³⁰⁰ · 10¹⁶ = ∞` and then `∞ · 0 = NaN`, where every
+  finite probe reads `0`. A `NaN` is not a derivative that moved; probe entries
+  where the tape's own arithmetic left the finite range are skipped (415 of
+  them).
+* **Seed 1293** — a row whose adjoint accumulation sums `±10³⁰⁸` contributions
+  that cancel mathematically into a running total of `−10³⁰⁰`. The constant it
+  lands on drifts with `x`: `4.5e-12` relative, the only drift in 3 000 seeds.
+  The comparison is still bitwise, with that one escape bounded by
+  `TAPE_WOBBLE_REL = 1e-9` — three orders above the observed drift and far
+  below the smallest change a *degree* defect makes, which moves a derivative
+  off zero or by factors of `x`.
+
+Both are the tape being ill-conditioned on a body the recognizer reads exactly,
+which is the opposite of the gh #683 failure (the recognizer reading a body the
+tape has right). The frozen derivative is the value the drift is around.
+
+Regression: the two issue files gain the other direction —
+`an_exactly_cancelled_quadratic_row_is_still_proved_affine` (with
+`DerivativeProof::Constant` asserted on the row, so the claim is checked and
+not just the flag) and `an_exactly_cancelled_row_is_still_admitted_for_evaluation`
+(with the admitted form's `g` checked against the tape's). `nl_quadratic`'s own
+tests cover the fold directly: the exact and absorbed cancellations, the
+absorption flagged *before* anything drops, rounding carried across
+subexpressions, cancellation inside a product, the underflowing multiply, the
+cancelled constant, and the two-sum/two-product/reciprocal tests themselves.
+
 ### Correctness: the differential is the load-bearing artefact
 
 `crates/pounce-cli/tests/constant_derivative_proofs.rs`, in the shape of Q3's,


### PR DESCRIPTION
## Problem

`Quad2::dropped_terms` records that the recognizer dropped a coefficient. It does not record whether the arithmetic that produced that coefficient was **exact**, and those are different questions — so a body that cancels exactly is refused alongside one that cancels catastrophically:

| body | the fold | maps | truth | pre-#687 verdict |
|---|---|---|---|---|
| `x − x` | `fl(1) + fl(−1) = 0`, **exact** | empty | degree 0, nothing lost | refused |
| `2⁵³·x² + x² − 2⁵³·x²` | `fl(2⁵³ + 1) = 2⁵³`, **inexact**, then an exact cancel | empty | degree 2, `x²` lost | refused |

Refusing both is sound and closed two wrong-answer defects (#683, #685 part 1). What it costs is reach on the first row, on every consumer at once: not provably affine (its Jacobian is re-evaluated every iteration instead of once), not evaluated from its own — correct, empty — matrices, and once the classifier gates on the same bit (#685 part 2, merged in #691) it loses the LP/QP route as well.

Nothing in the fixture corpus is affected in either direction, so this is a latent cost on models we do not have, not a measured regression on ones we do.

## Cause

The loss happens at the **inexact add**, not at the drop. `fl(2⁵³ + 1) = 2⁵³` is where the `x²` goes; the `− 2⁵³` that follows is exact and only makes the loss visible. A float add can reach zero *only* by exact cancellation, so the drop site itself carries no information about whether anything was lost — the information is one or more folds upstream.

## Fix

`Quad2` carries two bits instead of one:

* **`inexact`** — some arithmetic behind these coefficients rounded. Clear ⇒ every stored coefficient is exactly the real-arithmetic value of the terms folded into it.
* **`lost_terms`** — a term may be missing: something was dropped *while* `inexact` was set, or a live coefficient was flushed to zero (or `NaN`) outright. This is the bit the consumers read, under the contract `dropped_terms` had.

Three exactness tests feed the first, none of them a tolerance:

| operation | test |
|---|---|
| `a + b` | Knuth two-sum — exact for every finite pair, 4 flops per merge |
| `a · b` | `fma(a, b, −p) == 0`, with `±1`/`0` answered directly (every variable enters with coefficient `1.0`) and a non-normal product — underflow, subnormal, overflow — answered *inexact* |
| `a / d` | the recognizer scales by `fl(1/d)`, the reciprocal only for a power of two: `fma(r, d, −1) == 0` |

Two smaller holes closed with them, both from `as_constant` reading a number out of a form and leaving its flags behind: a `Div`'s divisor and a `Pow`'s exponent now hand their `lost_terms`/`inexact` to the result. Dividing by a constant that swallowed a variable term is not dividing by a constant.

`dropped_terms` → `lost_terms` is a rename on purpose: the meaning changed, and a call site that does not compile is better than one that silently keeps reading the old question.

**Rejected: flagging every inexact add**, which is what the issue proposes literally. It is sound and gives back less than it costs — `0.1·x² + 0.2·x²` rounds, drops nothing, and has complete maps, so under that rule it would lose the matrix evaluation and the LP/QP route for a form that is missing nothing. The drop is still necessary; what changed is that it is no longer sufficient.

**Kept: one pair of bits per form, not per monomial.** Q3's `Quad2` allocates nothing per term and the recognizer is affordable at 65 341 rows because of it. The price is that this answer is conservative: an inexact fold on one coefficient makes an exact cancellation on an unrelated one count as lost.

## Blast radius

Baseline `d38167a` (the parent commit), release builds both sides:

* `scripts/sweep-fixtures.sh` over the 57 fixtures — **diff empty**.
* `Problem class:` over the 61 loadable `.nl` files in the repository — **diff empty** (4 LP, 24 convex QP, 2 convex QCQP, 1 nonconvex QP, 30 NLP; `idaes_helmholtz.nl` wants `AMPLFUNC` and does not load here, as before).

Bit-identical except where the flag fires, and no fixture body drops a term at all — the same reason #683's and #685's own reach costs measured zero. What moves is synthetic material that does drop terms:

| measurement | parent | this branch |
|---|---|---|
| ill-scaled degree battery (9 000 bodies): rows demoted for a lost term | 499 | **302** (197 regain the proof) |
| …rows proved affine / proved degree 2 | 5 500 / 1 812 | 5 697 / 1 812 |
| evaluator differential battery: seeds skipped | 204 of 1 500 | **7 of 1 500** |
| …problems compared against their tapes | 1 296 | 1 493 (4 479 quadratic rows, 54 132 Hessian entries, **0 not bit-identical**) |
| …worst `g`/Jacobian relative deviation | `4.385e-15` | `4.774e-15` (pinned tolerance `1e-14`) |

**Cost of the extra flops.** `qssp180` could not be re-measured — the bench corpus is not on this machine — so the worst case was measured synthetically instead (release, 200 recognitions, three runs a side): a body that is nothing but merges (20 000 monomials onto 64 keys) goes 7.00/7.04/7.15 ms → 7.72/7.79/7.80 ms, **+10%**; a product-heavy `(Σ⁶⁴ xᵢ)²` is unchanged within noise, because the `±1` shortcut answers almost every product without an `fma`. The sweep's wall clock shows no change.

**What admitting these rows turned up.** A class of body reached #683's battery that never had before, and it found two things — neither a defect in the claim, both the *tape* being ill-conditioned on a body the recognizer reads exactly:

* **seed 565** — `x₀²·((x₁ − x₁)·x₁)·10³⁰⁰` is identically zero and is proved so; its tape multiplies before it sums, so at `x₀ = 10⁸` the adjoint reaches `∞` and then `∞ · 0 = NaN` where every finite probe reads `0`.
* **seed 1293** — a row whose adjoint accumulation sums `±10³⁰⁸` contributions into a running `−10³⁰⁰`, so the constant it lands on drifts `4.5e-12` with `x`. The only drift in 3 000 seeds.

The battery now skips probe entries where the tape's own arithmetic left the finite range (415 of them) and bounds the drift at `TAPE_WOBBLE_REL = 1e-9` — three orders above what was observed, and far below what a *degree* defect moves (those take a derivative off zero, or scale it by `x`). This is the opposite failure from #683's: there the recognizer was wrong about a body the tape had right.

## Tests

New, and failing on the parent commit for the stated reason:

* `issue_683…::an_exactly_cancelled_quadratic_row_is_still_proved_affine` — `provably_affine` reads `None` pre-fix, on both parse arms; also asserts `DerivativeProof::Constant` on the row, so the claim is checked and not just the flag.
* `issue_685…::an_exactly_cancelled_row_is_still_admitted_for_evaluation` — `admitted_quad_form` is `None` pre-fix; the admitted form's `g` is checked against the tape's.
* `nl_quadratic` unit tests on the fold itself: the exact and the absorbed cancellation, the absorption flagged *before* anything drops, rounding carried across subexpressions into a later drop, cancellation inside a product (`(x₀+x₁)(x₀−x₁)` has no cross term and is not demoted for noticing), the underflowing product, the exactly-cancelled versus absorbed constant, a rounded scale that loses nothing, and the two-sum / two-product tests themselves.

Unchanged and still passing, i.e. the refusals this sharpens are still refusals: every `2⁵³` and `10⁻²⁰⁰` case in both issue files, on both parse arms, including the partial-cancellation model and the CLI A/B against `POUNCE_DBG_NO_QUAD=1`.

Not pinned: `qssp180`'s recognizer timing (no bench corpus on this machine — the synthetic worst case above stands in for it).

## Merged with `main` after #691 landed

This branch opened from `d38167a`, nine minutes before #691 merged gh#685 part 2, so the green run above never saw the classifier gating on this flag. `main` is now merged in, and the merge is the interesting part: `git merge` reports it clean and the result **does not compile** — #691 added four `dropped_terms()` call sites in `nl_reader.rs`, which is exactly what renaming the accessor was meant to catch.

Resolved by carrying #691's gate onto `lost_terms()` and by taking the two `dispatch.rs` assertions this PR's sharper gate is *meant* to flip. Both now assert **both** sides rather than merely relaxing: `x0² − x0²` (exact) routes `Lp`/`NonlinearPartsCancelled`, and a `2⁵³·x0² + x0² − 2⁵³·x0²` companion routes `Nlp`/`ObjectiveTermsDropped`. `ClassReason::explain()`'s wording moved from "dropped a term to floating-point cancellation" — no longer what the gate tests — to "lost a term to an inexact floating-point fold or a flush to zero".

Re-run on the merge result, against the post-#691 `main` baseline:

* `scripts/sweep-fixtures.sh`, 57 models — **byte-identical**.
* `Problem class:` over all 62 loadable `.nl` files — **identical**. (My earlier baseline held 61: `crates/pounce-wasm/tests/simple.nl` was dropped building that list. Checked against the `main` binary directly — same class.)
* `cargo test --workspace`: **3 198 passed, 0 failed**.
* `cargo fmt --all --check` clean; CI's clippy invocation (`-D clippy::correctness -D clippy::suspicious`) clean.

Fixes #687

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — none applies; this is internal to the recognizer, and the trajectory-visible record is `dev-notes/quadratic-structure-exploitation.md`, which gains the section
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkLW9jjXX98sQjFTQBkhNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkLW9jjXX98sQjFTQBkhNV)_
