### PR TITLE
Size the direct convex driver's cold start to the data, and stop HSDE certifying non-optimal iterates (#689)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,72 @@ changes.
 
 ## [Unreleased]
 
+- **The direct convex QP driver no longer diverges on a badly-scaled
+  feasible model** (#689).
+
+  At `qp_hsde=no` — the driver `QpWarmStart`, the build-once
+  `QpFactorization` handle and the dual-infeasibility reverify guard all
+  use, and which cannot fall back to HSDE the way the one-shot path can —
+  `scaled_feasible_a` ran to the 199-iteration cap at `final_kkt_error
+  8.4e45`, `final_dual_inf 3.7e41` and objective `1.14e11`. It was
+  diverging, not converging slowly; HSDE solves the same model in 16.
+
+  The cause was the cold start. It was `s = z = e` regardless of the
+  data, and on this model the Ruiz-equilibrated feasible set sits at
+  `‖ĥ‖ ≈ 5e9`, so the starting slacks were nine orders too small: the
+  first Newton direction was correct (`‖dx‖ ≈ 2.9e9`, pointed at the
+  optimum) and fraction-to-boundary cut it to `α ≈ 8e-9`. The iterate
+  could not move, the corrector then divided `σμ` by slacks still pinned
+  at `1` and returned directions of `1e18`, and `z` ran away to `7e21`.
+  The cold seed now goes through the same Mehrotra recentering the warm
+  path already used, which takes the starting slacks from the implied
+  `s̃ = h − Gx` and so sizes them to the problem.
+
+  That alone reaches the optimum but cannot recognize it: `‖x̂‖ ≈ 5e9`
+  against `‖ĥ‖ ≈ 5e9` floors the primal residual at `5e-6 ≈ 4 ulp`, a
+  thousand times `tol`, so the loop ran 175 iterations past its own
+  answer (true KKT error `4e-25`) until `s` and `z` underflowed into the
+  denormals. The driver therefore also gets the scale-relative stopping
+  arm HSDE already has, under the same gate — but with complementarity
+  held **absolute**, since `μ = ⟨s,z⟩/deg` is a sum of products of
+  nonnegatives with no cancellation floor to excuse relaxing it.
+
+  Both fixtures now solve at `qp_hsde=no`: `scaled_feasible_a` in 27
+  iterations and `scaled_feasible_b` in 28, both at objective `0` — which
+  is the true optimum (each model minimizes `Σ(xᵢ − aᵢ)²` with `a` inside
+  the feasible set). This answers the second half of #689: the two are
+  *not* flat or degenerate optima, and HSDE's `236.85` / `456.33` on them
+  are iterates it stops at, not answers. Its relative gap test normalizes
+  by the objective magnitude, which on these models is `5e11` of constant
+  offset — a blanket `5e3` tolerance on the gap. HSDE is unchanged here
+  and still reports those values; the fixture pair should not be read as
+  an objective sentinel for the sweep until that is addressed. Full
+  analysis and the case for a follow-up:
+  `dev-notes/issue-689-direct-driver-cold-start.md` §3.
+
+  A direct-driver `Optimal` is now also re-checked in the caller's own
+  coordinates before it is returned. The driver's convergence test runs
+  inside the Ruiz metric, and Ruiz's dual map divides by the column
+  scaling, so a `Dc` spanning many decades inflates the recovered dual
+  residual: on `feasible_x0_extreme_row` the pre-fix direct route
+  returned `Solve_Succeeded` at objective `5.0e11` — with an unscaled
+  dual infeasibility of `2.6e6` — where the true optimum is `0`. That
+  false success, and the equivalent one the new stopping arm would
+  otherwise have produced on `feasible_x0_sentinel_bound`, are now
+  demoted to an honest failure.
+
+  The default (HSDE) route is bit-for-bit unchanged across the fixture
+  corpus, both legs. On the `qp_hsde=no` leg the sweep also shows
+  `lp_afiro` 135 → 10 iterations (and closer to the NETLIB optimum:
+  `-464.7531428` against `-464.7531419`), `rankdef_eq_qp` 12 → 6,
+  `wyndor_min` 7 → 6, `qcqp_ball` 15 → 12; `feasible_x0_wide_scale` 4 →
+  13 and `dual_order` / `dual_scaled` 4 → 5, the last three at a better
+  final KKT error. Three lines end slightly less accurate and are
+  recorded rather than waved past: `lp_row_constant` /
+  `lp_row_constant_expr` at `1.8e-8` against `7.2e-10`, and `qcqp_ball`
+  at `1.2e-8` against `7.3e-9` — all still inside the solved band. Per-
+  line detail: `dev-notes/issue-689-direct-driver-cold-start.md`.
+
 - **`recalc_y` no longer degrades the multipliers it exists to sharpen**
   (#688).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,16 +52,29 @@ changes.
   POWELL20 exactly. The constant is the only thing that actually
   distinguishes the two families.
 
+  One knock-on had to be corrected with it. The `large_scale` gate that
+  admits the relative test at all is keyed on
+  `max(scale_d, scale_p, scale_g)`, so making `scale_g` *accurate* — small,
+  once the constant is accounted for — could **close** it, stripping the
+  primal and dual residuals of a relaxation they still need and that has
+  nothing to do with the objective constant. On `feasible_x0_wide_scale`
+  it did exactly that: the solve is converged by iteration 18 (`inf_pr`
+  on its own `5e-9` floor, `μ = 9e-18`) and then span for 180 more
+  iterations, twice collapsing into the denormals and restarting, before
+  reaching the cap at 198 with an answer it had found long before. The
+  gate now reads the objective's own magnitude — it is asked whether
+  absolute `tol` accuracy is reachable on this data, which is a property
+  of the magnitudes actually being computed — while `scale_g` supplies
+  the gap's normalizer. That model now converges in 80.
+
   Fixture sweep, both legs: the `qp_hsde=no` leg is unchanged, and on the
   default leg only the four models with a large objective constant move —
   `scaled_feasible_a` 16 → 123 iterations (`236.85` → `0`, KKT error
   `2.5e2` → `4.6e-3`), `scaled_feasible_b` 21 → 47 (`456.33` → `0`,
-  `9.3e2` → `1.2e-10`), `feasible_x0_wide_scale` 16 → 198 (KKT error
+  `9.3e2` → `1.2e-10`), `feasible_x0_wide_scale` 16 → 80 (KKT error
   `3.6e4` → `6.6e-15`), `feasible_x0_extreme_row` 32 → 33 (`7.6e-4` →
-  `3.8e-5`). The iteration counts are the honest cost of the work these
-  solves were previously skipping; `feasible_x0_wide_scale` at 198
-  against a 200 cap is thin margin and is called out in
-  `dev-notes/issue-689-direct-driver-cold-start.md` §5.
+  `3.8e-5`). The counts are the cost of the work these solves were
+  previously skipping.
 
 - **The direct convex QP driver no longer diverges on a badly-scaled
   feasible model** (#689).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,60 @@ changes.
 
 ## [Unreleased]
 
+- **HSDE no longer certifies `Optimal` a few hundred short of the optimum
+  when the objective carries a large constant** (#689).
+
+  The default route returned `Solve_Succeeded` on
+  `crates/pounce-cli/tests/fixtures/scaled_feasible_a.nl` at objective
+  `236.85`, and on `scaled_feasible_b` at `456.33`, where the true
+  optimum of both is **`0`** — each minimizes `Σ(xᵢ − aᵢ)²` with `a`
+  inside the feasible set, which the NLP route confirms at `1.0e-9` and
+  `3.8e-9`. Two more fixtures were doing the same thing:
+  `feasible_x0_wide_scale` returned a point with an `Overall NLP error`
+  of `3.6e4`, and `feasible_x0_extreme_row` one at `7.6e-4`.
+
+  HSDE's scale-relative stopping test normalizes the duality gap by the
+  objective magnitude — the standard convention, and correct. But
+  `QpProblem` models `½xᵀPx + cᵀx` only: a model whose objective has a
+  degree-0 term hands the solver an objective displaced by it, and for a
+  least-squares objective the constant is `Σaᵢ²` — `5.0e11` on this pair.
+  Normalizing by *that* turns `gap_rel < tol` into a blanket `tol·|Σaᵢ²|`
+  = `5e3` absolute slack on the gap. The gh #414 guard missed it for the
+  same reason (its complementarity normalizer is also the objective): it
+  read `4.9e-10` on a point whose absolute KKT error is `2.5e2`.
+
+  `QpOptions::obj_constant` (default `0.0`) now carries that constant,
+  and the CLI sets it from the `.nl` degree-0 term it already tracks for
+  reporting, plus presolve's own objective offset, in the solver's
+  minimize sense. It travels through both cost scalings — divided by
+  `hsde_cost_scale`'s `σ`, multiplied by Ruiz's. It is **only** a
+  convergence-test normalizer: it enters no residual, no search
+  direction, no dual, and not `QpSolution::obj`. The default `0.0` is the
+  *tightest* choice, so every library caller that does not set it, and
+  every problem whose objective genuinely is large (POWELL20 and the rest
+  of the large-data cluster the relative test exists for), is unchanged.
+
+  This was the alternative to two tempting fixes that do not work.
+  Requiring absolute complementarity in the relative arm separates this
+  fixture pair cleanly (`1.2e3`/`1.5e3` against `2.3e-11`/`1.1e-28` on
+  the corpus) but rejects the gh #286 huge-magnitude optima, whose
+  *genuine* complementarity is `1.5e9` and `1.4e13`; normalizing the gap
+  by the gradient scale instead of the objective is tighter by a factor
+  `‖x̂‖`, which rejects any problem whose magnitude lives in `‖x*‖` —
+  POWELL20 exactly. The constant is the only thing that actually
+  distinguishes the two families.
+
+  Fixture sweep, both legs: the `qp_hsde=no` leg is unchanged, and on the
+  default leg only the four models with a large objective constant move —
+  `scaled_feasible_a` 16 → 123 iterations (`236.85` → `0`, KKT error
+  `2.5e2` → `4.6e-3`), `scaled_feasible_b` 21 → 47 (`456.33` → `0`,
+  `9.3e2` → `1.2e-10`), `feasible_x0_wide_scale` 16 → 198 (KKT error
+  `3.6e4` → `6.6e-15`), `feasible_x0_extreme_row` 32 → 33 (`7.6e-4` →
+  `3.8e-5`). The iteration counts are the honest cost of the work these
+  solves were previously skipping; `feasible_x0_wide_scale` at 198
+  against a 200 cap is thin margin and is called out in
+  `dev-notes/issue-689-direct-driver-cold-start.md` §5.
+
 - **The direct convex QP driver no longer diverges on a badly-scaled
   feasible model** (#689).
 

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2473,9 +2473,32 @@ fn run_convex_qp(
     let want_trace = matches!(&json_cfg, Some((_, ReportDetail::Full, _)));
     let qp_opts = QpOptions {
         collect_iterates: want_trace,
+        // Tell the solver the objective constant it is *not* carrying (gh
+        // #689). `QpProblem` holds the quadratic form only, so on a
+        // least-squares-shaped objective the solver's `obj` is the reported one
+        // displaced by `obj_const` — unbounded displacement, `5e11` on the
+        // `scaled_feasible` pair — and the scale-relative stopping test then
+        // normalizes the duality gap by a magnitude that belongs to the
+        // constant rather than to the solution. In the solver's own (minimize)
+        // sense the constant is `sign · obj_const`, the inverse of the
+        // `reported_obj` line below. Convergence-test normalizer only: it
+        // changes no residual, no dual, and not `sol.obj`.
+        obj_constant: sign * obj_const,
         ..convex_opts
     };
-    let solve_opts = || convex_opts_with_remaining(qp_opts, t0);
+    // The reduced problem presolve hands the solver differs from `qp` by
+    // `ps.obj_offset`, so the constant that makes *it* commensurate with the
+    // user's objective carries that offset too.
+    let solve_opts_offset = |offset: f64| {
+        convex_opts_with_remaining(
+            QpOptions {
+                obj_constant: qp_opts.obj_constant + offset,
+                ..qp_opts
+            },
+            t0,
+        )
+    };
+    let solve_opts = || solve_opts_offset(0.0);
     // What presolve did, held back until we know this solve is the one that
     // reports (gh #535). These lines describe the reduction, not the verdict,
     // but they are the *only* stdout a declined convex attempt would otherwise
@@ -2555,9 +2578,14 @@ fn run_convex_qp(
                 }
                 let red = if use_active_set {
                     let mut mk = backend;
-                    solve_qp_active_set(&ps.reduced, &solve_opts(), &engine_overrides, &mut mk)
+                    solve_qp_active_set(
+                        &ps.reduced,
+                        &solve_opts_offset(ps.obj_offset),
+                        &engine_overrides,
+                        &mut mk,
+                    )
                 } else {
-                    solve_qp_ipm(&ps.reduced, &solve_opts(), backend)
+                    solve_qp_ipm(&ps.reduced, &solve_opts_offset(ps.obj_offset), backend)
                 };
                 ps.postsolve(&red)
             }
@@ -2809,6 +2837,10 @@ fn run_convex_socp(
     let want_trace = matches!(&json_cfg, Some((_, ReportDetail::Full, _)));
     let qp_opts = QpOptions {
         collect_iterates: want_trace,
+        // The objective constant the solver is not carrying, in its own
+        // (minimize) sense — see the QP path for what it is for (gh #689).
+        // This path does not presolve, so there is no reduction offset to add.
+        obj_constant: sign * obj_const,
         ..convex_opts
     };
     let solve_opts = || convex_opts_with_remaining(qp_opts, t0);

--- a/crates/pounce-cli/tests/issue_689_direct_driver_scaled_feasible.rs
+++ b/crates/pounce-cli/tests/issue_689_direct_driver_scaled_feasible.rs
@@ -1,0 +1,148 @@
+//! Issue #689 regression: the direct convex driver (`qp_hsde=no`) must solve
+//! `scaled_feasible_a` / `scaled_feasible_b` instead of diverging on them.
+//!
+//! Both fixtures are `min Σ(xᵢ − aᵢ)²` with the objective's own centre `a`
+//! *inside* the feasible set — three constraints of it exactly active there —
+//! so the optimum is `x* = a` at objective `0` — checkable by hand against the
+//! `.nl` file, and independently what the NLP route returns.
+//!
+//! Before the fix, at `qp_hsde=no`, `a` ran to the 199-iteration cap at
+//! `final_kkt_error 8.4e45`, `final_dual_inf 3.7e41`, objective `1.14e11`; `b`
+//! broke down at 99 iterations with objective `5.0e11`. Neither was slow
+//! convergence — the driver was diverging. The cause was the cold start: on
+//! these models the Ruiz-equilibrated feasible set sits at `‖ĥ‖ ≈ 5e9`, and
+//! `s = z = e` put the starting slacks nine orders below it, so
+//! fraction-to-boundary cut the first (good) Newton step to `α ≈ 8e-9` and the
+//! corrector's `σμ / s` then returned directions of `1e18`.
+//!
+//! This is not a debug-only path. `QpWarmStart`, the build-once
+//! `QpFactorization` handle and the dual-infeasibility reverify guard all use
+//! the direct driver, and none of them can fall back to HSDE the way the
+//! one-shot path can.
+//!
+//! The objective assertion is the sharper half of the test. HSDE stops on these
+//! two at `236.85` and `456.33` — its scale-relative gap test normalizes by the
+//! objective magnitude, which here is `5e11` of constant offset, so it certifies
+//! `Optimal` a few hundred short of the real optimum. That is the "objective
+//! moves under any trajectory perturbation" half of #689: the fixtures are not
+//! degenerate, the relative gap test is simply admitting non-optimal iterates.
+//! The direct driver lands on `0`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use pounce_cli::solve_report::SolveReport;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn tmp_path(suffix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "pounce_issue689_{}_{}_{suffix}",
+        std::process::id(),
+        n
+    ));
+    p
+}
+
+fn solve(fixture_name: &str, extra_opts: &[&str]) -> SolveReport {
+    let json_path = tmp_path(&format!("{fixture_name}.json"));
+    let sol_path = tmp_path(&format!("{fixture_name}.sol"));
+    let mut cmd = Command::new(pounce_exe());
+    cmd.arg(fixture(fixture_name))
+        .arg(&sol_path)
+        .arg("--json-output")
+        .arg(&json_path);
+    for opt in extra_opts {
+        cmd.arg(opt);
+    }
+    let _ = cmd.status().expect("spawn pounce");
+    let text = std::fs::read_to_string(&json_path).expect("read json report");
+    let _ = std::fs::remove_file(&json_path);
+    let _ = std::fs::remove_file(&sol_path);
+    serde_json::from_str(&text).expect("deserialize SolveReport")
+}
+
+/// The iteration cap the pre-fix runs hit (`max_iter` 200, reported as 199) and
+/// the neighbourhood a healthy solve of these models lands in (27–28). Anything
+/// past this is the divergence coming back, whatever status it wears.
+const ITER_BUDGET: i32 = 60;
+
+/// Both fixtures' true optimum. The objective is a sum of squares whose centre
+/// is feasible, so it is exactly `0`; the tolerance is what the cancellation
+/// against the `5e11` constant offset leaves resolvable.
+const OPTIMUM_TOL: f64 = 1e-3;
+
+#[test]
+fn direct_driver_solves_the_scaled_feasible_pair() {
+    for model in ["scaled_feasible_a.nl", "scaled_feasible_b.nl"] {
+        let report = solve(model, &["qp_hsde=no"]);
+        let code = report.solution.solve_result_num;
+        assert!(
+            (0..100).contains(&code),
+            "{model} at qp_hsde=no: solve_result_num={code} (status {:?}) after \
+             {} iterations, objective {:e}, kkt_error {:e}. This model is \
+             feasible with optimum 0 and the direct driver must reach it \
+             (gh #689).",
+            report.solution.status,
+            report.statistics.iteration_count,
+            report.solution.objective,
+            report.statistics.final_kkt_error,
+        );
+        assert!(
+            report.statistics.iteration_count <= ITER_BUDGET,
+            "{model} at qp_hsde=no: {} iterations (budget {ITER_BUDGET}); the \
+             pre-fix divergence ran to the 199-iteration cap",
+            report.statistics.iteration_count,
+        );
+        assert!(
+            report.solution.objective.abs() <= OPTIMUM_TOL,
+            "{model} at qp_hsde=no: objective {:e}, want 0 ± {OPTIMUM_TOL:e}. \
+             The objective's own centre is feasible on this model, so 0 is the \
+             optimum, not a tolerance artifact.",
+            report.solution.objective,
+        );
+    }
+}
+
+/// A canary, not a fix: the default route never enters the direct driver, so
+/// #689 leaves it exactly as it was — reporting `Optimal` a few hundred above
+/// the optimum the direct driver reaches (`236.85` / `456.33` as measured).
+/// The assertion is deliberately one-sided and loose: it records *that* HSDE
+/// stops short, not where. If it ever fails, HSDE has started reaching the real
+/// optimum on these models — which is the outcome we want. Delete this test
+/// then, and with it the caveat in
+/// `dev-notes/issue-689-direct-driver-cold-start.md` §3 about reading these two
+/// fixtures as objective sentinels in the sweep.
+#[test]
+fn hsde_still_stops_short_of_the_optimum_on_the_same_pair() {
+    for model in ["scaled_feasible_a.nl", "scaled_feasible_b.nl"] {
+        let report = solve(model, &[]);
+        assert!(
+            (0..100).contains(&report.solution.solve_result_num),
+            "{model} at defaults: HSDE must still report solved",
+        );
+        assert!(
+            report.solution.objective.abs() > 1.0,
+            "{model} at defaults: HSDE returned objective {:e}, at or near the \
+             true optimum 0 — better than the `236.85`/`456.33` this canary was \
+             written against. Nothing is broken: delete this test and the \
+             sweep caveat it guards (dev-notes/issue-689-direct-driver-cold-\
+             start.md §3).",
+            report.solution.objective,
+        );
+    }
+}

--- a/crates/pounce-cli/tests/issue_689_direct_driver_scaled_feasible.rs
+++ b/crates/pounce-cli/tests/issue_689_direct_driver_scaled_feasible.rs
@@ -20,13 +20,16 @@
 //! the direct driver, and none of them can fall back to HSDE the way the
 //! one-shot path can.
 //!
-//! The objective assertion is the sharper half of the test. HSDE stops on these
-//! two at `236.85` and `456.33` — its scale-relative gap test normalizes by the
-//! objective magnitude, which here is `5e11` of constant offset, so it certifies
-//! `Optimal` a few hundred short of the real optimum. That is the "objective
-//! moves under any trajectory perturbation" half of #689: the fixtures are not
-//! degenerate, the relative gap test is simply admitting non-optimal iterates.
-//! The direct driver lands on `0`.
+//! The objective assertion is the sharper half of the test, and it is asserted
+//! on **both** routes. HSDE used to stop on these two at `236.85` and `456.33`:
+//! its scale-relative gap test normalizes by the objective magnitude, and
+//! `QpProblem` carries the quadratic form only, so on a least-squares objective
+//! that magnitude is `Σaᵢ² = 5e11` of constant — a blanket `5e3` slack on the
+//! gap. That is the "objective moves under any trajectory perturbation" half of
+//! #689: the fixtures are not degenerate, the stopping test was admitting
+//! non-optimal iterates. Telling the solver its objective constant
+//! (`QpOptions::obj_constant`) makes the same test normalize by the objective
+//! the user reads, and both routes now land on `0`.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -118,30 +121,32 @@ fn direct_driver_solves_the_scaled_feasible_pair() {
     }
 }
 
-/// A canary, not a fix: the default route never enters the direct driver, so
-/// #689 leaves it exactly as it was — reporting `Optimal` a few hundred above
-/// the optimum the direct driver reaches (`236.85` / `456.33` as measured).
-/// The assertion is deliberately one-sided and loose: it records *that* HSDE
-/// stops short, not where. If it ever fails, HSDE has started reaching the real
-/// optimum on these models — which is the outcome we want. Delete this test
-/// then, and with it the caveat in
-/// `dev-notes/issue-689-direct-driver-cold-start.md` §3 about reading these two
-/// fixtures as objective sentinels in the sweep.
+/// The other half of #689: the **default** route must reach the same optimum.
+///
+/// HSDE returned `Optimal` here at `236.85` / `456.33` — `4.7e-10` relative in
+/// its own metric, and 100% wrong in the caller's, because the metric was the
+/// `5e11` constant the solver had never been told about. With
+/// `QpOptions::obj_constant` supplied it normalizes by the caller's objective
+/// and runs on to `0`.
+///
+/// Kept separate from the `qp_hsde=no` test above because the two are fixed by
+/// different changes and can regress independently.
 #[test]
-fn hsde_still_stops_short_of_the_optimum_on_the_same_pair() {
+fn the_default_route_reaches_the_same_optimum() {
     for model in ["scaled_feasible_a.nl", "scaled_feasible_b.nl"] {
         let report = solve(model, &[]);
+        let code = report.solution.solve_result_num;
         assert!(
-            (0..100).contains(&report.solution.solve_result_num),
-            "{model} at defaults: HSDE must still report solved",
+            (0..100).contains(&code),
+            "{model} at defaults: solve_result_num={code} (status {:?})",
+            report.solution.status,
         );
         assert!(
-            report.solution.objective.abs() > 1.0,
-            "{model} at defaults: HSDE returned objective {:e}, at or near the \
-             true optimum 0 — better than the `236.85`/`456.33` this canary was \
-             written against. Nothing is broken: delete this test and the \
-             sweep caveat it guards (dev-notes/issue-689-direct-driver-cold-\
-             start.md §3).",
+            report.solution.objective.abs() <= OPTIMUM_TOL,
+            "{model} at defaults: objective {:e}, want 0 ± {OPTIMUM_TOL:e}. This \
+             is the gh #689 false optimum: the scale-relative gap test \
+             normalizing by an objective magnitude that is `5e11` of constant \
+             offset rather than by the objective the caller reads.",
             report.solution.objective,
         );
     }

--- a/crates/pounce-convex/src/equilibrate.rs
+++ b/crates/pounce-convex/src/equilibrate.rs
@@ -247,6 +247,15 @@ fn scale_bounds(bnd: &[f64], dcol: &[f64], inf: f64) -> Vec<f64> {
 }
 
 impl Scaling {
+    /// The scalar cost scaling `σ` applied to the objective (`1` for a QP, and
+    /// for any LP whose `‖ĉ‖` needs no normalization). The scaled problem's
+    /// objective is `σ` times the original's, so a caller carrying an objective
+    /// *constant* alongside the data must scale it by the same `σ` to keep the
+    /// two commensurate — see [`crate::ipm::QpOptions::obj_constant`].
+    pub(crate) fn sigma(&self) -> f64 {
+        self.sigma
+    }
+
     /// Map a solution of the scaled problem back to the original problem's
     /// variables and duals, in place. `orig` is the unscaled problem, used to
     /// recompute the objective `½xᵀPx + cᵀx` directly at the recovered `x`

--- a/crates/pounce-convex/src/hsde.rs
+++ b/crates/pounce-convex/src/hsde.rs
@@ -526,7 +526,21 @@ where
             .max(norm_b)
             .max(norm_h);
         let d_obj = -0.5 * xpx / (tau * tau) - bty / tau - htz / tau;
-        let scale_g = obj_hat.abs().max(d_obj.abs());
+        // Measured **including the caller's objective constant** (gh #689).
+        // `QpProblem` holds the quadratic form only, so on a model whose
+        // objective carries a degree-0 term — every least-squares objective —
+        // `obj_hat` is the caller's objective displaced by that constant, and
+        // the displacement is unbounded (`scaled_feasible_a`: caller optimum
+        // `0`, solver optimum `−5.0e11`). Normalizing the gap by the displaced
+        // magnitude turns `gap_rel < tol` into a blanket `tol·|constant|`
+        // absolute slack — `5e3` there — which is how this loop certified
+        // `Optimal` at a caller-visible `236.85`. `opts.obj_constant` is `0.0`
+        // unless a caller supplies it, so this is a no-op for everything else,
+        // including every problem whose objective genuinely *is* large
+        // (POWELL20 and the rest of the large-data cluster below).
+        let scale_g = (obj_hat + opts.obj_constant)
+            .abs()
+            .max((d_obj + opts.obj_constant).abs());
         let pres_rel = pres / (1.0 + scale_p);
         let dres_rel = dres / (1.0 + scale_d);
         let gap_rel = gap / (1.0 + scale_g);

--- a/crates/pounce-convex/src/hsde.rs
+++ b/crates/pounce-convex/src/hsde.rs
@@ -553,7 +553,17 @@ where
         // scale ≲ 30) reach the tight absolute test, while the large-data
         // cluster (POWELL20/BOYD/QFORPLAN/QSHELL at scale 7e9–4e12) can only be
         // certified relatively.
-        let large_scale = relative_stop_permitted(scale_d.max(scale_p).max(scale_g), opts.tol);
+        // The gate is asked whether `tol`-level *absolute* accuracy is reachable
+        // on this data at all, which is a property of the magnitudes actually
+        // being computed — so it reads the objective's own magnitude, not the
+        // caller-relative one `scale_g` became in gh #689. Correcting `scale_g`
+        // by a constant that makes the caller's objective come out near zero
+        // must not *close* this gate: on `feasible_x0_wide_scale` it did, and
+        // the primal and dual residuals — which floor at `5e-9` and `5e-6` on
+        // data of this scale, and have nothing to do with the objective
+        // constant — lost a relaxation they still needed.
+        let scale_g_raw = obj_hat.abs().max(d_obj.abs());
+        let large_scale = relative_stop_permitted(scale_d.max(scale_p).max(scale_g_raw), opts.tol);
         // `res` (used only for the `near_opt` salvage check below) tracks
         // whichever test governs this iterate.
         let res = if large_scale {

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -362,17 +362,10 @@ where
     // over-condition the reduced KKT system and trip the factorization near the
     // boundary (a `NumericalFailure` that neither transform produces alone).
     // See `crate::equilibrate`.
-    if opts.equilibrate && !opts.use_hsde {
-        let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
-        let inner = QpOptions {
-            equilibrate: false,
-            ..*opts
-        };
-        let mut sol = solve_qp_ipm_unscaled(&scaled, &inner, make_backend);
-        scaling.unscale_solution(prob, &mut sol);
-        return sol;
-    }
     let mut make_backend = make_backend;
+    if opts.equilibrate && !opts.use_hsde {
+        return equilibrated_solve(prob, opts, /* use_hsde */ false, &mut make_backend);
+    }
     let sol = solve_qp_ipm_unscaled(prob, opts, &mut make_backend);
     // HSDE robustness fallback. The self-dual driver normally conditions itself
     // through its per-cone NT scaling and so deliberately skips Ruiz pre-scaling
@@ -543,7 +536,49 @@ where
     };
     let mut sol = solve_qp_ipm_unscaled(&scaled, &inner, make_backend);
     scaling.unscale_solution(prob, &mut sol);
-    sol
+    if use_hsde {
+        sol
+    } else {
+        demote_false_equilibrated_optimum(prob, sol, opts.tol)
+    }
+}
+
+/// Re-check a direct-driver `Optimal` **in the caller's own coordinates**, and
+/// demote it when it does not survive the trip back out of the Ruiz metric.
+///
+/// The direct driver's convergence test — absolute or scale-relative — is
+/// applied to the *equilibrated* problem, and that is not the same statement as
+/// optimality of the point the caller receives. Ruiz is a diagonal change of
+/// variables `x = Dc x̂` whose dual map divides by `Dc`, so a `Dc` spanning many
+/// decades multiplies the recovered dual residual by up to `1/min Dc`. On
+/// `feasible_x0_sentinel_bound` (coefficients from `1e-320` to `1e30`, so
+/// `min Dc ≈ 6e-16`) the returned iterate reads `‖r_d‖ = 2.3e-9` in the scaled
+/// metric — comfortably converged — and `2.3` in the user's, at an objective of
+/// `1.30` against a true `0`. That is the same class of false success gh #414
+/// caught on the HSDE side, arriving through the opposite door: there the
+/// unscaled test was blind and the equilibrated one decisive, here it is the
+/// equilibrated test that is blind. So neither metric is trusted alone — a
+/// point has to look optimal in *both* to keep the verdict.
+///
+/// Costs nothing on a solve that converged outright: a point whose *absolute*
+/// KKT error in the user's coordinates is already within `tol` needs no
+/// argument at all and short-circuits before any extra work.
+///
+/// Demotes to [`QpStatus::NumericalFailure`] rather than
+/// [`QpStatus::OptimalInaccurate`], for the reason [`verify_or_repair_optimum`]
+/// gives: "usable at reduced accuracy" still reports `ok` / exit 0 through the
+/// CLI, which a point this far out is not.
+fn demote_false_equilibrated_optimum(prob: &QpProblem, sol: QpSolution, tol: f64) -> QpSolution {
+    if sol.status != QpStatus::Optimal
+        || sol.kkt_residuals(prob).kkt_error() <= tol
+        || normalized_optimum_is_genuine(prob, &sol)
+    {
+        return sol;
+    }
+    QpSolution {
+        status: QpStatus::NumericalFailure,
+        ..sol
+    }
 }
 
 /// The relative-KKT cut separating a genuine optimum from a scaling artifact,
@@ -895,7 +930,10 @@ where
         let scaled_warm = scaling.scale_warm_start(warm);
         let mut sol = solve_qp_ipm_warm_inner(&scaled, &direct, &scaled_warm, make_backend);
         scaling.unscale_solution(prob, &mut sol);
-        return sol;
+        // Same re-check the cold equilibrated path applies: a verdict reached
+        // inside the Ruiz metric is not yet a statement about the point the
+        // caller receives. See [`demote_false_equilibrated_optimum`].
+        return demote_false_equilibrated_optimum(prob, sol, opts.tol);
     }
     if !prob.has_bounds() {
         let w = WarmStart {
@@ -2126,20 +2164,120 @@ where
     Ok((kkt, fact))
 }
 
-/// Build the starting iterate `(x, y, z, s)` for [`run_ipm`].
+/// The **scale-relative** convergence arm of the direct driver: the primal and
+/// dual residuals measured against the natural magnitude of their own terms,
+/// and *permitted to conclude only* once `tol`-level absolute accuracy is below
+/// the finite-precision floor ([`crate::hsde::relative_stop_permitted`], the
+/// same gate and the same normalizers the HSDE loop already applies).
 ///
-/// With no warm start (`warm = None`) this is the cold default
-/// `x = 0, y = 0, z = 1, s = 1` — a perfectly centered interior point
-/// (`s∘z = 1`) — preserving the established cold-start behavior exactly.
+/// Without it the direct driver has no way to finish a solve whose data puts
+/// the absolute test out of reach. `scaled_feasible_a` (gh #689) is the
+/// canonical case: the Ruiz-equilibrated problem's optimum sits at `‖x̂‖ ≈ 5e9`
+/// against `‖ĥ‖ ≈ 5e9`, so forming `Gx + s − h` cancels two `5e9` quantities
+/// and the primal residual floors at `5e-6 ≈ 4 ulp` — a thousand times `tol` —
+/// while the iterate is the *exact* optimum (its true KKT error reads `4e-25`).
+/// The absolute test can never pass there, so the loop ran on past its own
+/// answer until `s` and `z` underflowed into the denormals and the
+/// factorization broke down: 175 iterations to a `NumericalFailure` sitting on
+/// the optimum. With this arm the same solve stops at 27.
 ///
-/// With a warm start it applies a **Mehrotra-style recentering** seeded
-/// from the warm point (Mehrotra 1992, §7, adapted for warm starting):
+/// **Complementarity is deliberately left absolute.** The relaxation is
+/// justified by *cancellation*, not by size: `Gx + s − h` and
+/// `Px + c + Aᵀy + Gᵀz` are differences of like-magnitude terms, so their
+/// achievable accuracy is `≈ scale·ε` and below that floor only a relative
+/// statement is meaningful. `μ = ⟨s,z⟩/deg` is a **sum of products of
+/// nonnegatives** — nothing cancels, and it converges to zero at any problem
+/// scale — so there is no floor to excuse relaxing it, and relaxing it costs
+/// real accuracy: normalizing `μ` by the objective magnitude (the shape
+/// [`equilibrated_kkt_rel_parts`] and HSDE's `gap_rel` use) hands a QP whose
+/// objective is dominated by a constant offset a blanket `|obj|`-sized
+/// tolerance on the gap. On `scaled_feasible_a` that offset is `5e11`, so the
+/// relative-gap form stops `~5e3` of objective early — the very
+/// objective instability gh #689 reports on this fixture pair. Holding `μ`
+/// absolute lands the same solve on the exact optimum.
 ///
-/// 1. Keep the warm primal `x` and equality multipliers `y`.
+/// Two gates, cheap-first. The outer one uses only quantities already to hand
+/// (`‖c‖, ‖b‖, ‖h‖, ‖s‖` — each a term of `scale_d`/`scale_p`, hence a lower
+/// bound on the natural scale, so it can only ever open *later* than the real
+/// gate), which keeps an ordinarily-scaled solve — every solve where this arm
+/// could not fire anyway — at one comparison and no matvecs.
+fn scale_relative_stop(
+    prob: &QpProblem,
+    x: &[f64],
+    y: &[f64],
+    z: &[f64],
+    s: &[f64],
+    pinf: f64,
+    dinf: f64,
+    mu: f64,
+    tol: f64,
+) -> bool {
+    if !(mu < tol) {
+        return false;
+    }
+    let norm_s = inf_norm(s);
+    let cheap = inf_norm(&prob.c)
+        .max(inf_norm(&prob.b))
+        .max(inf_norm(&prob.h))
+        .max(norm_s);
+    if !crate::hsde::relative_stop_permitted(cheap, tol) {
+        return false;
+    }
+    let (n, m_eq, m_ineq) = (prob.n, prob.m_eq(), prob.m_ineq());
+    let mut px = vec![0.0; n];
+    prob.p_mul(x, &mut px);
+    let mut aty = vec![0.0; n];
+    prob.at_mul(y, &mut aty);
+    let mut gtz = vec![0.0; n];
+    prob.gt_mul(z, &mut gtz);
+    let mut ax = vec![0.0; m_eq];
+    prob.a_mul(x, &mut ax);
+    let mut gx = vec![0.0; m_ineq];
+    prob.g_mul(x, &mut gx);
+
+    let scale_d = inf_norm(&px)
+        .max(inf_norm(&aty))
+        .max(inf_norm(&gtz))
+        .max(inf_norm(&prob.c));
+    let scale_p = inf_norm(&ax)
+        .max(inf_norm(&gx))
+        .max(norm_s)
+        .max(inf_norm(&prob.b))
+        .max(inf_norm(&prob.h));
+    if !crate::hsde::relative_stop_permitted(scale_d.max(scale_p), tol) {
+        return false;
+    }
+    pinf / (1.0 + scale_p) < tol && dinf / (1.0 + scale_d) < tol
+}
+
+/// Build the starting iterate `(x, y, z, s)` for [`run_ipm`] by **Mehrotra-style
+/// recentering** (Mehrotra 1992, §7) of a seed point — the warm start when one
+/// is supplied, otherwise the origin `x = 0, y = 0, z = e`.
+///
+/// The cold seed goes through the same recentering as a warm one, which is what
+/// sizes it to the problem's own data (gh #689). The historical cold start,
+/// `s = z = e` regardless of the data, is *not* a starting point: it is a fixed
+/// point of unit scale asserted over a problem whose slacks may live anywhere.
+/// On `scaled_feasible_a` the Ruiz-equilibrated feasible set sits at
+/// `‖h‖ ≈ 5e9`, so from `s = e` the very first Newton direction — a perfectly
+/// good `‖dx‖ ≈ 2.9e9`, pointed at the optimum — was cut by
+/// fraction-to-boundary to `α ≈ 8e-9`. The iterate could not move; the
+/// corrector, dividing `σμ` by slacks pinned at `1`, then returned directions
+/// of `1e18`, `z` blew up to `7e21`, and the solve diverged to the iteration
+/// cap at `kkt_error 8e45`. Seeding `s` from the implied slacks instead makes
+/// the same solve converge in 27 iterations. (This is the failure mode
+/// [`QpOptions::use_hsde`] documents the direct driver for — NETLIB `nl`,
+/// "`mu` to ~1e11" — with a measurement attached.)
+///
+/// The recentering, for either seed:
+///
+/// 1. Keep the seed primal `x` and equality multipliers `y`.
 /// 2. Take the implied slacks `s̃ = h − Gx` (their signs encode which
-///    inequalities the warm `x` makes active/violated) and the warm `z`.
+///    inequalities the seed `x` makes active/violated) and the seed `z`.
+///    From the origin this is `s̃ = h`, so the primal scale of the start is
+///    the problem's own.
 /// 3. Shift both into the strict interior by `δ = max(−1.5·min(·), floor)`.
-///    The `floor` is **adaptive**: it is the warm point's KKT residual `ρ`
+///    The `floor` is **adaptive**: it is the seed point's KKT residual `ρ`
 ///    on *this* problem, clamped to `[1e-9·scale, 0.1·scale]` with
 ///    `scale = max(1, ‖s̃‖∞, ‖z‖∞)`. A converged warm point sits on the
 ///    complementarity boundary (`s̃ᵢ` or `zᵢ ≈ 0`), so a floor is required
@@ -2150,13 +2288,15 @@ where
 ///    IPM exploits the warm duals — and softens toward the conservative
 ///    `0.1·scale` when the active set has moved (large `ρ`). This both
 ///    deepens the benefit on nearby problems and keeps it from ever doing
-///    worse than a centered start.
+///    worse than a centered start. From the cold seed the same rule reads
+///    as "size the interior floor to the residual the origin leaves", which
+///    is the scale the first Newton step has to work in.
 /// 4. A final centering shift `½(s·z)/Σz`, `½(s·z)/Σs` balances `s` and
 ///    `z` (Mehrotra's second step).
 ///
 /// The returned iterate always satisfies `s > 0, z > 0`. If `warm`'s
 /// dimensions don't match the (expanded) problem it is ignored and the
-/// cold start is used, so a stale warm start can never corrupt a solve.
+/// cold seed is used, so a stale warm start can never corrupt a solve.
 fn init_iterate(
     prob: &QpProblem,
     cone: &CompositeCone,
@@ -2165,33 +2305,32 @@ fn init_iterate(
     m_ineq: usize,
     warm: Option<&WarmStart>,
 ) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
-    // Cold start at the cone identity e (orthant: all ones; SOC: (1,0,…)),
-    // a perfectly centered interior point (s∘z = e).
-    let cold = || {
-        let mut e = vec![0.0; m_ineq];
-        cone.identity(&mut e);
-        (vec![0.0; n], vec![0.0; m_eq], e.clone(), e)
-    };
-    // A matching primal `x` is enough to warm start; `y`/`z` fall back to
-    // the cold values when they don't match (so a primal-only warm start —
-    // e.g. feeding back just the previous primal — is supported).
-    let w = match warm {
-        Some(w) if w.x.len() == n => w,
-        _ => return cold(),
-    };
-
-    let x = w.x.clone();
-    let y = if w.y.len() == m_eq {
-        w.y.clone()
-    } else {
-        vec![0.0; m_eq]
-    };
-    let mut z = if w.z.len() == m_ineq {
-        w.z.clone()
-    } else {
-        let mut e = vec![0.0; m_ineq];
-        cone.identity(&mut e);
-        e
+    // The seed point. A matching warm primal `x` is enough to warm start;
+    // `y`/`z` fall back to the cold values when they don't match (so a
+    // primal-only warm start — e.g. feeding back just the previous primal —
+    // is supported). With no warm start the seed is the origin with the cone
+    // identity duals — the historical cold start's `(x, y, z)`.
+    //
+    // Both seeds then go through the *same* Mehrotra recentering below, which
+    // is what sizes the cold start to the problem's own data (gh #689). See
+    // this function's doc comment for why `s = z = e` is not a starting point.
+    let mut ident = vec![0.0; m_ineq];
+    cone.identity(&mut ident);
+    let (x, y, mut z) = match warm {
+        Some(w) if w.x.len() == n => (
+            w.x.clone(),
+            if w.y.len() == m_eq {
+                w.y.clone()
+            } else {
+                vec![0.0; m_eq]
+            },
+            if w.z.len() == m_ineq {
+                w.z.clone()
+            } else {
+                ident.clone()
+            },
+        ),
+        _ => (vec![0.0; n], vec![0.0; m_eq], ident.clone()),
     };
 
     // No cone: x/y are the whole iterate, s/z are empty.
@@ -2206,15 +2345,17 @@ fn init_iterate(
 
     let scale = 1.0_f64.max(inf_norm(&s)).max(inf_norm(&z));
 
-    // Adaptive interior floor sized to the warm point's KKT residual ρ on
-    // *this* problem. ρ measures how far the warm point is from satisfying
-    // the new KKT system: a small ρ (nearby problem, stable active set)
-    // lets the slacks/multipliers stay near their warm — correctly
-    // structured — values, so the IPM exploits the warm duals and needs
-    // few steps; a large ρ (the active set moved, so the warm point is
-    // badly infeasible) softens the floor toward the conservative cold
-    // level `0.1·scale`. This self-corrects: warm starting never does
-    // worse than a centered start, and gains the most when it can.
+    // Adaptive interior floor sized to the seed point's KKT residual ρ on
+    // *this* problem. ρ measures how far the seed is from satisfying the
+    // KKT system: a small ρ (nearby problem, stable active set) lets the
+    // slacks/multipliers stay near their warm — correctly structured —
+    // values, so the IPM exploits the warm duals and needs few steps; a
+    // large ρ (the active set moved, so the warm point is badly infeasible)
+    // softens the floor toward the conservative `0.1·scale`. This
+    // self-corrects: warm starting never does worse than a centered start,
+    // and gains the most when it can. From the cold seed ρ is just the
+    // residual the origin leaves, which is the scale the first Newton step
+    // has to work in.
     let floor = {
         let mut rd = prob.c.clone();
         prob.p_mul_add(&x, &mut rd);
@@ -2222,7 +2363,7 @@ fn init_iterate(
         prob.gt_mul_add(&z, &mut rd);
         let mut rp: Vec<f64> = prob.b.iter().map(|b| -b).collect();
         prob.a_mul_add(&x, &mut rp);
-        // Inequality infeasibility of the warm point: max(0, Gx − h) = −s̃.
+        // Inequality infeasibility of the seed point: max(0, Gx − h) = −s̃.
         let viol = s.iter().fold(0.0_f64, |m, &si| m.max((-si).max(0.0)));
         let rho = inf_norm(&rd).max(inf_norm(&rp)).max(viol);
         rho.clamp(1e-9 * scale, 0.1 * scale)
@@ -2360,7 +2501,7 @@ fn run_ipm(
             break;
         }
 
-        if res < opts.tol {
+        if res < opts.tol || scale_relative_stop(prob, &x, &y, &z, &s, pinf, dinf, mu, opts.tol) {
             status = QpStatus::Optimal;
             // Record the converged iterate so the trace *ends* at the
             // optimum, matching the NLP path's N+1 convention (a problem

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -237,6 +237,36 @@ pub struct QpOptions {
     /// does not exceed the interior iterate's. A no-op for genuine QPs
     /// (`P ≠ 0`) and for the warm-start / debug entry points.
     ///
+    /// A constant added to `½xᵀPx + cᵀx` to obtain the objective the **caller**
+    /// reports. Default `0.0`.
+    ///
+    /// [`QpProblem`] models the quadratic form only, so a model whose objective
+    /// carries a degree-0 term hands the solver an objective displaced by that
+    /// term. Least-squares objectives — `Σ(xᵢ − aᵢ)²`, constant `Σaᵢ²` — are the
+    /// common case, and the displacement is unbounded: on the
+    /// `scaled_feasible_a` fixture the caller's optimum is `0` while the
+    /// solver's is `−5.0e11`.
+    ///
+    /// That matters because the scale-relative stopping test
+    /// ([`crate::hsde::relative_stop_permitted`]) normalizes the duality gap by
+    /// the objective *magnitude*, the standard convention. Under a large
+    /// displacement that magnitude is a property of the constant and not of the
+    /// solution, so `tol`-relative becomes a blanket `tol·|constant|` absolute
+    /// slack on the gap: HSDE certified `Optimal` on `scaled_feasible_a` at a
+    /// caller-visible objective of `236.85` — `4.7e-10` relative in *its* metric
+    /// and 100% wrong in the caller's (gh #689). Told the constant, the same
+    /// solve normalizes by the objective the caller actually reads and runs on
+    /// to the true optimum.
+    ///
+    /// **Purely a convergence-test normalizer.** It never enters the KKT
+    /// system, the search direction, the duals, or [`QpSolution::obj`] (which
+    /// stays the quadratic form's own value, as before — the caller adds the
+    /// constant back exactly as it always did). A wrong or missing value can
+    /// therefore only make the gap test tighter or looser, never unsound; `0.0`
+    /// — the default, and what every caller that does not set it gets — is the
+    /// tightest choice and reproduces the historical test whenever the true
+    /// constant is small next to the objective.
+    pub obj_constant: f64,
     /// **Default `false` — opt-in.** Crossover is correct (never-regress) but
     /// the active-set purification is currently *slow* on the degenerate /
     /// large NETLIB LPs it most targets: on the LP suite it regressed solve
@@ -270,6 +300,7 @@ impl Default for QpOptions {
             use_hsde: true,
             collect_iterates: false,
             equilibrate: true,
+            obj_constant: 0.0,
             // Opt-in: off by default. See the field doc — correct but slow on
             // the LPs it targets, and does not yet reach Optimal on GEN (#133).
             crossover: false,
@@ -532,6 +563,10 @@ where
     let inner = QpOptions {
         equilibrate: false,
         use_hsde,
+        // The equilibrated objective is `σ` times the original's, so the
+        // objective constant travels with it (`σ = 1` for a QP; only a pure
+        // LP's cost normalization makes this anything else).
+        obj_constant: opts.obj_constant * scaling.sigma(),
         ..*opts
     };
     let mut sol = solve_qp_ipm_unscaled(&scaled, &inner, make_backend);
@@ -922,12 +957,18 @@ where
         equilibrate: false,
         ..*opts
     };
+    // (`direct.obj_constant` is fixed up below for the equilibrated branch,
+    // whose scaled objective carries the cost scaling `σ`.)
     // Equilibrate (default on) just as the cold path does, mapping the
     // warm-start point into the scaled coordinates so the warm benefit is
     // preserved and the two paths run on identically-conditioned data.
     if opts.equilibrate {
         let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
         let scaled_warm = scaling.scale_warm_start(warm);
+        let direct = QpOptions {
+            obj_constant: direct.obj_constant * scaling.sigma(),
+            ..direct
+        };
         let mut sol = solve_qp_ipm_warm_inner(&scaled, &direct, &scaled_warm, make_backend);
         scaling.unscale_solution(prob, &mut sol);
         // Same re-check the cold equilibrated path applies: a verdict reached
@@ -2082,8 +2123,15 @@ where
         let sigma = hsde_cost_scale(prob, opts.tol);
         if sigma != 1.0 {
             let scaled = prob.scaled_objective(1.0 / sigma);
+            // The normalized objective is the original divided by `σ`; the
+            // caller's objective constant is in the original metric, so it is
+            // divided too (see [`QpOptions::obj_constant`]).
+            let inner = QpOptions {
+                obj_constant: opts.obj_constant / sigma,
+                ..*opts
+            };
             let mut sol =
-                crate::hsde::solve_conic_hsde(&scaled, cone, opts, &mut make_backend, None);
+                crate::hsde::solve_conic_hsde(&scaled, cone, &inner, &mut make_backend, None);
             for v in sol.y.iter_mut().chain(sol.z.iter_mut()) {
                 *v *= sigma;
             }

--- a/crates/pounce-convex/tests/issue_689_direct_cold_start_scale.rs
+++ b/crates/pounce-convex/tests/issue_689_direct_cold_start_scale.rs
@@ -1,0 +1,101 @@
+//! gh #689: the direct convex driver must start from a point sized to the
+//! problem's data, not from `s = z = e`.
+//!
+//! The failure the fixed cold start removes is not slow convergence — it is
+//! divergence. On a QP whose feasible set lives far from the origin, `s = e`
+//! makes the fraction-to-boundary rule cut the *first* Newton step (a perfectly
+//! good direction, pointed at the optimum) by the ratio `1 / ‖ds‖`. The iterate
+//! cannot move; the corrector then divides `σμ` by slacks still pinned at `1`,
+//! returns a direction many orders larger, and `z` runs away. On
+//! `crates/pounce-cli/tests/fixtures/scaled_feasible_a.nl` that took the driver
+//! to `kkt_error 8.4e45` at the iteration cap while HSDE solved the same model
+//! in 16 iterations.
+//!
+//! These are the same shape, in the small: the box sits at `x ≈ 1e9`, so the
+//! implied slacks at the origin are `~1e9` and a unit-scaled start is nine
+//! orders too small. Both drivers must land on the same optimum, and the direct
+//! one must do it in an ordinary iteration count.
+
+use pounce_convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+/// `min ½‖x − t‖²` over the box `0 ≤ xᵢ ≤ 2·shift`, with `t = (shift, shift/2)`
+/// strictly inside it. The unconstrained minimizer is feasible, so the optimum
+/// is `x* = t` at objective `−½‖t‖²` whatever `shift` is — only the *scale* of
+/// the feasible set moves with it.
+fn shifted_box_qp(shift: f64) -> QpProblem {
+    let target = [shift, 0.5 * shift];
+    QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+        c: vec![-target[0], -target[1]],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(1, 1, 1.0),
+            Triplet::new(2, 0, -1.0),
+            Triplet::new(3, 1, -1.0),
+        ],
+        h: vec![2.0 * shift, 2.0 * shift, 0.0, 0.0],
+        lb: vec![],
+        ub: vec![],
+    }
+}
+
+fn direct_opts() -> QpOptions {
+    QpOptions {
+        // The direct infeasible-start driver — what `QpWarmStart`, the
+        // build-once `QpFactorization` handle and the dual-infeasibility
+        // reverify guard all use, and what `qp_hsde=no` selects.
+        use_hsde: false,
+        ..QpOptions::default()
+    }
+}
+
+#[test]
+fn direct_driver_converges_when_the_feasible_set_is_far_from_the_origin() {
+    for &shift in &[1.0, 1e3, 1e6, 1e9] {
+        let prob = shifted_box_qp(shift);
+        let sol = solve_qp_ipm(&prob, &direct_opts(), backend);
+        assert_eq!(
+            sol.status,
+            QpStatus::Optimal,
+            "shift={shift:e}: direct driver did not converge ({:?} after {} iters)",
+            sol.status,
+            sol.iters
+        );
+        let want = [shift, 0.5 * shift];
+        for (i, (&got, &w)) in sol.x.iter().zip(&want).enumerate() {
+            assert!(
+                (got - w).abs() <= 1e-6 * w.max(1.0),
+                "shift={shift:e}: x[{i}] = {got:e}, want {w:e}"
+            );
+        }
+    }
+}
+
+#[test]
+fn iteration_count_does_not_grow_with_the_distance_to_the_feasible_set() {
+    // With a unit-scaled cold start the count grew without bound with `shift`
+    // (and past `~1e8` the solve diverged instead of converging), because every
+    // iteration could only close a fixed *fraction* of a gap that starts nine
+    // orders wide. Sizing the start to the data makes the count flat.
+    let counts: Vec<usize> = [1.0, 1e3, 1e6, 1e9]
+        .iter()
+        .map(|&shift| {
+            let sol = solve_qp_ipm(&shifted_box_qp(shift), &direct_opts(), backend);
+            assert_eq!(sol.status, QpStatus::Optimal, "shift={shift:e}");
+            sol.iters
+        })
+        .collect();
+    assert!(
+        counts.iter().all(|&c| c <= 20),
+        "iteration count is not flat across nine orders of problem scale: {counts:?}"
+    );
+}

--- a/dev-notes/issue-689-direct-driver-cold-start.md
+++ b/dev-notes/issue-689-direct-driver-cold-start.md
@@ -1,8 +1,8 @@
 # gh #689 — the direct convex driver's cold start, and what the
 # `scaled_feasible` pair actually measures
 
-Two findings: one fixed here, one measured and left for a separate change
-(HSDE's stopping rule — see §3).
+Two defects, both fixed: the direct driver's cold start (§1–§2) and HSDE's
+scale-relative stopping test (§3).
 
 ## 1. The divergence: a cold start with no relation to the data
 
@@ -118,11 +118,49 @@ the relative test. Until HSDE's stopping rule is revisited, an objective move
 on `scaled_feasible_a`/`_b` on the default leg should not be read as a
 trajectory regression — the iteration count still should.
 
-HSDE is deliberately **not** changed here. Its stopping rule is the default
-path for every LP/QP; changing it is a trajectory change across the whole
-corpus and needs its own sweep and its own issue. `crates/pounce-cli/tests/
-issue_689_direct_driver_scaled_feasible.rs` pins the current HSDE behaviour so
-the change, when it comes, is visible.
+### The fix, and the two that do not work
+
+The gap normalizer is right in form and wrong in its input. Told the objective
+constant, `scale_g` measures the objective the caller reads and everything
+follows: `QpOptions::obj_constant` (default `0.0`) carries it, the CLI sets it
+from the `.nl` degree-0 term it already tracks for reporting plus presolve's
+`obj_offset`, in the solver's minimize sense, and it travels through both cost
+scalings (divided by `hsde_cost_scale`'s `σ`, multiplied by Ruiz's). It is a
+convergence-test normalizer only — no residual, no direction, no dual, and not
+`QpSolution::obj` — and `0.0` is the *tightest* value, so nothing that does not
+set it changes.
+
+Two tighter-looking rules were measured first and rejected, both on the same
+evidence:
+
+*Require absolute complementarity in the relative arm* — the rule the direct
+driver uses (§2). Across the whole fixture corpus exactly five models reach the
+relative arm, and it separates them perfectly:
+
+| fixture | `⟨ŝ,ẑ⟩` at the stop | verdict |
+|---|---|---|
+| `feasible_x0_extreme_row` | 2.3e-11 | genuine |
+| `feasible_x0_sentinel_bound` | 1.1e-28 | genuine |
+| `feasible_x0_wide_scale` | 7.8e2 | false (KKT error 3.6e4) |
+| `scaled_feasible_a` | 1.2e3 | false |
+| `scaled_feasible_b` | 1.5e3 | false |
+
+Thirteen orders of separation — and it still fails, because the *genuine*
+gh #286 huge-magnitude optima sit at `⟨ŝ,ẑ⟩` of `1.5e9`
+(`huge_magnitude_qp_recovers_exact_optimum_at_default_budget`) and `1.4e13`
+(`issue_286_illconditioned_huge_scale_is_optimal_and_feasible`). Those are
+points the tests certify against an exact oracle; absolute complementarity is
+genuinely unreachable there (`x` is `O(1)` with duals at `1e18`, so the products
+floor at `~1e9`), which is what the relative arm exists for.
+
+*Normalize the gap by the gradient scale `scale_d` instead of the objective* —
+offset-invariant, and it rejects all three false stops. But `|obj| ≈ ‖∇f‖·‖x̂‖`,
+so this is tighter than the current rule by a factor `‖x̂‖`: it rejects any
+problem whose magnitude lives in `‖x*‖` rather than in its coefficients, which
+is POWELL20 (`‖x*‖ ~ 1e7`, `‖Px̂‖ ~ 7.5e3`, gap `4e2` — `5e-2` under this rule).
+
+The constant is the only thing that actually separates the two families, so the
+constant is what the fix supplies.
 
 ## 4. A false success the fix exposed, and the guard for it
 
@@ -177,3 +215,34 @@ path from a different start, not a change in what the driver certifies — the
 same sweep shows the reverse sign on `wyndor_min` (`1.7e-8 → 9.6e-10`),
 `lp_afiro` (`2.1e-7 → 2.3e-9`), `dual_order` (`1.6e-9 → 1.5e-11`) and
 `feasible_x0_wide_scale` (`6.7e-16 → 5.0e-17`).
+
+## 5. Sweep — the HSDE half
+
+`scripts/sweep-fixtures.sh`, both legs, after §3's fix.
+
+* **`qp_hsde=no` leg: empty diff.** `obj_constant` enters only HSDE's
+  `scale_g`; the direct driver's tests do not read it.
+* **Default (HSDE) leg**, every line that moved — all four are models with a
+  large objective constant, which is the whole affected class:
+
+| fixture | before | after | KKT error |
+|---|---|---|---|
+| `scaled_feasible_a` | Optimal 16, obj 236.85 | Optimal 123, obj 0 | 2.5e2 → 4.6e-3 |
+| `scaled_feasible_b` | Optimal 21, obj 456.33 | Optimal 47, obj 0 | 9.3e2 → 1.2e-10 |
+| `feasible_x0_wide_scale` | Optimal 16 | Optimal 198 | 3.6e4 → 6.6e-15 |
+| `feasible_x0_extreme_row` | Optimal 32 | Optimal 33 | 7.6e-4 → 3.8e-5 |
+
+Three of the four were false optima — `feasible_x0_wide_scale` was returning a
+point with a KKT error of `3.6e4` under a `Solve_Succeeded`. The iteration
+counts are the cost of the work those solves were skipping: with the constant
+supplied, `scale_g` on these models is the *caller's* objective, which tends to
+`0` at the optimum, so the relative test degenerates to the absolute one and
+HSDE has to drive the gap to `tol` outright — which is exactly what the direct
+driver does on the same models in 27 and 28 iterations.
+
+**`feasible_x0_wide_scale` at 198 against a 200 cap is thin margin** and is the
+one line here that should not be left unwatched: a change that costs this solve
+three iterations turns a correct answer into `IterationLimit`. It is recorded
+rather than tuned away — raising the cap or loosening the test to buy margin
+would be trading the correctness this change just bought for a number that
+looks better.

--- a/dev-notes/issue-689-direct-driver-cold-start.md
+++ b/dev-notes/issue-689-direct-driver-cold-start.md
@@ -229,7 +229,7 @@ same sweep shows the reverse sign on `wyndor_min` (`1.7e-8 → 9.6e-10`),
 |---|---|---|---|
 | `scaled_feasible_a` | Optimal 16, obj 236.85 | Optimal 123, obj 0 | 2.5e2 → 4.6e-3 |
 | `scaled_feasible_b` | Optimal 21, obj 456.33 | Optimal 47, obj 0 | 9.3e2 → 1.2e-10 |
-| `feasible_x0_wide_scale` | Optimal 16 | Optimal 198 | 3.6e4 → 6.6e-15 |
+| `feasible_x0_wide_scale` | Optimal 16 | Optimal 80 | 3.6e4 → 6.6e-15 |
 | `feasible_x0_extreme_row` | Optimal 32 | Optimal 33 | 7.6e-4 → 3.8e-5 |
 
 Three of the four were false optima — `feasible_x0_wide_scale` was returning a
@@ -240,9 +240,44 @@ supplied, `scale_g` on these models is the *caller's* objective, which tends to
 HSDE has to drive the gap to `tol` outright — which is exactly what the direct
 driver does on the same models in 27 and 28 iterations.
 
-**`feasible_x0_wide_scale` at 198 against a 200 cap is thin margin** and is the
-one line here that should not be left unwatched: a change that costs this solve
-three iterations turns a correct answer into `IterationLimit`. It is recorded
-rather than tuned away — raising the cap or loosening the test to buy margin
-would be trading the correctness this change just bought for a number that
-looks better.
+### The gate, and why `feasible_x0_wide_scale` first went to 198
+
+Correcting `scale_g` had one knock-on that had to be corrected with it, and it
+is the more interesting half. `large_scale` — the gate that admits the relative
+test at all — is keyed on `max(scale_d, scale_p, scale_g)`. Making `scale_g`
+*accurate* makes it *small* on exactly the models this change targets, and on
+`feasible_x0_wide_scale` that closed the gate outright, leaving only the
+absolute test. The primal and dual residuals there floor at `5e-9` and `5e-6`
+on `5e13`-scale data — facts about the constraint system, with nothing to do
+with the objective constant — so the solve could never finish:
+
+```
+it=18 inf_pr=5.089e-09 inf_du=4.929e-05 mu=9.062e-18 a_p=9.813e-01
+it=20 inf_pr=5.007e-09 inf_du=8.332e-06 mu=1.088e-19 a_p=1.000e+00
+it=25 inf_pr=5.102e-09 inf_du=4.496e-06 mu=1.448e-24 a_p=1.000e+00
+...
+it=120 inf_pr=5.051e-09 inf_du=4.927e-08 mu=1.621e-119    <- denormals
+it=130 inf_pr=5.040e-09 inf_du=6.687e-11 mu=3.465e-118 a_p=2.784e-07
+it=140 inf_pr=4.343e-01 inf_du=4.984e-05 mu=1.823e+05    <- iterate discarded
+it=180 inf_pr=4.846e-09 inf_du=2.023e-07 mu=1.641e+09    <- and again
+```
+
+Converged at 18, then 180 iterations of collapse-and-restart, terminating at
+198 against a 200 cap on an answer it had found long before — and
+`crates/pounce-cli/tests/false_local_infeasibility.rs::the_convex_route_still_solves_both_shapes`
+asserts `solve_result_num == 0` on this model, so that was two iterations from
+a red test, not just an ugly sweep line.
+
+The gate is asked whether `tol`-level *absolute* accuracy is reachable on this
+data at all. That is a property of the magnitudes actually being computed, not
+of where the caller's zero happens to sit, so it reads the objective's own
+magnitude (`scale_g_raw`) while `scale_g` supplies the gap's *normalizer*. With
+that split the model converges in 80.
+
+A gap floor (`gap ≤ N·ε·max|term|`, the same "relax to the arithmetic floor"
+rule §2 applies to the direct driver) was tried on top and **dropped**. It is
+faster — 23/28/39/32 iterations at `N = 8` — but it costs real accuracy on the
+two fixtures the issue is about (`scaled_feasible_a` reports `6.1e-5` and `_b`
+`2.4e-4` instead of `0`), and every `N` large enough to matter is a constant
+fitted to one fixture's `τ`-collapse noise. The gate correction alone is
+exact everywhere and needs no such constant.

--- a/dev-notes/issue-689-direct-driver-cold-start.md
+++ b/dev-notes/issue-689-direct-driver-cold-start.md
@@ -1,0 +1,179 @@
+# gh #689 — the direct convex driver's cold start, and what the
+# `scaled_feasible` pair actually measures
+
+Two findings: one fixed here, one measured and left for a separate change
+(HSDE's stopping rule — see §3).
+
+## 1. The divergence: a cold start with no relation to the data
+
+`crates/pounce-cli/tests/fixtures/scaled_feasible_a.nl` at `qp_hsde=no`:
+
+| route | status | iters | objective | `final_kkt_error` |
+|---|---|---|---|---|
+| HSDE (default) | Optimal | 16 | 236.85 | 2.5e2 |
+| direct, before | IterationLimit | 199 | 1.14e11 | 8.4e45 |
+| direct, after | Optimal | 27 | ~0 | 2.6e-6 |
+
+The pre-fix run was diverging, not crawling. The per-iteration trace of the
+Ruiz-equilibrated solve makes the mechanism plain:
+
+```
+it=0 mu=1.0e0 pinf=5.0e9 dinf=1.0e2  |x|=0  |s|=1  |z|=1
+  predictor: |dx_aff|=2.85e9   ap_aff=8.4e-9  ad_aff=3.3e-10
+  corrector: |dx|=7.7e17 |dz|=7.4e18  step_p=1.2e-18 step_d=2.8e-18
+it=3 mu=2.7e21 ... |z|=7.3e21
+```
+
+The **predictor direction is correct**: `‖dx_aff‖ = 2.85e9` against an optimum
+at `‖x̂*‖ ≈ 5e9`. What kills the solve is that `init_iterate`'s cold start was
+`s = z = e` — a unit-scale point asserted over a problem whose slacks are
+`O(5e9)`. Fraction-to-boundary then caps the step at `≈ 0.95·s/‖ds‖ ≈ 3e-10`,
+the iterate cannot move, and the corrector — which divides `σμ` by slacks still
+pinned at `1` — returns directions eighteen orders larger. `z` runs away to
+`7e21` and `μ` with it.
+
+Why the equilibration does not save it: Ruiz balances the **matrix** `K`, not
+the right-hand side. On this model `‖P‖ = 2`, `‖G‖ = 1e8`, so the symmetric
+sweep settles at `Dc ≈ R_G ≈ 1e-4` — which lifts `Ĝ` to `O(1)`, drops `P̂` to
+`2e-8`, and leaves `ĥ` at `5e9`. The equilibrated problem is well-*conditioned*
+and badly *placed*: its optimum is at `‖x̂‖ ≈ 5e9` where the original was at
+`‖x‖ ≈ 5e5`. (The claim in `equilibrate.rs` that "the Ruiz pass already
+normalizes the `P` block to O(1)" holds only when the `P` entries dominate
+their own rows of `K`; here the `G` entries do, by eight orders.)
+
+**Fix.** The cold seed now runs through the same Mehrotra recentering
+(Mehrotra 1992 §7) that the warm path already used, with the origin as its
+seed: `s̃ = h − G·0 = h`, then the positivity shift and the centering shift.
+The starting slacks are the problem's own scale by construction, and nothing
+about a well-scaled problem changes (`h = O(1)` ⇒ the seed is `O(1)`).
+
+## 2. Reaching the optimum is not the same as recognizing it
+
+With the start fixed, the driver reaches the exact optimum at iteration ~27 —
+and then runs another 148 iterations past it. `pinf` floors at `5.0000e-6` and
+never moves:
+
+```
+it=27 mu=8.4e-9  pinf=5.0000e-6 dinf=2.6e-10  |x|=5.0000e9
+...
+it=175 mu=3.3e-293 pinf=5.0000e-6 dinf=1.0e-286  → NumericalFailure
+```
+
+`5e-6` is four ulp of `5e9`: forming `Gx + s − h` cancels two `5e9` quantities,
+so no iterate can drive that residual under `tol = 1e-8`. The absolute
+convergence test is unreachable, the loop keeps stepping, `s` and `z` underflow
+into the denormals, and the factorization breaks down — on top of the optimum
+(its true KKT error at that point reads `4e-25`).
+
+HSDE already has the answer to this: `hsde::relative_stop_permitted` opens a
+scale-relative arm exactly when `max_scale·ε > tol`. The direct driver now uses
+the same gate and the same normalizers — **except that complementarity stays
+absolute**. That distinction matters and is not cosmetic:
+
+- `Gx + s − h` and `Px + c + Aᵀy + Gᵀz` are *differences of like-magnitude
+  terms*. Their achievable accuracy is `≈ scale·ε`; below that floor only a
+  relative statement means anything.
+- `μ = ⟨s,z⟩/deg` is a *sum of products of nonnegatives*. Nothing cancels; it
+  reaches zero at any problem scale. There is no floor to excuse relaxing it,
+  and relaxing it costs real accuracy — see §3.
+
+Measured both ways on `scaled_feasible_a`: with the gap normalized by `|obj|`
+(HSDE's shape) the solve stops at iteration 18 with objective `0.486`; with `μ`
+held absolute it stops at 27 with objective `-6e-5`, i.e. the optimum.
+
+## 3. What the `scaled_feasible` pair actually measures
+
+#689 asks whether these two fixtures "have genuinely flat or degenerate optima
+— in which case the fixtures are poor trajectory sentinels — or the success
+criterion is passing on iterates that are not optimal." It is the second.
+
+Both models are `min Σ(xᵢ − aᵢ)²` where the objective's own centre `a` is the
+`.nl` file's initial guess **and is feasible**, with three constraints exactly
+active there. So `x* = a` and the optimum is `0`, exactly — verifiable by hand
+from the fixture. The fixed direct driver returns
+
+```
+scaled_feasible_a  x = (-3.80752631972466071, 5.0e5, 0.5, 4.99999e5)   obj 0
+scaled_feasible_b  x = ( 5.0e5, -9.216393895220474, 0.5, 5.0e5)        obj 0
+```
+
+against HSDE's `236.85` and `456.33`. Those are not answers; they are iterates
+HSDE's stopping test admits. The mechanism is the same relative-gap
+normalization discussed in §2, in HSDE's `gap_rel = gap/(1+scale_g)` with
+`scale_g = |primal obj| ∨ |dual obj|`. `QpProblem` has no constant term, so the
+objective the solver sees is `½xᵀPx + cᵀx = (user objective) − Σaᵢ²`, and
+`Σaᵢ² ≈ 5e11` here. A gap of `5e3` therefore passes a `1e-8` relative test —
+and `5e3` of gap is `5e3` of user-visible objective, because the user's
+objective is that same near-total cancellation. The `#414` guard
+(`verify_or_repair_optimum`) does not catch it for the same reason: its
+`cscale` is the objective magnitude, so it reads `4.9e-10` on a point whose
+absolute KKT error is `2.5e2`.
+
+**Consequence for the sweep.** `scripts/sweep-fixtures.sh` treats an objective
+move as signal, and on the default (HSDE) leg these two fixtures report a
+number that is a property of where the trajectory happened to stop, not of the
+model. That is why `qp_gondzio_corr=0` moves `a` 236.85 → 315.67 and the
+adaptive-τ tail (#690) moves it to 272.94: all three are equally "converged" by
+the relative test. Until HSDE's stopping rule is revisited, an objective move
+on `scaled_feasible_a`/`_b` on the default leg should not be read as a
+trajectory regression — the iteration count still should.
+
+HSDE is deliberately **not** changed here. Its stopping rule is the default
+path for every LP/QP; changing it is a trajectory change across the whole
+corpus and needs its own sweep and its own issue. `crates/pounce-cli/tests/
+issue_689_direct_driver_scaled_feasible.rs` pins the current HSDE behaviour so
+the change, when it comes, is visible.
+
+## 4. A false success the fix exposed, and the guard for it
+
+The direct driver's convergence test — absolute or relative — is applied to the
+*equilibrated* problem. That is not a statement about the point the caller gets:
+Ruiz's dual map divides by `Dc`, so a `Dc` spanning many decades inflates the
+recovered dual residual by up to `1/min Dc`.
+
+`feasible_x0_sentinel_bound` (coefficients from `1e-320` to `1e30`,
+`min Dc ≈ 6e-16`) is the case: at the stopping iterate `‖r_d‖ = 2.3e-9` in the
+scaled metric and `2.3` in the user's, at objective `1.30` against a true `0`.
+`feasible_x0_extreme_row` was already doing this **before** this change — the
+pre-fix direct route returned `Solve_Succeeded` at objective `5.0e11`, with an
+unscaled dual infeasibility of `2.6e6`, where the true optimum is `0`.
+
+So a direct-driver `Optimal` reached through the equilibrated path is now
+re-checked in the caller's coordinates (`demote_false_equilibrated_optimum`)
+and demoted to `NumericalFailure` when it does not hold up there. Note the
+symmetry with gh #414: there the *unscaled* relative test was the blind one and
+the equilibrated metric was decisive; here it is the reverse. Neither metric is
+trusted alone — a point has to look optimal in both.
+
+## Sweep
+
+`scripts/sweep-fixtures.sh`, both legs, 57 fixtures.
+
+* **Default (HSDE) leg: empty diff.** Nothing in this change is reachable from
+  the default route.
+* **`qp_hsde=no` leg**, every line that moved:
+
+| fixture | before | after | note |
+|---|---|---|---|
+| `scaled_feasible_a` | IterLimit 199, obj 1.14e11 | Optimal 27, obj ~0 | the issue |
+| `scaled_feasible_b` | NumericalFailure 99, obj 5.0e11 | Optimal 28, obj 0 | the issue |
+| `lp_afiro` | Optimal 135, obj -464.7531419 | Optimal 10, obj -464.7531428 | 13× fewer, and closer to the NETLIB optimum -464.75314286 |
+| `rankdef_eq_qp` | Optimal 12 | Optimal 6 | KKT 2.7e-13 → 1.6e-12 |
+| `qcqp_ball` | Optimal 15 | Optimal 12 | KKT 7.3e-9 → 1.2e-8 |
+| `wyndor_min` | Optimal 7, obj -35.99999997 | Optimal 6, obj -36 | KKT 1.7e-8 → 9.6e-10 |
+| `dual_order` | Optimal 4 | Optimal 5 | KKT 1.6e-9 → 1.5e-11 |
+| `dual_scaled` | Optimal 4 | Optimal 5 | KKT 1.5e-11 |
+| `feasible_x0_wide_scale` | Optimal 4 | Optimal 13 | KKT 6.7e-16 → 5.0e-17 |
+| `feasible_x0_extreme_row` | **Optimal** 4, obj 5.0e11 | NumericalFailure 4 | pre-existing false success (true optimum 0), now demoted — see §4 |
+| `feasible_x0_sentinel_bound` | NumericalFailure 101 | NumericalFailure 19 | same verdict, 5× cheaper |
+| `lp_row_constant`, `_expr` | Optimal 5, KKT 7.2e-10 | Optimal 5, KKT 1.8e-8 | the largest accuracy regression in the diff |
+
+Three lines end slightly less accurate: `lp_row_constant` / `_expr`
+(`7.2e-10 → 1.8e-8`), `qcqp_ball` (`7.3e-9 → 1.2e-8`) and `rankdef_eq_qp`
+(`2.7e-13 → 1.6e-12`). All stay inside the solved band, and the largest of them
+moves `lp_row_constant`'s objective `-5.999999998 → -5.999999961` against an
+exact `-6`. This is the cost of landing on a different point of the central
+path from a different start, not a change in what the driver certifies — the
+same sweep shows the reverse sign on `wyndor_min` (`1.7e-8 → 9.6e-10`),
+`lp_afiro` (`2.1e-7 → 2.3e-9`), `dual_order` (`1.6e-9 → 1.5e-11`) and
+`feasible_x0_wide_scale` (`6.7e-16 → 5.0e-17`).


### PR DESCRIPTION
Fixes #689.

Two defects, found one behind the other. The issue reports the first and asks a
question whose answer turned out to be the second.

## Problem

**1. The direct driver diverges.** At `qp_hsde=no` on
`crates/pounce-cli/tests/fixtures/scaled_feasible_a.nl`:

| | status | objective | NLP error | iters |
|---|---|---|---|---|
| before | `MaximumIterationsExceeded` | 1.14e11 | 8.4e45 | 199 |
| after | `SolveSucceeded` | ~0 | 2.6e-6 | 27 |
| oracle | — | **0** | — | — |

Not slow convergence — `final_dual_inf` 3.7e41 at the cap. This is not a
debug-only path: `QpWarmStart`, the build-once `QpFactorization` handle and the
dual-infeasibility reverify guard all use the direct driver, and none of them
can fall back to HSDE the way the one-shot path can.

**2. The default route returns wrong answers as `Optimal`.** The issue's second
half asks whether the `scaled_feasible` pair has "genuinely flat or degenerate
optima ... or the success criterion is passing on iterates that are not
optimal." It is the second, and it affects four fixtures, not two:

| fixture (default route) | before | after |
|---|---|---|
| `scaled_feasible_a` | obj **236.85**, KKT 2.5e2 | obj **0**, KKT 4.6e-3 |
| `scaled_feasible_b` | obj **456.33**, KKT 9.3e2 | obj **0**, KKT 1.2e-10 |
| `feasible_x0_wide_scale` | KKT **3.6e4** | KKT 6.6e-15 |
| `feasible_x0_extreme_row` | KKT 7.6e-4 | KKT 3.8e-5 |

The oracle is exact and solver-independent: each model is `min Σ(xᵢ − aᵢ)²`
whose centre `a` is the `.nl` file's own initial guess *and is feasible*, so
`x* = a` and the optimum is `0`. Confirmed by hand from the fixtures, and
independently by `solver_selection=nlp` (`1.0e-9` and `3.8e-9`).

The direct driver was additionally certifying `Solve_Succeeded` on
`feasible_x0_extreme_row` at objective `5.0e11` — unscaled dual infeasibility
2.6e6, true optimum 0. That one predates this branch.

## Cause

**Cold start.** `init_iterate` used `s = z = e` regardless of the data. On these
models the Ruiz-equilibrated feasible set sits at `‖ĥ‖ ≈ 5e9`, so the starting
slacks were nine orders too small. The trace shows the first Newton direction is
*correct* — `‖dx_aff‖ = 2.85e9`, pointed at an optimum at `‖x̂*‖ ≈ 5e9` — and
fraction-to-boundary cuts it to `α ≈ 8e-9`:

```
it=0 mu=1.0e0 pinf=5.0e9 |x|=0 |s|=1 |z|=1
  predictor: |dx_aff|=2.85e9  ap_aff=8.4e-9
  corrector: |dx|=7.7e17 |dz|=7.4e18  step_p=1.2e-18
it=3 mu=2.7e21 ... |z|=7.3e21
```

The iterate cannot move; the corrector then divides `σμ` by slacks still pinned
at `1` and returns directions eighteen orders larger. Ruiz does not save it: it
balances the *matrix*, and with `‖P‖ = 2` against `‖G‖ = 1e8` the sweep settles
at `Dc ≈ 1e-4`, which lifts `Ĝ` to `O(1)`, drops `P̂` to `2e-8`, and leaves `ĥ`
at `5e9`. The equilibrated problem is well-*conditioned* and badly *placed*.

**Stopping test.** HSDE's scale-relative arm normalizes the duality gap by the
objective magnitude, `scale_g = |primal obj| ∨ |dual obj|` — the standard
convention. But `QpProblem` models `½xᵀPx + cᵀx` only; the `.nl` objective's
degree-0 term lives in the CLI. On a least-squares objective that term is
`Σaᵢ² ≈ 5e11`, so the solver normalized by a magnitude belonging to the constant
rather than to the solution, and `gap_rel < 1e-8` became a blanket `5e3`
absolute slack. The gh #414 guard misses it for the same reason — its `cscale`
is also the objective magnitude, so it reads `4.9e-10` on a point whose absolute
KKT error is `2.5e2`.

## Fix

Three commits, separable and independently revertible.

**`6cdc364` — cold start sized to the data.** The cold seed now runs through the
same Mehrotra recentering (1992 §7) the warm path already used, with the origin
as its seed: `s̃ = h − G·0 = h`. Nothing changes for a well-scaled problem
(`h = O(1)` ⇒ the seed is `O(1)`).

That reaches the optimum but cannot *recognize* it: with `‖x̂‖ ≈ 5e9` against
`‖ĥ‖ ≈ 5e9`, forming `Gx + s − h` cancels, `pinf` floors at `5e-6 ≈ 4 ulp`, and
the absolute test is unreachable — so the loop ran 175 iterations past its own
answer (true KKT error `4e-25`) until `s` and `z` underflowed into the
denormals. The driver therefore also gets HSDE's scale-relative arm, under the
same gate, **with complementarity held absolute**: `Gx + s − h` and
`Px + c + Aᵀy + Gᵀz` are differences of like-magnitude terms and floor at
`scale·ε`, whereas `μ = ⟨s,z⟩/deg` is a sum of products of nonnegatives, has no
cancellation floor, and reaches zero at any scale. Measured both ways —
normalizing `μ` by `|obj|` stops at iteration 18 with objective `0.486`; holding
it absolute stops at 27 on the optimum.

A direct `Optimal` reached through the equilibrated path is now re-checked in
the caller's coordinates. Ruiz's dual map divides by `Dc`, so a `Dc` spanning
decades inflates the recovered dual residual: on `feasible_x0_sentinel_bound`
(`min Dc ≈ 6e-16`) the iterate reads `‖r_d‖ = 2.3e-9` scaled and `2.3` unscaled.
This is gh #414's failure through the opposite door — there the unscaled test
was blind and the equilibrated one decisive; here it is the reverse — so a point
must now look optimal in **both** metrics.

**`962ac37` — tell the solver its objective constant.** `QpOptions::obj_constant`
(default `0.0`); the CLI sets it from the `.nl` degree-0 term it already tracks
for reporting, plus presolve's `obj_offset`, in the solver's minimize sense. It
travels through both cost scalings (divided by `hsde_cost_scale`'s `σ`,
multiplied by Ruiz's). Convergence-test normalizer only — no residual, no
direction, no dual, and not `QpSolution::obj`. `0.0` is the *tightest* value, so
nothing that does not set it changes.

Two tighter-looking rules were measured first and **rejected**, both on the same
evidence. Exactly five models in the corpus reach the relative arm, and
*requiring absolute complementarity there* separates them by thirteen orders
(`2.3e-11`, `1.1e-28` genuine; `7.8e2`, `1.2e3`, `1.5e3` false) — yet it fails,
because the genuine gh #286 huge-magnitude optima sit at `⟨ŝ,ẑ⟩` of `1.5e9` and
`1.4e13`, so the rule would break the POWELL20-class problems the relative arm
exists for. *Normalizing the gap by the gradient scale* fails the same way: it
is tighter than the objective scale by a factor `‖x̂‖`, which is ~1 on the #286
box QPs but `1e7` on POWELL20. The only thing that actually distinguishes the
two families is the constant offset.

**`cb43358` — keep the relative-stop gate on the objective's own magnitude.**
The knock-on from the previous commit, and the more interesting half.
`large_scale` is keyed on `max(scale_d, scale_p, scale_g)`, so making `scale_g`
*accurate* — small, once the constant is accounted for — could **close** it,
stripping the primal and dual residuals of a relaxation that has nothing to do
with the objective constant. On `feasible_x0_wide_scale` it did:

```
it=18  inf_pr=5.089e-09  inf_du=4.929e-05  mu=9.062e-18   <- converged here
it=120 inf_pr=5.051e-09  inf_du=4.927e-08  mu=1.621e-119  <- denormals
it=140 inf_pr=4.343e-01  inf_du=4.984e-05  mu=1.823e+05   <- iterate discarded
it=180 inf_pr=4.846e-09  inf_du=2.023e-07  mu=1.641e+09   <- and again
```

Converged at 18, then 180 iterations of collapse-and-restart, reaching the cap
at 198 on an answer it had found long before — and
`false_local_infeasibility.rs::the_convex_route_still_solves_both_shapes`
asserts `solve_result_num == 0` on that model, so this was two iterations from a
red test, not just an ugly sweep line. The gate is asked whether absolute `tol`
accuracy is reachable *on this data*, which is a property of the magnitudes
actually being computed, so it reads the objective's own magnitude while
`scale_g` supplies only the gap's normalizer. That model now converges in 80.

A gap floor (`gap ≤ N·ε·max|term|`, the same "relax to the arithmetic floor"
rule used above) was tried on top and **dropped**: faster (23/28/39/32 iterations
at `N = 8`) but it costs real accuracy on the two fixtures the issue is about
(`6.1e-5` and `2.4e-4` instead of `0`), and every `N` large enough to matter is a
constant fitted to one fixture's `τ`-collapse noise.

Full derivation, including the rejected rules and their measurements:
`dev-notes/issue-689-direct-driver-cold-start.md`.

## Blast radius

`scripts/sweep-fixtures.sh`, both legs, 57 fixtures, against `6cdc364^`
(= `be04338`).

**Default (HSDE) leg** — only the four models carrying a large objective
constant move; everything else is bit-identical:

| fixture | before | after |
|---|---|---|
| `scaled_feasible_a` | Optimal 16, obj 236.85 | Optimal 123, obj 0 |
| `scaled_feasible_b` | Optimal 21, obj 456.33 | Optimal 47, obj 0 |
| `feasible_x0_wide_scale` | Optimal 16, KKT 3.6e4 | Optimal 80, KKT 6.6e-15 |
| `feasible_x0_extreme_row` | Optimal 32 | Optimal 33 |

**`qp_hsde=no` leg** — the cold-start change, plus two pre-existing false
successes now demoted to honest failures:

| fixture | before | after |
|---|---|---|
| `scaled_feasible_a` | IterLimit 199, obj 1.14e11 | Optimal 27, obj ~0 |
| `scaled_feasible_b` | NumericalFailure 99, obj 5.0e11 | Optimal 28, obj 0 |
| `lp_afiro` | Optimal 135, obj -464.7531419 | Optimal 10, obj -464.7531428 |
| `rankdef_eq_qp` | Optimal 12 | Optimal 6 |
| `qcqp_ball` | Optimal 15 | Optimal 12 |
| `wyndor_min` | Optimal 7, obj -35.99999997 | Optimal 6, obj -36 |
| `dual_order` / `dual_scaled` | Optimal 4 | Optimal 5 |
| `feasible_x0_wide_scale` | Optimal 4 | Optimal 13 |
| `feasible_x0_extreme_row` | **Optimal** 4, obj 5.0e11 | NumericalFailure 4 |
| `feasible_x0_sentinel_bound` | NumericalFailure 101 | NumericalFailure 19 |
| `lp_row_constant`, `_expr` | Optimal 5, KKT 7.2e-10 | Optimal 5, KKT 1.8e-8 |

`lp_afiro` is 13× fewer iterations *and* closer to the NETLIB optimum
(`-464.75314286`). Three lines end slightly less accurate and are recorded
rather than waved past: `lp_row_constant`/`_expr` (`7.2e-10 → 1.8e-8`),
`qcqp_ball` (`7.3e-9 → 1.2e-8`), `rankdef_eq_qp` (`2.7e-13 → 1.6e-12`) — all
inside the solved band, and the same sweep shows the reverse sign on
`wyndor_min`, `lp_afiro`, `dual_order` and `feasible_x0_wide_scale`.

Library callers that do not set `obj_constant` get `0.0` and are unaffected;
`QpOptions` gained a field but only 4 literals in the tree lack a rest-pattern.

## Tests

- `crates/pounce-convex/tests/issue_689_direct_cold_start_scale.rs` — a box QP
  whose feasible set sits at `1e0 … 1e9`, asserting the direct driver converges
  and that the iteration count stays flat across nine orders of problem scale.
  **Verified to fail on `6cdc364^`**: `shift=1e6: direct driver did not converge
  (NumericalFailure after 146 iters)`, both tests red — the divergence itself,
  not an incidental assertion.
- `crates/pounce-cli/tests/issue_689_direct_driver_scaled_feasible.rs` — both
  routes on both fixtures: solved status, an iteration budget, and objective
  `0 ± 1e-3` against the hand-verified optimum. The two routes are separate
  tests because they are fixed by different commits and can regress
  independently.

Not pinned, deliberately: the gh #286 large-data cluster (POWELL20/BOYD/
QFORPLAN/QSHELL) that the rejected rules would have broken. Those `.nl` are
generated from Maros-Mészáros rather than vendored, so the argument against
those rules rests on the in-tree `illconditioned_huge_scale.rs` optima
(`⟨ŝ,ẑ⟩ = 1.5e9` and `1.4e13`) plus the scale reasoning, not on a POWELL20 run.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a, no user-facing option or
      routing change (`obj_constant` is set by the CLI, not by the user)
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace -D correctness
      -D suspicious`, `cargo test --workspace` (255 binaries) all clean
- [x] Every claim here is true of the code as it stands

Note for scheduling: #694 (`feat/588-q9-correctors`) also touches
`crates/pounce-convex/src/ipm.rs`. This branch merges cleanly into `main` as of
`68d6298`, but whichever of the two lands second will want a re-sweep rather
than just a textual merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFgsipcwFCsuDEzc7iPVyE)_