### PR TITLE
Fix two documentation defects left by #696

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,14 +67,17 @@ changes.
   of the magnitudes actually being computed — while `scale_g` supplies
   the gap's normalizer. That model now converges in 80.
 
-  Fixture sweep, both legs: the `qp_hsde=no` leg is unchanged, and on the
-  default leg only the four models with a large objective constant move —
+  Fixture sweep, both legs, **for this change in isolation**: the
+  `qp_hsde=no` leg is unchanged by it, and on the default leg only the
+  four models with a large objective constant move —
   `scaled_feasible_a` 16 → 123 iterations (`236.85` → `0`, KKT error
   `2.5e2` → `4.6e-3`), `scaled_feasible_b` 21 → 47 (`456.33` → `0`,
   `9.3e2` → `1.2e-10`), `feasible_x0_wide_scale` 16 → 80 (KKT error
   `3.6e4` → `6.6e-15`), `feasible_x0_extreme_row` 32 → 33 (`7.6e-4` →
   `3.8e-5`). The counts are the cost of the work these solves were
-  previously skipping.
+  previously skipping. (The direct-driver cold-start entry below lands in
+  the same release and *does* move the `qp_hsde=no` leg; the two sweeps
+  are each measured against the change they describe, not cumulatively.)
 
 - **The direct convex QP driver no longer diverges on a badly-scaled
   feasible model** (#689).

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -224,19 +224,6 @@ pub struct QpOptions {
     /// preserves the cone; the SOCP/conic driver never equilibrates, since
     /// per-row scaling is unsound for non-orthant cones. Default `true`.
     pub equilibrate: bool,
-    /// Run the LP-crossover phase ([`crate::crossover`]) after the interior-
-    /// point solve. For a **pure LP** (`P = 0`), crossover hands the near-
-    /// optimal interior iterate to the active-set engine ([`pounce_qp`]),
-    /// which pivots it to an *exact* optimal vertex basis. This closes the
-    /// gap on degenerate LPs (NETLIB GEN family), where strict
-    /// complementarity fails, the fraction-to-boundary step collapses, and a
-    /// pure IPM cannot certify the vertex to `tol` — exactly the
-    /// IPM-then-crossover pairing every commercial LP solver uses
-    /// (Andersen & Ye 1996). It is a strict, **never-regress** refinement: the
-    /// purified vertex is returned only when it is feasible and its KKT error
-    /// does not exceed the interior iterate's. A no-op for genuine QPs
-    /// (`P ≠ 0`) and for the warm-start / debug entry points.
-    ///
     /// A constant added to `½xᵀPx + cᵀx` to obtain the objective the **caller**
     /// reports. Default `0.0`.
     ///
@@ -267,6 +254,19 @@ pub struct QpOptions {
     /// tightest choice and reproduces the historical test whenever the true
     /// constant is small next to the objective.
     pub obj_constant: f64,
+    /// Run the LP-crossover phase ([`crate::crossover`]) after the interior-
+    /// point solve. For a **pure LP** (`P = 0`), crossover hands the near-
+    /// optimal interior iterate to the active-set engine ([`pounce_qp`]),
+    /// which pivots it to an *exact* optimal vertex basis. This closes the
+    /// gap on degenerate LPs (NETLIB GEN family), where strict
+    /// complementarity fails, the fraction-to-boundary step collapses, and a
+    /// pure IPM cannot certify the vertex to `tol` — exactly the
+    /// IPM-then-crossover pairing every commercial LP solver uses
+    /// (Andersen & Ye 1996). It is a strict, **never-regress** refinement: the
+    /// purified vertex is returned only when it is feasible and its KKT error
+    /// does not exceed the interior iterate's. A no-op for genuine QPs
+    /// (`P ≠ 0`) and for the warm-start / debug entry points.
+    ///
     /// **Default `false` — opt-in.** Crossover is correct (never-regress) but
     /// the active-set purification is currently *slow* on the degenerate /
     /// large NETLIB LPs it most targets: on the LP suite it regressed solve


### PR DESCRIPTION
Two documentation defects I found while reviewing #696 locally before merging
it. Neither blocked the merge — both are documentation only, no code, no
behaviour, no trajectory change — but they should not sit in the release.

### 1. The crossover description ended up on the wrong field

#696 added `QpOptions::obj_constant` between `equilibrate` and `crossover`,
and its doc block was inserted *inside* the existing crossover doc block
rather than before it. The result on `main` is that rustdoc renders the
"Run the LP-crossover phase…" paragraph as the opening paragraph of
`obj_constant`, and `crossover` is documented only by its
"**Default `false` — opt-in**" justification — the reader is told why it is
off by default, but never what it is.

Moved the paragraph down to rejoin `crossover`. Neither block's text is
otherwise changed, which is why the diff is a clean move.

### 2. The CHANGELOG `[Unreleased]` section contradicts itself

The `obj_constant` entry says the `qp_hsde=no` leg is unchanged; the
direct-driver cold-start entry a few bullets below lists a page of
`qp_hsde=no` changes (`lp_afiro` 135 → 10, `rankdef_eq_qp` 12 → 6, …).

Both statements are correct against the change each describes — the sweeps
are per-change, not cumulative — but a reader of the finished release section
has no way to know that, and the natural reading is that one of them is
wrong. Marked the first as measured for that change in isolation and stated
outright that the two sweeps are not cumulative.

### Verification

`cargo build` and `cargo fmt --all -- --check` clean. `cargo doc -p
pounce-convex --no-deps` emits the same pre-existing private-item link
warnings as before and no new ones. No test or fixture behaviour is reachable
from either change.
