### PR TITLE
Sum the presolve chain's objective offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ changes.
 
 ## [Unreleased]
 
+- **`Presolve::obj_offset` reported `0.0` for every multi-layer presolve**
+  (#697).
+
+  An iterated presolve hands back a wrapper object whose per-pass layers
+  live in a `chain`; the wrapper substitutes nothing itself. The aggregate
+  objective offset was a stored field on that wrapper, initialized to `0.0`
+  and never filled in — only `postsolve` walked the chain — so any reduction
+  that took two or more layers reported no offset at all. The value is now
+  computed on demand by summing the chain (`obj_orig = obj_reduced +
+  Σₖ offsetₖ`, one term per layer, because layer `k+1` reduces layer `k`'s
+  reduced problem), and the field behind it is private, so it cannot be read
+  as complete when it is not.
+
+  The consumer is #689's `QpOptions::obj_constant`: the CLI adds presolve's
+  offset to the `.nl` constant before handing the reduced problem to the
+  solver. With the offset dropped, the "plus presolve's own objective
+  offset" half of that fix held only for single-layer reductions. Three
+  fixtures in the corpus are multi-layer with a nonzero offset —
+  `dual_scaled` (`-5999`), `dual_order` (`-59`) and `tame` (`1`) — and all
+  three were passing `0.0` through.
+
+  Same bounded blast radius as #689: `obj_constant` is a convergence-test
+  normalizer only, consumed by `scale_g` and the two cost scalings. It
+  enters no residual, no search direction, no dual, and not
+  `QpSolution::obj`. The failure mode was a stopping test slightly too
+  loose on models where presolve moved a large constant into the objective —
+  an accuracy effect, which is the class gh#544 taught us not to wave
+  through on "it cannot produce a wrong answer". Fixture sweep, both legs:
+  **no diff**; the corrected constant moves no trajectory in the corpus.
+
 - **HSDE no longer certifies `Optimal` a few hundred short of the optimum
   when the objective carries a large constant** (#689).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,10 @@ changes.
   `QpSolution::obj`. The failure mode was a stopping test slightly too
   loose on models where presolve moved a large constant into the objective —
   an accuracy effect, which is the class gh#544 taught us not to wave
-  through on "it cannot produce a wrong answer". Fixture sweep, both legs:
-  **no diff**; the corrected constant moves no trajectory in the corpus.
+  through on "it cannot produce a wrong answer". Fixture sweep, both legs,
+  **for this change in isolation**: no diff — the corrected constant moves
+  no trajectory in the corpus. (Like the #689 sweeps in this section, that
+  is measured against the change this entry describes, not cumulatively.)
 
 - **HSDE no longer certifies `Optimal` a few hundred short of the optimum
   when the objective carries a large constant** (#689).

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2487,7 +2487,7 @@ fn run_convex_qp(
         ..convex_opts
     };
     // The reduced problem presolve hands the solver differs from `qp` by
-    // `ps.obj_offset`, so the constant that makes *it* commensurate with the
+    // `ps.obj_offset()`, so the constant that makes *it* commensurate with the
     // user's objective carries that offset too.
     let solve_opts_offset = |offset: f64| {
         convex_opts_with_remaining(
@@ -2580,12 +2580,12 @@ fn run_convex_qp(
                     let mut mk = backend;
                     solve_qp_active_set(
                         &ps.reduced,
-                        &solve_opts_offset(ps.obj_offset),
+                        &solve_opts_offset(ps.obj_offset()),
                         &engine_overrides,
                         &mut mk,
                     )
                 } else {
-                    solve_qp_ipm(&ps.reduced, &solve_opts_offset(ps.obj_offset), backend)
+                    solve_qp_ipm(&ps.reduced, &solve_opts_offset(ps.obj_offset()), backend)
                 };
                 ps.postsolve(&red)
             }

--- a/crates/pounce-convex/src/presolve.rs
+++ b/crates/pounce-convex/src/presolve.rs
@@ -498,9 +498,16 @@ enum Reduction {
 pub struct Presolve {
     /// The reduced problem to hand to the solver.
     pub reduced: QpProblem,
-    /// Constant added to the objective by variable substitutions; the
-    /// reduced objective plus this equals the original objective.
-    pub obj_offset: f64,
+    /// Constant **this layer's** variable substitutions moved into the
+    /// objective; the layer's reduced objective plus this equals the
+    /// objective of the problem the layer was built from.
+    ///
+    /// For an iterated presolve the wrapper performs no substitution of its
+    /// own — the offsets live one per layer in `chain` — so this is `0.0`
+    /// there and reading it as the reduction's total is wrong (gh #697).
+    /// [`Presolve::obj_offset`] is that total; keep this field private so
+    /// nothing outside can confuse the two.
+    layer_obj_offset: f64,
     /// Original problem dimensions.
     orig_n: usize,
     orig_m_eq: usize,
@@ -900,7 +907,9 @@ fn presolve_fixpoint(prob: &QpProblem, catalog: Catalog, memo: DedupMemo) -> Pre
     let reduced = chain.last().expect("chain non-empty").reduced.clone();
     PresolveOutcome::Reduced(Presolve {
         reduced,
-        obj_offset: 0.0,
+        // The wrapper substitutes nothing itself; each layer in `chain`
+        // carries its own offset and `Presolve::obj_offset` sums them.
+        layer_obj_offset: 0.0,
         orig_n: prob.n,
         orig_m_eq: prob.m_eq(),
         orig_m_ineq: prob.m_ineq(),
@@ -929,7 +938,7 @@ fn aggregate_once(prob: &QpProblem) -> Option<Presolve> {
     let (reduced, obj_offset) = crate::aggregate::reduce(prob, &plan)?;
     Some(Presolve {
         reduced,
-        obj_offset,
+        layer_obj_offset: obj_offset,
         orig_n: prob.n,
         orig_m_eq: prob.m_eq(),
         orig_m_ineq: prob.m_ineq(),
@@ -1981,7 +1990,7 @@ fn presolve_once(
 
     PresolveOutcome::Reduced(Presolve {
         reduced,
-        obj_offset: offset,
+        layer_obj_offset: offset,
         orig_n: n,
         orig_m_eq: m_eq,
         orig_m_ineq: m_ineq,
@@ -2450,6 +2459,22 @@ impl Presolve {
         s
     }
 
+    /// Constant the whole reduction moved into the objective: adding this
+    /// to the reduced problem's objective gives the original problem's.
+    ///
+    /// For an iterated presolve that is the **sum over the chain**, one term
+    /// per layer, because layer `k+1` reduces layer `k`'s reduced problem:
+    /// `obj_orig = obj_reduced + Σₖ offsetₖ`. The wrapper object itself
+    /// substitutes nothing, so reading a stored field instead reported `0.0`
+    /// for every multi-layer reduction — which this repo's own CHANGELOG
+    /// calls the common case (gh #697). Computed here so it cannot go stale.
+    pub fn obj_offset(&self) -> f64 {
+        if self.chain.is_empty() {
+            return self.layer_obj_offset;
+        }
+        self.chain.iter().map(|l| l.obj_offset()).sum()
+    }
+
     /// Expand a reduced-problem solution back to the original space,
     /// recovering primal `x` and duals `(y, z)`. For an iterated presolve,
     /// folds the per-round postsolves in reverse.
@@ -2479,9 +2504,9 @@ impl Presolve {
         // the *reduced* problem — which differs by exactly the constant any
         // substitution moved into the objective. Put it back, per layer, so
         // the chain composes to the user's objective.
-        if self.obj_offset != 0.0 {
+        if self.layer_obj_offset != 0.0 {
             for it in &mut out.iterates {
-                it.objective += self.obj_offset;
+                it.objective += self.layer_obj_offset;
             }
         }
         out

--- a/crates/pounce-convex/tests/issue697_multilayer_obj_offset.rs
+++ b/crates/pounce-convex/tests/issue697_multilayer_obj_offset.rs
@@ -1,0 +1,149 @@
+//! gh #697 — `Presolve::obj_offset` must be the *whole* reduction's objective
+//! constant, not just the top object's own.
+//!
+//! An iterated presolve returns a wrapper whose layers live in a chain; the
+//! wrapper itself substitutes nothing. The aggregate offset used to be a
+//! stored field on that wrapper, initialized to `0.0` and never filled in, so
+//! every multi-layer reduction reported "no offset" — and the CLI, which
+//! feeds this value into the solver's `obj_constant`, silently dropped the
+//! presolve contribution on exactly the reductions that had one.
+//!
+//! The defining property, layer by layer, is
+//! `obj_original(x) = obj_reduced(x_reduced) + Σ offsetₖ`, so that is what
+//! these tests assert — against an independently computed objective, not
+//! against a restatement of the implementation.
+
+use pounce_convex::presolve::{PresolveOutcome, presolve};
+use pounce_convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+/// `0.5·xᵀPx + cᵀx`, with `p_lower` the lower triangle: the diagonal carries
+/// the `0.5`, each off-diagonal entry stands for both symmetric halves.
+fn objective(prob: &QpProblem, x: &[f64]) -> f64 {
+    let mut v = 0.0;
+    for t in &prob.p_lower {
+        v += if t.row == t.col {
+            0.5 * t.val * x[t.row] * x[t.col]
+        } else {
+            t.val * x[t.row] * x[t.col]
+        };
+    }
+    for (i, &ci) in prob.c.iter().enumerate() {
+        v += ci * x[i];
+    }
+    v
+}
+
+/// A cascade of equality rows: `x3 = 4` is a singleton, which turns
+/// `x2 + x3 = 7` into one, which turns `x1 + x2 = 5` into one. No single pass
+/// can take all three, so the fixpoint runs more than one layer — and each
+/// fixed variable carries a linear and a quadratic term into the objective.
+fn cascade() -> QpProblem {
+    QpProblem {
+        n: 4,
+        p_lower: vec![
+            Triplet::new(0, 0, 2.0),
+            Triplet::new(1, 1, 2.0),
+            Triplet::new(2, 2, 2.0),
+            Triplet::new(3, 3, 2.0),
+        ],
+        c: vec![-2.0, 1.0, 1.0, 1.0],
+        a: vec![
+            Triplet::new(0, 3, 1.0), // x3 = 4
+            Triplet::new(1, 2, 1.0), // x2 + x3 = 7
+            Triplet::new(1, 3, 1.0),
+            Triplet::new(2, 1, 1.0), // x1 + x2 = 5
+            Triplet::new(2, 2, 1.0),
+        ],
+        b: vec![4.0, 7.0, 5.0],
+        g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+        h: vec![10.0], // slack at the optimum; keeps x0 in the reduced problem
+        lb: vec![],
+        ub: vec![],
+    }
+}
+
+#[test]
+fn multi_layer_presolve_reports_the_summed_objective_offset() {
+    let prob = cascade();
+    let PresolveOutcome::Reduced(ps) = presolve(&prob) else {
+        panic!("cascade should reduce, not prove infeasible or unbounded");
+    };
+
+    // The premise of the bug: this reduction really is multi-layer.
+    let rounds = ps.stats().rounds;
+    assert!(
+        rounds >= 2,
+        "expected an iterated presolve, got {rounds} layer(s)"
+    );
+
+    let red = solve_qp_ipm(&ps.reduced, &QpOptions::default(), backend);
+    assert_eq!(red.status, QpStatus::Optimal);
+    let full = ps.postsolve(&red);
+    assert_eq!(full.status, QpStatus::Optimal);
+
+    let want = objective(&prob, &full.x) - objective(&ps.reduced, &red.x);
+    // x3=4, x2=3, x1=2 → (1·4 + 4²) + (1·3 + 3²) + (1·2 + 2²) = 38.
+    assert!(
+        (want - 38.0).abs() < 1e-6,
+        "fixture drifted: expected a 38.0 constant, measured {want}"
+    );
+    assert!(
+        (ps.obj_offset() - want).abs() < 1e-6,
+        "obj_offset() = {}, but the reduction moved {want} into the objective",
+        ps.obj_offset()
+    );
+}
+
+/// The single-pass path is the one that already worked; it must keep working.
+/// One singleton row, one layer, one offset — read through the same accessor.
+#[test]
+fn single_layer_presolve_still_reports_its_own_offset() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+        c: vec![-2.0, 1.0],
+        a: vec![Triplet::new(0, 1, 1.0)], // x1 = 4
+        b: vec![4.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    };
+    let PresolveOutcome::Reduced(ps) = presolve(&prob) else {
+        panic!("singleton row should reduce");
+    };
+    assert_eq!(ps.stats().rounds, 1, "fixture should be a single layer");
+    // x1 = 4 → 1·4 + 0.5·2·4² = 20.
+    assert!(
+        (ps.obj_offset() - 20.0).abs() < 1e-9,
+        "obj_offset() = {}",
+        ps.obj_offset()
+    );
+}
+
+/// A presolve that finds nothing reports no offset — the accessor must not
+/// invent one for the passthrough layer.
+#[test]
+fn no_op_presolve_reports_zero_offset() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+        c: vec![-2.0, -3.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    };
+    let PresolveOutcome::Reduced(ps) = presolve(&prob) else {
+        panic!("unconstrained strictly convex QP should not be infeasible");
+    };
+    assert_eq!(ps.obj_offset(), 0.0);
+}

--- a/dev-notes/issue-689-direct-driver-cold-start.md
+++ b/dev-notes/issue-689-direct-driver-cold-start.md
@@ -124,7 +124,9 @@ The gap normalizer is right in form and wrong in its input. Told the objective
 constant, `scale_g` measures the objective the caller reads and everything
 follows: `QpOptions::obj_constant` (default `0.0`) carries it, the CLI sets it
 from the `.nl` degree-0 term it already tracks for reporting plus presolve's
-`obj_offset`, in the solver's minimize sense, and it travels through both cost
+`obj_offset()` (an accessor, and summed over the reduction chain, since gh
+#697 — the field it replaced read `0.0` for every multi-layer presolve),
+in the solver's minimize sense, and it travels through both cost
 scalings (divided by `hsde_cost_scale`'s `σ`, multiplied by Ruiz's). It is a
 convergence-test normalizer only — no residual, no direction, no dual, and not
 `QpSolution::obj` — and `0.0` is the *tightest* value, so nothing that does not


### PR DESCRIPTION
Fixes #697.

## Problem

`Presolve::obj_offset` read `0.0` for every presolve that took two or more
layers — which the CHANGELOG describes as the common case. The corpus bears
that out: three fixtures reduce in multiple layers *and* have a nonzero
offset, and all three reported nothing.

| fixture | layers | true offset | reported (before) | reported (after) |
|---|---|---|---|---|
| `dual_scaled` | 2 | `-5999` | `0` | `-5999` |
| `dual_order` | 2 | `-59` | `0` | `-59` |
| `tame` | 2 | `1` | `0` | `1` |
| `convex_qp` | 1 | `4` | `4` | `4` |
| `presolve_float_trap` | 1 | `0.09` | `0.09` | `0.09` |

(Measured by instrumenting `run_convex_qp` to print `stats().rounds` and the
offset, then sweeping the fixture corpus. The single-layer rows are the path
that already worked, included to show the fix does not disturb it. Re-measured
after merging current `main` — see Blast radius — and unchanged.)

The consumer is #696's `QpOptions::obj_constant`: the CLI adds presolve's
offset to the `.nl` degree-0 constant before handing the reduced problem to
the solver (`main.rs:2583`/`:2588`). With the offset dropped, the "plus
presolve's own objective offset" half of that fix held only for single-layer
reductions.

## Cause

`presolve` returns a single `Presolve`, but for an iterated reduction that
object is a *wrapper*: the real per-pass layers live in its `chain`, and the
wrapper performs no substitution of its own. `obj_offset` was a plain `pub`
field, constructed as `0.0` on that wrapper and never filled in. Only
`postsolve` walked the chain, so the value stayed correct for the one path
that consumed it and silently wrong for the accessor.

## Fix

Issue #697 offered two options — sum the offsets when building the wrapper,
or drop the field and make callers walk the chain. I took a third that has
the second's safety without its call-site burden: the field is now a private
`layer_obj_offset` (this layer's own offset, which is exactly what
`postsolve_once` wants), and the public reader is a computed accessor:

```rust
pub fn obj_offset(&self) -> f64 {
    if self.chain.is_empty() {
        return self.layer_obj_offset;
    }
    self.chain.iter().map(|l| l.obj_offset()).sum()
}
```

The sum is the right composition because layer *k+1* reduces layer *k*'s
reduced problem, so the offsets telescope: `obj_orig = obj_reduced + Σₖ
offsetₖ`.

Summing into the stored field at construction — the issue's first option —
was rejected: it leaves a public field that is correct only because one
constructor remembered to fill it, and the defect being fixed is precisely a
constructor that did not. Computing on demand cannot go stale, and making the
per-layer value private means the two cannot be confused at a call site.

No double-counting risk in `postsolve`: the multi-layer path folds the chain
and never reads the wrapper's own offset, and `postsolve_once` now names the
private field explicitly.

## Blast radius

Same as #696's, and bounded for the same reason. `obj_constant` is a
convergence-test normalizer only — consumed by `scale_g` (`hsde.rs`) and
passed through the two cost scalings (`ipm.rs`). It enters no residual, no
search direction, no dual, and not `QpSolution::obj`. The failure mode was a
stopping test slightly too loose on models where presolve moved a large
constant into the objective.

That is an accuracy/trajectory effect, not a wrong answer, so it got the
trajectory treatment rather than the "it cannot produce a wrong answer"
wave-through that shipped gh#544.

**Full sweep, both legs (`exact` + `lbfgs`), 116 fixture-legs, baseline
`3e8383f` (current `main`): bit-identical, empty diff.**

That baseline is deliberate. The first sweep on this branch was measured
against `ef9f773`, and #694 (`feat/588-q9-correctors`) then merged — a
*trajectory* change to the same direct convex QP driver this change feeds
("Gate the direct driver's Gondzio correctors on a short predictor step",
"Recalibrate the corrector gate … 0.9 → 0.85"). A sweep taken before a
sibling trajectory PR lands is the stale-baseline case this repo's PR
template calls out, and the interaction was plausible rather than theoretical:
with correctors newly gated, a corrected `obj_constant` could have moved
trajectories it previously did not. So `main` is merged into this branch here
and everything was re-measured from scratch against it — baseline binary
rebuilt from `3e8383f`, both legs, still empty. The offset table above was
re-derived on the new base too.

The merge itself is clean. #694 touched `presolve.rs`, but doc comments and
one `debug_assert` only — no new `Presolve { … }` construction site, so the
`layer_obj_offset` rename does not collide. Confirmed by compiling, not by
reading the diff.

Sweep results in this PR are measured against the change this PR describes,
on top of its base — not cumulatively across the release. Same convention as
the #689 entries, and the CHANGELOG entry says so.

The API change is a `pub` field becoming a `pub` method. The only reader in
the tree is the CLI, updated here; nothing in `python/`, `pyomo-pounce/` or
the other crates touches it.

Still merges cleanly with #699 (re-verified with `git merge-tree` against
this head); that PR is documentation-only and touches a different region of
the same CHANGELOG section.

## Tests

New `crates/pounce-convex/tests/issue697_multilayer_obj_offset.rs`, three
cases. The multi-layer one asserts the defining property against an
*independently computed* objective rather than restating the implementation:

```
obj_original(x) - obj_reduced(x_reduced) == obj_offset()
```

The fixture is a cascade of equality rows (`x3 = 4` is a singleton, which
turns `x2 + x3 = 7` into one, which turns `x1 + x2 = 5` into one), so no
single pass can take all three; the test asserts `stats().rounds >= 2` up
front so it cannot silently stop testing the multi-layer path if presolve
gets smarter. The expected constant is also pinned at `38.0` with a
"fixture drifted" message, so a change in what presolve eliminates fails
loudly instead of quietly making the test tautological.

The other two cover the single-layer and no-op paths, which already worked
and must keep working through the new accessor.

**These bite.** I confirmed the multi-layer case fails on the pre-fix
behaviour, and for the right reason — reverting the accessor body to return
the stored field reproduces the failure at the `obj_offset()` assertion,
while the single-layer and no-op cases still pass.

Suites, all on the merged head `15e1acd`: `pounce-convex` 38 targets green,
`pounce-cli` 83 targets green, 0 failures in either. `cargo fmt --all --
--check` clean, `cargo clippy` adds no new findings,
`scripts/check-release-consistency.sh` OK.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
      — n/a; no user-facing option, doc or CLI surface changes. The one prose
      reference to `obj_offset` outside the code
      (`dev-notes/issue-689-direct-driver-cold-start.md`) is updated.
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now