### PR TITLE
Sum the presolve chain's objective offsets, so the accessor is honest (#697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,40 @@ changes.
   solver by the reformulation-cost guards, and the members that do route
   conic carry SOC blocks). `POUNCE_DBG_GONDZIO=1` prints the per-solve
   corrector tally so this is checkable rather than assumed.
+- **`Presolve::obj_offset` now reports the whole reduction chain, not
+  `0.0`** (#697).
+
+  The fixpoint wrapper `presolve` returns holds the composed reduction:
+  its per-layer objective offsets live in `chain`, and only `postsolve`
+  walked that chain. The public aggregate accessor was built with a
+  literal `obj_offset: 0.0`, so any reduction that took **two or more
+  layers** — the common case — reported that presolve had moved no
+  constant into the objective however large a constant it had actually
+  moved. It is now the sum over the chain, which telescopes to the
+  constant between the final `reduced` problem and the user's. No
+  double-count: with a non-empty chain `postsolve` folds the layers and
+  never reads this field.
+
+  The reader that made a stale `0.0` matter is #689's `obj_constant`,
+  which the CLI builds from the `.nl` degree-0 term *plus this offset* to
+  normalize the scale-relative stopping test. Where presolve took more
+  than one layer only the `.nl` term survived. Bounded, but not nothing:
+  `obj_constant` is a convergence-test normalizer only — it enters no
+  residual, no direction, no dual, and not `QpSolution::obj` — so it
+  cannot produce a wrong answer, it can only leave the relative gap test
+  too loose. That is a trajectory/accuracy effect, which is the class
+  gh#544 established goes unnoticed, so it is fixed rather than filed as
+  cosmetic.
+
+  Measured over the CLI fixture corpus, three models reach the convex
+  route with a multi-layer presolve and a nonzero offset that was being
+  dropped: `dual_order` (2 layers, `−59` against an `obj_constant` of
+  `909`), `dual_scaled` (2 layers, `−5999` against `9.0e6`) and `tame`
+  (2 layers, `1`). None of them moves: `scripts/sweep-fixtures.sh` is
+  bit-for-bit identical across all four legs — `exact` and `lbfgs`, at
+  the default route and at `qp_hsde=no` — so this corrects the value
+  every future reader gets without rerouting any solve today.
+
 - **HSDE no longer certifies `Optimal` a few hundred short of the optimum
   when the objective carries a large constant** (#689).
 

--- a/crates/pounce-convex/src/presolve.rs
+++ b/crates/pounce-convex/src/presolve.rs
@@ -499,7 +499,10 @@ pub struct Presolve {
     /// The reduced problem to hand to the solver.
     pub reduced: QpProblem,
     /// Constant added to the objective by variable substitutions; the
-    /// reduced objective plus this equals the original objective.
+    /// reduced objective plus this equals the original objective. For an
+    /// iterated presolve this is the sum over `chain` — the constant between
+    /// the *final* `reduced` problem and the user's, not one layer's share of
+    /// it (gh #697).
     pub obj_offset: f64,
     /// Original problem dimensions.
     orig_n: usize,
@@ -912,9 +915,18 @@ fn presolve_fixpoint(prob: &QpProblem, catalog: Catalog, memo: DedupMemo) -> Pre
         return PresolveOutcome::Reduced(only);
     }
     let reduced = chain.last().expect("chain non-empty").reduced.clone();
+    // The constant each layer moved into its own objective, composed (gh
+    // #697). Layer `Lₖ`'s objective is `Lₖ₊₁`'s plus `Lₖ₊₁.obj_offset`, so
+    // telescoping the chain gives the constant between the *final* reduced
+    // problem — the one this wrapper hands the solver — and the user's. Left
+    // at `0.0`, the accessor reported "presolve moved no constant" for every
+    // multi-layer reduction, which is the common case. No double-count in
+    // `postsolve`: with a non-empty chain it folds the layers and never reads
+    // this field.
+    let obj_offset = chain.iter().map(|l| l.obj_offset).sum();
     PresolveOutcome::Reduced(Presolve {
         reduced,
-        obj_offset: 0.0,
+        obj_offset,
         orig_n: prob.n,
         orig_m_eq: prob.m_eq(),
         orig_m_ineq: prob.m_ineq(),

--- a/crates/pounce-convex/tests/issue697_multilayer_obj_offset.rs
+++ b/crates/pounce-convex/tests/issue697_multilayer_obj_offset.rs
@@ -1,0 +1,125 @@
+//! gh #697: `Presolve::obj_offset` must aggregate the whole reduction chain.
+//!
+//! The fixpoint wrapper `presolve` returns holds the composed reduction; the
+//! per-layer offsets live in its chain, and only `postsolve` walked that chain.
+//! The aggregate accessor was hard-coded to `0.0`, so every multi-layer
+//! reduction — which this repo's own notes call the common case — reported
+//! "presolve moved no constant into the objective" however large a constant it
+//! had actually moved.
+//!
+//! The reader that made this matter is the CLI's `obj_constant` (gh #689),
+//! which normalizes the relative stopping test by the objective's own
+//! magnitude. A dropped offset there cannot produce a wrong answer — it makes
+//! the gap test too loose, on exactly the models presolve reduces hardest,
+//! which is the trajectory/accuracy class that goes unnoticed.
+
+use pounce_convex::presolve::{PresolveOutcome, presolve};
+use pounce_convex::{QpOptions, QpProblem, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+/// `½·xᵀPx + cᵀx`, the objective `QpProblem` carries.
+fn objective(prob: &QpProblem, x: &[f64]) -> f64 {
+    let mut px = vec![0.0; prob.n];
+    prob.p_mul(x, &mut px);
+    0.5 * px.iter().zip(x).map(|(a, b)| a * b).sum::<f64>()
+        + prob.c.iter().zip(x).map(|(a, b)| a * b).sum::<f64>()
+}
+
+/// A reduction that takes two layers and moves a constant in each.
+///
+/// ```text
+/// min  10·x₀ + 100·x₁ + ½·(x₁² + x₂²)
+/// s.t.     x₀             = 2
+///                x₁ + x₂  = 4
+/// ```
+///
+/// Round 1's catalog pass fixes the singleton `x₀ = 2`, moving `10·2` into the
+/// objective. The doubleton `x₁ + x₂ = 4` is not a catalog reduction — both of
+/// its columns are quadratic — so it falls to the aggregation, which always
+/// forms a layer of its own and carries the constant its substitution leaves
+/// behind. Two layers, both with a nonzero offset.
+fn two_layer_reduction() -> QpProblem {
+    QpProblem {
+        n: 3,
+        p_lower: vec![Triplet::new(1, 1, 1.0), Triplet::new(2, 2, 1.0)],
+        c: vec![10.0, 100.0, 0.0],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(1, 1, 1.0),
+            Triplet::new(1, 2, 1.0),
+        ],
+        b: vec![2.0, 4.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    }
+}
+
+#[test]
+fn multilayer_presolve_reports_its_composed_objective_offset() {
+    let prob = two_layer_reduction();
+    let PresolveOutcome::Reduced(ps) = presolve(&prob) else {
+        panic!("this reduction is feasible and bounded");
+    };
+    let stats = ps.stats();
+    assert!(
+        stats.rounds >= 2,
+        "fixture must exercise the multi-layer path, took {} layer(s)",
+        stats.rounds
+    );
+    assert_eq!(stats.fixed_vars, 1, "the singleton should have fired");
+    assert_eq!(stats.aggregated_vars, 1, "the doubleton should have fired");
+
+    // The documented contract: reduced objective + offset == original
+    // objective, at the point the two describe. Asserted against a solve
+    // rather than a literal because which of a doubleton's two columns the
+    // aggregation folds decides how much of the linear term lands in the
+    // constant — the *contract* is invariant to that choice, the number is
+    // not. (It is 428 as this is written.)
+    let red = solve_qp_ipm(&ps.reduced, &QpOptions::default(), backend);
+    let full = ps.postsolve(&red);
+    let want = objective(&prob, &full.x) - objective(&ps.reduced, &red.x);
+    assert!(
+        want.abs() > 1.0,
+        "fixture must move a constant worth measuring, moved {want}"
+    );
+    assert!(
+        (ps.obj_offset - want).abs() < 1e-6 * want.abs().max(1.0),
+        "composed offset over {} layers: got {}, want {want}",
+        stats.rounds,
+        ps.obj_offset
+    );
+}
+
+/// The single-layer path already reported its offset; keep it reporting the
+/// same value, so the fix reads as "the chain case joins it" rather than as a
+/// change of meaning.
+#[test]
+fn single_layer_presolve_still_reports_its_own_offset() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(1, 1, 1.0)],
+        c: vec![10.0, 0.0],
+        a: vec![Triplet::new(0, 0, 1.0)],
+        b: vec![2.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    };
+    let PresolveOutcome::Reduced(ps) = presolve(&prob) else {
+        panic!("this reduction is feasible and bounded");
+    };
+    assert_eq!(ps.stats().rounds, 1, "fixture must stay a single layer");
+    assert!(
+        (ps.obj_offset - 20.0).abs() < 1e-12,
+        "fixing x₀ = 2 moves 10·2 into the objective, got {}",
+        ps.obj_offset
+    );
+}


### PR DESCRIPTION
Fixes #697.

## Problem

`Presolve::obj_offset` was a literal `0.0` on the fixpoint wrapper. The real
per-layer offsets live in `chain`, and only `postsolve` walked it — so the
public accessor reported "presolve moved no constant into the objective" for
every reduction that took two or more layers, which this repo's own #530 sweep
records as the common case (the layer cap binds on 46% of LP and 25% of QP
models). Nothing distinguished that from a genuine zero.

Reached in practice, not merely reachable — three corpus fixtures presolve into
two layers with a nonzero offset and reported `0.0`:

| fixture | layers | true offset | `obj_constant` it feeds |
|---|---|---|---|
| `dual_order` | 2 | `-59` | 909 |
| `dual_scaled` | 2 | `-5999` | 9.0e6 |
| `tame` | 2 | `1` | — |

## Cause

The wrapper standing for the composition of the layers owns none of their
offsets, and was constructed with the placeholder the field was never updated
from. `postsolve` folds the layers in reverse and each applies its own, so the
*recovery* path was always correct; only the aggregate accessor was not, which
is why nothing caught it until a caller read the value directly.

## Fix

Telescope the chain: layer `Lₖ`'s objective is `Lₖ₊₁`'s plus `Lₖ₊₁.obj_offset`,
so the sum is exactly the constant between the final reduced problem — the one
this wrapper hands the solver — and the user's. Exact, not an approximation.

No double-count in `postsolve`: with a non-empty chain it folds the layers and
never reads this field. Verified by reading every use, and pinned by the test's
identity below, which fails just as loudly on a double-count as it did on the
drop.

The reader that made the stale value matter is #689's `QpOptions::obj_constant`,
which the CLI builds from the `.nl` degree-0 term plus this offset to normalize
the scale-relative stopping test. Where presolve took more than one layer only
the `.nl` term survived, leaving the relative gap test looser than intended.

**Bounded, and the bound is stated rather than leaned on.** `obj_constant` is a
convergence-test normalizer only — no residual, no direction, no dual, not
`QpSolution::obj` — so this could not produce a wrong answer, only a too-loose
stop. That is the trajectory/accuracy class, and "it cannot produce a wrong
answer" is precisely the argument that shipped gh #544, so it is not offered
here as a reason the defect did not matter.

## Blast radius

`scripts/sweep-fixtures.sh`, both legs (`exact` and `lbfgs`), 58 fixtures,
against a binary built from this PR's base — **`3e8383f`, current `main`,
including #694**:

| leg | moving lines |
|---|---|
| default | **0** |
| `qp_hsde=no` | **0** |

Bit-identical. The three fixtures whose `obj_constant` actually changes do not
move because on each the constant is small next to the objective itself
(`dual_scaled` solves at `8994002`), so the normalizer barely shifts and the
relative arm is not what governs their stopping test anyway.

Worth being precise about what that does *not* establish: the corrected value is
right rather than merely different, and no fixture in the corpus demonstrates
the size of error the defect can hide. A model whose presolve moves a constant
*comparable to* its objective would, and there isn't one.

This branch was rebased onto `3e8383f` specifically so the sweep is measured on
the tree the PR merges into — #694 recalibrated the corrector gate on the
post-#689 direct driver after the first measurement was taken, and a sweep
against the older base would not have covered that interaction.

## Tests

`crates/pounce-convex/tests/issue697_multilayer_obj_offset.rs` (2, new).

The multi-layer test asserts the documented contract — reduced objective plus
offset equals the original — against a solve rather than a literal constant.
That choice is deliberate: which of a doubleton's columns the aggregation folds
decides how much of the linear term lands in the constant, and the contract is
invariant to that choice while the number is not. A literal would have pinned an
implementation detail and broken on a benign change.

**How I know it bites:** restoring the `0.0` and rerunning gives
`original objective -20 != reduced 0 + reported offset 0` — the identity failing
by the whole constant, which is the defect itself and not an incidental
assertion.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a, no user-facing option, routing
      or output change; `obj_offset` is an internal accessor
- [x] `cargo fmt --all -- --check`, `check-release-consistency.sh`,
      `check-docs-consistency.sh`, `cargo test --workspace --exclude pounce-hsl`
      (260 binaries) all clean
- [x] Every claim here is true of the code as it stands

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFgsipcwFCsuDEzc7iPVyE)_