### PR TITLE
dev-notes: cut Q7/Q8 and close out the #588 Q-series

### DIFF
--- a/dev-notes/quadratic-structure-exploitation.md
+++ b/dev-notes/quadratic-structure-exploitation.md
@@ -34,10 +34,10 @@ describes.
 | Q4 — `QuadraticStructure` + `NlTnlp` fast path | **done** | (this commit) | `qcqp1000-2c` (**real**) 131.4 s → 97.6–103.3 s (1.27–1.35×), 100 → 100 iterations, `eval_h` 19.58 s → 0.20 s (~95×); the ≈1.4× forecast was at or above this machine's Amdahl ceiling; the fast path had to be gated on *already-expanded*, *unshared* forms after it cost `airport.nl` 16 → 300 iterations and a shared-DAG model 0.00 s → 172 s — see §0e |
 | Q5 — parse-time recognition | **done** | (this commit) | peak RSS on a **generated** `qcqp500-3c` shape 1253 → 586 MB (2.14×), on the **real** `qcqp1000-2c` 577 → 445 MB, and its load 0.98 → 0.71 s; the two recognizers agree bitwise over 1 631 corpus bodies and both instances solve bit-identically; the forecast's `~0.4 GB` floor is not reached and what is left is the file text and the parser's line index, not the `Expr` DAG — see §0f |
 | Q6 — the four constant-derivative hints | **done** | (this commit) | proofs are three-valued and a hint that contradicts one is **warned and ignored**; `UNEXPLOITED_HINTS` emptied for the NLP route (the convex route keeps its own warning — see §0g); over 57 fixtures `∇f` evaluations 1729 → 1161 and `∇g` 2005 → 1573 at bit-identical trajectories, `∇²L` only 1880 → 1873; the **real** `qcqp1000-2c` does not move at all, as forecast; the "single-digit % on true QPs" half of the forecast is capped at 2.7% by Q4's own Amdahl share and is unobservable — see §0g |
-| Q7 — `QcqpProblem` extraction | pending | — | — |
-| Q8 — native QCQP barrier driver | pending | — | — |
+| Q7 — `QcqpProblem` extraction | **cut** | — | premise retired by Q5 — the triple tree expansion it removes no longer happens; see §0j |
+| Q8 — native QCQP barrier driver | **cut** | — | its headline forecast was met by Q4 without it (`qcqp500-3c` 110.6 s → 12.1 s), and its addressable set is 22 of 1437 corpus models; see §0j |
 | Q9a — Gondzio correctors + adaptive τ | **done** | (this commit) | correctors extracted to `correctors.rs` (sweep byte-identical) and given to `run_ipm`; `qp_gondzio_corr` (default 3) reaches both drivers; **real** `afiro` 10 → 9 it direct post-#689 (pre-#689 it was 135 → low 120s); the direct-driver claim now rests on 52 NETLIB LPs, 688 → 644 / 15 → 13 HSDE with the KKT error improving; **generated** 400-var QP 12 → 10 / 17 → 15. `qcqp1000-2nc` **could not be run** (no corpus) — and would not have been served anyway: the `qcqp*` family reaches neither convex driver. Adaptive τ already shipped as gh #417; the HSDE study is measured (−3.0% iterations, no status change, objective movers are all noise-floor fixtures) and **not** shipped — the driver it would change is the default cold path for every LP/QP/SOCP and its real coverage is the missing corpus — see §0h |
-| Q9b — QCQP presolve/equilibration (§7–§8) | **done, in part** | (this commit) | The `dedup_rows` hazard is **real on the conic path and already guarded**: `extract_socp_with_map` writes a quadratic row's linear part `aᵢ` verbatim as SOC rows 0 and 1, so two quadratic rows sharing a linear part give byte-identical `G` rows in different cones — and `presolve_conic` already protects every non-orthant row. Demonstrated (unprotected: 9 → 4 rows, `Optimal` at −17.35 for a problem whose optimum is −10.40) and pinned, with a 64-instance differential battery. `presolve_conic` **wired into `run_convex_socp`**, which Q1 deferred here: `qp_presolve` was registered, documented and silently ignored on every convex QCQP. **No speedup claimed** — the two pre-existing conic fixtures have zero orthant rows, so there is nothing to reduce; sweep at four option sets moves only the fixture added with the phase (11 → 12 it, NLP error 9.92e-10 → 8.14e-11). Everything in §7's table that needs a native `Qᵢ`, and all of §8, stays **blocked on Q7/Q8** — see §0i |
+| Q9b — QCQP presolve/equilibration (§7–§8) | **done, in part** | (this commit) | The `dedup_rows` hazard is **real on the conic path and already guarded**: `extract_socp_with_map` writes a quadratic row's linear part `aᵢ` verbatim as SOC rows 0 and 1, so two quadratic rows sharing a linear part give byte-identical `G` rows in different cones — and `presolve_conic` already protects every non-orthant row. Demonstrated (unprotected: 9 → 4 rows, `Optimal` at −17.35 for a problem whose optimum is −10.40) and pinned, with a 64-instance differential battery. `presolve_conic` **wired into `run_convex_socp`**, which Q1 deferred here: `qp_presolve` was registered, documented and silently ignored on every convex QCQP. **No speedup claimed** — the two pre-existing conic fixtures have zero orthant rows, so there is nothing to reduce; sweep at four option sets moves only the fixture added with the phase (11 → 12 it, NLP error 9.92e-10 → 8.14e-11). Everything in §7's table that needs a native `Qᵢ` dies with Q7/Q8 (§0j); §8 does **not** — its diagnosis is a property of the model and is carried forward as gh #703 — see §0i, §0j |
 | Q10 — dense-front factorization (gated on Q0) | **cut** | — | Q0(a): feral beats MA57 on 2/3; premise false |
 
 **The series was frozen at Q6 for merge** (PR #603). Q7–Q9 moved to follow-up
@@ -45,10 +45,12 @@ PRs on fresh branches; Q10 is cut. The first of those follow-ups is **Q9a**,
 the corrector half of Q9, on `feat/588-q9-correctors` — its own branch and its
 own PR, measured the same way and written up in §0h. **Q9b landed on that
 same branch and in that same PR**, at the user's request that Q9 ship as one
-unit; it is written up in §0i. Q7/Q8 are still pending, each on its own
-branch. The cumulative sweep against `3bfb4e41` — the commit
-before Q0 — moves **one line of 57**, the one Q4 already accounted for, and it
-is worked through in §0g.
+unit; it is written up in §0i. **Q7 and Q8 are now cut** — the evidence, and
+the three corrections it forced, are §0j; gh #588 is closed. The cumulative
+sweep against `3bfb4e41` — which is **not** the commit before Q0, see §0j —
+moves **one line of 57**, the one Q4 already accounted for, and it is worked
+through in §0g. That sweep sees no Mittelmann instance at all, which is how
+the `qcqp1500-1c` regression in §0j went unnoticed through the whole series.
 
 Two defects found reviewing the frozen series are fixed on it rather than
 deferred: a row whose quadratic coefficients cancel was reported **proved
@@ -112,7 +114,7 @@ assumed a centrality-shaped stall. Only one of the two instances has one.
 
 | | `qcqp500-3c` | `qcqp1000-2nc` |
 |---|---|---|
-| iterations | 333 | 162 |
+| iterations | 333 | 162 † |
 | held at μ = 1e-1 | **320** (96%) | **113** (70%) |
 | distinct μ levels | 6 | 5 |
 | median α_primal | 4.4e-4 | 6.2e-2 |
@@ -120,6 +122,13 @@ assumed a centrality-shaped stall. Only one of the two instances has one.
 | regularized iterations | 17 (5%) | 10 (6%) |
 
 Both stall, **for different reasons**, and only one is a corrector problem:
+
+† **The 162 does not reproduce.** The real Mittelmann `qcqp1000-2nc` takes
+**289** iterations at `fd738d46`, at `3bfb4e41` and on today's `main`, with an
+identical objective (93279.08929) and with `--json-detail full` set. Whether
+this row was taken on a generated instance is unrecorded; if it was, it is
+reported here without the label `scripts/gen-qcqp-nl.py`'s own docstring
+requires. Do not read 162 → 289 as a regression — see §0j.
 
 * `qcqp1000-2nc` — every step accepted on the first trial, but short. That is
   fraction-to-boundary limiting caused by poor centrality, which is exactly what
@@ -1613,7 +1622,11 @@ ability away.
 Each phase swept against its own predecessor. That is not the same claim as
 "the series moved one line" — six diff-empty steps can still compose into a
 drift no single step saw. So the sweep was run once more end to end, against
-`3bfb4e41`, the commit before Q0.
+`3bfb4e41`. **That commit is not "before Q0"** — it is the `origin/main`
+merge that sits *after* Q0 and Q1, so this sweep covers Q2–Q6 only. Q0
+shipped no code and Q1 changed no routing, so the diff below is unaffected;
+the mislabel matters because it was also used to scope a regression hunt. See
+§0j.
 
 Baseline binary: `3bfb4e41` built in a detached worktree with its own
 `CARGO_TARGET_DIR`. Head binary: the Q6 tree including both corrections
@@ -1998,7 +2011,9 @@ PR as §0h at the user's request that Q9 ship as one unit.
 **does not exist**. §7 reasons about a native `QcqpProblem` carrying a per-row
 `Qᵢ` alongside `P, c, A, G` — that is Q7, which was skipped. §8's
 recommendation is explicitly "ship equilibration on by default for **the QCQP
-driver**" — that is Q8, blocked on Q7. Neither is on `main`.
+driver**" — that is Q8. Neither is on `main`, and neither will be: **both
+phases are cut (§0j).** §7's table dies with them; §8's diagnosis does not,
+and is carried forward as gh #703.
 
 What exists is the conic path, and it changes the problem in a way that
 matters more than it first appears. `extract_socp_with_map` does **not** keep
@@ -2207,6 +2222,163 @@ the stated reason — no `Presolve:` line is printed there whatever the option
 says. The other five pass at the parent and say so in their doc comments: they
 are guards on a protection that was already correct, not regressions, and the
 distinction is stated rather than blurred.
+
+---
+
+## 0j. Q7 and Q8 are cut — the close-out (measured 2026-08-19)
+
+Q7 and Q8 were the last two open phases of the series. Both are **cut**. This
+section is the evidence, and it also corrects three things earlier in the note.
+
+### Q7's premise no longer describes the code
+
+The phase spec (§9) opens: "Today `to_poly` expands the same tree **three
+times** per row (classify, convexity check, extract)". `to_poly` does not
+exist anywhere in the repository. Q5 replaced it: a degree-2 body is
+recognized at parse time and stored as `NlBody::Quad(q)`, and
+`analyze_quadratic_full` on such a body is a coefficient readout —
+
+```rust
+NlBody::Quad(q) => (!q.form.lost_terms()).then(|| quad_form_readout(&q.form)),
+```
+
+— where `quad_form_readout` (`nl_quadratic.rs:832`) is a map over stored
+entries with no tree walk in it. The 232k-term sumlist is expanded **once**,
+by the parser, and never rebuilt. Q7's entire deliverable was removing an
+expansion that Q5 already removed.
+
+### Q8's forecast was met by Q4, without Q8
+
+Forecast: `qcqp500-3c` 109.3 s → 15–20 s. On `main` it is **12.1 s at 330
+iterations** — past the target, and the phase was never built.
+
+The attribution is not inferred, it is measured against the series' own
+control. `POUNCE_DBG_NO_QUAD=1` forces the AD tape, i.e. the pre-Q4
+evaluator, on today's binary:
+
+| instance | default (Q4) | `NO_QUAD` (tape) | Q4 effect |
+|---|---:|---:|---|
+| `qcqp500-3c` | 330 it / 13.7 s | 332 it / 110.6 s | **8.1×** |
+| `qcqp750-2c` | 63 it / 8.5 s | 67 it / 45.7 s | **5.4×** |
+| `qcqp500-3nc` | 121 it / 4.6 s | 122 it / 25.4 s | **5.5×** |
+| `qcqp750-2nc` | 69 it / 9.7 s | 71 it / 49.9 s | **5.1×** |
+| `qcqp1000-1nc` | 177 it / 16.4 s | 177 it / 19.5 s | 1.2× |
+| `qcqp1500-1c` | 131 it / 213.5 s | 103 it / 162.8 s | **0.76× — see below** |
+
+`qcqp500-3c` on the tape leg is 110.6 s, within noise of the 109.3 s baseline
+Q8's forecast was written against. Q4 is what closed that gap.
+
+This is consistent with what the series already established twice: §6.3 found
+the KKT *form* is not the lever, and Q0(a) found feral already beats MA57 on
+this family (which is why Q10 was cut). Q8 was the third bet on the same
+premise — that the win is in the linear algebra — and the win turned out to be
+in the **evaluation**, which is where Q4 took it.
+
+### The addressable set is 1.5% of the corpus
+
+Every `.nl` file on the bench machine, classified with
+`POUNCE_DBG_CLASSIFY=1` (1437 models, all corpora):
+
+| class | count |
+|---|---:|
+| NLP | 693 |
+| LP | 398 |
+| convex QP | 265 |
+| nonconvex QP | 65 |
+| **convex QCQP (routes conic)** | **16** |
+| **convex QCQP (downgraded → NLP)** | **6** |
+
+Q7/Q8 could only serve the last two rows — **22 models, 1.5%** — and it splits
+badly:
+
+* The **16 that route conic** are all textbook-scale: `airport` (n=84, m=42,
+  15 it, 7.3 ms) is the largest, then `demymalo`, `hs011`, `hs012`, `hs014`,
+  `hs030`, `hs043`, `hs065`, `makela1/2/3`, `mifflin1/2`, `minmaxbd`,
+  `polak4`, `rosenmmx`. Every one is n ≤ 84 and ≤ 7.3 ms of wall time. A
+  native driver cannot show a measurable win on any of them.
+* The **6 downgraded ones** are the family this note has been measuring all
+  along — `nql180`, `qssp180`, `qcqp500-3c`, `qcqp750-2c`, `qcqp1000-2c`,
+  `qcqp1500-1c` — downgraded by `SOCP_REFORM_FLOP_BUDGET` (2e7) or
+  `SOCP_SOLVE_SIZE_CAP` (1e8).
+
+The 663 LP and convex-QP models are the broad convex population, and they are
+served by the drivers **Q9a** already improved. There is no third
+constituency that a QCQP path would reach.
+
+### The family on `main`, against the note's own baselines
+
+| instance | note s | now s | note it | now it |
+|---|---:|---:|---:|---:|
+| `qcqp500-3c` | 109.3 | **12.1** | 333 | 330 |
+| `qcqp1000-2c` | 100.0 | **29.6** | 100 | 101 |
+| `qcqp1500-1nc` | 62.8 | 53.8 | 77 | 77 |
+| `nql180` | 57.5 | 61.1 | 36 | 36 |
+| `qssp180` | 46.1 | 45.7 | 27 | 27 |
+| `qcqp1500-1c` | 166.6 | **212.0** | 103 | **131** |
+
+### Correction 1 — `qcqp1500-1c` is a real trajectory regression (gh #702)
+
+The last row is not noise. `qcqp1500-1c` goes **103 → 131 iterations, 163 →
+212 s**, at an identical objective (3882979.491 to ten digits) and a *better*
+final KKT error. Two bisects attribute it: the first, over `main`'s
+first-parent chain, reached the PR #603 merge (`d38167a9`); the second, inside
+the branch, reached
+
+    947b3aa3  Q4: evaluate recognized quadratics from their constant matrices
+
+`fd738d46` (Q3) is 103, `947b3aa3` (Q4) is 131, and `POUNCE_DBG_NO_QUAD=1` on
+today's `main` reproduces the pre-Q4 run digit for digit. There is no bug in
+the evaluator — it computes the same quantities by a different summation, and
+on this one instance the ULP-level difference kicks the barrier onto a longer
+central path.
+
+It is not a reason to revert Q4, which is a 5–8× win on every other member of
+the family. It is a reason to have an issue: **gh #702**, with an owner.
+
+Two things about how this was missed are worth keeping:
+
+* `scripts/sweep-fixtures.sh` **structurally cannot see it.**
+  `qcqp1500-1c` is a Mittelmann instance, not a CLI fixture, so it is not in
+  the corpus the sweep walks. The Q0→Q6 cumulative sweep moving "one line of
+  57" was true and did not mean what it was taken to mean.
+* Q4's own before/after used `qcqp1000-2c`, which genuinely does not move
+  (100 → 100), and the conclusion was generalised from it to the family. The
+  one instance that moved was not in the measurement.
+
+This is the gh#544 / gh#592 shape `CLAUDE.md` warns about, reproduced inside
+the very series that was being measured phase by phase to avoid it.
+
+### Correction 2 — `3bfb4e41` is not "the commit before Q0"
+
+Stated twice (§0 and §0g's cumulative sweep). `3bfb4e41` is the
+`origin/main` merge whose branch-side parent is `c7d3f97b` (Q1), so it sits
+**after** Q0 and Q1. Q0 shipped no code and Q1 changed no routing, so no
+sweep conclusion changes — but the mislabel was load-bearing for the
+regression hunt above, where it initially scoped the search to the wrong
+range. Both occurrences are corrected in place.
+
+### Correction 3 — `qcqp1000-2nc` is 289 iterations, not 162
+
+§0b's Q0(b) table records 162. The real Mittelmann instance takes **289** at
+`fd738d46`, at `3bfb4e41` and on `main`, objective 93279.08929, with
+`--json-detail full` set. It is *not* a regression — `main` is about 20%
+faster than pre-Q4 at an identical trajectory. Whether the 162 came from a
+generated instance is unrecorded; `scripts/gen-qcqp-nl.py` calibrates only
+against the convex `qcqp1000-2c` shape, and its own docstring forbids
+reporting a generated number as a real one. Flagged in place.
+
+### What survives, and where it lives
+
+* **gh #702** — the `qcqp1500-1c` trajectory regression, owned.
+* **gh #703** — §8's equilibration argument. Its header said "blocked on
+  Q7/Q8"; the *diagnosis* is a property of the model, not of the driver, and
+  `qcqp1500-1c` is on the NLP path today. Corrected in place.
+* **gh #673** — Q4's exactness gate skipping factored quadratics, already
+  open and independent of this decision.
+
+With those homed, **gh #588 is closed.** Q0–Q6 and Q9 shipped and are
+measured above; Q10 was cut by Q0(a); Q7 and Q8 are cut here.
+
 
 ---
 
@@ -2963,14 +3135,22 @@ reason a non-orthant cone row is.
 
 ## 8. Equilibration — *more* available on the native path than the conic one
 
-**Nothing in this section shipped, and nothing in it is implementable
-today (Q9b, §0i).** Its whole argument is that a *native* quadratic row has
-no cone-preservation obstacle, and its recommendation names "the QCQP
-driver" — which is Q8, blocked on Q7. On the conic path the obstacle
+**Nothing in this section shipped.** Its whole argument is that a *native*
+quadratic row has no cone-preservation obstacle, and its recommendation names
+"the QCQP driver" — which was Q8. On the conic path the obstacle
 `equilibrate.rs:44-49` documents is the live one and stands: per-row scaling
 of `G` breaks a second-order cone, whose rows must scale uniformly. The
 congruence argument below is correct and is about a representation POUNCE
-does not have. Treat the whole section as **blocked on Q7/Q8**.
+does not have.
+
+**Correction (§0j): this section is no longer "blocked on Q7/Q8", and Q7/Q8
+are cut.** What survives is the *diagnosis*, which is a property of the model
+and not of the driver: the `qcqp1500-1c` row/curvature mismatch quantified
+below is present whichever path picks the instance up, and today that path is
+the **NLP** one — `qcqp1500-1c` is a convex QCQP downgraded past
+`SOCP_REFORM_FLOP_BUDGET`. Carried forward as **gh #703**, together with the
+prior question §0j raises: measure what the NLP path's existing scaling
+already does to these rows before building anything from this section.
 
 `equilibrate.rs:44-49` is explicit that per-row scaling of `G` preserves `z ≥ 0`
 for the orthant but **breaks a second-order cone**, whose rows must scale
@@ -3280,11 +3460,26 @@ expansions of a 232k-term sumlist × 10 rows. `to_socp()` reproduces
 `extract_socp_with_map`'s cones bit-for-bit on the small fixtures as a
 differential test.
 
+> **CUT (§0j).** Every sentence above describes code that no longer exists.
+> `to_poly` is gone from the repository, and Q5 stores a degree-2 body as
+> `NlBody::Quad`, so `analyze_quadratic_full` reads stored coefficients out
+> through `quad_form_readout` instead of expanding a tree. The triple
+> expansion this phase was designed to remove does not happen, so the phase
+> has nothing left to do.
+
 **Q8 — the native QCQP barrier driver** (`qcqp_ipm.rs`), **augmented form only**,
 `solver_selection=qcqp`, no `auto` routing yet. `PdPerturbationHandler` wired for
 `δ_x`/`δ_c` from the start. Validated against closed-form ellipsoid optima and
 differentially against `solve_socp_ipm(to_socp(p))`. Forecast: `qcqp500-3c`
 109.3 s → 15–20 s even at the same 332 iterations; `num_hess_evals` → 0.
+
+> **CUT (§0j).** The forecast was met, by Q4, without building the driver:
+> `qcqp500-3c` is **12.1 s at 330 iterations** on `main`, under the 15–20 s
+> target. The phase's own control confirms the attribution —
+> `POUNCE_DBG_NO_QUAD=1` puts the same instance back at 110.6 s, within noise
+> of the 109.3 s baseline this forecast was written against. Its addressable
+> set is also far smaller than the phase assumed: 22 of 1437 corpus models,
+> 16 of which solve in under 7.3 ms. See §0j.
 
 **Q9 — Gondzio correctors + adaptive `τ`** (extract from `hsde.rs` into a shared
 `correctors.rs`; a behaviour-preserving refactor guarded by
@@ -3294,7 +3489,8 @@ The corrector work is a bonus for every existing LP/QP/SOCP solve routed through
 
 **Both halves are now done, in the same PR. The corrector half is §0h and
 three claims in the paragraph above are wrong; the presolve half is §0i and it
-is done only in part — §8 is blocked on Q7/Q8 and says so now.** Corrections
+is done only in part — §8 was marked blocked on Q7/Q8, and §0j lifts that:
+Q7/Q8 are cut and §8 survives them as gh #703.** Corrections
 to the corrector half, in ascending order of how much they change the phase
 (the presolve half's corrections are §0i's own table):
 


### PR DESCRIPTION
Documentation only — one file, `dev-notes/quadratic-structure-exploitation.md`.
No code, no test, no sweep-relevant change.

This closes out the Q-series by cutting its last two open phases and
correcting three things the series got wrong along the way. The full argument
is the new §0j; this is the summary.

## Q7 is cut — its premise no longer describes the code

The phase spec opens "today `to_poly` expands the same tree **three times**
per row". `to_poly` does not exist anywhere in the repository. Q5 replaced it:
a degree-2 body is recognized at parse time and stored as `NlBody::Quad`, so
`analyze_quadratic_full` reads stored coefficients out through
`quad_form_readout` with no tree walk in it. The 232k-term sumlist is expanded
once, by the parser. Q7's deliverable was removing an expansion Q5 already
removed.

## Q8 is cut — Q4 met its forecast without it

Forecast: `qcqp500-3c` 109.3 s → 15–20 s. On `main` it is **12.1 s at 330
iterations**, and the phase was never built.

The attribution is measured, not inferred, using the series' own control:

| instance | default (Q4) | `POUNCE_DBG_NO_QUAD=1` | Q4 effect |
|---|---:|---:|---|
| `qcqp500-3c` | 330 it / 13.7 s | 332 it / 110.6 s | 8.1x |
| `qcqp750-2c` | 63 it / 8.5 s | 67 it / 45.7 s | 5.4x |
| `qcqp500-3nc` | 121 it / 4.6 s | 122 it / 25.4 s | 5.5x |
| `qcqp750-2nc` | 69 it / 9.7 s | 71 it / 49.9 s | 5.1x |
| `qcqp1000-1nc` | 177 it / 16.4 s | 177 it / 19.5 s | 1.2x |
| `qcqp1500-1c` | 131 it / 213.5 s | 103 it / 162.8 s | **0.76x** |

`qcqp500-3c` on the tape leg is 110.6 s, within noise of the 109.3 s baseline
Q8's forecast was written against.

Q8's addressable set is also much smaller than the phase assumed. Classifying
all 1437 `.nl` files on the bench machine with `POUNCE_DBG_CLASSIFY=1`: 693
NLP, 398 LP, 265 convex QP, 65 nonconvex QP, **16 convex QCQP routing conic**,
**6 convex QCQP downgraded to NLP**. Q7/Q8 could serve only the last two rows
— 22 models, 1.5% — and all 16 conic ones are textbook-scale (largest
`airport`, n=84, 7.3 ms).

## Three corrections

**1. `qcqp1500-1c` is a real trajectory regression** — 103 → 131 iterations,
163 → 212 s, identical objective to ten digits, *better* final KKT. Two
bisects attribute it to `947b3aa3` (Q4), and `POUNCE_DBG_NO_QUAD=1` on today's
`main` reproduces the pre-Q4 run digit for digit.

Not a reason to revert Q4 — it is a 5–8x win on every other family member.
But per `CLAUDE.md` a measured regression needs an issue and an owner, so it
has one: **#702**.

Worth recording *why* six per-phase sweeps saw nothing: `sweep-fixtures.sh`
walks CLI fixtures, and `qcqp1500-1c` is a Mittelmann instance, so it is
structurally outside the corpus. Q4's own before/after used `qcqp1000-2c`,
which genuinely does not move (100 → 100), and the conclusion was generalised
from it to the family. This is the gh#544 / gh#592 shape, reproduced inside
the series that was being measured phase by phase to avoid it.

**2. `3bfb4e41` is not "the commit before Q0"** (stated twice). It is the
`origin/main` merge whose branch-side parent is `c7d3f97b` (Q1), so it sits
after Q0 and Q1. Q0 shipped no code and Q1 changed no routing, so no sweep
conclusion changes — but the mislabel scoped the regression hunt above to the
wrong commit range at first, which is how it earns a correction rather than a
silent fix.

**3. `qcqp1000-2nc` is 289 iterations, not the 162** in §0b's table — at
`fd738d46`, at `3bfb4e41`, and on `main`, objective 93279.08929, including
with `--json-detail full`. It is *not* a regression; `main` is ~20% faster
than pre-Q4 there at an identical trajectory.

## §8 was not actually blocked

Its header read "blocked on Q7/Q8" because its recommendation names the native
QCQP driver. But its *diagnosis* — `qcqp1500-1c` right-hand sides 1.58e5–1.80e5
against `λ_max(Qᵢ) ≈ 1.6e3` — is a property of the model, present whichever
driver picks it up, and that instance is on the **NLP** path today. Carried
forward as **#703** instead of being dropped with the phases.

## What this leaves

- **#702** — the `qcqp1500-1c` regression, owned.
- **#703** — §8's equilibration argument, salvaged.
- **#673** — Q4's exactness gate, already open and independent.

With those homed, **#588 can be closed.**
