### PR TITLE
Reject a non-finite objective at the success verdict (#695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ changes.
 
 ## [Unreleased]
 
+- **A `NaN` or `inf` objective is no longer reported as a successful
+  solve** (#695).
+
+  A model whose objective evaluated to `NaN` while every derivative stayed
+  finite terminated `Solve_Succeeded` / `obj_val = nan` — `status = 0`
+  asserting the convergence test passed, next to an objective that is not
+  a number. A caller gating on `success` and then reading `fun` silently
+  received `NaN`.
+
+  The convergence test cannot notice on its own: it reads gradients,
+  residuals and complementarity, never the objective *value*. With finite
+  derivatives and a satisfied equality the KKT residuals are genuinely
+  small (`2.5e-9` on the reported model), and the returned point is
+  actually correct — `x = (0.5, 0.5)` really is the minimizer of `x·x`
+  subject to `x0 + x1 = 1`. Only the `Solve_Succeeded` / `nan` pair was
+  wrong.
+
+  Specific to the **equality**-constrained shape, which is how it survived
+  #292. That fix closed the `NaN`-*gradient* hole and recorded
+  `f`-returns-`NaN` as the safe contrast case — true of the shapes it
+  exercised (unconstrained and bounds-only fail at
+  `Error_In_Step_Computation`, inequality-constrained at
+  `Invalid_Number_Detected`) and not once an equality constraint is
+  present.
+
+  A successful verdict is now gated on a finite objective, reporting
+  `Invalid_Number_Detected` otherwise — the status Ipopt's `Eval_f` gives
+  a non-finite objective, and the one POUNCE's own inequality-constrained
+  shape already gave. This is not a new rule: the same
+  `curr_f().is_finite()` check already guarded the restoration
+  near-feasible exit (added for CUTE `himmelbj`); it now also guards the
+  ordinary convergence exit.
+
+  Callback-API only — an `.nl` model cannot express a `NaN` objective with
+  a consistent finite gradient, so no CLI model can reach it. The fixture
+  corpus is bit-identical.
+
 - **`Presolve::obj_offset` reported `0.0` for every multi-layer presolve**
   (#697).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,17 @@ changes.
   near-feasible exit (added for CUTE `himmelbj`); it now also guards the
   ordinary convergence exit.
 
-  Callback-API only — an `.nl` model cannot express a `NaN` objective with
-  a consistent finite gradient, so no CLI model can reach it. The fixture
-  corpus is bit-identical.
+  No CLI model is known to reach it, and the fixture corpus is
+  bit-identical. Note that the reason is *not* that an `.nl` file cannot
+  express the shape: `log(x)` at `x < 0` evaluates to `NaN` with `f' = 1/x`
+  and `f'' = -1/x²` both finite, which is exactly the combination involved.
+  Such models are stopped by an earlier guard before the convergence test
+  is reached — three built to try to reach it (including the matching
+  equality-constrained shape, with `x` confined strictly negative) return
+  `Error_In_Step_Computation` or `Invalid_Number_Detected` identically on
+  both sides of this change. So the defect is callback-API only in
+  practice, by which path fires first, rather than by what the format can
+  represent.
 
 - **`Presolve::obj_offset` reported `0.0` for every multi-layer presolve**
   (#697).

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -2100,6 +2100,37 @@ impl IpoptAlgorithm {
             self.vetoed_acceptable_seen = true;
             self.vetoed_acceptable = self.snapshot_current(iter_count);
         }
+        // gh #695: a successful verdict asserts the convergence test passed;
+        // reporting one alongside a non-finite objective is self-contradictory,
+        // and a caller that gates on `status` and then reads `obj_val` silently
+        // receives `NaN`. The convergence test cannot notice on its own — it
+        // reads gradients, residuals and complementarity, never the objective
+        // *value* — so with finite derivatives and a satisfied equality the KKT
+        // residuals are genuinely small and the solve converges on a point
+        // whose objective is not a number.
+        //
+        // Only the *equality*-constrained shape reached here: the unconstrained
+        // and bounds-only shapes fail in the step computation and the
+        // inequality-constrained one already trips an invalid-number guard, so
+        // this closes the one column of that matrix that was reporting success.
+        // gh #292 closed the NaN-*gradient* hole and recorded `f`-returns-NaN as
+        // the safe contrast case, which held for the shapes it exercised and not
+        // for this one.
+        //
+        // `Invalid_Number_Detected` is the status Ipopt's `Eval_f` gives a
+        // non-finite objective, which POUNCE's own inequality-constrained shape
+        // already agreed with. The same check already guards the restoration
+        // near-feasible exit below, for the same reason on a different path
+        // (CUTE `himmelbj`); this extends it to the ordinary convergence exit
+        // rather than adding a second rule.
+        let converged_success = matches!(
+            conv_status,
+            ConvergenceStatus::Converged | ConvergenceStatus::ConvergedToAcceptable
+        );
+        if converged_success && !self.cq.borrow().curr_f().is_finite() {
+            timing.check_convergence.end();
+            return IterateOutcome::Terminate(SolverReturn::InvalidNumberDetected);
+        }
         match conv_status {
             ConvergenceStatus::Continue => {}
             ConvergenceStatus::Converged => {

--- a/crates/pounce-algorithm/tests/issue_695_nan_objective_false_success.rs
+++ b/crates/pounce-algorithm/tests/issue_695_nan_objective_false_success.rs
@@ -1,0 +1,362 @@
+//! gh #695: a non-finite **objective value** must never be reported as a
+//! successful solve.
+//!
+//! `min f(x) s.t. x0 + x1 = 1`, where `f` returns `NaN` (or `inf`) and every
+//! derivative is finite and exact. The NLP path returned
+//! `Solve_Succeeded` / `obj_val = nan` — `status = 0` asserts the convergence
+//! test passed, while the objective it reports is not a number, which is
+//! self-contradictory on its face.
+//!
+//! The returned point is not wrong: `x = (0.5, 0.5)` is the minimizer of
+//! `x·x` subject to `x0 + x1 = 1`, and with finite derivatives and a satisfied
+//! equality the KKT residuals are genuinely small (`2.5e-9`). That is exactly
+//! why the guard is needed — the convergence test never reads the objective
+//! *value*, so nothing in it can notice.
+//!
+//! Specific to the equality-constrained shape, which is what made it survive
+//! gh #292. That issue closed the NaN-*gradient* hole and explicitly recorded
+//! `f`-returns-NaN as the safe contrast case — true for the shapes it
+//! exercised (unconstrained, bounds-only, inequality-constrained, which return
+//! `-3` or `-13`), and not once an equality constraint is present. The shape
+//! matrix below is asserted in full so the next change cannot close one column
+//! and reopen another.
+//!
+//! Oracle: Ipopt's `Eval_f` rejects a non-finite objective and terminates
+//! `Invalid_Number_Detected`, and POUNCE documents itself as drop-in
+//! compatible. POUNCE's own adjacent shapes agree.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// The starting point that reproduces. It is feasible for `x0 + x1 = 1` and is
+/// already the minimizer of `x·x` there, so the solve converges directly and
+/// reaches the convergence test with a `NaN` objective in hand — which is the
+/// defect. From an *infeasible* start (`[1, 1]`) this driver instead enters
+/// restoration and fails honestly (`Restoration_Failed`), because restoration's
+/// line search cannot make progress on a `NaN`. The reporter's Python run took
+/// that second route and its restoration *did* converge, after which the same
+/// convergence test declared success — same defect, reached two ways. This is
+/// the one that reproduces deterministically here.
+const AT_OPTIMUM: [Number; 2] = [0.5, 0.5];
+
+/// Which constraint the model carries — the axis gh #695 turns on.
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum Shape {
+    /// No constraints at all.
+    None,
+    /// `x0 + x1 = 1`.
+    Equality,
+    /// `x0 + x1 <= 1`.
+    Inequality,
+}
+
+/// `min f(x)` with `f` non-finite by construction and `∇f = 2x`, `∇²f = 2I`
+/// exact — so every quantity the convergence test *does* read is finite and
+/// the solve converges on them.
+struct NonFiniteObjective {
+    value: Number,
+    shape: Shape,
+    bounded: bool,
+    x0: [Number; 2],
+}
+
+impl TNLP for NonFiniteObjective {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        let m = pounce_common::types::Index::from(self.shape != Shape::None);
+        Some(NlpInfo {
+            n: 2,
+            m,
+            nnz_jac_g: 2 * m,
+            nnz_h_lag: 2,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        let (lo, hi) = if self.bounded {
+            (-10.0, 10.0)
+        } else {
+            (-2.0e19, 2.0e19)
+        };
+        b.x_l.copy_from_slice(&[lo; 2]);
+        b.x_u.copy_from_slice(&[hi; 2]);
+        match self.shape {
+            Shape::None => {}
+            Shape::Equality => {
+                b.g_l[0] = 1.0;
+                b.g_u[0] = 1.0;
+            }
+            Shape::Inequality => {
+                b.g_l[0] = -2.0e19;
+                b.g_u[0] = 1.0;
+            }
+        }
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&self.x0);
+        true
+    }
+
+    fn eval_f(&mut self, _x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(self.value)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * x[0];
+        g[1] = 2.0 * x[1];
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        if self.shape != Shape::None {
+            g[0] = x[0] + x[1];
+        }
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        if self.shape == Shape::None {
+            return true;
+        }
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, 1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                // The constraint is linear, so `lambda` contributes nothing.
+                values.copy_from_slice(&[obj_factor * 2.0, obj_factor * 2.0]);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn solve(
+    value: Number,
+    shape: Shape,
+    bounded: bool,
+    x0: [Number; 2],
+) -> (ApplicationReturnStatus, Number) {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(NonFiniteObjective {
+        value,
+        shape,
+        bounded,
+        x0,
+    }));
+    let status = app.optimize_tnlp(tnlp);
+    (status, app.statistics().final_objective)
+}
+
+/// A successful status and a non-finite objective is a contradiction, whatever
+/// the shape. This is the property that matters; the shape matrix below only
+/// records *which* column was broken.
+#[test]
+fn a_non_finite_objective_is_never_a_successful_solve() {
+    for value in [Number::NAN, Number::INFINITY, Number::NEG_INFINITY] {
+        for shape in [Shape::None, Shape::Equality, Shape::Inequality] {
+            for bounded in [false, true] {
+                let (status, obj) = solve(value, shape, bounded, AT_OPTIMUM);
+                let succeeded = matches!(
+                    status,
+                    ApplicationReturnStatus::SolveSucceeded
+                        | ApplicationReturnStatus::SolvedToAcceptableLevel
+                );
+                assert!(
+                    !succeeded || obj.is_finite(),
+                    "f = {value}, {shape:?}, bounded = {bounded}: reported {status:?} with \
+                     final_objective = {obj}. `status` asserts the convergence test passed \
+                     and the objective it reports is not a number (gh #695).",
+                );
+            }
+        }
+    }
+}
+
+/// The equality column specifically — the one that regressed — pinned against
+/// the status the issue's three oracles agree on.
+#[test]
+fn the_equality_constrained_shape_reports_invalid_number() {
+    for bounded in [false, true] {
+        let (status, _) = solve(Number::NAN, Shape::Equality, bounded, AT_OPTIMUM);
+        assert_eq!(
+            status,
+            ApplicationReturnStatus::InvalidNumberDetected,
+            "NaN objective with an equality constraint (bounded = {bounded}) must report \
+             Invalid_Number_Detected, as Ipopt's Eval_f does and as POUNCE's own \
+             inequality-constrained shape already did",
+        );
+    }
+}
+
+/// The shapes that were already honest must stay honest — the guard must not
+/// be bought by making a *finite* objective fail, and must not shift the
+/// adjacent columns onto a different failure mode.
+#[test]
+fn the_shapes_that_already_failed_honestly_still_do() {
+    for shape in [Shape::None, Shape::Inequality] {
+        for bounded in [false, true] {
+            let (status, _) = solve(Number::NAN, shape, bounded, AT_OPTIMUM);
+            assert!(
+                !matches!(
+                    status,
+                    ApplicationReturnStatus::SolveSucceeded
+                        | ApplicationReturnStatus::SolvedToAcceptableLevel
+                ),
+                "{shape:?} (bounded = {bounded}) reported {status:?} on a NaN objective",
+            );
+        }
+    }
+}
+
+/// The control: the same model with a *finite* objective still solves, to the
+/// analytic optimum. Without this the guard could pass by rejecting everything.
+#[test]
+fn a_finite_objective_on_the_same_shape_still_solves() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    // `f = x·x` rather than a constant, so the objective genuinely drives the
+    // solve; minimized over `x0 + x1 = 1` at `x = (0.5, 0.5)`, `f* = 0.5`.
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(SumOfSquares));
+    let status = app.optimize_tnlp(tnlp);
+    let obj = app.statistics().final_objective;
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "finite control did not solve: {status:?}",
+    );
+    assert!(
+        (obj - 0.5).abs() < 1e-6,
+        "finite control objective {obj}, expected 0.5",
+    );
+}
+
+/// `min x·x s.t. x0 + x1 = 1` — [`NonFiniteObjective`] with a real objective.
+struct SumOfSquares;
+
+impl TNLP for SumOfSquares {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 1,
+            nnz_jac_g: 2,
+            nnz_h_lag: 2,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-10.0; 2]);
+        b.x_u.copy_from_slice(&[10.0; 2]);
+        b.g_l[0] = 1.0;
+        b.g_u[0] = 1.0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[1.0, 1.0]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(x[0] * x[0] + x[1] * x[1])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * x[0];
+        g[1] = 2.0 * x[1];
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] + x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => values.copy_from_slice(&[1.0, 1.0]),
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[obj_factor * 2.0, obj_factor * 2.0])
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}

--- a/python/tests/test_issue_695_nan_objective.py
+++ b/python/tests/test_issue_695_nan_objective.py
@@ -1,0 +1,148 @@
+"""gh #695: a non-finite objective must never be reported as a successful solve.
+
+A model whose ``objective`` returns ``NaN`` (or ``inf``) while every derivative
+is finite converged to ``status = 0 Solve_Succeeded`` with ``obj_val = nan``.
+A caller that gates on ``success`` and then reads ``fun`` silently received
+``NaN``.
+
+The bug was specific to the **equality-constrained** shape. That is what let it
+survive gh #292, which closed the NaN-*gradient* hole and explicitly recorded
+``fun``-returns-NaN as the safe contrast case — true for the shapes it
+exercised, and not once an equality constraint is present. The whole shape
+matrix is asserted here so a later change cannot close one column and reopen
+another.
+
+This lives in the Python suite because the defect is callback-API-only: an
+``.nl`` model cannot express a NaN objective with a consistent finite gradient,
+so the CLI path cannot reach it. The in-process regression test is
+``crates/pounce-algorithm/tests/issue_695_nan_objective_false_success.rs``; this
+one pins the reporter's own route, where the solve reaches the convergence test
+*through restoration* rather than directly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pounce
+
+BIG = 2.0e19
+
+
+class _NonFiniteObjective:
+    """``min f(x) s.t. x0 + x1 == 1`` with ``f`` non-finite by construction.
+
+    Every derivative is finite and exact, so each quantity the convergence test
+    actually reads — gradients, residuals, complementarity — is well defined and
+    the solve converges on them. Nothing in that test looks at the objective
+    *value*, which is precisely why the guard has to be explicit.
+    """
+
+    def __init__(self, value: float, m: int) -> None:
+        self.value = value
+        self.m = m
+
+    def objective(self, x):
+        return self.value
+
+    def gradient(self, x):
+        return 2.0 * np.asarray(x, float)
+
+    def constraints(self, x):
+        return np.array([float(np.sum(x))]) if self.m else np.zeros(0)
+
+    def jacobian(self, x):
+        return np.ones(2) if self.m else np.zeros(0)
+
+    def jacobianstructure(self):
+        return (np.zeros(2, dtype=int), np.arange(2))
+
+    def hessian(self, x, lag, of):
+        return of * 2.0 * np.ones(2)
+
+    def hessianstructure(self):
+        return (np.arange(2), np.arange(2))
+
+
+def _solve(value, *, m, cl=None, cu=None, lb=(-BIG, -BIG), ub=(BIG, BIG)):
+    kwargs = dict(n=2, m=m, problem_obj=_NonFiniteObjective(value, m), lb=list(lb), ub=list(ub))
+    if m:
+        kwargs.update(cl=list(cl), cu=list(cu))
+    problem = pounce.Problem(**kwargs)
+    problem.add_option("print_level", 0)
+    _, info = problem.solve(x0=np.array([1.0, 1.0]))
+    return info
+
+
+# (tag, kwargs) for every shape in the issue's matrix.
+_SHAPES = [
+    ("no bounds, no constraints", dict(m=0)),
+    ("bounds only", dict(m=0, lb=(-10.0, -10.0), ub=(10.0, 10.0))),
+    ("eq constraint only", dict(m=1, cl=(1.0,), cu=(1.0,))),
+    (
+        "bounds + eq constraint",
+        dict(m=1, cl=(1.0,), cu=(1.0,), lb=(-10.0, -10.0), ub=(10.0, 10.0)),
+    ),
+    (
+        "bounds + ineq constraint",
+        dict(m=1, cl=(-BIG,), cu=(1.0,), lb=(-10.0, -10.0), ub=(10.0, 10.0)),
+    ),
+]
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+@pytest.mark.parametrize("tag,kwargs", _SHAPES, ids=[t for t, _ in _SHAPES])
+def test_non_finite_objective_is_never_a_successful_solve(value, tag, kwargs):
+    """``status == 0`` asserts the convergence test passed. Reporting it next to
+    an objective that is not a number is self-contradictory, whatever the shape.
+    """
+    info = _solve(value, **kwargs)
+    assert info["status"] != 0 or np.isfinite(info["obj_val"]), (
+        f"{tag}: reported status={info['status']} {info['status_msg']} with "
+        f"obj_val={info['obj_val']} (gh #695)"
+    )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_equality_constrained_shape_reports_invalid_number(value):
+    """The column that regressed, against the status the issue's oracles agree
+    on: Ipopt's ``Eval_f`` rejects a non-finite objective with
+    ``Invalid_Number_Detected``, and POUNCE's own inequality-constrained shape
+    already did the same.
+    """
+    info = _solve(value, m=1, cl=(1.0,), cu=(1.0,), lb=(-10.0, -10.0), ub=(10.0, 10.0))
+    assert info["status"] == -13, (
+        f"expected -13 Invalid_Number_Detected, got {info['status']} "
+        f"{info['status_msg']}"
+    )
+
+
+def test_a_finite_objective_on_the_same_shape_still_solves():
+    """The control: the guard must not be bought by rejecting good solves.
+
+    ``min x·x s.t. x0 + x1 == 1`` has its optimum at ``x = (0.5, 0.5)``,
+    ``f* = 0.5``.
+    """
+
+    class SumOfSquares(_NonFiniteObjective):
+        def __init__(self):
+            super().__init__(0.0, 1)
+
+        def objective(self, x):
+            return float(np.dot(x, x))
+
+    problem = pounce.Problem(
+        n=2,
+        m=1,
+        problem_obj=SumOfSquares(),
+        lb=[-10.0, -10.0],
+        ub=[10.0, 10.0],
+        cl=[1.0],
+        cu=[1.0],
+    )
+    problem.add_option("print_level", 0)
+    x, info = problem.solve(x0=np.array([1.0, 1.0]))
+    assert info["status"] == 0, f"{info['status']} {info['status_msg']}"
+    assert info["obj_val"] == pytest.approx(0.5, abs=1e-6)
+    assert np.allclose(x, [0.5, 0.5], atol=1e-6)


### PR DESCRIPTION
Fixes #695.

## Problem

A model whose objective evaluates to `NaN` (or `inf`) while every derivative
stays finite terminated `Solve_Succeeded` with `obj_val = nan`. A caller gating
on `success` and then reading `fun` silently received `NaN`.

Confirmed live on current `main` — the issue was filed against the released
0.10.0 wheel and its Scope note says `main` was never rebuilt to check, so I
built one from this branch's base and ran the reporter's script verbatim:

| shape (`f = NaN`) | before | after |
|---|---|---|
| no bounds, no constraints | `-3 Error_In_Step_Computation` | unchanged |
| bounds only | `-3` | unchanged |
| **eq constraint only** | **`0 Solve_Succeeded`, obj=nan** | **`-13 Invalid_Number_Detected`** |
| **bounds + eq constraint** | **`0 Solve_Succeeded`, obj=nan** | **`-13`** |
| bounds + ineq constraint | `-13` | unchanged |

Identical matrix for `inf` and `-inf`.

The returned point is not wrong: `x = (0.5, 0.5)` really is the minimizer of
`x·x` subject to `x0 + x1 = 1`. Only the `Solve_Succeeded` / `nan` pair is —
`status = 0` asserts the convergence test passed, and the objective it reports
is not a number.

## Cause

The convergence test reads gradients, residuals and complementarity, and never
the objective *value*. With finite derivatives and a satisfied equality the KKT
residuals are genuinely small (`2.5e-9`), so nothing in it can notice.

The `print_level=5` trace shows how the equality shape reaches that test: the
solve spends its life in restoration, which minimizes constraint violation and
likewise never looks at `f`, converges there (`inf_pr 4.44e-16`,
`inf_du 1.85e-11`), and the outer convergence test then passes.

This is why the shape matters, and why gh #292 did not already cover it. That
issue closed the NaN-*gradient* hole and explicitly recorded `f`-returns-NaN as
the safe contrast case — true of the shapes it exercised, and not once an
equality constraint is present.

## Fix

Gate the success verdict on a finite objective, reporting
`Invalid_Number_Detected` otherwise.

Not a new rule: the identical `curr_f().is_finite()` check already guarded the
restoration near-feasible exit a few hundred lines below (added for CUTE
`himmelbj`, for the same reason on a different path). This extends it to the
ordinary convergence exit rather than introducing a second mechanism.
`Invalid_Number_Detected` is what Ipopt's `Eval_f` gives a non-finite objective
— POUNCE documents itself as drop-in compatible — and what POUNCE's own
inequality-constrained shape already gave.

## Blast radius

`scripts/sweep-fixtures.sh`, both legs, 58 fixtures, against a baseline binary
built from this PR's exact base (`62d8f11`): **bit-identical, empty diff.**

That baseline is deliberate. An earlier measurement used `3e8383f`, one commit
behind; the only commit between them (#700) had itself measured bit-identical
on this leg, so the chain held — but a termination-verdict change deserves a
direct A/B rather than a two-step argument, so the baseline was rebuilt and
re-swept.

Bit-identical is the expected result rather than a lucky one: the guard can only
fire where a solve reaches its success verdict holding a non-finite objective.

The issue attributes that to `.nl` being unable to express a NaN objective with
a consistent finite gradient, and this PR originally repeated it. **That reason
is wrong** — `log(x)` at `x < 0` evaluates to NaN with `f' = 1/x` and
`f'' = -1/x²` both finite, which is exactly the combination at issue.

The conclusion survives on different evidence. Three `.nl` models built to reach
the guard — including the matching equality-constrained shape, with `x` confined
strictly negative so the objective is NaN everywhere feasible while the
derivatives stay well-conditioned — return `Error_In_Step_Computation` or
`Invalid_Number_Detected` *identically* on `62d8f11` and on this branch. An
earlier guard stops them before the convergence test is reached.

So the defect is callback-API only by which path fires first, not by what the
format can represent. The CHANGELOG records the empirical result rather than the
expressibility argument.

## Tests

**`crates/pounce-algorithm/tests/issue_695_nan_objective_false_success.rs`** (4).
The primary assertion is the invariant — a successful status implies a finite
objective — across all three shapes × NaN/±inf × bounded/unbounded, so it cannot
be satisfied by closing one column and reopening another. Plus the equality
column pinned to `-13`, the already-honest shapes pinned as still honest, and a
finite-objective control so the guard cannot pass by rejecting everything.

**How I know it bites:** reverting the guard turns two of the four red, with
`reported SolveSucceeded with final_objective = NaN`, while the control and the
already-honest shapes stay green.

One thing worth recording, because it cost real time and would mislead the next
reader. The defect is reachable two ways and the *starting point* decides which:

* From an infeasible start (`[1, 1]`, the reporter's) the driver enters
  restoration. In-process that restoration fails honestly
  (`Restoration_Failed`); in the reporter's Python run it converged, after
  which the convergence test declared success.
* From a feasible start already at the optimum (`[0.5, 0.5]`) the solve
  converges directly and reaches the same test holding a `NaN`.

My first Rust harness used the reporter's starting point, returned
`Restoration_Failed`, and looked like evidence the bug was already fixed. It was
not — the Python wheel reproduced it on the same commit. The Rust test therefore
uses the second route, which reproduces deterministically in-process, and the
first is documented on the constant so nobody re-derives it.

**`python/tests/test_issue_695_nan_objective.py`** (18) pins the reporter's own
route — through a converged restoration — which the in-process test cannot reach
from its feasible start. It is the reason both files exist rather than one.

Suites: `cargo test --workspace --exclude pounce-hsl` — 261 binaries, 0 failures.
`cargo fmt --all -- --check`, `check-release-consistency.sh`,
`check-docs-consistency.sh` all clean.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a; no user-facing option, routing
      or output surface changes, only a status on an already-failing model
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim here is true of the code as it stands

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFgsipcwFCsuDEzc7iPVyE)_
