### PR TITLE
Measure combined coverage in CI, and stop depending on Zenodo's badge service

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,218 @@
+name: Coverage
+
+# Scoped to `main` on both triggers so a PR from a branch in this repo produces
+# ONE coverage run, not the two that `on: [push, pull_request]` gives. This job
+# is the most expensive thing in the repo — it builds the whole workspace
+# unoptimized and instrumented, then runs the Rust, Python and pyomo suites on
+# top — so a duplicate is not a rounding error. Codecov keys its comparison off
+# a single head commit and merges duplicate uploads for the same SHA anyway, so
+# the second run buys nothing.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# A superseded coverage run is ~an hour of runner time nobody will read.
+# Never cancel on `main`, where each commit's number is the record of that
+# commit and the baseline every PR is compared against.
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  coverage:
+    name: combined coverage -> Codecov
+    # Same gate every publishing workflow here carries, for the same reason
+    # (see CLAUDE.md): `push: branches: [main]` fires in a fork when the owner
+    # syncs, CODECOV_TOKEN does not exist there, and `fail_ci_if_error: true`
+    # below turns that into a red run and an email for a contributor who did
+    # nothing. `pull_request` runs in the base repo's context, so PR checks
+    # from forks are unaffected.
+    if: github.repository == 'jkitchin/pounce'
+    runs-on: ubuntu-latest
+    # The instrumented build is unoptimized and carries per-region counters,
+    # and this runs three suites on it. Generous, but far below the 6 h
+    # default: a job that hangs should fail in an hour, not burn six.
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          # `llvm-profdata` / `llvm-cov`, which coverage-combined.sh drives
+          # directly. Without this it exits with a FATAL naming the component.
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Distinct from ci.yml's cache: everything here is built with
+          # `-C instrument-coverage`, so the artifacts are not interchangeable
+          # and sharing a key would just thrash both.
+          shared-key: coverage
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # `maturin develop` refuses to run outside a virtualenv, and the script
+      # calls it. Activating the venv for every later step (rather than
+      # `source`-ing it inside one) also means the script's own
+      # `python -c 'import pounce._pounce'` probe resolves to the interpreter
+      # that maturin just installed into.
+      - name: Create and activate a virtualenv
+        run: |
+          python -m venv .venv
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      # The point of coverage-combined.sh is that paths reachable only through
+      # the extension module or the CLI stop reading as 0%. That only holds if
+      # the suites those paths live behind can actually run: an absent optional
+      # dependency does not fail a test, it skips it, and a skipped test is
+      # indistinguishable from dead code in the report. So install what
+      # ci.yml's `python-test` and `pyomo-pounce-smoke` jobs install.
+      #
+      # torch is deliberately not here. Its wheel is ~800 MB and the torch
+      # suites drive the same Rust solve paths the jax ones do, so it costs a
+      # lot of runner time to move the number very little. ci.yml's
+      # `python-test-torch` job is what keeps that frontend honest.
+      - name: Install Python test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install maturin pytest
+          python -m pip install scipy "jax[cpu]" diffrax
+          # pyomo-pounce's suite: pyomo itself, plus the numpy/pandas/networkx
+          # /scipy set that keeps its incidence and sensitivity tests from
+          # importorskip-ing away (see the same list in ci.yml).
+          python -m pip install pyomo numpy pandas networkx
+          # --no-deps: the declared `pounce-solver` dependency is satisfied by
+          # the local `maturin develop` the script runs, not by PyPI. Without
+          # this pip would pull the last *released* wheel over it.
+          python -m pip install --no-deps ./pyomo-pounce
+
+      # This is `make coverage`. Running the same script CI and contributors
+      # run means the number on the badge and the number you get locally are
+      # produced by the same code path — a CI-only reimplementation would
+      # drift, and the two would disagree with no way to tell which was right.
+      #
+      # Note what this step does NOT do: gate on test results. The script runs
+      # under `set -uo pipefail` without `-e` and keeps going through failures
+      # on purpose — a partial profile is still a measurement, and
+      # `test_qp_solve_releases_the_gil` is a *known* casualty of running under
+      # instrumentation (it times concurrent threads to prove a QP solve
+      # releases the GIL, and the counter overhead breaks the margin). ci.yml
+      # is the test gate; this job is the measurement. What it does gate on is
+      # the report being trustworthy — see the next step.
+      - name: Measure combined Rust + Python coverage
+        run: scripts/coverage-combined.sh
+
+      # CONTRIBUTING.md's sanity check, as an assertion.
+      #
+      # crates/pounce-py/* is reachable ONLY through the extension module, so
+      # it reads 0% in any Rust-only report and 60-90% here. If it reads zero,
+      # the .so did not get attributed — and the failure is silent: llvm-cov
+      # emits a complete, plausible, badly wrong report rather than an error.
+      # Uploading that would move the badge by tens of points and read as a
+      # genuine coverage collapse. Fail here instead, where the cause is named.
+      - name: Report is trustworthy (extension module was attributed)
+        run: |
+          python3 - <<'PY'
+          import sys
+          rows = []
+          for line in open("target/coverage-combined/summary.txt"):
+              parts = line.split()
+              if len(parts) < 4 or "crates/pounce-py/" not in parts[0]:
+                  continue
+              try:
+                  rows.append((parts[0], int(parts[1]), int(parts[2])))
+              except ValueError:
+                  pass
+          if not rows:
+              sys.exit("::error::no crates/pounce-py rows in the report at all; "
+                       "the extension module was not measured")
+          total = sum(r[1] for r in rows)
+          missed = sum(r[2] for r in rows)
+          covered = 100 * (1 - missed / total) if total else 0.0
+          print(f"pounce-py: {covered:.1f}% region coverage "
+                f"({total - missed} of {total} regions, {len(rows)} files)")
+          if covered < 1.0:
+              sys.exit("::error::crates/pounce-py reads ~0%, which is the "
+                       "signature of the .so not being attributed to the "
+                       "profile. The whole report is suspect - do not upload "
+                       "it. See CONTRIBUTING.md, 'Measuring coverage'.")
+          PY
+
+      # A percentage is only readable next to what it covers. core.txt is the
+      # numerical core ranked by uncovered regions — the gaps where a miss can
+      # hide a silently-wrong answer, as opposed to an unexercised diagnostic
+      # printer. Putting it in the job summary means a reviewer sees the
+      # ranking without opening Codecov.
+      - name: Surface the numerical-core ranking
+        if: always()
+        run: |
+          {
+            echo "### Numerical-core coverage"
+            echo ""
+            echo '```'
+            cat target/coverage-combined/core.txt 2>/dev/null \
+              || echo "core.txt was not produced - the run did not reach the report step"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # llvm-cov writes absolute `SF:` paths. Codecov's own path fixing can
+      # usually guess the prefix, but "usually" here means the whole report
+      # silently maps to no files and shows as an empty diff. Strip the
+      # workspace prefix ourselves so the mapping is not a guess.
+      - name: Rewrite lcov paths as repo-relative
+        run: |
+          set -euo pipefail
+          lcov=target/coverage-combined/lcov.info
+          test -s "$lcov" || { echo "::error::$lcov is missing or empty"; exit 1; }
+          sed -i "s|^SF:${GITHUB_WORKSPACE}/|SF:|" "$lcov"
+          # Anything still absolute is outside the repo (a registry or sysroot
+          # path the ignore regex missed) and Codecov cannot map it. Report
+          # rather than upload rows that will read as untracked files.
+          if grep -q '^SF:/' "$lcov"; then
+            echo "::warning::lcov still contains absolute paths outside the repo:"
+            grep '^SF:/' "$lcov" | sort -u | head -20
+          fi
+          echo "$(grep -c '^SF:' "$lcov") files in the report"
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: target/coverage-combined/lcov.info
+          flags: combined
+          # Fail loudly on a broken upload. A silently-missing upload leaves
+          # Codecov comparing against a stale baseline, which is worse than a
+          # red check because it looks like a real coverage change.
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      # The full per-file table and the pytest logs, for when the number moves
+      # and the Codecov diff does not explain why (a suite that skipped rather
+      # than ran shows up here as FAILED/ERROR lines, and nowhere else).
+      - name: Upload the raw report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-combined
+          path: |
+            target/coverage-combined/summary.txt
+            target/coverage-combined/core.txt
+            target/coverage-combined/lcov.info
+            target/coverage-combined/objects.txt
+            target/coverage-combined/pytest-*.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ changes.
 
 ## [Unreleased]
 
+- **Coverage is measured in CI, and the DOI badge no longer depends on
+  Zenodo's badge service.**
+
+  `.github/workflows/coverage.yml` runs `scripts/coverage-combined.sh` (i.e.
+  `make coverage`) on every PR and every push to `main` and uploads the result
+  to Codecov. It deliberately does *not* run `cargo llvm-cov --workspace`:
+  large parts of POUNCE are reachable only through the `pounce._pounce`
+  extension module or through the CLI, and a Rust-only report shows those at
+  0% — inventing gaps in code that is well covered, which is the one failure
+  mode that makes a coverage number worse than no number. Running the same
+  script CI and contributors run also means the badge and a local `make
+  coverage` cannot disagree.
+
+  The job asserts its own trustworthiness before uploading. `crates/pounce-py`
+  is reachable *only* through the `.so`, so if the extension module fails to
+  get attributed to the profile it reads ~0% — and llvm-cov reports that as a
+  complete, plausible, badly wrong number rather than as an error. The check
+  fails the job with the cause named instead of moving the badge by tens of
+  points. Requires the `CODECOV_TOKEN` repository secret; the job carries the
+  same `github.repository ==` gate the publishing workflows do, so a fork sync
+  does not produce a red run for a token it cannot have.
+
+  Two fixes to the script fell out of wiring it up. It now excludes
+  `pounce-hsl` from its cargo invocations, as ci.yml does — that crate cannot
+  link without licensed HSL, and the failure was invisible because the same
+  `2>/dev/null` that hid it also dropped every *other* crate's test binary from
+  `objects.txt`. And it stages the instrumented CLI at
+  `python/pounce/bin/pounce` before `maturin develop`, so the pyomo-pounce
+  suite has a bundled binary it will trust (its `conftest.py` refuses an
+  unvetted `pounce` on `PATH`, gh #403) rather than skipping — previously the
+  CLI was passed to llvm-cov as an `-object` that nothing ever executed, and
+  every CLI and `.nl` path reported 0%.
+
+  Separately, the README DOI badge now comes from shields.io rather than
+  `zenodo.org/badge/DOI/....svg`. Zenodo's badge endpoint has broken the badge
+  more than once, and GitHub's Camo image proxy *caches* the error, so one bad
+  fetch outlives the outage that caused it. The concept DOI is stable by
+  definition, so a static shields badge cannot go stale, and the README's PyPI
+  badges already come from the same host. `dev-notes/zenodo-setup.md` no longer
+  tells the next person to copy the badge markdown off the Zenodo record page,
+  which is how it came back the last time.
+
 - **FERAL 0.15.1 → 0.17.0, and the refinement budget it was released for**
   (#710).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,21 @@ docs deploy — gates its first job on `github.repository ==
 succeed there, so without the gate a contributor's fork sync is a failed run
 and an email. Keep the gate on the job every other job reaches through
 `needs`; `pull_request` runs in the base repo's context, so PR checks are
-unaffected.
+unaffected. `coverage.yml` carries the same gate for the same reason — it is
+not a publishing workflow, but it needs `secrets.CODECOV_TOKEN`, which no fork
+has, and it fails loudly on a bad upload.
+
+## Coverage is measured combined, never Rust-only
+
+`.github/workflows/coverage.yml` runs `scripts/coverage-combined.sh` (i.e.
+`make coverage`) and uploads to Codecov. It does **not** run `cargo llvm-cov
+--workspace`: large parts of POUNCE are reachable only through the
+`pounce._pounce` extension module or the CLI, and a Rust-only report shows
+those at 0% — inventing gaps in code that is well covered. The job asserts the
+attribution worked before uploading, by checking that `crates/pounce-py/*`
+does not read ~0% (it can only be reached through the `.so`). Requires the
+`CODECOV_TOKEN` repository secret. Full rationale: CONTRIBUTING.md,
+"Measuring coverage".
 
 ## Trajectory changes need the fixture sweep
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,14 @@ These run on every PR; run them locally before pushing to get fast feedback:
 Use `make coverage` (or `make coverage-quick` to skip the slow pytest suite),
 **not** `cargo llvm-cov --workspace`.
 
+`.github/workflows/coverage.yml` runs the same script on every PR and every
+push to `main` and uploads the result to
+[Codecov](https://codecov.io/gh/jkitchin/pounce) — so the badge, the Codecov
+diff, and what you get locally are all produced by one code path. That job is
+a *measurement*, not a test gate: it deliberately does not fail on a failing
+test (`ci.yml` does that). It does fail if the report is untrustworthy — see
+the `pounce-py` sanity check below, which it asserts.
+
 `cargo llvm-cov` instruments and runs only the Rust test suite. Large parts of
 POUNCE are exercised solely through the Python extension (`pounce._pounce`) or
 through the CLI driven by pytest/pyomo, and those paths read as 0% in a
@@ -108,7 +116,12 @@ Three things to know before running it:
 
 - **The run leaves `python/pounce/_pounce*.so` built with instrumentation**,
   which is slower and can upset timing-sensitive tests. Restore it with
-  `make python-ext` (or `cd python && maturin develop --release`).
+  `make python-ext` (or `cd python && maturin develop --release`). It also
+  stages an instrumented debug CLI at `python/pounce/bin/pounce`, so that the
+  pyomo-pounce suite has a bundled binary it will trust (its `conftest.py`
+  refuses an unvetted `pounce` on `PATH`) and the CLI paths get measured
+  instead of reading 0%. Both are gitignored; `rm -f python/pounce/bin/pounce`
+  when you want the plain source checkout back.
 - **`test_qp_solve_releases_the_gil` fails during the run.** That is expected,
   not a regression: it asserts that a QP solve actually releases the GIL by
   timing concurrent threads, and the instrumentation overhead breaks the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![CI](https://github.com/jkitchin/pounce/actions/workflows/ci.yml/badge.svg)](https://github.com/jkitchin/pounce/actions/workflows/ci.yml)
 [![Docs](https://github.com/jkitchin/pounce/actions/workflows/docs.yml/badge.svg)](https://jkitchin.github.io/pounce/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20387011.svg)](https://doi.org/10.5281/zenodo.20387011)
+[![Coverage](https://codecov.io/gh/jkitchin/pounce/branch/main/graph/badge.svg)](https://codecov.io/gh/jkitchin/pounce)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20387011-blue.svg)](https://doi.org/10.5281/zenodo.20387011)
 
 [![PyPI: pounce-solver](https://img.shields.io/pypi/v/pounce-solver.svg?label=pypi%3A%20pounce-solver)](https://pypi.org/project/pounce-solver/)
 [![Downloads: pounce-solver](https://static.pepy.tech/badge/pounce-solver)](https://pepy.tech/project/pounce-solver)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+# Codecov configuration for pounce.
+#
+# The report uploaded here comes from `scripts/coverage-combined.sh`, not from
+# `cargo llvm-cov` — see CONTRIBUTING.md, "Measuring coverage". It merges the
+# Rust test binaries, the CLI, and the `pounce._pounce` extension module into
+# one profile, so paths reachable only through Python or the CLI are attributed
+# to the crates that implement them.
+
+coverage:
+  status:
+    # Informational to start with. The combined run reaches three suites, and
+    # a suite that skips (a missing optional dep, a timing-sensitive test that
+    # loses its margin under instrumentation) moves the number without anyone
+    # touching the code. Blocking PRs on that before we know the run-to-run
+    # spread would teach people to ignore the check, which is worse than not
+    # having it. Flip `informational` off once the baseline holds steady.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# Paths that exist to be read by a human, not executed by a solve. Low coverage
+# in them is real and uninteresting, and letting it into the headline number
+# crowds out the gaps in the numerical core that can hide a wrong answer — the
+# same reasoning behind core.txt's exclusions in coverage-combined.sh.
+ignore:
+  - "**/benches/**"
+  - "**/examples/**"
+  - "tools/iter-diff/**"
+  - "crates/pounce-wasm/tests/**"
+
+comment:
+  layout: "reach, diff, flags, files"
+  # Nothing changed the coverage, nothing to say.
+  require_changes: true

--- a/dev-notes/zenodo-setup.md
+++ b/dev-notes/zenodo-setup.md
@@ -34,11 +34,34 @@ record (it's listed as "Cite all versions"). Replace the placeholder
 in `README.md`:
 
 ```markdown
-[![DOI](https://zenodo.org/badge/DOI/<CONCEPT_DOI>.svg)](https://doi.org/<CONCEPT_DOI>)
+[![DOI](https://img.shields.io/badge/DOI-<CONCEPT_DOI_URLENCODED>-blue.svg)](https://doi.org/<CONCEPT_DOI>)
 ```
 
-Or, easier: copy the **DOI badge** markdown directly from the Zenodo
-record page (there's a "Cite as" / badge widget on the right sidebar).
+`<CONCEPT_DOI_URLENCODED>` is the DOI with its `/` written `%2F` — shields
+reads `/` as a path separator, so `10.5281/zenodo.20387011` goes in as
+`10.5281%2Fzenodo.20387011`. (Any literal `-` would likewise need doubling
+to `--`; Zenodo DOIs don't contain one.)
+
+**Do not** use the badge markdown Zenodo offers on the record page
+(the "Cite as" widget on the right sidebar). It points at
+
+```
+https://zenodo.org/badge/DOI/<CONCEPT_DOI>.svg
+```
+
+which is Zenodo's own badge service, and that endpoint is unreliable enough
+that the README badge has broken more than once. The failure is worse than a
+missing image: GitHub proxies README images through Camo, and Camo *caches*
+what it gets — including an error or a timeout — so one bad fetch leaves a
+broken badge sitting on the repo front page long after Zenodo has recovered,
+with nothing in the repo to explain it. The shields.io form above has no
+Zenodo dependency at all; it is a static label, and the concept DOI is stable
+by definition (that is the whole point of a concept DOI), so it cannot go
+stale. The README's PyPI and download badges already come from shields, so
+this also means one image host to trust instead of two.
+
+Nothing needs updating here on a new release — the concept DOI does not
+change. If a *version* DOI ever goes in the README, that one does.
 
 ## Editing the deposit metadata
 

--- a/scripts/coverage-combined.sh
+++ b/scripts/coverage-combined.sh
@@ -48,7 +48,15 @@ export LLVM_PROFILE_FILE="$PROFDIR/pounce-%p-%m.profraw"
 
 echo "==> [1/5] building instrumented Rust test binaries"
 # --no-run so nothing executes before every artifact exists.
-cargo test --workspace --no-run --message-format=json 2>/dev/null \
+#
+# `--exclude pounce-hsl` matches ci.yml. That crate FFI-links libcoinhsl, which
+# is licensed and absent from CI and from most checkouts, so linking its test
+# binary fails. It contributes no coverage either way: without COINHSL_DIR its
+# build.rs emits no link directives and the MA57 paths are unreachable. Leaving
+# it in made the failure invisible here — the 2>/dev/null below swallows it —
+# and silently dropped every OTHER crate's test binary from objects.txt on the
+# same cargo invocation.
+cargo test --workspace --exclude pounce-hsl --no-run --message-format=json 2>/dev/null \
   | python3 -c '
 import json,sys
 for line in sys.stdin:
@@ -60,10 +68,28 @@ for line in sys.stdin:
 echo "    $(wc -l < "$COV_OUT/objects.txt") test binaries"
 
 echo "==> [2/5] building instrumented CLI + Python extension"
-cargo build --workspace >/dev/null 2>&1
+cargo build --workspace --exclude pounce-hsl >/dev/null 2>&1
 # Absolute path: cargo's JSON already reports absolute executables, so a
 # relative entry here would hand llvm-cov the same object twice.
 [ -x target/debug/pounce ] && echo "$REPO/target/debug/pounce" >> "$COV_OUT/objects.txt"
+
+# Stage the instrumented CLI where the pounce package (and, through it, the
+# pyomo-pounce plugin) looks for a bundled binary. This has to happen BEFORE
+# `maturin develop`, which copies python/pounce/ into site-packages.
+#
+# Without it the CLI is listed as an -object above but nothing ever executes
+# it: pyomo-pounce/tests/conftest.py finds no bundled binary, refuses to trust
+# whatever `pounce` happens to be on PATH (gh #403), and skips the suite — so
+# every CLI and `.nl` path reports 0% and the report understates in exactly the
+# way this script exists to prevent. The conftest docstring recommends this
+# staging by hand; doing it here means the measurement no longer depends on
+# whether the caller remembered. python/pounce/bin/ is gitignored and is where
+# the release workflow stages the binary too.
+if [ -x target/debug/pounce ]; then
+  mkdir -p python/pounce/bin
+  cp target/debug/pounce python/pounce/bin/pounce
+fi
+
 (cd python && maturin develop --release 2>&1 | tail -1)
 SO="$(python -c 'import pounce._pounce as m; print(m.__file__)')"
 echo "$SO" >> "$COV_OUT/objects.txt"
@@ -81,7 +107,7 @@ run_pytest() {
 }
 
 echo "==> [3/5] running Rust tests"
-cargo test --workspace >/dev/null 2>&1
+cargo test --workspace --exclude pounce-hsl >/dev/null 2>&1
 echo "==> [4/5] running Python + pyomo suites"
 if [ "$QUICK" = "1" ]; then
   (cd python && run_pytest python python -m pytest tests/ -q -x -k "problem or minimize")
@@ -145,3 +171,6 @@ echo
 echo "NOTE: this leaves python/pounce/_pounce.abi3.so built WITH instrumentation"
 echo "      (slower, and timing-sensitive tests may fail). Restore with:"
 echo "      cd python && maturin develop --release"
+echo "      It also stages an instrumented debug CLI at python/pounce/bin/pounce."
+echo "      Remove it, or replace it with a release build, when you are done:"
+echo "      rm -f python/pounce/bin/pounce"


### PR DESCRIPTION
## Problem

Two unrelated things, both about what the repo front page tells you.

**No coverage is measured in CI.** `make coverage` exists and works, but nothing runs it automatically, so the number only exists on whatever machine last ran it by hand.

**The README DOI badge is broken again.** It pointed at `https://zenodo.org/badge/DOI/10.5281/zenodo.20387011.svg`. The README's PyPI/download badges — served from `img.shields.io` — render fine on the same page, so the failure is specific to Zenodo's badge endpoint, not to image proxying in general.

## Cause

**Coverage.** Nothing to diagnose; it was simply never wired up.

The interesting part is what the workflow should run. This PR is modelled on [feral's `coverage.yml`](https://github.com/jkitchin/feral/blob/main/.github/workflows/coverage.yml), but the one line carrying feral's whole design — `cargo llvm-cov --workspace` — is the thing `CONTRIBUTING.md` already tells you not to run here:

> `cargo llvm-cov` instruments and runs only the Rust test suite. Large parts of POUNCE are exercised solely through the Python extension (`pounce._pounce`) or through the CLI driven by pytest/pyomo, and those paths read as 0% in a Rust-only report. That makes the report actively misleading as a "what is under-tested?" signal: it invents gaps that are in fact well covered.

A badge fed by that number is worse than no badge: it points reviewers at code that is already covered, and moves for reasons unrelated to tests.

**DOI badge.** Zenodo's badge endpoint is unreliable. What makes it *stay* broken is GitHub's Camo image proxy, which caches what it gets — including an error or a timeout — so one bad fetch outlives the outage that caused it, with nothing in the repo to explain the broken image. And it comes back because `dev-notes/zenodo-setup.md` told the next person to copy the badge markdown straight off the Zenodo record page, which is exactly the URL that breaks.

## Fix

`.github/workflows/coverage.yml` runs `scripts/coverage-combined.sh` — i.e. `make coverage` — and uploads the merged lcov to Codecov. CI and contributors therefore measure via the same code path; a CI-only reimplementation would drift, and the two numbers would disagree with no way to tell which was right.

Kept from feral, with its reasoning: the `main`-scoped double trigger (one run per commit, not two), `llvm-tools-preview`, a coverage-specific cache key, `fail_ci_if_error: true`, the Codecov upload. Dropped as inapplicable: the fixture-gated `SKIP:` surfacing step (pounce has no fixture-gated tests — `grep -rn 'SKIP:' crates/` is empty) and feral's single-test `--skip` for a wall-clock assertion (pounce's instrumentation casualty is `test_qp_solve_releases_the_gil`, a Python test the script already tolerates and documents).

Added, because the combined report has a silent failure mode feral's does not: `crates/pounce-py` is reachable *only* through the `.so`, so if the extension module fails to get attributed, llvm-cov emits a complete, plausible, badly wrong report rather than an error. The job asserts `pounce-py` is non-zero before uploading, so the failure names its own cause instead of moving the badge by tens of points and reading as a coverage collapse. This is `CONTRIBUTING.md`'s existing sanity check, turned into an assertion.

The job is a *measurement*, not a test gate — the script deliberately runs without `set -e` so a partial profile still gets reported, and `ci.yml` remains the thing that fails on a failing test.

Considered and rejected: uploading a Rust-only `cargo llvm-cov` report anyway, on the grounds that it is simpler and cheaper. It is both, but it puts a number on the README that the repo's own docs describe as misleading, and the first person to act on it would go add tests for `pounce-py` paths that pytest already covers.

Two defects in `coverage-combined.sh` surfaced while wiring it up:

- It ran `cargo test --workspace` **including `pounce-hsl`**, which cannot link without licensed HSL. The failure was invisible: the same `2>/dev/null` that hid it also dropped every *other* crate's test binary from `objects.txt` on that invocation. Now `--exclude pounce-hsl`, matching `ci.yml`.
- It handed the CLI to llvm-cov as an `-object` that **nothing ever executed**. `pyomo-pounce/tests/conftest.py` finds no bundled binary, refuses an unvetted `pounce` on `PATH` (gh #403), and skips — so every CLI and `.nl` path reported 0%. The instrumented CLI is now staged at `python/pounce/bin/pounce` before `maturin develop`, which is what that conftest's own docstring tells you to do by hand.

The DOI badge now comes from shields.io, like the README's PyPI badges already do. The concept DOI is stable by definition — that is the point of a concept DOI — so a static badge cannot go stale, and it removes a second image host from the README's dependencies. `dev-notes/zenodo-setup.md` now documents the URL-encoding rule and says why not to use Zenodo's own badge markdown.

## Blast radius

No solver code is touched: this is workflows, a measurement script, and docs. Not a trajectory change, so no fixture sweep applies.

The one behavioural change for existing users is to `make coverage` locally. It now excludes `pounce-hsl` (previously a hidden failure, so this strictly improves what gets measured) and leaves an instrumented debug CLI at `python/pounce/bin/pounce` in addition to the instrumented `.so` it already left behind. Both are gitignored; the script's closing NOTE and `CONTRIBUTING.md` now name both and how to restore.

The job carries the `github.repository == 'jkitchin/pounce'` gate the publishing workflows use. `push: branches: [main]` fires when a fork syncs, `CODECOV_TOKEN` does not exist there, and `fail_ci_if_error: true` would turn that into a red run and an email for a contributor who did nothing.

**Setup required before this is useful: add the `CODECOV_TOKEN` repository secret.** Without it the first run fails at the upload step. The README's Codecov badge reads "unknown" until a run lands on `main`.

## Tests

The workflow is the test; it cannot run until merged to `main` (and the token is added), which is the honest limit here. What I did verify locally:

- Both inline Python checks were run against synthetic `llvm-cov report` output covering all three cases: healthy (exit 0, prints the percentage), `pounce-py` at 0% (exit 1, names the `.so` attribution as the cause), and no `pounce-py` rows at all (exit 1, distinct message).
- The lcov path-rewrite step was run against a synthetic `lcov.info` with a workspace-relative and a registry-absolute `SF:` line: the first is rewritten, the second is warned about rather than uploaded silently.
- `bash -n scripts/coverage-combined.sh`, and both YAML files parse.
- `scripts/check-docs-consistency.sh` passes.

Deliberately **not** pinned, so the gaps are known ones:

- `timeout-minutes: 120` is a guess. The instrumented build is unoptimized and carries per-region counters, and this runs three suites on it; `ci.yml`'s Test job takes ~21 min for the Rust half alone. Worth tightening once a real run lands.
- torch is not installed in the coverage job. Its wheel is ~800 MB and the torch suites drive the same Rust solve paths the jax ones do, so it costs a lot of runner time to move the number very little. `ci.yml`'s `python-test-torch` keeps that frontend honest.
- I could not fetch either badge URL to confirm rendering — this sandbox's egress proxy returns 403 for both `zenodo.org` and `img.shields.io`. The evidence for the diagnosis is that the shields-served PyPI badges on the same README render while the Zenodo-served one does not.
- `codecov.yml` sets both statuses `informational: true` to start. The combined run reaches three suites, and a suite that skips (a missing optional dep, a timing-sensitive test losing its margin under instrumentation) moves the number without anyone touching the code. Blocking PRs on that before the run-to-run spread is known would teach people to ignore the check.

---

- [ ] Tests fail on the parent commit for the stated reason — n/a, no solver change; the verification actually performed is listed above
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a; the docs touched are `CONTRIBUTING.md`, `CLAUDE.md` and `dev-notes/zenodo-setup.md`, none of which are book pages
- [x] `scripts/check-docs-consistency.sh` clean; no Rust changed, so `fmt`/`clippy`/`test` are unaffected by this diff
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtpiFrSaNzvTKSHXUxB8kw)_