### PR TITLE
coverage: stop Codecov globbing GAMS fixtures into the report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -192,6 +192,20 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           files: target/coverage-combined/lcov.info
+          # `files:` names a report to upload; it does NOT stop the uploader
+          # from also globbing the tree for anything that looks like one. On
+          # the first real run that glob found two GAMS listing fixtures --
+          # studio/mcp/fixtures/ex8_3_10.lst and spawn_failed.lst -- and
+          # shipped them as coverage reports ("Found 3 coverage files to
+          # report"). `.lst` is a coverage extension to Codecov and a solver
+          # log to us. Nothing failed, because report *processing* is async
+          # and happens after the step exits, so the damage would have shown
+          # up as an unexplained number on the badge rather than as a red
+          # check -- and with fail_ci_if_error set, a future rejection of an
+          # unparseable fixture would fail this job for a reason nothing in
+          # the diff would explain. This report is assembled deliberately by
+          # coverage-combined.sh; there is nothing for a search to find.
+          disable_search: true
           flags: combined
           # Fail loudly on a broken upload. A silently-missing upload leaves
           # Codecov comparing against a stale baseline, which is worse than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ changes.
 
 ## [Unreleased]
 
+- **The coverage upload was shipping two GAMS listing fixtures to Codecov
+  alongside the real report.**
+
+  The first live run of `.github/workflows/coverage.yml` logged `Found 3
+  coverage files to report`, and the two it found on its own were
+  `studio/mcp/fixtures/ex8_3_10.lst` and `spawn_failed.lst` — solver listing
+  fixtures, not coverage data. Naming a report in the action's `files:` input
+  does not turn its directory search off, and `.lst` is one of the extensions
+  that search looks for.
+
+  Nothing went red, which is the part worth remembering: Codecov processes an
+  uploaded report asynchronously, well after the step exits, so a junk report
+  cannot fail the job that sent it. It would have surfaced as an unexplained
+  number on the badge. And since the step sets `fail_ci_if_error`, a later
+  rejection of an unparseable fixture would have failed the coverage job for a
+  reason nothing in the diff explained. Fixed with `disable_search: true`: the
+  report is assembled deliberately by `scripts/coverage-combined.sh`, so there
+  is nothing for a search to contribute.
+
 - **Coverage is measured in CI, and the DOI badge no longer depends on
   Zenodo's badge service.**
 


### PR DESCRIPTION
## Problem

The first live run of `.github/workflows/coverage.yml` ([#722](https://github.com/jkitchin/pounce/pull/722), run [32368144424](https://github.com/jkitchin/pounce/actions/runs/32368144424)) went green and uploaded — but the uploader logged this:

```
info -- Found 3 coverage files to report
 > /home/runner/work/pounce/pounce/target/coverage-combined/lcov.info
 > /home/runner/work/pounce/pounce/studio/mcp/fixtures/ex8_3_10.lst
 > /home/runner/work/pounce/pounce/studio/mcp/fixtures/spawn_failed.lst
```

Two of the three are GAMS listing fixtures, sent to Codecov as coverage data:

```
$ head -1 studio/mcp/fixtures/ex8_3_10.lst
GAMS 53.2.0  f9f809f7 Mar 3, 2026           DAX-DAC arm 64bit/macOS - 05/26/26 17:01:32 Page 1
```

## Cause

`files:` names a report to upload. It does **not** turn off the uploader's own directory search — that is `disable_search`, and the job's env dump confirms it was left at the default:

```
CC_FILES: target/coverage-combined/lcov.info
CC_DISABLE_SEARCH: false
```

`.lst` is one of the extensions that search matches. It is a coverage report to Codecov and a solver log to us, and both fixtures are tracked in the repo, so every run finds them.

## Fix

`disable_search: true` on the Codecov step. The report here is assembled deliberately by `scripts/coverage-combined.sh` from an explicit object list; a directory search has nothing legitimate to contribute, so turning it off costs nothing and closes the whole class.

Considered and rejected: `exclude:` with the fixture path. It fixes these two files and leaves the next `.lst`, `.lcov` or `coverage.xml` anyone adds to a fixture directory free to reappear in the upload — a denylist against a problem whose shape is "anything in the tree that pattern-matches".

## Blast radius

One line plus its comment, in a workflow that is a measurement rather than a gate. No solver code, no trajectory implications.

The effect on the number is not yet knowable: whether Codecov's processing accepted, ignored, or partially parsed those two fixtures happens server-side and asynchronously. If it did fold them in, the first upload after this merge is the one to compare against — it is the first report guaranteed to be lcov and nothing else.

## Tests

There is no way to pin this in the repo: the behaviour under test belongs to Codecov's uploader, and the only place it is observable is the uploader's own log line on a real run. What I can state precisely is the evidence and the expected change:

- **Before** (run 32368144424, PR #722 head `c9a8a6e`): `Found 3 coverage files to report`, listing the two `.lst` fixtures by path, with `CC_DISABLE_SEARCH: false` in the same job's env dump.
- **After**: the same line should read `Found 1 coverage file to report`, naming only `target/coverage-combined/lcov.info`, with `CC_DISABLE_SEARCH: true`. That is the check to make on this PR's own coverage run before merging — it is a one-line grep of the "Upload to Codecov" step.

Also verified locally: the workflow still parses (`yaml.safe_load`), and `scripts/check-docs-consistency.sh` passes.

Not addressed here, flagged from the same run so it does not get lost: the job took **33 minutes** wall-clock (12:18:11 → 12:51:21) against `timeout-minutes: 120`. That guess was made before any real run existed and is now measurably about 4x too generous. I have left it alone rather than widen this PR — worth its own change once a few runs establish the spread, since a cold cargo cache will be slower than this run's.

---

- [ ] Tests fail on the parent commit for the stated reason — n/a; the defect is only observable in a third-party uploader's log, see above for the before/after evidence
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a, workflow-only change
- [x] `scripts/check-docs-consistency.sh` clean, workflow YAML parses; no Rust changed
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtpiFrSaNzvTKSHXUxB8kw)_