### PR TITLE
coverage: measure on main, not on every pull request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,21 +1,37 @@
 name: Coverage
 
-# Scoped to `main` on both triggers so a PR from a branch in this repo produces
-# ONE coverage run, not the two that `on: [push, pull_request]` gives. This job
-# is the most expensive thing in the repo — it builds the whole workspace
-# unoptimized and instrumented, then runs the Rust, Python and pyomo suites on
-# top — so a duplicate is not a rounding error. Codecov keys its comparison off
-# a single head commit and merges duplicate uploads for the same SHA anyway, so
-# the second run buys nothing.
+# Coverage does NOT run on pull requests, deliberately.
+#
+# This job is the most expensive thing in the repo: it builds the whole
+# workspace unoptimized and instrumented, then runs the Rust, Python and pyomo
+# suites on top of that. Three measured runs: 33, 40 and 33 minutes. ci.yml —
+# the checks that can actually reject a change — finishes in about 10. Running
+# coverage on PRs meant a PR sat visibly un-green for another half hour after
+# everything that could reject it had already passed, and a reviewer looking at
+# a spinner does not distinguish "the tests are still running" from "the
+# measurement is still running". The wait bought nothing: nobody blocks a merge
+# on this number, and codecov.yml marks both statuses `informational`.
+#
+# So the number is tracked on `main`. Every merge produces exactly one run, on
+# the commit the badge and the Codecov trend line actually refer to. What that
+# gives up is Codecov's per-PR patch-coverage status — which, being
+# informational, could not have blocked anything either.
+#
+# `workflow_dispatch` covers a branch that genuinely needs a number before it
+# merges: Actions -> Coverage -> Run workflow -> pick the branch. It is also
+# the only way left to exercise a change to THIS FILE before it lands. Without
+# a `pull_request` trigger, a PR editing this workflow no longer proves the
+# workflow still runs — so dispatch it from the branch before merging one.
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
-# A superseded coverage run is ~an hour of runner time nobody will read.
+# A superseded coverage run is ~40 minutes of runner time nobody will read.
 # Never cancel on `main`, where each commit's number is the record of that
-# commit and the baseline every PR is compared against.
+# commit and the baseline every later commit is compared against. That leaves
+# `workflow_dispatch` runs on a branch, where re-dispatching after a push
+# should supersede the run you have just invalidated.
 concurrency:
   group: coverage-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -34,14 +50,16 @@ jobs:
     # (see CLAUDE.md): `push: branches: [main]` fires in a fork when the owner
     # syncs, CODECOV_TOKEN does not exist there, and `fail_ci_if_error: true`
     # below turns that into a red run and an email for a contributor who did
-    # nothing. `pull_request` runs in the base repo's context, so PR checks
-    # from forks are unaffected.
+    # nothing. Now that `push` is the only automatic trigger, this gate is the
+    # only thing standing between a fork sync and that email.
     if: github.repository == 'jkitchin/pounce'
     runs-on: ubuntu-latest
-    # The instrumented build is unoptimized and carries per-region counters,
-    # and this runs three suites on it. Generous, but far below the 6 h
-    # default: a job that hangs should fail in an hour, not burn six.
-    timeout-minutes: 120
+    # 120 was a guess made before any run existed. Measured since: 33.2, 40.4
+    # and 33.3 minutes, the spread coming from how warm the cargo cache is. 90
+    # keeps better than 2x headroom over the slowest of those (and well over
+    # the cold-cache case, which none of the three was) while making a hung job
+    # fail in an hour and a half rather than burning the 6 h default.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ changes.
 
 ## [Unreleased]
 
+- **Coverage no longer runs on pull requests; it is measured on `main`.**
+
+  The combined coverage job takes 33–40 minutes (three measured runs: 33.2,
+  40.4, 33.3, the spread coming from cargo-cache warmth). `ci.yml` — everything
+  that can actually reject a change — finishes in about 10. Running both on a
+  PR meant the PR sat visibly un-green for another half hour after the checks
+  that matter had passed, and a reviewer looking at a spinner cannot tell "the
+  tests are still running" from "the measurement is still running". Nothing
+  blocked on the number: `codecov.yml` marks both statuses `informational`.
+
+  `coverage.yml` now triggers on pushes to `main` plus `workflow_dispatch`.
+  Every merge still produces exactly one run, on the commit the badge and the
+  Codecov trend actually refer to. A branch that needs a number before it
+  merges can get one on demand (Actions → Coverage → Run workflow → pick the
+  branch).
+
+  Two costs, both stated rather than discovered later. Codecov's per-PR
+  patch-coverage status is gone, because no report is uploaded for a PR head —
+  it was informational, so it could not have blocked anything. And a PR that
+  edits `coverage.yml` no longer exercises the workflow before merging, since
+  `pull_request` was what used to do that; dispatch such a branch by hand
+  first.
+
+  `timeout-minutes` also drops from 120 to 90. The 120 was a guess made before
+  any run existed; 90 keeps better than 2x headroom over the slowest run seen.
+
 - **The coverage upload was shipping two GAMS listing fixtures to Codecov
   alongside the real report.**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,15 @@ has, and it fails loudly on a bad upload.
 ## Coverage is measured combined, never Rust-only
 
 `.github/workflows/coverage.yml` runs `scripts/coverage-combined.sh` (i.e.
-`make coverage`) and uploads to Codecov. It does **not** run `cargo llvm-cov
---workspace`: large parts of POUNCE are reachable only through the
+`make coverage`) and uploads to Codecov. It runs on **pushes to `main` only** —
+plus `workflow_dispatch` for an on-demand run against a branch. It was on
+`pull_request` too until the wait proved indefensible: 33–40 minutes against
+ci.yml's ~10, holding every PR visibly un-green long after the checks that can
+reject it had passed, for a number nothing blocks on. The cost of that choice
+is the per-PR patch-coverage status, which was `informational` anyway; the
+other cost is that a PR editing `coverage.yml` no longer exercises it, so
+dispatch such a branch manually before merging. It does **not** run `cargo
+llvm-cov --workspace`: large parts of POUNCE are reachable only through the
 `pounce._pounce` extension module or the CLI, and a Rust-only report shows
 those at 0% — inventing gaps in code that is well covered. The job asserts the
 attribution worked before uploading, by checking that `crates/pounce-py/*`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,13 +78,22 @@ These run on every PR; run them locally before pushing to get fast feedback:
 Use `make coverage` (or `make coverage-quick` to skip the slow pytest suite),
 **not** `cargo llvm-cov --workspace`.
 
-`.github/workflows/coverage.yml` runs the same script on every PR and every
-push to `main` and uploads the result to
-[Codecov](https://codecov.io/gh/jkitchin/pounce) — so the badge, the Codecov
-diff, and what you get locally are all produced by one code path. That job is
-a *measurement*, not a test gate: it deliberately does not fail on a failing
-test (`ci.yml` does that). It does fail if the report is untrustworthy — see
-the `pounce-py` sanity check below, which it asserts.
+`.github/workflows/coverage.yml` runs the same script on every push to `main`
+and uploads the result to [Codecov](https://codecov.io/gh/jkitchin/pounce) —
+so the badge, the Codecov trend, and what you get locally are all produced by
+one code path. That job is a *measurement*, not a test gate: it deliberately
+does not fail on a failing test (`ci.yml` does that). It does fail if the
+report is untrustworthy — see the `pounce-py` sanity check below, which it
+asserts.
+
+**It does not run on pull requests.** The job takes 33–40 minutes against
+ci.yml's ~10, so running it on PRs left every PR visibly un-green for half an
+hour after the checks that can actually reject it had passed. Nothing blocked
+on the number, so the wait bought nothing. If a particular branch does need a
+number before it merges, run it on demand: Actions → Coverage → Run workflow →
+pick the branch. Do that too for any PR that edits `coverage.yml` itself —
+without a `pull_request` trigger, nothing else proves the workflow still runs
+before you merge it.
 
 `cargo llvm-cov` instruments and runs only the Rust test suite. Large parts of
 POUNCE are exercised solely through the Python extension (`pounce._pounce`) or

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,12 +8,17 @@
 
 coverage:
   status:
-    # Informational to start with. The combined run reaches three suites, and
-    # a suite that skips (a missing optional dep, a timing-sensitive test that
-    # loses its margin under instrumentation) moves the number without anyone
-    # touching the code. Blocking PRs on that before we know the run-to-run
-    # spread would teach people to ignore the check, which is worse than not
-    # having it. Flip `informational` off once the baseline holds steady.
+    # Informational. The combined run reaches three suites, and a suite that
+    # skips (a missing optional dep, a timing-sensitive test that loses its
+    # margin under instrumentation) moves the number without anyone touching
+    # the code. Gating on that before we know the run-to-run spread would
+    # teach people to ignore the check, which is worse than not having it.
+    #
+    # These now evaluate on `main` commits rather than on PRs: coverage.yml
+    # has no `pull_request` trigger, so no report is ever uploaded for a PR
+    # head and Codecov has nothing to compare there. Reinstating that trigger
+    # is what would bring the per-PR statuses back — this file is not what
+    # turned them off.
     project:
       default:
         informational: true


### PR DESCRIPTION
## Problem

The combined coverage job is slow, and until now every PR waited on it.

| run | trigger | wall clock |
|---|---|---|
| [32368144424](https://github.com/jkitchin/pounce/actions/runs/32368144424) | pull_request (#722) | 33.2 min |
| [32371210449](https://github.com/jkitchin/pounce/actions/runs/32371210449) | push to main | 33.3 min |
| [32371559315](https://github.com/jkitchin/pounce/actions/runs/32371559315) | pull_request (#723) | 40.4 min |

`ci.yml` — the eleven checks that can actually reject a change — finishes in about 10 minutes. So a PR sat visibly un-green for another half hour after everything that matters had already passed. A reviewer looking at a spinner cannot tell "the tests are still running" from "the measurement is still running", so the practical effect was a half-hour tax on every merge.

## Cause

Not a defect — a design choice made when nobody knew what the job cost. `coverage.yml` shipped with `pull_request: branches: [main]` alongside the `push` trigger, on the reasoning that per-PR patch coverage is useful. Three real runs later, the price of that is measurable and the benefit is not: `codecov.yml` marks both the `project` and `patch` statuses `informational: true`, so the per-PR status could not fail a PR even in principle. Nothing blocked on the number; the wait was pure latency.

## Fix

`coverage.yml` now triggers on `push: branches: [main]` plus `workflow_dispatch`. Every merge still produces exactly one run, on the commit the badge and the Codecov trend line actually refer to — the number does not get less accurate, it just stops being in the critical path.

`workflow_dispatch` covers the branch that genuinely wants a number before merging: Actions → Coverage → Run workflow → pick the branch.

Considered and rejected:

- **Leave the trigger and un-require the check.** It is already not required — the wait is what people react to, not the merge button. This does not fix what was actually complained about.
- **Speed the job up** (`--quick`, drop the pyomo leg). Every suite dropped is a chunk of the tree that goes back to reading 0%, which is the exact failure mode `coverage-combined.sh` exists to prevent. Making the measurement cheaper by making it wrong is not a trade worth taking.
- **Add a nightly cron.** Redundant here — `main` takes several merges a day, so a schedule would mostly re-measure commits already measured. Worth adding if the repo goes quiet.

`timeout-minutes` also drops 120 → 90. The 120 was a guess made before any run existed; 90 is better than 2x the slowest observed, and still fails a hung job in an hour and a half instead of burning the 6 h default.

## Blast radius

Two costs, stated here rather than left to be discovered:

1. **Codecov's per-PR patch status is gone**, because no report is uploaded for a PR head and Codecov has nothing to compare against. It was informational. `codecov.yml` keeps both status blocks — they now evaluate on `main` commits, and reinstating the `pull_request` trigger is what would bring the PR statuses back. That file is not what turned them off, and its comment now says so.
2. **A PR that edits `coverage.yml` no longer exercises it before merging** — `pull_request` was what did that. This is the sharper of the two, because the failure mode is a broken workflow landing on `main` unnoticed. Mitigation is `workflow_dispatch`: dispatch the branch by hand first. Called out in the workflow's own header comment and in CONTRIBUTING.md, so it is not folklore.

No solver code; workflows and docs only.

## Tests

Self-demonstrating, and worth watching for on this PR specifically: **because GitHub resolves `pull_request` triggers from the PR's own head, this PR removes its own coverage run.** If the change works, #724 shows the eleven `ci.yml` checks and no `combined coverage -> Codecov`, and goes green in ~10 minutes instead of ~40. That is the entire claim, observable on the PR page.

Also verified locally: both YAML files parse (`yaml.safe_load`), the parsed trigger set is exactly `{push: {branches: [main]}, workflow_dispatch: None}`, `timeout-minutes` reads 90, and `scripts/check-docs-consistency.sh` passes.

Not verifiable until after merge: that `workflow_dispatch` actually offers the branch picker and runs. It is a one-line trigger with no inputs, so the risk is low, but it is the replacement for what this PR removes and nothing here proves it works. Worth one manual dispatch after merging to confirm.

---

- [ ] Tests fail on the parent commit for the stated reason — n/a, no solver change; the observable claim is stated above and lands on this PR's own check list
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a; docs touched are `CONTRIBUTING.md` and `CLAUDE.md`, neither a book page
- [x] `scripts/check-docs-consistency.sh` clean, both YAML files parse; no Rust changed
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now — including the three timings, which come from the run IDs linked above

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtpiFrSaNzvTKSHXUxB8kw)_