### PR TITLE
Pin eigena2's status single-valued again, and assert why it is safe (#706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -479,6 +479,20 @@ changes.
   at a `1e-12` perturbation — which is a simpler and worse explanation. It is
   deterministic now.
 
+  **#706 is closed on a stronger measurement than the ulp screen above.**
+  `mu_init` is what that screen perturbs, and on `eigena2` it no longer
+  perturbs anything: moved from `0.1` to `100` — three decades, not an ulp —
+  every iterate of the `=yes` run is bit-identical (objective, `inf_pr`,
+  `‖d‖`, both step sizes, 17 iterations), and only the printed `lg(mu)` column
+  differs. On #693's parent the same model swings between 61 and 127
+  iterations and both statuses under a `1e-12` change to the same option. A
+  trajectory that ignores a thousandfold change in the barrier parameter is
+  not sitting on a tolerance band, so the `eigena2` pin in
+  `issue_616_ls_init_downgrades.rs` — two-valued while #706 was open, because
+  CI had caught the platforms disagreeing — is single-valued again, and the
+  barrier-independence itself is now asserted alongside it rather than
+  described.
+
 - **A test and a doc page asserted opposite things about `pooling_rt2stp`,
   and both were written from one draw** (#616).
 

--- a/crates/pounce-cli/tests/issue_616_ls_init_downgrades.rs
+++ b/crates/pounce-cli/tests/issue_616_ls_init_downgrades.rs
@@ -163,6 +163,13 @@ fn solve(model: &str, ls_init: bool) -> SolveReport {
 /// which is how a fixture that moved under gh#588's Q4 is made to say
 /// so instead of being asserted around.
 fn solve_with_env(model: &str, ls_init: bool, env: &[(&str, &str)]) -> SolveReport {
+    solve_with(model, ls_init, env, &[])
+}
+
+/// `solve_with_env`, plus extra CLI options appended verbatim. Used by
+/// the barrier-independence screen below, which is the same run at two
+/// values of `mu_init`.
+fn solve_with(model: &str, ls_init: bool, env: &[(&str, &str)], opts: &[&str]) -> SolveReport {
     let json = tmp_path(model, "json");
     // Explicit, so a fixture that solves does not drop a `.sol` beside
     // the `.nl` in the source tree.
@@ -178,6 +185,9 @@ fn solve_with_env(model: &str, ls_init: bool, env: &[(&str, &str)]) -> SolveRepo
         .arg("print_level=0");
     if ls_init {
         cmd.arg("least_square_init_primal=yes");
+    }
+    for o in opts {
+        cmd.arg(o);
     }
     for (k, v) in env {
         cmd.env(k, v);
@@ -459,6 +469,13 @@ fn the_safeguards_measured_cost_is_now_csfi2_alone() {
 /// | tape                     | 0.2500000062500001   | succeeded  | acceptable|
 /// | Q4, uncompensated        | 0.2500000062500003   | succeeded  | succeeded |
 /// | Q4, compensated (gh#702) | 0.25000000624999996  | *platform* | acceptable|
+/// | …plus gh#693 (`main`)    | 0.25000000624999996  | succeeded  | succeeded |
+///
+/// The last row is the current one, and it is bit-identical to the row
+/// above it in every field the safeguard reads — gh#693 changes nothing
+/// this test asserts about the decision, only where the iteration after
+/// it lands. That is the fourth reassociation and the third verdict on
+/// the pair, which is the point: the accept test never decided either.
 ///
 /// Three associations, three verdicts on the pair, off inputs that stay
 /// bit-for-bit identical between the two models every time. So neither
@@ -469,21 +486,44 @@ fn the_safeguards_measured_cost_is_now_csfi2_alone() {
 /// would have been tuned against round-off — gh#616's conclusion, now
 /// re-derived twice.
 ///
-/// **`eigena2` is why that last row says *platform*.** Under gh#702's
-/// compensated sum it reaches `SolveSucceeded` on Linux and
+/// **`eigena2` is why that third row says *platform*.** Under gh#702's
+/// compensated sum it reached `SolveSucceeded` on Linux and
 /// `SolvedToAcceptableLevel` in 127 iterations on macOS, for an objective
-/// correct to 82.50000000000348 either way. That is not a status this
-/// file can pin, and the attempt to pin it is what caught the fact: the
+/// correct to 82.50000000000348 either way. That was not a status this
+/// file could pin, and the attempt to pin it is what caught the fact: the
 /// first version of this assertion asserted the macOS reading and failed
-/// on CI.
+/// on CI. It was filed as gh#706, whose question was not how to get 51
+/// iterations back — that number was luck — but why a model this
+/// well-behaved sat close enough to the band that libm decided it.
 ///
-/// So the assertion below is deliberately two-valued, and the *fact* is
-/// tracked as gh#706. This is the only place in this file where a status
-/// is platform-dependent, which makes it worth a defect rather than a
-/// shrug: every other model here lands the same way on both. The question
-/// for gh#706 is not how to get 51 iterations back — that number was luck
-/// — but why this model sits close enough to the band that libm decides
-/// it.
+/// gh#693 answered that, and not by carrying the model across the band:
+/// it took the barrier parameter out of this model's steering
+/// altogether. Measured on gh#693's parent (`fe631b0c^`) against `main`,
+/// same machine, same fixture, `least_square_init_primal=yes`:
+///
+/// ```text
+///                mu_init screen at 1e-12      mu_init 0.1 -> 100 (1000x)
+///   fe631b0c^    11 succeeded / 6 acceptable  n/a: the 1e-12 screen
+///                iterations 61 … 127          already moves it 2x
+///   main         17 succeeded, 17 iterations  every iterate bit-identical
+///                every time                   — objective, inf_pr, ‖d‖,
+///                                             both alphas; only the
+///                                             printed lg(mu) column moves
+/// ```
+///
+/// A trajectory that swings 61 → 127 iterations on a last-ulp change in
+/// `mu_init` is what "sitting on the band" meant here. One that does not
+/// move at all when `mu_init` moves three decades is not near one, and
+/// the cause was the Tikhonov `δ` in the multiplier initializer rather
+/// than gh#702's compensated sum. The tape route now agrees with the
+/// compensated one bit-for-bit on the objective, where gh#706 recorded
+/// three different values across the three routes above.
+///
+/// So the assertion below is single-valued again. If it starts failing on
+/// one platform's CI leg only, that is gh#706 returning and the two-valued
+/// pin was load-bearing after all — say so in the issue rather than
+/// widening the `matches!` back out, which is how a defect becomes a
+/// shrug.
 ///
 /// The absolute values pinned below are the ones the accept test reads
 /// (`violation_initial`, `alpha`, `rejected_trials`, `termination`).
@@ -526,25 +566,27 @@ fn eigena2_and_eigenb2_hand_the_safeguard_identical_numbers() {
     assert_eq!(at("rejected_trials"), Some("1"));
     assert_eq!(at("termination"), Some("accepted"));
 
-    // Same decision, and — since gh#702 — the same verdict again, at
-    // the other status. Pinned so that the pair moving is a finding
-    // rather than a surprise; the premise above is what gh#616 rests
-    // on, and these two are downstream round-off.
-    // Two-valued on purpose — see the note above. `eigena2` is the one
-    // model in this file whose status is platform-dependent since
-    // gh#702, and gh#706 tracks that. What must not happen is a third
-    // outcome: this model still solves, on every platform, to 82.5.
+    // Same decision, same verdict — and since gh#693, the same verdict
+    // on both models on every platform. Pinned so that the pair moving
+    // is a finding rather than a surprise; the premise above is what
+    // gh#616 rests on, and these two used to be downstream round-off.
+    //
+    // Single-valued, and deliberately: this assertion was two-valued
+    // while gh#706 was open because gh#702's compensated sum left the
+    // model close enough to the band for the platform to pick a side.
+    // gh#693 moved it off — 17 iterations, and `mu_init` across three
+    // decades does not change a single iterate — so a two-valued pin
+    // here would now assert less than is known and let a return to
+    // `SolvedToAcceptableLevel` in 127 iterations pass unnoticed, which
+    // is the failure mode this whole file exists to prevent.
     let eigena2 = solve("eigena2", true);
-    assert!(
-        matches!(
-            status_of(&eigena2).as_str(),
-            "SolveSucceeded" | "SolvedToAcceptableLevel"
-        ),
-        "eigena2 accepts the alpha = 0.5 step and must still converge; \
-         gh#702's compensated sum leaves it close enough to the accept \
-         band that the platform decides which side (gh#706), but \
-         anything outside those two is a different defect. Got: {}",
+    assert_eq!(
         status_of(&eigena2),
+        "SolveSucceeded",
+        "eigena2 accepts the alpha = 0.5 step and, since gh#693, \
+         converges cleanly from it — see the round-off screen in the \
+         note above. A `SolvedToAcceptableLevel` here is gh#706 \
+         returning, not a tolerance to widen the pin for.",
     );
     assert_eq!(
         status_of(&solve("eigenb2", true)),
@@ -556,6 +598,43 @@ fn eigena2_and_eigenb2_hand_the_safeguard_identical_numbers() {
     assert!(
         (solve("eigena2", true).solution.objective - 82.5).abs() < 1e-6,
         "eigena2 objective drifted",
+    );
+}
+
+/// The measurement that makes the single-valued pin above safe, kept as
+/// an assertion instead of as a paragraph: `eigena2`'s trajectory no
+/// longer depends on the barrier parameter at all.
+///
+/// `mu_init` is what gh#706's round-off screen perturbed, and on gh#693's
+/// parent a change of one part in `1e12` swung this model between 61 and
+/// 127 iterations and between both statuses. Here it moves by three
+/// decades — a thousandfold, not an ulp — and the run does not notice:
+/// same iteration count, same objective to the bit. Only the printed
+/// `lg(mu)` column differs.
+///
+/// A model whose steps are steered by the barrier parameter cannot
+/// produce that. So a failure here says the pin above has stopped being
+/// safe for the reason it was tightened — the status is a coin flip
+/// again, whether or not it has yet landed on the wrong side of the band
+/// on this platform.
+#[test]
+fn eigena2_no_longer_takes_its_trajectory_from_the_barrier_parameter() {
+    let default_mu = solve_with("eigena2", true, &[], &[]);
+    let big_mu = solve_with("eigena2", true, &[], &["mu_init=100.0"]);
+
+    assert_eq!(
+        default_mu.statistics.iteration_count, big_mu.statistics.iteration_count,
+        "mu_init 0.1 -> 100 moved eigena2's iteration count, so the \
+         barrier parameter steers this model again and gh#706's coin \
+         flip is back within reach",
+    );
+    assert_eq!(
+        default_mu.solution.objective.to_bits(),
+        big_mu.solution.objective.to_bits(),
+        "mu_init 0.1 -> 100 moved eigena2's objective ({} vs {}); the \
+         iterates are supposed to be identical, not merely close",
+        default_mu.solution.objective,
+        big_mu.solution.objective,
     );
 }
 


### PR DESCRIPTION
Fixes #706.

#706 recorded `eigena2` under `least_square_init_primal=yes` as
platform-dependent — `SolveSucceeded` on Linux, `SolvedToAcceptableLevel` in 127
iterations on macOS — and asked the right question about it: not how to get the
old 51 iterations back, which was luck, but *why a model this well-behaved sat
on a knife edge at all*.

#693 answered that, as a side effect. On `main` today, macOS:

| `eigena2`, `least_square_init_primal=yes` | status | iters | objective |
|---|---|---|---|
| as filed in #706 | `SolvedToAcceptableLevel` | 127 | 82.50000000000348 |
| `main` | `SolveSucceeded` | **17** | 82.5000000001501 |

So this PR does not fix anything — it stops `issue_616_ls_init_downgrades.rs`
from asserting less than is known.

## Why the pin can be tightened

The file's `1e-12` `mu_init` screen is a weak instrument on this model now, so
the tightening does not rest on it. It rests on the model having stopped taking
its trajectory from the barrier parameter at all. Measured on #693's parent
(`fe631b0c^`, built from a worktree) against `main`, same machine, same fixture:

```
fe631b0c^   1e-12 mu_init screen: 11 succeeded / 6 acceptable, 61 … 127 it
main        1e-12 mu_init screen: 17 succeeded, 17 iterations every time
main        mu_init 0.1 -> 100:   every iterate bit-identical — objective,
                                  inf_pr, ‖d‖, both alphas; only the printed
                                  lg(mu) column moves
```

The first line is the coin flip #706 is about, reproduced: a last-ulp change to
`mu_init` swinging the trajectory 2× and the status both ways. The third is the
one that matters — a thousandfold change in the barrier parameter that the
iterates do not notice. A model sitting on a tolerance band cannot do that.

The cause was the Tikhonov `δ` in the multiplier initializer, not #702's
compensated sum, which is what #706 suspected and explicitly declined to blame.
The AD-tape route (`POUNCE_DBG_NO_QUAD=1`, a genuine reassociation of `eval_g`)
now agrees with the compensated one bit-for-bit on the objective, where #706
recorded three different values across three routes.

## Changes

* `eigena2`'s status pin goes from `matches!(… "SolveSucceeded" |
  "SolvedToAcceptableLevel")` back to `assert_eq!(… "SolveSucceeded")`, matching
  what #693 already did for `eigenb2` in the same function. As it stood, a
  regression to 127 iterations at acceptable level passed silently — the failure
  mode that file exists to prevent.
* New test `eigena2_no_longer_takes_its_trajectory_from_the_barrier_parameter`:
  the same solve at `mu_init=0.1` and `mu_init=100.0` must return the same
  iteration count and a bit-identical objective. This asserts the property the
  tightened pin depends on, so a future change that re-couples the barrier
  parameter fails here — with a message saying the pin is no longer safe —
  rather than by flipping a status on one CI leg some months later.
* The route table in the same doc block gains the current reading. It is
  bit-identical to the compensated row in every field the accept test reads
  (`violation_initial=1.0`, `violation_final=0.25000000624999996`, `alpha=0.5`,
  `rejected_trials=1`, `accepted`, on both models): #693 changes where the
  iteration *after* the safeguard lands, not the decision. Fourth
  reassociation, third verdict on the pair — #616's point, not an exception to
  it.
* `CHANGELOG.md`'s existing #616/#681/#706 entry gains the closing measurement.

## Note on the L-BFGS leg

#706's third bullet guessed that `eigena2`'s L-BFGS behaviour might be "the same
underlying conditioning problem showing up louder". The measurements here argue
against that and it is deliberately not addressed by this PR. That leg takes 242
iterations to `SolvedToAcceptableLevel`, stalling at dual infeasibility 4.6e-8
with α down to 2e-3 and 10–14 line-search trials per step — while reaching 82.5
to 15 digits with `inf_pr` 2.2e-16. It is a curvature-limited quasi-Newton
stall, it is identical before and after this change, and the exact-Hessian leg
that #706 was filed about is now the *stable* one. If it is worth pursuing it is
its own issue.

## Verification

`cargo test -p pounce-cli --test issue_616_ls_init_downgrades` — 8 passed.
The cross-platform half of the determinism claim is what CI's matrix is for: if
the tightened assertion fails on one leg only, that is #706 returning, and the
test's own message says to reopen it rather than widen the `matches!` back out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9Tqn6nrW7B91fC1HpJsHp
