### PR TITLE
Floor the degeneracy_iter retry advice, and close out the #708 review leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ changes.
   exact decision. The engine's `use_schur_updates`
   path hits `MaxIter` on dense reduced problems of hundreds of rows and
   stays off here; that is engine-side follow-up work.
+
+  One caller-visible consequence of the split: `estimate_report()`'s
+  `max_iter` no longer does anything, since the decision was the only
+  work it budgeted there and that is `degeneracy_iter` now. It is still
+  accepted, for positional compatibility, but passing it raises a
+  `DeprecationWarning` rather than being ignored quietly —
+  `estimate_report(..., max_iter=0)` used to force the one-sided
+  fallback and would otherwise have started returning the directional
+  step without saying so. `estimate()` and `active_set_changes()` keep
+  `max_iter` as the mode's own work, where it still bites.
+
 - **`nlp_scaling_method=curvature-based`: scale a QCQP by its coefficients
   instead of by one derivative sample** (#703).
 

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -923,8 +923,18 @@ impl Solver {
         // differ by enough that raising one at a time is dozens of
         // retries. The engaged set can still grow on a later pass, so
         // the figure is a floor and says so.
+        //
+        // `engaged_now + 2` prices a decision that finishes on one
+        // pass. Each expansion round pays another combined solve, so
+        // on a multi-pass decision that total is short, and once the
+        // engaged set stops growing it stops moving at all: the
+        // combined solve of the last round would otherwise be told to
+        // raise the budget to the number already spent, which is a
+        // retry that buys nothing and reads as self-contradictory.
+        // Flooring at `spent + 1` keeps the advice strictly larger
+        // than what is gone, so every retry makes progress.
         let budget = |engaged_now: usize, spent: usize| {
-            let need = engaged_now + 2;
+            let need = (engaged_now + 2).max(spent + 1);
             SolverError::SensComputationFailed(format!(
                 "directional derivative: {spent} of {max_iter} back-solve(s) \
                  spent, and {engaged_now} of {nw} weakly active bound(s) are \

--- a/crates/pounce-sensitivity/tests/degenerate_reentry.rs
+++ b/crates/pounce-sensitivity/tests/degenerate_reentry.rs
@@ -1,0 +1,330 @@
+//! The directional decision on a fixture whose engaged set grows on a
+//! second pass, and the budget message that fixture's retries read.
+//!
+//! `degenerate_expansion.rs` covers the decision that finishes on one
+//! pass: with uniform negative coupling, holding a weak row only ever
+//! raises the other rows' movement, so every row that engages does so
+//! against the all-released direction and the expansion loop never
+//! re-enters. That leaves the loop's second pass, and a decision that
+//! holds some rows while releasing others, reachable only on the
+//! dynamic column model, which CI cannot run.
+//!
+//! This fixture reaches both. Over
+//!
+//! ```text
+//!     H = [[ 1.0, -1.2, -0.5],      c = [1.6, 1.4, 0.8]
+//!          [-1.2,  5.0,  3.5],
+//!          [-0.5,  3.5,  3.0]]
+//! ```
+//!
+//! `H` is positive definite (eigenvalues 0.186, 0.943, 7.87), so at
+//! `p = 0` the unconstrained minimizer is the origin and all three
+//! variables sit on a lower bound with a vanishing multiplier: three
+//! weakly active bounds, as in `Ke3Qp`. The coupling signs are what
+//! differ. With `M = H^-1`, `Mc` has a negative third entry, so on
+//! one side of the kink the third row does not engage against the
+//! all-released direction, and `M`'s third row is negative enough on
+//! its first two entries that holding rows 1 and 2 drives it into
+//! violation. The decision has to come back for it.
+//!
+//! Both sides are hand-computable:
+//!
+//! * `dp = -1` engages rows 1 and 2 against `d0 = -Mc`, holds them
+//!   with `lambda = [26/15, 7/15]`, and the resulting direction moves
+//!   row 3 to `-4/15`. Row 3 then engages, and the second pass returns
+//!   `lambda = c`, all three strictly positive, direction exactly zero.
+//! * `dp = +1` engages only row 3. Holding it and releasing the other
+//!   two leaves the reduced system `H[1..2, 1..2] dx = c[1..2]`, whose
+//!   solution is `[9.68/3.56, 3.32/3.56]`.
+//!
+//! The back-solve counts are what prove the loop re-entered. A
+//! decision that finishes on one pass costs `ke + 2`; the `dp = -1`
+//! side costs 6 over a final `ke` of 3, which one pass cannot reach.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::TNLP;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+};
+use pounce_sensitivity::Solver;
+
+const H11: Number = 1.0;
+const H12: Number = -1.2;
+const H13: Number = -0.5;
+const H22: Number = 5.0;
+const H23: Number = 3.5;
+const H33: Number = 3.0;
+const C1: Number = 1.6;
+const C2: Number = 1.4;
+const C3: Number = 0.8;
+
+/// Three decision variables, all weakly active at `p = 0`, coupled so
+/// that one of them engages only after the other two are held:
+///
+/// ```text
+/// min 0.5 x^T H x - p c^T x
+/// s.t. x4 = p,   0 <= x1, x2, x3 <= 10
+/// ```
+struct ReentryQp;
+
+impl TNLP for ReentryQp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 4,
+            m: 1,
+            nnz_jac_g: 1,
+            nnz_h_lag: 9,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        for i in 0..3 {
+            b.x_l[i] = 0.0;
+            b.x_u[i] = 10.0;
+        }
+        b.x_l[3] = -1.0e19;
+        b.x_u[3] = 1.0e19;
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.3;
+        sp.x[1] = 0.3;
+        sp.x[2] = 0.3;
+        sp.x[3] = 0.0;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let (x1, x2, x3, p) = (x[0], x[1], x[2], x[3]);
+        Some(
+            0.5 * (H11 * x1 * x1 + H22 * x2 * x2 + H33 * x3 * x3)
+                + H12 * x1 * x2
+                + H13 * x1 * x3
+                + H23 * x2 * x3
+                - p * (C1 * x1 + C2 * x2 + C3 * x3),
+        )
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (x1, x2, x3, p) = (x[0], x[1], x[2], x[3]);
+        g[0] = H11 * x1 + H12 * x2 + H13 * x3 - C1 * p;
+        g[1] = H12 * x1 + H22 * x2 + H23 * x3 - C2 * p;
+        g[2] = H13 * x1 + H23 * x2 + H33 * x3 - C3 * p;
+        g[3] = -(C1 * x1 + C2 * x2 + C3 * x3);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[3];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 3;
+            }
+            SparsityRequest::Values { values } => values[0] = 1.0,
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let rs: [Index; 9] = [0, 1, 1, 2, 2, 2, 3, 3, 3];
+                let cs: [Index; 9] = [0, 0, 1, 0, 1, 2, 0, 1, 2];
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = obj_factor * H11;
+                values[1] = obj_factor * H12;
+                values[2] = obj_factor * H22;
+                values[3] = obj_factor * H13;
+                values[4] = obj_factor * H23;
+                values[5] = obj_factor * H33;
+                values[6] = -obj_factor * C1;
+                values[7] = -obj_factor * C2;
+                values[8] = -obj_factor * C3;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+/// Solve to a tight tolerance with the bounds unrelaxed, so the
+/// classifier can read the slacks and call the three vanishing
+/// multipliers weakly active.
+fn solved(tnlp: Rc<RefCell<dyn TNLP>>) -> Solver {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("tol", 1e-10, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("bound_relax_factor", 0.0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let mut solver = Solver::new(app, tnlp);
+    let status = solver.solve();
+    assert!(
+        matches!(status, ApplicationReturnStatus::SolveSucceeded),
+        "base solve failed: {status:?}",
+    );
+    solver
+}
+
+#[test]
+fn all_three_bounds_are_weakly_active() {
+    let solver = solved(Rc::new(RefCell::new(ReentryQp)));
+    let x = solver.converged().expect("converged").x.clone();
+    for i in 0..3 {
+        assert!(
+            x[i].abs() < 1e-3,
+            "x{} should sit on its bound, got {}",
+            i + 1,
+            x[i]
+        );
+    }
+    let mut weak: Vec<usize> = solver
+        .weakly_active_bounds()
+        .expect("classification")
+        .iter()
+        .inspect(|w| assert!(w.lower, "weak bounds here are all lower: {w:?}"))
+        .map(|w| w.var_row)
+        .collect();
+    weak.sort_unstable();
+    assert_eq!(weak, vec![0, 1, 2], "all three variables weakly active");
+}
+
+#[test]
+fn a_row_that_engages_only_after_the_others_are_held_still_enters() {
+    let solver = solved(Rc::new(RefCell::new(ReentryQp)));
+    let (d, mut held, work) = solver
+        .parametric_step_directional(&[0], &[-1.0], 16)
+        .expect("hold side");
+
+    // Every row ends up held, so the direction is zero on the primal
+    // block. Row 3 gets there only on the second pass: against the
+    // all-released direction it moves to +2.849, the feasible side of
+    // its lower bound, and it is holding rows 1 and 2 that pushes it
+    // to -4/15.
+    for i in 0..3 {
+        assert!(d[i].abs() < 1e-8, "hold side d[{i}] = {} should be 0", d[i]);
+    }
+    held.sort_unstable();
+    assert_eq!(held, vec![0, 1, 2], "all three rows held");
+
+    // The count is the evidence of re-entry, so it is asserted
+    // exactly. One pass over a final engaged set of three costs
+    // `ke + 2 = 5`: the all-released solve, three basis columns, and
+    // one combined solve. Six is that plus the extra combined solve
+    // the first pass spent before row 3 entered, and no arrangement
+    // of a single pass reaches it.
+    assert_eq!(
+        work, 6,
+        "the all-released solve, two basis columns and a combined solve on \
+         the first pass, then row 3's column and a second combined solve",
+    );
+}
+
+#[test]
+fn the_other_side_holds_one_row_and_releases_two() {
+    let solver = solved(Rc::new(RefCell::new(ReentryQp)));
+    let (d, held, work) = solver
+        .parametric_step_directional(&[0], &[1.0], 16)
+        .expect("release side");
+
+    // Only row 3 engages here. With x3 pinned, x1 and x2 solve the
+    // reduced system H[1..2, 1..2] dx = c[1..2], whose determinant is
+    // 5 - 1.44 = 3.56.
+    let det = H11 * H22 - H12 * H12;
+    let want = [(C1 * H22 - H12 * C2) / det, (H11 * C2 - H12 * C1) / det];
+    for i in 0..2 {
+        assert!(
+            (d[i] - want[i]).abs() < 1e-6,
+            "release side d[{i}] = {} should be {}",
+            d[i],
+            want[i],
+        );
+    }
+    assert!(
+        d[2].abs() < 1e-8,
+        "the held row does not move, got {}",
+        d[2]
+    );
+    assert_eq!(held, vec![2], "only the third row is held");
+    assert_eq!(
+        work, 3,
+        "the all-released solve, one basis column, and the combined solve",
+    );
+}
+
+#[test]
+fn every_budget_retry_the_message_asks_for_buys_progress() {
+    // A caller raises degeneracy_iter to whatever the message names
+    // and calls again. On a decision that expands, the engaged count
+    // alone prices only a single pass, so the floor has to stay above
+    // what has already been spent or a retry asks for a budget the
+    // caller is already at. Walking the budgets here must produce a
+    // strictly increasing sequence that terminates.
+    let solver = solved(Rc::new(RefCell::new(ReentryQp)));
+    let mut budget = 1usize;
+    let mut asked = Vec::new();
+    let spent = loop {
+        assert!(
+            asked.len() < 16,
+            "the retry sequence did not terminate: {asked:?}",
+        );
+        match solver.parametric_step_directional(&[0], &[-1.0], budget) {
+            Ok((_, _, work)) => break work,
+            Err(pounce_sensitivity::SolverError::SensComputationFailed(msg)) => {
+                let need: usize = msg
+                    .split("Raise degeneracy_iter to at least ")
+                    .nth(1)
+                    .and_then(|t| t.split(';').next())
+                    .and_then(|t| t.trim().parse().ok())
+                    .unwrap_or_else(|| panic!("no number to raise to in: {msg}"));
+                assert!(
+                    need > budget,
+                    "budget {budget} was told to raise to {need}, which is not a raise: {msg}",
+                );
+                asked.push(need);
+                budget = need;
+            }
+            Err(other) => panic!("wrong error at budget {budget}: {other:?}"),
+        }
+    };
+    assert_eq!(
+        asked,
+        vec![4, 5, 6],
+        "the sequence a caller walks, each entry the previous call's answer",
+    );
+    assert_eq!(spent, 6, "the budget the last answer bought");
+}

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -389,7 +389,9 @@ The cost is gated by the condition, and budgeted by
 `degeneracy_iter` (default 16): the released solve, one further
 back-solve per engaged row, and one more to recover the direction all
 count against it, so the decision costs a handful of back-solves at a
-kink that engages a handful of bounds.
+kink that engages a handful of bounds. A decision whose engaged set
+grows pays that recovering solve once per pass, so a set reached in
+two passes costs one more than the same set reached in one.
 
 A direction that engages more rows than the budget covers falls back to
 the one-sided step with a warning. Only a budget of zero fails before
@@ -397,8 +399,10 @@ any work: which rows engage is not known until the released solve has
 run, so a budget too small to finish still pays that one factorization
 before reporting the shortfall. The warning names the engaged count and
 the number to raise `degeneracy_iter` to, which is the retry price and
-is a floor, since a later pass can engage more rows. `max_iter` keeps its meaning as the mode's own
-work and plays no part in the decision. Detection also returns
+is a floor, since a later pass can engage more rows. It is always
+strictly above what the failed call spent, so each retry buys progress.
+`max_iter` keeps its meaning as the mode's own work and plays no part
+in the decision. Detection also returns
 nothing on a solve with relaxed bounds, where the classifier cannot
 read the slacks.
 

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1543,7 +1543,7 @@ def _user_row_names(session):
     return [back.get(nm, nm) for nm in session.con_names]
 
 
-def estimate_report(model, perturb, max_iter=16,
+def estimate_report(model, perturb, max_iter=None,
                     degeneracy="directional", degeneracy_iter=16):
     """Report what `estimate()`'s linear step does about the bounds.
 
@@ -1551,8 +1551,14 @@ def estimate_report(model, perturb, max_iter=16,
     the same names, so the step measured here is the step `estimate()`
     takes for the same arguments, including the directional-derivative
     correction at a degenerate base point. degeneracy_iter budgets that
-    correction's back-solves. max_iter is accepted for signature
-    parity with `estimate()` and is unused here.
+    correction's back-solves.
+
+    max_iter is accepted for positional compatibility and does nothing.
+    It used to budget the directional decision here, so passing it -- in
+    particular `max_iter=0` to force the one-sided fallback -- changed
+    the reported step; `degeneracy_iter` is that knob now. Passing it
+    raises a DeprecationWarning rather than being ignored in silence,
+    since the two readings differ and nothing else would say so.
 
     Takes the same perturbation argument `estimate()` takes and returns
     an EstimateReport. Nothing about the estimate changes: this runs
@@ -1579,6 +1585,12 @@ def estimate_report(model, perturb, max_iter=16,
         raise ValueError(
             "estimate_report: degeneracy must be 'directional' or "
             f"'one_sided', got {degeneracy!r}")
+    if max_iter is not None:
+        warnings.warn(
+            "estimate_report: max_iter no longer does anything here and is "
+            "ignored; it used to budget the directional decision, which "
+            "degeneracy_iter budgets now. Pass degeneracy_iter instead.",
+            DeprecationWarning, stacklevel=2)
     pin_idx, deltas = _perturbation_deltas(session, perturb)
     if degeneracy == "directional":
         try:
@@ -1698,13 +1710,15 @@ def active_set_changes(model, perturb, max_iter=16,
     A list of length `max_iter` means the cap stopped the path before
     the target, the same condition `estimate()` warns about.
 
-    degeneracy matches `estimate()`'s argument of the same name. Under
-    "directional" (the default), a weakly active bound the perturbation
-    releases appears in the record as a departure at the fraction
-    where its multiplier reaches zero: essentially zero at an exact
-    kink, and partway along the step when the held solve sits inside
-    the ambiguous band, where the bound is genuinely active for the
-    first stretch.
+    degeneracy and degeneracy_iter match `estimate()`'s arguments of the
+    same names. Under "directional" (the default), a weakly active bound
+    the perturbation releases appears in the record as a departure at
+    the fraction where its multiplier reaches zero: essentially zero at
+    an exact kink, and partway along the step when the held solve sits
+    inside the ambiguous band, where the bound is genuinely active for
+    the first stretch. degeneracy_iter budgets that decision's
+    back-solves, and a budget it cannot fit falls back to the one-sided
+    record with a warning; max_iter, above, still caps the path itself.
     """
     reg = model.__dict__.get(_REG)
     session = reg.session if reg else None

--- a/pyomo-pounce/tests/test_estimate_report.py
+++ b/pyomo-pounce/tests/test_estimate_report.py
@@ -6,7 +6,8 @@ import pytest
 import pyomo.environ as pyo
 
 import pyomo_pounce  # noqa: F401  (registers 'pounce')
-from pyomo_pounce import declare_sens_param, estimate, estimate_report
+from pyomo_pounce import (active_set_changes, declare_sens_param, estimate,
+                          estimate_report)
 from pyomo_pounce.sens import _NO_BOUND, _ratio_test
 
 
@@ -666,3 +667,31 @@ def test_no_session_is_a_clean_error():
     m.obj = pyo.Objective(expr=(m.x - m.p) ** 2)
     with pytest.raises(RuntimeError, match="no sensitivity session"):
         estimate_report(m, [(m.p, 2.0)])
+
+
+def test_max_iter_here_warns_instead_of_being_ignored():
+    """`max_iter` used to budget the directional decision here, so
+    `max_iter=0` forced the one-sided fallback. `degeneracy_iter` is
+    that knob now and `max_iter` does nothing, which would silently
+    change what this returns for a caller who passed it."""
+    m = bounded()
+    with pytest.warns(DeprecationWarning, match="max_iter no longer"):
+        got = estimate_report(m, [(m.p, 4.0)], max_iter=0)
+    # and it really is ignored: the report is the one the same call
+    # without it produces, not the one-sided fallback max_iter=0 used
+    # to force
+    assert got.alpha == pytest.approx(estimate_report(m, [(m.p, 4.0)]).alpha)
+
+
+def test_the_other_two_surfaces_keep_max_iter_silent():
+    """`estimate` and `active_set_changes` still spend `max_iter` on
+    the mode's own work, so passing it there is not deprecated. Matched
+    on this deprecation's own text rather than on DeprecationWarning as
+    a class, so an unrelated one from pyomo or numpy cannot fail it."""
+    import warnings as _w
+    m = bounded()
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        estimate(m, [(m.p, 1.2)], max_iter=8)
+        active_set_changes(m, [(m.p, 1.2)], max_iter=8)
+    assert not [w for w in caught if "max_iter no longer" in str(w.message)]


### PR DESCRIPTION
Follow-up to #708, from the review of it. Two commits:

1. **`afcf741`** — a defect in the budget message that PR introduced, plus the fixture that exposes it, which also reaches the expansion loop's second pass, a path nothing in CI executed.
2. **`1187bf3`** — the three remaining review notes, none of which changed with the fix.

## Problem

`degeneracy_iter` is a budget a caller is expected to raise on the strength of what the error tells them. On a decision whose engaged set grows, the number it tells them can be one they are already at, so the retry buys nothing and the loop never terminates.

Walking the budgets on the fixture added here, against `e7eb84d`:

| `degeneracy_iter` | outcome | message says raise to |
|---|---|---|
| 1 | error, 2 of 3 engaged | 4 |
| 2 | error, 2 of 3 engaged | 4 |
| 3 | error, 2 of 3 engaged | 4 |
| 4 | error, 3 of 3 engaged | 5 |
| 5 | error, 3 of 3 engaged | **5** ← already there |
| 6 | success, 6 back-solves | — |

At 5 it reads `5 of 5 back-solve(s) spent … Raise degeneracy_iter to at least 5`. A caller following it mechanically never gets out; a human reads it as self-contradictory. This is the same class of problem as the original finding on this message (that it named `nw` and cost ~60 retries), just relocated into the replacement.

Separately, `estimate_report()`'s `max_iter` stopped doing anything when the decision moved to `degeneracy_iter`, but stayed in the signature and was ignored in silence. It used to budget the directional decision, so `estimate_report(..., max_iter=0)` forced the one-sided fallback — the same call now returns the directional step, with nothing saying so.

## Cause

`solver.rs` computed the floor as `engaged_now + 2`, which prices a decision that finishes in **one** pass: the all-released solve, one basis column per engaged row, one combined solve to recover the direction.

The combined solve is inside the expansion loop, so each pass pays one. #708's own top-level comment records this — the `ke + 1` to `ke + 2` change — but the floor formula was not carried along with it. Once the engaged set stops growing, `engaged_now` is fixed while `spent` keeps climbing, so the advice stalls at a number below what has already been consumed.

## Fix

```rust
let need = (engaged_now + 2).max(spent + 1);
```

The floor can never sit at or below what the failed call already spent. Retries become strictly increasing — `4 → 5 → 6 → done` above — so each one makes progress and the sequence terminates.

I kept `engaged_now + 2` as the leading term rather than replacing it with `spent + 1`. It is the better estimate when it is the larger one: at a low budget it jumps the caller most of the way in a single retry instead of walking them up one back-solve at a time, which is exactly what the original finding on this message was about.

Rejected: computing the true multi-pass total. It is not knowable at the point of failure — how many further passes the set needs is what the decision has not finished determining. `spent + 1` is the honest bound, and the message already says the figure is a floor.

For `estimate_report`, the argument keeps working positionally but its default is now a sentinel, and passing it raises a `DeprecationWarning` naming the knob that replaced it. Rejected: dropping it outright, which breaks positional callers for no gain, and leaving it silent, which is the reported defect.

## Blast radius

The retry floor is confined to the text of one recoverable error inside `parametric_step_directional`. No change to any computed direction, held set, or back-solve count: the closure builds a `SensComputationFailed` message and nothing reads the number programmatically. Callers hitting the budget still fall back to the one-sided step with a warning — the pyomo `except RuntimeError` path matches on the `"directional derivative"` prefix, untouched.

The deprecation is caller-visible but narrow: no call site anywhere in the repo, docs or notebooks passes `max_iter` to `estimate_report`, and there is no `filterwarnings = error` config, so no existing test changes behaviour. `estimate()` and `active_set_changes()` are untouched — `max_iter` is still the mode's own work there, and a test pins that they stay silent.

Not a trajectory change; `parametric_step_*` runs post-convergence, so no fixture sweep applies.

## Tests

**`crates/pounce-sensitivity/tests/degenerate_reentry.rs`** — new, four tests, ~10 ms.

`degenerate_expansion.rs` cannot reach this: with its uniform negative coupling, holding a weak row only raises the other rows' movement, so every engaged row enters on the first pass and the expansion loop never re-enters. #708 flagged that gap twice as CI-unreachable. This fixture closes it by choosing the coupling signs so one row does not engage until the other two are held:

```text
H = [[ 1.0, -1.2, -0.5],      c = [1.6, 1.4, 0.8]
     [-1.2,  5.0,  3.5],
     [-0.5,  3.5,  3.0]]      eig(H) = [0.186, 0.943, 7.87]
```

`H` is positive definite, so at `p = 0` the minimizer is the origin and all three variables sit on a lower bound with a vanishing multiplier — three weakly active bounds, as in `Ke3Qp`.

- **`every_budget_retry_the_message_asks_for_buys_progress`** — walks the retry loop as a caller would, parsing the number out of each message and calling again, asserting each answer strictly exceeds the budget it was given, and that the sequence is exactly `[4, 5, 6]`. **This is the one that bites.**
- **`a_row_that_engages_only_after_the_others_are_held_still_enters`** — `dp = -1`. Pass 1 engages `{0,1}` and holds them with `λ = [26/15, 7/15]`, moving row 3 to `-4/15`; row 3 then enters and pass 2 returns `λ = c`, direction exactly zero. `assert_eq!(work, 6)` is the evidence of re-entry: one pass over a final `ke = 3` costs `ke + 2 = 5`, which 6 cannot be.
- **`the_other_side_holds_one_row_and_releases_two`** — `dp = +1`, the partial-hold case, also previously unexecuted. Against the reduced system `H[1..2,1..2] dx = c[1..2]`, i.e. `[9.68/3.56, 3.32/3.56]`, matching to 1e-15. `work == 3`.
- **`all_three_bounds_are_weakly_active`** — the base-point precondition.

**`pyomo-pounce/tests/test_estimate_report.py`** — two added:

- **`test_max_iter_here_warns_instead_of_being_ignored`** — the argument warns, and is genuinely ignored rather than quietly changing the report.
- **`test_the_other_two_surfaces_keep_max_iter_silent`** — `estimate` and `active_set_changes` do not warn. Matched on this deprecation's own text rather than on `DeprecationWarning` as a class, so an unrelated one from pyomo or numpy cannot fail it.

**How I know they bite.** Reverting `.max(spent + 1)` fails `every_budget_retry_the_message_asks_for_buys_progress` on the `need > budget` assertion at budget 5, and it alone:

```
test every_budget_retry_the_message_asks_for_buys_progress ... FAILED
test result: FAILED. 3 passed; 1 failed
```

The other three pass either way, and that is correct rather than a weakness — they are re-entry and partial-hold coverage, independent of the message. They are regression evidence for #708's rewrite, not for this fix, and they are the reason the file is worth landing beyond the one line. The two Python tests fail on the parent commit by not raising, and by `estimate_report(..., max_iter=0)` returning a different report there.

Locally: 17 Rust targets in `pounce-sensitivity` green, and 79 pyomo tests across `test_estimate_report`, `test_degeneracy`, `test_path` and `test_fix_relax` green against a wheel built from this tree. Twelve failures elsewhere in the pyomo suite on this machine (`test_block_init_row_scale`, `test_scale_invariance`, `test_issue_591_…`, `test_infeasibility_…`) reproduce identically on the parent commit and are a stale `pounce` binary on the box's PATH, not this change — CI's own `wheel smoke (pyomo-pounce)` is green on the parent.

## Docs

`docs/src/sensitivity.md` described only the one-pass cost, so it under-stated the same thing the formula did. Two clauses: that a decision whose engaged set grows pays the recovering solve once per pass, and that the number in the warning is always strictly above what the failed call spent. This also rewraps the over-long line #708 left there.

`active_set_changes()`'s docstring gained `degeneracy_iter`, which it took as an argument in #708 without ever mentioning it — the knob was invisible to `help()` on one of the three surfaces the CHANGELOG names.

The `[Unreleased]` entry gets the blank line it was missing before the entry below it, and a paragraph on the `estimate_report` deprecation, which is the one caller-visible consequence of the `max_iter` / `degeneracy_iter` split. The retry floor itself gets no entry: that defect exists only between #708 and the next release, so no user can observe the old behaviour.

---

- [x] Tests fail on the parent commit for the stated reason — `every_budget_retry_the_message_asks_for_buys_progress` on `need > budget` at budget 5; the two Python tests by not raising
- [x] `CHANGELOG.md` `[Unreleased]` entry — for the deprecation; deliberately none for the retry floor, which never ships
- [x] Book page under `docs/src/` updated — `sensitivity.md`; no `SUMMARY.md` change, the page already exists
- [x] `cargo fmt --all -- --check`, `cargo clippy -p pounce-sensitivity --all-targets -- -D clippy::correctness -D clippy::suspicious`, `cargo test -p pounce-sensitivity` (17 targets) clean; pyomo sens suite green, see **Tests**
- [x] Every claim in this body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)