### PR TITLE
sens: one violation list per fix-relax pass, so max_iter stops picking the answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@ changes.
   discontinuity came from (a budget of 200 reached a release, wiped
   100+ pins and ended with 3).
 
+  The release batch backs off the way the pin batch does, and the
+  asymmetry is the point: a pin ADDS a condition, so an over-large batch
+  shows up as an augmented system that cannot be solved, while a release
+  REMOVES one — each bound taken out is stiffness no longer holding its
+  variable, and taking too many at once carries variables off bounds
+  they were sitting on with nothing left to pin them back, and no failed
+  solve anywhere to say so. On notebook 36's CSTR that was 56 releases
+  where 41 were right, and two of its four perturbations came back worse
+  than the unrefined step. A batch of more than one is now kept only
+  when the step it produces is no further outside the bounds than the
+  step in hand; otherwise the most negative multiplier goes alone and
+  the next pass re-measures the rest under it. A release also survives a
+  pin batch that cannot be solved, rather than being rolled back with
+  it: a release repairs the active set on its own terms.
+
+  A bound whose release the factorization refuses is barred rather than
+  retried — the same factorization was being asked for again on every
+  later pass — and the stop for it is `degrees_of_freedom`, which no
+  budget reaches, rather than the pass limit.
+
   `max_iter` is a safety limit now, and the refinement reports which of
   its stopping conditions fired. `Solver::parametric_step_bounded`,
   `parametric_step_bounded_decided` and their Python bindings return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ changes.
 
 ## [Unreleased]
 
+- **`mode="fix_relax"` pins every crossing in a pass, so `max_iter` no
+  longer picks the answer (gh#732).**
+
+  The refinement took the single worst violation per pass, so repairing
+  `k` crossings needed `k` passes and `max_iter` — documented as a cost
+  budget — was the loop's only termination condition on any model with
+  more crossings than passes. On the CSTR of notebook 36 the pin count
+  equalled the budget at 16, 30, 60 and 100; at 100 pins, half that
+  problem's degrees of freedom, the refined step came back with a
+  largest relative error of 7.16 against `mode="linear"`'s 0.83 — 8.6
+  times worse than not refining at all — and the error was not even
+  monotonic in the budget.
+
+  A pass now collects the whole violation list, both halves of
+  fix-relax together, constrains all of it and re-solves, which is
+  upstream's own structure: one `x_bound_violations_idx` per pass and
+  `while (bounds_violated)` as the termination condition. The loop ends
+  when the list empties.
+
+  A release keeps its re-factorization rather than becoming a Schur row
+  as upstream has it — that is the computation the `eps · sigma`
+  cancellation measured at 2e-4 off at `tol = 1e-10` is about — but it
+  no longer clears the pins: their right-hand sides are re-measured
+  against the re-solved base. Clearing them is where the budget table's
+  discontinuity came from (a budget of 200 reached a release, wiped
+  100+ pins and ended with 3).
+
+  `max_iter` is a safety limit now, and the refinement reports which of
+  its stopping conditions fired. `Solver::parametric_step_bounded`,
+  `parametric_step_bounded_decided` and their Python bindings return
+  `(dx, pinned, stop)`, where `stop` is `"settled"`,
+  `"iteration_limit"`, `"degrees_of_freedom"` or `"worse_than_plain"`.
+  `estimate()` names it in the warning instead of inferring the reason
+  from the pin count, which a batched pass makes meaningless.
+
+  Two guards independent of the loop shape, both suggested on the
+  issue. A pass is refused when its correction is out of scale with the
+  step it corrects, not only when a pinned row misses its target: the
+  hundred pins above each landed within `1e-3` of where they were asked
+  to go, because achieving the pinned coordinates says nothing about
+  what the correction did to the other 1300. And the unrefined step is
+  returned when the refinement ends further outside the bounds than it
+  started, which is free — `dx_plain` is already in scope.
+
+  Also fixed on the way: the refinement's augmented solves routed an
+  empty released set through `solve_released`, which a backsolver
+  without release support answers `false` to, so such a backsolver
+  could not pin at all.
+
 - **`degeneracy="directional"` decides through the active-set QP engine,
   budgeted by its own `degeneracy_iter`.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,10 @@ changes.
   step in hand; otherwise the most negative multiplier goes alone and
   the next pass re-measures the rest under it. A release also survives a
   pin batch that cannot be solved, rather than being rolled back with
-  it: a release repairs the active set on its own terms.
+  it: a release repairs the active set on its own terms. That is two
+  separable things — the released set itself, and the step it produced
+  — and a pass that rolls back only the first recovers the released
+  bounds while still answering with the unrefined step.
 
   A bound whose release the factorization refuses is barred rather than
   retried — the same factorization was being asked for again on every

--- a/crates/pounce-cli/src/sens.rs
+++ b/crates/pounce-cli/src/sens.rs
@@ -476,13 +476,31 @@ fn try_compute_sens_step(
             eps,
             16,
         ) {
-            Ok((refined, pinned)) => {
-                if !pinned.is_empty() {
+            Ok((refined, rows, stop)) => {
+                if !rows.is_empty() {
                     eprintln!(
                         "pounce: --sens-boundcheck pinned or released {} bound(s) \
                          and re-solved",
-                        pinned.len()
+                        rows.len()
                     );
+                }
+                // A safety limit that fired, or a refinement that gave
+                // up, is the caller's business: the step returned is
+                // not the one the refinement was asked for.
+                match stop {
+                    pounce_sensitivity::boundcheck::RefineStop::Settled => {}
+                    pounce_sensitivity::boundcheck::RefineStop::IterationLimit => eprintln!(
+                        "pounce: --sens-boundcheck stopped at its pass limit with \
+                         bounds still violated"
+                    ),
+                    pounce_sensitivity::boundcheck::RefineStop::DegreesOfFreedom => eprintln!(
+                        "pounce: --sens-boundcheck could not hold every bound at \
+                         once; the problem's degrees of freedom are spent"
+                    ),
+                    pounce_sensitivity::boundcheck::RefineStop::WorseThanPlain => eprintln!(
+                        "pounce: --sens-boundcheck ended further outside the bounds \
+                         than the unrefined step, which was returned instead"
+                    ),
                 }
                 dx_full = refined;
             }

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -253,7 +253,7 @@ impl PySolver {
     }
 
     /// Parametric step with the bounds respected by pinning rather than
-    /// clamping, as `(dx, pinned)`.
+    /// clamping, as `(dx, pinned, stop)`.
     ///
     /// `parametric_step` points where the linear predictor points,
     /// which can be outside the box. Clamping a coordinate back to its
@@ -280,18 +280,34 @@ impl PySolver {
     /// already respects every bound, and the step is then the plain
     /// one.
     ///
-    /// `max_iter` is a budget rather than a safeguard: the
-    /// refinement is only worth running while it stays cheaper than a
-    /// re-solve. The factorization is never rebuilt, but the Schur
-    /// complement is rebuilt each pass, so pass `k` costs one dense
-    /// `k × k` solve and `k + 1` back-solves and the total grows
-    /// quadratically. The default of 16 is 136 back-solves. What counts
-    /// as outside a bound comes from the solve's own
-    /// `bound_relax_factor` rather than from an argument. Passes stop
-    /// when nothing is outside by that much, at `max_iter`, or when
-    /// the conditions exhaust the problem's degrees of freedom, which
-    /// makes the augmented system singular. None is an error, and
-    /// `pinned` says how far the refinement got.
+    /// A pass takes every crossing it can see, pins them together and
+    /// re-solves, so the number of passes tracks how far the active set
+    /// has to move rather than how many bounds it moves. The
+    /// factorization is never rebuilt for a pin, but the Schur
+    /// complement is, so a pass carrying `k` pins costs one dense
+    /// `k × k` solve and `k + 1` back-solves. What counts as outside a
+    /// bound comes from the solve's own `bound_relax_factor` rather
+    /// than from an argument.
+    ///
+    /// `max_iter` is a safety limit rather than a budget. It was a
+    /// budget while a pass took one pin, which needed as many passes as
+    /// there were crossings, and on a model with more crossings than
+    /// passes the limit picked the answer (gh#732).
+    ///
+    /// `stop` says why the refinement stopped, and is one of:
+    ///
+    /// * `"settled"` — nothing is outside a bound and no multiplier is
+    ///   negative. Only this one says it finished.
+    /// * `"iteration_limit"` — `max_iter` passes were spent with
+    ///   violations left. Raising it may finish the job.
+    /// * `"degrees_of_freedom"` — the conditions exhausted the
+    ///   problem's degrees of freedom, so no step holds every bound at
+    ///   once. No budget helps.
+    /// * `"worse_than_plain"` — the refinement ended further outside
+    ///   the bounds than the unrefined step, which was returned instead
+    ///   with an empty `pinned`.
+    ///
+    /// None is an error, and `pinned` says how far the refinement got.
     #[pyo3(signature = (pin_constraint_indices, deltas, max_iter=16))]
     fn parametric_step_bounded<'py>(
         &self,
@@ -299,7 +315,7 @@ impl PySolver {
         pin_constraint_indices: Vec<i64>,
         deltas: Vec<Number>,
         max_iter: usize,
-    ) -> PyResult<(Bound<'py, PyArray1<Number>>, Vec<i64>)> {
+    ) -> PyResult<(Bound<'py, PyArray1<Number>>, Vec<i64>, &'static str)> {
         let s = self.state.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err(
                 "parametric_step_bounded: no converged factor (call solve() first)",
@@ -313,13 +329,14 @@ impl PySolver {
                 pins.len(),
             )));
         }
-        let (dx, pinned) = s
+        let (dx, pinned, stop) = s
             .inner
             .parametric_step_bounded(&pins, &deltas, max_iter)
             .map_err(solver_error_to_py)?;
         Ok((
             dx.into_pyarray_bound(py),
             pinned.into_iter().map(|p| p as i64).collect(),
+            stop.as_str(),
         ))
     }
 
@@ -397,8 +414,8 @@ impl PySolver {
 
     /// `parametric_step_bounded` with the weak-row decision
     /// supplied by the caller (var-x rows the direction holds) instead
-    /// of searched for. Study surface for an externally solved eq. 14
-    /// QP.
+    /// of searched for, as `(dx, pinned, stop)`. Study surface for an
+    /// externally solved eq. 14 QP.
     #[pyo3(signature = (pin_constraint_indices, deltas, held_var_rows, max_iter=16))]
     fn parametric_step_bounded_decided<'py>(
         &self,
@@ -407,7 +424,7 @@ impl PySolver {
         deltas: Vec<Number>,
         held_var_rows: Vec<i64>,
         max_iter: usize,
-    ) -> PyResult<(Bound<'py, PyArray1<Number>>, Vec<i64>)> {
+    ) -> PyResult<(Bound<'py, PyArray1<Number>>, Vec<i64>, &'static str)> {
         let s = self.state.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err(
                 "parametric_step_bounded_decided: no converged factor (call solve() first)",
@@ -432,13 +449,14 @@ impl PySolver {
             .block_dims()
             .ok_or_else(|| PyRuntimeError::new_err("no converged factor (call solve() first)"))?[0];
         let held: Vec<Index> = validate_var_rows(&held_var_rows, n_x)?;
-        let (dx, pinned) = s
+        let (dx, pinned, stop) = s
             .inner
             .parametric_step_bounded_decided(&pins, &deltas, max_iter, &held)
             .map_err(solver_error_to_py)?;
         Ok((
             dx.into_pyarray_bound(py),
             pinned.into_iter().map(|p| p as i64).collect(),
+            stop.as_str(),
         ))
     }
 

--- a/crates/pounce-sensitivity/src/boundcheck.rs
+++ b/crates/pounce-sensitivity/src/boundcheck.rs
@@ -345,6 +345,161 @@ mod tests {
         );
         assert_eq!(dx, dx_plain.to_vec());
     }
+
+    /// A backsolver whose release half is scripted: the plain solves go
+    /// through a `DenseLuBacksolver`, `solve_released_step` answers
+    /// from `steps` keyed by how many rows are released — a missing
+    /// entry is a factorization that failed — and every call to it is
+    /// counted.
+    #[derive(Clone)]
+    struct ScriptedRelease {
+        base: crate::backsolver::DenseLuBacksolver,
+        rows: Vec<crate::backsolver::BoundRow>,
+        steps: std::collections::BTreeMap<usize, Vec<Number>>,
+        calls: Rc<std::cell::Cell<usize>>,
+    }
+
+    impl crate::backsolver::SensBacksolver for ScriptedRelease {
+        fn dim(&self) -> usize {
+            self.base.dim()
+        }
+        fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
+            self.base.solve(rhs, lhs)
+        }
+        fn bound_rows(&self) -> Option<&[crate::backsolver::BoundRow]> {
+            Some(&self.rows)
+        }
+        fn supports_release(&self) -> bool {
+            true
+        }
+        fn solve_released(&self, _released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
+            self.base.solve(rhs, lhs)
+        }
+        fn solve_released_step(
+            &self,
+            released: &[usize],
+            _rhs: &[Number],
+            lhs: &mut [Number],
+        ) -> bool {
+            self.calls.set(self.calls.get() + 1);
+            match self.steps.get(&released.len()) {
+                Some(s) => {
+                    lhs.copy_from_slice(s);
+                    true
+                }
+                None => false,
+            }
+        }
+    }
+
+    /// `n × n` identity with `lever` at `(1, 0)`, so solving `K y = e0`
+    /// gives `y = (1, -lever, 0, …)`: pinning row 0 drags row 1.
+    fn lever_matrix(n: usize, lever: Number) -> Vec<Number> {
+        let mut a = vec![0.0; n * n];
+        for i in 0..n {
+            a[i * n + i] = 1.0;
+        }
+        a[n] = lever;
+        a
+    }
+
+    #[test]
+    fn a_release_batch_that_makes_the_step_worse_backs_off_to_one() {
+        // Two multipliers are negative. Releasing both takes x0 five
+        // below its lower bound; releasing the most negative one alone
+        // settles. The batch has to earn its place the way the pin
+        // batch does — without that, the CSTR of notebook 36 released
+        // 56 bounds where 41 were right and the step came back worse
+        // than not refining at all (gh#734 review).
+        let calls = Rc::new(std::cell::Cell::new(0));
+        let bs = ScriptedRelease {
+            base: crate::backsolver::DenseLuBacksolver::from_dense(4, &lever_matrix(4, 0.0))
+                .expect("nonsingular"),
+            rows: vec![
+                crate::backsolver::BoundRow {
+                    row: 2,
+                    var_row: 0,
+                    lower: true,
+                },
+                crate::backsolver::BoundRow {
+                    row: 3,
+                    var_row: 1,
+                    lower: true,
+                },
+            ],
+            steps: [
+                (2usize, vec![-5.0, 0.0, 0.0, 0.0]),
+                (1usize, vec![0.0, 0.0, 0.0, 0.0]),
+            ]
+            .into_iter()
+            .collect(),
+            calls: Rc::clone(&calls),
+        };
+        let mults = [
+            BoundMultiplier { row: 2, base: 1.0 },
+            BoundMultiplier { row: 3, base: 1.0 },
+        ];
+        // z2 = 1 - 2 = -1 and z3 = 1 - 1.5 = -0.5, so both want out
+        let (dx, rows, stop) = refine_step_onto_bounds(
+            &bs,
+            &[0.0, 0.0, -2.0, -1.5],
+            &[0.0, 0.0],
+            &[0.0, 0.0],
+            &[Number::INFINITY, Number::INFINITY],
+            &mults,
+            &[0.0; 4],
+            1e-9,
+            8,
+        )
+        .expect("refinement");
+        assert_eq!(rows, vec![2], "the most negative one, alone");
+        assert_eq!(stop, RefineStop::Settled);
+        assert_eq!(dx, vec![0.0, 0.0, -1.0, 0.0], "and its multiplier is zero");
+    }
+
+    #[test]
+    fn a_release_the_factorization_refuses_is_not_asked_for_twice() {
+        // The one negative multiplier cannot be released at all. The
+        // pins carry on without it, and the loop neither asks for that
+        // factorization again on every later pass nor reports the pass
+        // limit for something no budget reaches.
+        let calls = Rc::new(std::cell::Cell::new(0));
+        let bs = ScriptedRelease {
+            base: crate::backsolver::DenseLuBacksolver::from_dense(4, &lever_matrix(4, 1.0))
+                .expect("nonsingular"),
+            rows: vec![crate::backsolver::BoundRow {
+                row: 2,
+                var_row: 0,
+                lower: true,
+            }],
+            // no entry for any size: every released factorization fails
+            steps: std::collections::BTreeMap::new(),
+            calls: Rc::clone(&calls),
+        };
+        let mults = [BoundMultiplier { row: 2, base: 1.0 }];
+        // x0 is 1.0 below its bound and z2 = 1 - 2 = -1 wants out.
+        // Pinning x0 drags x1 to -1, under ITS bound of -0.5, so a
+        // second pass follows and would ask for the release again.
+        let (_dx, rows, stop) = refine_step_onto_bounds(
+            &bs,
+            &[-1.0, 0.0, -2.0, 0.0],
+            &[0.0, 0.0],
+            &[0.0, -0.5],
+            &[Number::INFINITY, Number::INFINITY],
+            &mults,
+            &[0.0; 4],
+            1e-9,
+            8,
+        )
+        .expect("refinement");
+        assert_eq!(calls.get(), 1, "asked for once, then barred");
+        assert_eq!(
+            stop,
+            RefineStop::DegreesOfFreedom,
+            "a bound that cannot leave the active set is not the pass limit",
+        );
+        assert_eq!(rows, vec![0, 1], "and the pins it could place still stand");
+    }
 }
 
 /// A bound multiplier the step can drive negative: where it sits in the
@@ -471,7 +626,21 @@ const WORSE_THAN_PLAIN_FACTOR: Number = 10.0;
 /// gh#732 fixes about a release is that the pins now survive it: their
 /// right-hand sides are re-measured against the re-solved base instead
 /// of the pin set being cleared, which is where that issue's budget
-/// table got its discontinuity.
+/// table got its discontinuity. A pin batch that cannot be solved
+/// leaves the releases of its own pass standing for the same reason —
+/// a release repairs the active set on its own terms.
+///
+/// The release batch backs off the way the pin batch does, and for a
+/// sharper reason. A pin adds a condition, so an over-large batch shows
+/// up as an augmented system that cannot be solved. A release REMOVES
+/// one: every bound taken out is stiffness that is no longer holding
+/// its variable, and a batch that takes too many carries variables off
+/// bounds they were sitting on, with nothing left to pin them back.
+/// That has no failed solve to report it — on notebook 36's CSTR it was
+/// 56 releases where 41 were right, and the step came back worse than
+/// not refining at all. So a batch of more than one is kept only when
+/// the step it produces is no further outside the bounds than the one
+/// in hand.
 ///
 /// `multipliers` carry their base values in the solve's own
 /// coordinates. They are converted here, once, with the backsolver's
@@ -533,15 +702,23 @@ where
     let bound_rows = backsolver.bound_rows();
     let can_release = backsolver.supports_release() && rhs_plain.len() == n_full;
 
+    // How far outside its bounds the worst coordinate of a step sits.
+    let worst_over = |d: &[Number]| {
+        bound_violations(x_curr, d, lo, hi, eps, &[])
+            .first()
+            .map_or(0.0, |&(_, _, over)| over)
+    };
+
     // Which multiplier rows the step drives negative, most negative
-    // first, ignoring any already out of the active set.
-    let releasable = |dx: &[Number], released: &[usize]| -> Vec<usize> {
+    // first, ignoring any already out of the active set and any the
+    // factorization has already refused to release.
+    let releasable = |dx: &[Number], released: &[usize], refused: &[usize]| -> Vec<usize> {
         if !can_release {
             return Vec::new();
         }
         let mut v: Vec<(usize, Number)> = multipliers
             .iter()
-            .filter(|m| !released.contains(&m.row))
+            .filter(|m| !released.contains(&m.row) && !refused.contains(&m.row))
             .filter(|m| bound_rows.is_some_and(|br| br.iter().any(|b| b.row == m.row)))
             .map(|m| (m.row, m.base + dx[m.row]))
             .filter(|&(_, v)| v < -eps)
@@ -619,6 +796,26 @@ where
         ))
     };
 
+    // The base step with `set` added to the released bounds, or `None`
+    // when the released system cannot be factored.
+    let apply_releases = |released: &[usize], set: &[usize]| -> Option<(Vec<usize>, Vec<Number>)> {
+        let mut trial = released.to_vec();
+        trial.extend_from_slice(set);
+        let mut base = vec![0.0; n_full];
+        if !backsolver.solve_released_step(&trial, rhs_plain, &mut base) {
+            return None;
+        }
+        // A released bound's multiplier is zero by construction; its
+        // own row of the re-solved step is a by-product of the
+        // complementarity row the factor still carries.
+        for &r in &trial {
+            if let Some(m) = multipliers.iter().find(|m| m.row == r) {
+                base[r] = -m.base;
+            }
+        }
+        Some((trial, base))
+    };
+
     // (var-x row, the bound it is held at). The right-hand side is
     // re-derived from the base step each pass rather than stored, so a
     // release moves the pins with it instead of clearing them.
@@ -631,50 +828,98 @@ where
     // The step corrections are measured from. It moves whenever the
     // released set does, since that is a different system.
     let mut dx_base = dx_plain.to_vec();
+    // Bounds whose release the factorization would not deliver. Barred
+    // rather than retried: the same factorization would be asked for
+    // again every pass until the limit, and the limit is not what
+    // stopped it.
+    let mut refused_releases: Vec<usize> = Vec::new();
     let mut stop = RefineStop::IterationLimit;
 
     for _ in 0..max_iter {
         let taken: Vec<usize> = pins.iter().map(|&(r, _)| r).collect();
         let fresh_pins = bound_violations(x_curr, &dx, lo, hi, eps, &taken);
-        let fresh_releases = releasable(&dx, &released);
+        let fresh_releases = releasable(&dx, &released, &refused_releases);
         if fresh_pins.is_empty() && fresh_releases.is_empty() {
-            stop = RefineStop::Settled;
+            // A bound whose release was refused is still one the step
+            // wants out of the active set. The loop has nothing left to
+            // try for it, which is not the same as having settled.
+            stop = if releasable(&dx, &released, &[]).is_empty() {
+                RefineStop::Settled
+            } else {
+                RefineStop::DegreesOfFreedom
+            };
             break;
         }
-
-        // What this pass can undo, so a pass that cannot be solved
-        // leaves the last one that could. `dx_base` is not among them:
-        // a pass that fails also ends the loop, and nothing reads the
-        // base after that.
-        let keep = (dx.clone(), pins.clone(), released.clone());
 
         if !fresh_releases.is_empty() {
             // A release is not a condition on the step, it is a
             // different system: re-solve with those bounds' `sigma`
             // gone, and measure the pins from the step that produces.
-            let mut trial = released.clone();
-            trial.extend_from_slice(&fresh_releases);
-            let mut base = vec![0.0; n_full];
-            if backsolver.solve_released_step(&trial, rhs_plain, &mut base) {
-                // A released bound's multiplier is zero by
-                // construction; its own row of the re-solved step is a
-                // by-product of the complementarity row the factor
-                // still carries.
-                for &r in &trial {
-                    if let Some(m) = multipliers.iter().find(|m| m.row == r) {
-                        base[r] = -m.base;
+            //
+            // The batch backs off the way the pin batch below does.
+            // Taking every negative multiplier at once can release more
+            // stiffness than the step wanted: on notebook 36's CSTR, 56
+            // releases where 41 were right carried five `v1` intervals
+            // off the bound they had been sitting on, with no degrees
+            // of freedom left to pin them back (gh#734 review). So the
+            // batch is kept only when the step it produces is no
+            // further outside the bounds than the one in hand, and
+            // otherwise the most negative multiplier goes alone and the
+            // next pass re-measures the rest under it.
+            let before = worst_over(&dx);
+            let mut sets: Vec<&[usize]> = vec![&fresh_releases[..]];
+            if fresh_releases.len() > 1 {
+                sets.push(&fresh_releases[..1]);
+            }
+            let mut taken: Option<(Vec<usize>, Vec<Number>, Vec<Number>)> = None;
+            for (k, set) in sets.iter().enumerate() {
+                let Some((trial, base)) = apply_releases(&released, set) else {
+                    continue;
+                };
+                let Some(step) = solve_pins(&pins, &trial, &base)? else {
+                    continue;
+                };
+                // A single release is the smallest step the loop can
+                // take toward a bound that has to leave the active set,
+                // so it is taken whether or not it helps: refusing it
+                // would leave a negative multiplier with nothing left
+                // to do about it. The guard at the end still has the
+                // last word on what comes back.
+                let alone = k + 1 == sets.len();
+                if alone || worst_over(&step) <= before.max(eps) {
+                    taken = Some((trial, base, step));
+                    break;
+                }
+            }
+            match taken {
+                Some((trial, base, step)) => {
+                    released = trial;
+                    dx_base = base;
+                    dx = step;
+                }
+                None => {
+                    // The released system could not be factored, or
+                    // could not carry the pins already placed.
+                    refused_releases.extend_from_slice(&fresh_releases);
+                    if fresh_pins.is_empty() {
+                        stop = RefineStop::DegreesOfFreedom;
+                        break;
                     }
                 }
-                released = trial;
-                dx_base = base;
-            } else if fresh_pins.is_empty() {
-                // Could not factor with those bounds out, and there is
-                // nothing else this pass could do.
-                stop = RefineStop::DegreesOfFreedom;
-                break;
+            }
+            if fresh_pins.is_empty() {
+                // The release phase already produced this pass's step.
+                continue;
             }
         }
 
+        // What the pin batch can undo. The releases above are not among
+        // them: a release repairs the active set on its own terms, and
+        // rolling one back because the pins that came with it did not
+        // fit discards a repair the step needed and returns the plain
+        // one instead.
+        let keep_pins = pins.clone();
+        let keep_dx = dx.clone();
         pins.extend(fresh_pins.iter().map(|&(i, bound, _)| (i, bound)));
         let mut next = solve_pins(&pins, &released, &dx_base)?;
         if next.is_none() && fresh_pins.len() > 1 {
@@ -682,17 +927,15 @@ where
             // freedom hold. Keep the worst of the new crossings and let
             // the next pass re-measure the rest under it, which is what
             // the one-at-a-time loop would have done.
-            pins.truncate(keep.1.len());
+            pins.truncate(keep_pins.len());
             pins.push((fresh_pins[0].0, fresh_pins[0].1));
             next = solve_pins(&pins, &released, &dx_base)?;
         }
         match next {
             Some(step) => dx = step,
             None => {
-                let (d, p, r) = keep;
-                dx = d;
-                pins = p;
-                released = r;
+                pins = keep_pins;
+                dx = keep_dx;
                 stop = RefineStop::DegreesOfFreedom;
                 break;
             }
@@ -700,25 +943,23 @@ where
     }
 
     // The loop can also run out of passes on the one that settled it,
-    // which is not the limit firing.
+    // which is not the limit firing. And what is left can be a bound
+    // the factorization refused to release, which no budget reaches.
     if stop == RefineStop::IterationLimit {
         let taken: Vec<usize> = pins.iter().map(|&(r, _)| r).collect();
-        if bound_violations(x_curr, &dx, lo, hi, eps, &taken).is_empty()
-            && releasable(&dx, &released).is_empty()
-        {
+        let pins_left = !bound_violations(x_curr, &dx, lo, hi, eps, &taken).is_empty();
+        let rel_left = releasable(&dx, &released, &[]);
+        if !pins_left && rel_left.is_empty() {
             stop = RefineStop::Settled;
+        } else if !pins_left && rel_left.iter().all(|r| refused_releases.contains(r)) {
+            stop = RefineStop::DegreesOfFreedom;
         }
     }
 
     // Whatever stopped it, a refinement that ends further outside the
     // bounds than the step it started from has failed on its own terms.
-    let worst = |d: &[Number]| {
-        bound_violations(x_curr, d, lo, hi, eps, &[])
-            .first()
-            .map_or(0.0, |&(_, _, over)| over)
-    };
-    let plain_worst = worst(dx_plain);
-    if worst(&dx) > WORSE_THAN_PLAIN_FACTOR * plain_worst.max(eps) {
+    let plain_worst = worst_over(dx_plain);
+    if worst_over(&dx) > WORSE_THAN_PLAIN_FACTOR * plain_worst.max(eps) {
         return Ok((dx_plain.to_vec(), Vec::new(), RefineStop::WorseThanPlain));
     }
 

--- a/crates/pounce-sensitivity/src/boundcheck.rs
+++ b/crates/pounce-sensitivity/src/boundcheck.rs
@@ -72,27 +72,34 @@ pub fn expand_bounds(
     (lo, hi)
 }
 
-/// The coordinate whose predicted value leaves its bound by the most,
-/// as `(index, the bound it leaves)`.
+/// Every coordinate whose predicted value leaves its bound, as
+/// `(index, the bound it leaves, how far past it)`, worst first.
 ///
 /// This is the half of the bound check that fix-relax keeps. The clamp
 /// above answers "put it back", which loses the other coordinates; the
-/// refinement needs "which one, and where does it belong", and then
-/// re-solves with that coordinate pinned so the rest respond.
+/// refinement needs "which ones, and where do they belong", and then
+/// re-solves with those coordinates pinned so the rest respond.
 ///
-/// The worst violator is chosen rather than the first by index, so the
-/// order of the pins does not depend on how the model was written.
+/// Upstream's `BoundCheck` collects the whole list in one sweep and
+/// its caller pins all of it before re-solving, which is what makes
+/// the loop terminate on its own rather than on a pass budget: pinning
+/// the single worst one per pass needs as many passes as there are
+/// crossings, so on a model with more crossings than passes the budget
+/// decides the answer (gh#732).
+///
+/// The list is ordered by overshoot rather than by index so the pins do
+/// not depend on how the model was written, and ties keep index order.
 /// `skip` names coordinates already pinned by an earlier pass, which
 /// sit ON their bound and would otherwise be picked again.
-pub fn worst_violation(
+pub fn bound_violations(
     x_curr: &[Number],
     dx: &[Number],
     lo: &[Number],
     hi: &[Number],
     eps: Number,
     skip: &[usize],
-) -> Option<(usize, Number)> {
-    let mut worst: Option<(usize, Number, Number)> = None;
+) -> Vec<(usize, Number, Number)> {
+    let mut out: Vec<(usize, Number, Number)> = Vec::new();
     for i in 0..x_curr.len().min(dx.len()) {
         if skip.contains(&i) {
             continue;
@@ -105,11 +112,29 @@ pub fn worst_violation(
         } else {
             continue;
         };
-        if over > eps && worst.is_none_or(|(_, _, w)| over > w) {
-            worst = Some((i, bound, over));
+        if over > eps {
+            out.push((i, bound, over));
         }
     }
-    worst.map(|(i, bound, _)| (i, bound))
+    // stable, so equal overshoots keep index order
+    out.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+    out
+}
+
+/// The coordinate whose predicted value leaves its bound by the most,
+/// as `(index, the bound it leaves)`. The head of
+/// [`bound_violations`].
+pub fn worst_violation(
+    x_curr: &[Number],
+    dx: &[Number],
+    lo: &[Number],
+    hi: &[Number],
+    eps: Number,
+    skip: &[usize],
+) -> Option<(usize, Number)> {
+    bound_violations(x_curr, dx, lo, hi, eps, skip)
+        .first()
+        .map(|&(i, bound, _)| (i, bound))
 }
 
 /// Extract dense values from a `dyn Vector` that wraps a `DenseVector`.
@@ -232,6 +257,94 @@ mod tests {
         // just outside, but under the tolerance
         assert!(worst_violation(&x, &[0.5 + 1e-12], &[0.0], &[1.0], 1e-9, &[]).is_none());
     }
+
+    #[test]
+    fn bound_violations_returns_every_crossing_worst_first() {
+        let x = [0.5, 0.5, 0.5, 0.5];
+        let dx = [-0.6, -2.0, -0.7, 0.1];
+        let lo = [0.0; 4];
+        let hi = [10.0; 4];
+        let v = bound_violations(&x, &dx, &lo, &hi, 1e-9, &[]);
+        // x3 stays inside; the other three are out by 0.1, 1.5 and 0.2
+        assert_eq!(
+            v.iter().map(|&(i, _, _)| i).collect::<Vec<_>>(),
+            vec![1, 2, 0],
+            "the whole list, ordered by overshoot",
+        );
+        assert_eq!(v[0].1, 0.0, "and each carries the bound it left");
+    }
+
+    #[test]
+    fn bound_violations_leaves_out_what_is_already_pinned() {
+        let x = [0.5, 0.5];
+        let dx = [-0.6, -2.0];
+        let v = bound_violations(&x, &dx, &[0.0, 0.0], &[10.0, 10.0], 1e-9, &[1]);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].0, 0, "the pinned coordinate is not offered again");
+    }
+
+    /// `K` for a two-row system where holding row 0 drags row 1 by
+    /// `lever`: solving `K y = e0` gives `y = (1, -lever)`.
+    fn lever_backsolver(lever: Number) -> crate::backsolver::DenseLuBacksolver {
+        crate::backsolver::DenseLuBacksolver::from_dense(2, &[1.0, 0.0, lever, 1.0])
+            .expect("nonsingular")
+    }
+
+    #[test]
+    fn a_refinement_that_ends_further_out_returns_the_unrefined_step() {
+        // Row 0 is 0.1 below its bound, and the pin that repairs it
+        // throws row 1 a thousand times further out than that. The pass
+        // limit stops the loop before it can pin row 1 as well, so what
+        // it has to return is worse than what it started from —
+        // gh#732's "return the unrefined step" guard, which the pin's
+        // own achievement check cannot see, since row 0 lands exactly
+        // where it was asked to.
+        let bs = lever_backsolver(1000.0);
+        let dx_plain = [-0.1, 0.0];
+        let (dx, rows, stop) = refine_step_onto_bounds(
+            &bs,
+            &dx_plain,
+            &[0.0, 0.0],
+            &[0.0, -1e-3],
+            &[Number::INFINITY, 1e-3],
+            &[],
+            &[0.0, 0.0],
+            1e-9,
+            1,
+        )
+        .expect("refinement");
+        assert_eq!(stop, RefineStop::WorseThanPlain);
+        assert!(rows.is_empty(), "nothing is reported as constrained");
+        assert_eq!(dx, dx_plain.to_vec(), "the unrefined step comes back");
+    }
+
+    #[test]
+    fn a_pass_whose_correction_is_out_of_scale_is_refused() {
+        // The same shape with the lever at 1e10: the pin is achieved to
+        // the last digit and the correction is 1e9 times the step it
+        // corrects, which is a near-singular solve rather than a
+        // repair. A check that reads only the pinned row accepts it.
+        let bs = lever_backsolver(1e10);
+        let dx_plain = [-0.1, 0.0];
+        let (dx, rows, stop) = refine_step_onto_bounds(
+            &bs,
+            &dx_plain,
+            &[0.0, 0.0],
+            &[0.0, Number::NEG_INFINITY],
+            &[Number::INFINITY, Number::INFINITY],
+            &[],
+            &[0.0, 0.0],
+            1e-9,
+            8,
+        )
+        .expect("refinement");
+        assert_eq!(stop, RefineStop::DegreesOfFreedom);
+        assert!(
+            rows.is_empty(),
+            "the pass was refused, so nothing is pinned"
+        );
+        assert_eq!(dx, dx_plain.to_vec());
+    }
 }
 
 /// A bound multiplier the step can drive negative: where it sits in the
@@ -250,10 +363,62 @@ pub struct BoundMultiplier {
     pub base: Number,
 }
 
+/// Why [`refine_step_onto_bounds`] stopped.
+///
+/// Only [`RefineStop::Settled`] says the refinement finished: the
+/// violation list emptied, which is the loop's own termination
+/// condition. Every other value says the step returned is the last one
+/// a pass could achieve, and names what stopped it, so a caller can
+/// tell a limit it may raise from one it cannot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefineStop {
+    /// Nothing is outside a bound and no bound multiplier is negative.
+    Settled,
+    /// `max_iter` passes were spent with the list still not empty. A
+    /// safety limit rather than a budget: a pass now takes every
+    /// violation it can see, so reaching this means the conditions kept
+    /// moving and the answer is whatever the last pass reached.
+    IterationLimit,
+    /// A pass could not be solved or could not be achieved: the
+    /// conditions have exhausted the problem's degrees of freedom, and
+    /// no step holds them all. No budget helps.
+    DegreesOfFreedom,
+    /// The refinement ended further outside the bounds than the step it
+    /// started from, so the unrefined step was returned and no rows are
+    /// reported as constrained.
+    WorseThanPlain,
+}
+
+impl RefineStop {
+    /// A stable short name, for a caller reporting this across a
+    /// language boundary.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RefineStop::Settled => "settled",
+            RefineStop::IterationLimit => "iteration_limit",
+            RefineStop::DegreesOfFreedom => "degrees_of_freedom",
+            RefineStop::WorseThanPlain => "worse_than_plain",
+        }
+    }
+}
+
+/// How far a pass's correction may exceed the step it corrects before
+/// the pass is refused. The singular case a dense LU does not report
+/// comes back around `1e15`, so this only has to sit above the
+/// leverage a real pin can have — moving one coordinate onto its bound
+/// can legitimately move another by orders of magnitude more.
+const CORRECTION_SCALE_LIMIT: Number = 1e4;
+
+/// How much further outside the bounds the refinement may end than the
+/// step it started from before the unrefined step is returned instead.
+/// A refinement that leaves a coordinate this much further out has not
+/// repaired an active set, whatever it achieved on the rows it pinned.
+const WORSE_THAN_PLAIN_FACTOR: Number = 10.0;
+
 /// Repair the active set the step implies, by pinning and releasing.
 ///
-/// Returns the refined step and the compound rows it constrained.
-/// This is upstream's fix-relax, both cases:
+/// Returns the refined step, the compound rows it constrained, and why
+/// it stopped. This is upstream's fix-relax, both cases:
 ///
 /// * a variable the step carries past a bound is pinned AT that bound,
 ///   which activates it (their equation 17);
@@ -265,28 +430,68 @@ pub struct BoundMultiplier {
 /// step holds complementarity. Measured on a model whose bound wants to
 /// release, that is the difference between 0.0 and 1.667.
 ///
-/// Each pass adds one condition and re-solves the augmented system
+/// # One list per pass
+///
+/// A pass takes EVERY violation it can see — every coordinate outside
+/// a bound and every multiplier driven negative — and constrains all of
+/// them before re-solving, which is upstream's `BoundCheck` filling one
+/// `x_bound_violations_idx` and its caller's `while (bounds_violated)`
+/// re-solving over the lot. The loop then ends on its own, when the
+/// list comes back empty.
+///
+/// Taking only the worst one per pass, which this did until gh#732,
+/// needs as many passes as there are crossings. On a model with more
+/// crossings than passes `max_iter` stopped the loop rather than the
+/// violations doing it, so the budget picked the answer: on the CSTR of
+/// notebook 36 the pin count equalled the budget at every budget tried,
+/// and at 100 pins — half that problem's degrees of freedom — the
+/// refined step came back 8.6 times worse than the unrefined one.
+/// `max_iter` is a safety limit now, and a stop of
+/// [`RefineStop::IterationLimit`] is what says it fired.
+///
+/// Each pass adds its conditions and re-solves the augmented system
 /// carrying all of them, against the original factorization, so its
-/// correction is measured from the plain step rather than the previous
+/// correction is measured from the base step rather than the previous
 /// pass. Adding successive corrections counts the earlier ones twice.
 /// The Schur complement over those rows is what upstream's equations 19
-/// through 22 describe. The factorization is never rebuilt, which is
-/// what makes this cheaper than a re-solve, but the Schur complement is
-/// rebuilt from scratch each pass: pass `k` costs one dense `k × k`
-/// solve and `k + 1` back-solves, so the work grows quadratically in
-/// the number of conditions, and the default `max_iter` of 16 is 136
-/// back-solves rather than 16.
+/// through 22 describe. The factorization is never rebuilt for a pin,
+/// which is what makes this cheaper than a re-solve; the Schur
+/// complement is rebuilt from scratch each pass, so a pass carrying `k`
+/// conditions costs one dense `k × k` solve and `k + 1` back-solves.
+/// Collecting the list makes `k` the number of crossings rather than
+/// the pass index, so the same repair costs passes instead of pins.
+///
+/// A release is not a Schur row here, unlike upstream, which puts the
+/// multiplier's row in the same list as the primal violations. It
+/// re-factors with that bound's `sigma` dropped, because an active
+/// bound's `sigma = z / s` grows as the solve converges and destroys
+/// the released system's information in the converged factor: computing
+/// a release from the held factor gets *worse* the better the solve
+/// converged, 2e-4 off at `tol = 1e-10` against 7e-9 at `1e-6`. What
+/// gh#732 fixes about a release is that the pins now survive it: their
+/// right-hand sides are re-measured against the re-solved base instead
+/// of the pin set being cleared, which is where that issue's budget
+/// table got its discontinuity.
 ///
 /// `multipliers` carry their base values in the solve's own
 /// coordinates. They are converted here, once, with the backsolver's
 /// [`SensBacksolver::natural_units_factor`], so they agree with the `z`
 /// rows of `dx_plain` before either is used.
 ///
-/// Passes stop when nothing is violated, at `max_iter`, or when a
-/// condition cannot be achieved, which is how an over-determined set is
-/// caught: once the conditions exhaust the problem's degrees of freedom
-/// no step satisfies them all, the augmented system is singular, and a
-/// dense LU returns a large solution rather than reporting it.
+/// # Two guards, independent of the loop
+///
+/// A pass is refused when its correction is out of scale with the step
+/// it corrects, not only when a pinned row misses its target. Checking
+/// the pinned rows alone is what let gh#732's 100 pins each land within
+/// `1e-3` of where they were asked to go while the step as a whole came
+/// back unusable: hitting the pinned coordinates says nothing about
+/// what the correction did to the other 1300.
+///
+/// And the unrefined step is returned when the refinement ends further
+/// outside the bounds than it started, which costs nothing since
+/// `dx_plain` is already in scope. Repairing an active set that leaves
+/// the box further out than not repairing it at all has failed on its
+/// own terms.
 pub fn refine_step_onto_bounds<B>(
     backsolver: &B,
     dx_plain: &[Number],
@@ -297,7 +502,7 @@ pub fn refine_step_onto_bounds<B>(
     rhs_plain: &[Number],
     eps: Number,
     max_iter: usize,
-) -> Result<(Vec<Number>, Vec<usize>), String>
+) -> Result<(Vec<Number>, Vec<usize>, RefineStop), String>
 where
     B: crate::backsolver::SensBacksolver + Clone,
 {
@@ -328,76 +533,40 @@ where
     let bound_rows = backsolver.bound_rows();
     let can_release = backsolver.supports_release() && rhs_plain.len() == n_full;
 
-    // (compound row, right-hand side), the rhs fixed at creation since
-    // it is measured from the base step
-    let mut pins: Vec<(usize, Number)> = Vec::new();
-    // Multiplier rows taken out of the active set. Unlike a pin these
-    // never become a Schur condition: they change the operator, so the
-    // step is re-solved against a factorization that does not carry
-    // their `sigma` at all.
-    let mut released: Vec<usize> = Vec::new();
-    // The step corrections are measured from. It moves whenever the
-    // released set does, since that is a different system.
-    let mut dx_base = dx_plain.to_vec();
+    // Which multiplier rows the step drives negative, most negative
+    // first, ignoring any already out of the active set.
+    let releasable = |dx: &[Number], released: &[usize]| -> Vec<usize> {
+        if !can_release {
+            return Vec::new();
+        }
+        let mut v: Vec<(usize, Number)> = multipliers
+            .iter()
+            .filter(|m| !released.contains(&m.row))
+            .filter(|m| bound_rows.is_some_and(|br| br.iter().any(|b| b.row == m.row)))
+            .map(|m| (m.row, m.base + dx[m.row]))
+            .filter(|&(_, v)| v < -eps)
+            .collect();
+        v.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        v.into_iter().map(|(r, _)| r).collect()
+    };
 
-    for _ in 0..max_iter {
-        let taken: Vec<usize> = pins.iter().map(|&(r, _)| r).collect();
-
-        // one condition per pass, primal first: a variable outside its
-        // bound is the more direct violation, and releasing a bound can
-        // only matter once the variables it constrains have settled
-        let next = match worst_violation(x_curr, &dx, lo, hi, eps, &taken) {
-            Some((i, bound)) => Some((i, (x_curr[i] + dx_base[i]) - bound)),
-            None => None,
-        };
-
-        // Pins first. Only when nothing is outside its bound do we look
-        // at releasing, so the primal violations settle before a bound
-        // leaves the active set.
-        let Some((row, rhs_row)) = next else {
-            // A release is not a condition on the step, it is a
-            // different system: re-solve with that bound's `sigma`
-            // gone, then start over from the step that produced.
-            let worst = if can_release {
-                multipliers
-                    .iter()
-                    .filter(|m| !released.contains(&m.row))
-                    .filter(|m| bound_rows.is_some_and(|br| br.iter().any(|b| b.row == m.row)))
-                    .map(|m| (m.row, m.base + dx[m.row]))
-                    .filter(|&(_, v)| v < -eps)
-                    // most negative first
-                    .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
-                    .map(|(r, _)| r)
-            } else {
-                None
-            };
-            let Some(row) = worst else { break };
-            released.push(row);
-            let mut base = vec![0.0; n_full];
-            if !backsolver.solve_released_step(&released, rhs_plain, &mut base) {
-                // Could not factor with that bound out. Keep the step
-                // reached without it, which is what every other stop
-                // here does.
-                released.pop();
-                break;
-            }
-            // A released bound's multiplier is zero by construction; its
-            // own row of the re-solved step is a by-product of the
-            // complementarity row the factor still carries.
-            for &r in &released {
-                if let Some(m) = multipliers.iter().find(|m| m.row == r) {
-                    base[r] = -m.base;
-                }
-            }
-            dx_base = base;
-            dx.copy_from_slice(&dx_base);
-            // pins are measured from the base, which just moved
-            pins.clear();
-            continue;
-        };
-        pins.push((row, rhs_row));
-
+    // The step under the given conditions, or `None` when the augmented
+    // system cannot deliver it. `Err` is reserved for a malformed
+    // condition set, which is a caller's bug rather than a refusal.
+    let solve_pins = |pins: &[(usize, Number)],
+                      released: &[usize],
+                      dx_base: &[Number]|
+     -> Result<Option<Vec<Number>>, String> {
+        if pins.is_empty() {
+            return Ok(Some(dx_base.to_vec()));
+        }
         let rows: Vec<Index> = pins.iter().map(|&(r, _)| r as Index).collect();
+        // Measured from the base step, which moves whenever the
+        // released set does, so a pin outlives a release.
+        let rhs: Vec<Number> = pins
+            .iter()
+            .map(|&(r, bound)| (x_curr[r] + dx_base[r]) - bound)
+            .collect();
         let signs = vec![1; rows.len()];
         let mk = |r: Vec<Index>| {
             IndexSchurData::from_parts(r, signs.clone()).map_err(|e| format!("{e:?}"))
@@ -411,42 +580,151 @@ where
         // be solved in the system that reflects that.
         let view = ReleasedView {
             base: backsolver.clone(),
-            rows: released.clone(),
+            rows: released.to_vec(),
         };
         let mut pin_app = SensApplication::new(mk(rows.clone())?, view, opts);
-        let rhs: Vec<Number> = pins.iter().map(|&(_, r)| r).collect();
         let mut du = vec![0.0; rows.len()];
         let mut corr = vec![0.0; n_full];
         if !pin_app.run_sens_step(&mk(rows)?, &rhs, &mut du, &mut corr) {
-            // An exactly singular augmented system, where the
-            // near-singular case is what the achievement check below
-            // catches. Drop the condition that could not be solved and
-            // stop, rather than discarding the refinement and the plain
-            // step with it: the caller is told how far it got by the
-            // rows returned, which is what every other stop does.
-            pins.pop();
+            // An exactly singular augmented system, where the two
+            // guards below catch the near-singular case.
+            return Ok(None);
+        }
+
+        // A healthy pass lands its conditions within a few parts per
+        // million, so this is not an accuracy check: it is for the
+        // singular case, where a dense LU returns a solution around
+        // 1e15 rather than reporting it.
+        let achieved = pins
+            .iter()
+            .zip(rhs.iter())
+            .all(|(&(r, _), &want)| (corr[r] + want).abs() <= 1e-3 * want.abs().max(1.0));
+        if !achieved {
+            return Ok(None);
+        }
+        // Achieving every pinned row says nothing about what the
+        // correction did to the rest of the vector (gh#732), so the
+        // correction's own size is checked too.
+        let inf = |v: &[Number]| v.iter().fold(0.0_f64, |a, b| a.max(b.abs()));
+        let scale = inf(dx_base).max(inf(&rhs)).max(1.0);
+        if inf(&corr) > CORRECTION_SCALE_LIMIT * scale {
+            return Ok(None);
+        }
+        Ok(Some(
+            dx_base
+                .iter()
+                .zip(corr.iter())
+                .map(|(b, c)| b + c)
+                .collect(),
+        ))
+    };
+
+    // (var-x row, the bound it is held at). The right-hand side is
+    // re-derived from the base step each pass rather than stored, so a
+    // release moves the pins with it instead of clearing them.
+    let mut pins: Vec<(usize, Number)> = Vec::new();
+    // Multiplier rows taken out of the active set. Unlike a pin these
+    // never become a Schur condition: they change the operator, so the
+    // step is re-solved against a factorization that does not carry
+    // their `sigma` at all.
+    let mut released: Vec<usize> = Vec::new();
+    // The step corrections are measured from. It moves whenever the
+    // released set does, since that is a different system.
+    let mut dx_base = dx_plain.to_vec();
+    let mut stop = RefineStop::IterationLimit;
+
+    for _ in 0..max_iter {
+        let taken: Vec<usize> = pins.iter().map(|&(r, _)| r).collect();
+        let fresh_pins = bound_violations(x_curr, &dx, lo, hi, eps, &taken);
+        let fresh_releases = releasable(&dx, &released);
+        if fresh_pins.is_empty() && fresh_releases.is_empty() {
+            stop = RefineStop::Settled;
             break;
         }
 
-        // The guard is for the singular case, where the conditions
-        // have exhausted the degrees of freedom and a dense LU returns a
-        // solution around 1e15 rather than reporting it. It is not an
-        // accuracy check: a healthy pass lands within a few parts per
-        // million, so demanding more than that rejects working pins.
-        let achieved = pins
-            .iter()
-            .all(|&(r, want)| (corr[r] + want).abs() <= 1e-3 * want.abs().max(1.0));
-        if !achieved {
-            pins.pop();
-            break;
+        // What this pass can undo, so a pass that cannot be solved
+        // leaves the last one that could. `dx_base` is not among them:
+        // a pass that fails also ends the loop, and nothing reads the
+        // base after that.
+        let keep = (dx.clone(), pins.clone(), released.clone());
+
+        if !fresh_releases.is_empty() {
+            // A release is not a condition on the step, it is a
+            // different system: re-solve with those bounds' `sigma`
+            // gone, and measure the pins from the step that produces.
+            let mut trial = released.clone();
+            trial.extend_from_slice(&fresh_releases);
+            let mut base = vec![0.0; n_full];
+            if backsolver.solve_released_step(&trial, rhs_plain, &mut base) {
+                // A released bound's multiplier is zero by
+                // construction; its own row of the re-solved step is a
+                // by-product of the complementarity row the factor
+                // still carries.
+                for &r in &trial {
+                    if let Some(m) = multipliers.iter().find(|m| m.row == r) {
+                        base[r] = -m.base;
+                    }
+                }
+                released = trial;
+                dx_base = base;
+            } else if fresh_pins.is_empty() {
+                // Could not factor with those bounds out, and there is
+                // nothing else this pass could do.
+                stop = RefineStop::DegreesOfFreedom;
+                break;
+            }
         }
-        for (k, d) in dx.iter_mut().enumerate() {
-            *d = dx_base[k] + corr[k];
+
+        pins.extend(fresh_pins.iter().map(|&(i, bound, _)| (i, bound)));
+        let mut next = solve_pins(&pins, &released, &dx_base)?;
+        if next.is_none() && fresh_pins.len() > 1 {
+            // The batch asked for more than the remaining degrees of
+            // freedom hold. Keep the worst of the new crossings and let
+            // the next pass re-measure the rest under it, which is what
+            // the one-at-a-time loop would have done.
+            pins.truncate(keep.1.len());
+            pins.push((fresh_pins[0].0, fresh_pins[0].1));
+            next = solve_pins(&pins, &released, &dx_base)?;
+        }
+        match next {
+            Some(step) => dx = step,
+            None => {
+                let (d, p, r) = keep;
+                dx = d;
+                pins = p;
+                released = r;
+                stop = RefineStop::DegreesOfFreedom;
+                break;
+            }
         }
     }
+
+    // The loop can also run out of passes on the one that settled it,
+    // which is not the limit firing.
+    if stop == RefineStop::IterationLimit {
+        let taken: Vec<usize> = pins.iter().map(|&(r, _)| r).collect();
+        if bound_violations(x_curr, &dx, lo, hi, eps, &taken).is_empty()
+            && releasable(&dx, &released).is_empty()
+        {
+            stop = RefineStop::Settled;
+        }
+    }
+
+    // Whatever stopped it, a refinement that ends further outside the
+    // bounds than the step it started from has failed on its own terms.
+    let worst = |d: &[Number]| {
+        bound_violations(x_curr, d, lo, hi, eps, &[])
+            .first()
+            .map_or(0.0, |&(_, _, over)| over)
+    };
+    let plain_worst = worst(dx_plain);
+    if worst(&dx) > WORSE_THAN_PLAIN_FACTOR * plain_worst.max(eps) {
+        return Ok((dx_plain.to_vec(), Vec::new(), RefineStop::WorseThanPlain));
+    }
+
     let mut out = released.clone();
     out.extend(pins.into_iter().map(|(r, _)| r));
-    Ok((dx, out))
+    Ok((dx, out, stop))
 }
 
 /// The converged backsolver with a set of bounds out of the active set,
@@ -465,6 +743,13 @@ impl<B: crate::backsolver::SensBacksolver + Clone> crate::backsolver::SensBackso
         self.base.dim()
     }
     fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
+        // Nothing released is the converged system, so ask for it
+        // directly: routing an empty set through `solve_released` asks
+        // a backsolver that cannot release for something it does not
+        // need to do, and the ones that can already short-circuit it.
+        if self.rows.is_empty() {
+            return self.base.solve(rhs, lhs);
+        }
         self.base.solve_released(&self.rows, rhs, lhs)
     }
     fn natural_units_factor(&self) -> Option<&[Number]> {

--- a/crates/pounce-sensitivity/src/boundcheck.rs
+++ b/crates/pounce-sensitivity/src/boundcheck.rs
@@ -913,11 +913,16 @@ where
             }
         }
 
-        // What the pin batch can undo. The releases above are not among
-        // them: a release repairs the active set on its own terms, and
-        // rolling one back because the pins that came with it did not
-        // fit discards a repair the step needed and returns the plain
-        // one instead.
+        // What the pin batch can undo, snapshotted BELOW the release
+        // phase so a release is not among it. Both halves of that
+        // matter and they are separable (gh#734 review bisected them):
+        // keeping `released` is what leaves the bounds out of the
+        // active set at all, and snapshotting `dx` here rather than
+        // above is what leaves the STEP the release produced. Roll back
+        // only the first and the rows come back while the answer stays
+        // the plain step's; roll back both and a sound release is
+        // discarded because the pins that came with it did not fit. A
+        // release repairs the active set on its own terms.
         let keep_pins = pins.clone();
         let keep_dx = dx.clone();
         pins.extend(fresh_pins.iter().map(|&(i, bound, _)| (i, bound)));

--- a/crates/pounce-sensitivity/src/convenience.rs
+++ b/crates/pounce-sensitivity/src/convenience.rs
@@ -573,7 +573,7 @@ impl SensSolve {
                         eps,
                         16,
                     ) {
-                        Ok((refined, _pinned)) => dx_full = refined,
+                        Ok((refined, _rows, _stop)) => dx_full = refined,
                         Err(e) => {
                             outbox_cb.borrow_mut().error = Some(e);
                             return;

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -636,49 +636,50 @@ impl Solver {
     }
 
     /// Parametric step with the bounds respected by pinning, not by
-    /// clamping. Returns the `n_x`-long primal step and the variables
-    /// pinned to reach it.
+    /// clamping. Returns the `n_x`-long primal step, the rows it
+    /// constrained to reach it, and why the refinement stopped.
     ///
     /// [`Self::parametric_step`] answers where the linear predictor
     /// points, which can be outside the box. Clamping a coordinate
     /// back to its bound leaves every other coordinate at its
     /// predictor value, so the answer is feasible but no longer
     /// consistent with the KKT relations. This instead adds a row
-    /// pinning the offending coordinate at the bound and re-solves, so
-    /// the others move to stay consistent under the pin, which is the
+    /// pinning each offending coordinate at its bound and re-solves, so
+    /// the others move to stay consistent under the pins, which is the
     /// refinement upstream runs under `sens_boundcheck`.
     ///
-    /// Each pass augments the held factorization with the pin rows and
-    /// takes the Schur complement over them. The factorization itself
-    /// is never rebuilt, but the Schur complement is rebuilt each pass,
-    /// so pass `k` costs one dense `k × k` solve and `k + 1`
-    /// back-solves and the total grows quadratically in the number of
-    /// pins. The default `max_iter` of 16 is 136 back-solves.
+    /// A pass takes every crossing it can see, pins them together, and
+    /// re-solves, so the loop ends when nothing is left outside rather
+    /// than when the passes run out. Each pass rebuilds the Schur
+    /// complement over the pins so far, so a pass carrying `k` of them
+    /// costs one dense `k × k` solve and `k + 1` back-solves; the
+    /// factorization itself is never rebuilt for a pin.
     ///
     /// What counts as outside a bound is taken from the solve rather
     /// than from the caller: it was willing to leave a converged point
     /// `bound_relax_factor` outside its bound, so anything within that
     /// is on the bound. An unrelaxed solve gets a roundoff floor.
     ///
-    /// Passes stop when nothing is outside its bound by that much, at
-    /// `max_iter`, or when a pin cannot be achieved because the pins
-    /// have exhausted the problem's degrees of freedom. None of those
-    /// is an error: the step returned is the last one computed, and the
-    /// returned pin list says how far the refinement got. `max_iter`
-    /// is a budget, since each pass costs a dense `k × k` solve and the
-    /// point of the refinement is to stay cheaper than a re-solve.
+    /// Passes stop when nothing is outside its bound by that much, when
+    /// a pin cannot be achieved because the pins have exhausted the
+    /// problem's degrees of freedom, or at `max_iter`, which is a
+    /// safety limit rather than a budget: it took one pin per pass
+    /// until gh#732, where a model with more crossings than passes had
+    /// its answer picked by the limit. None of those is an error, and
+    /// the returned [`crate::boundcheck::RefineStop`] says which
+    /// happened.
     pub fn parametric_step_bounded(
         &self,
         pin_constraint_indices: &[Index],
         deltas: &[Number],
         max_iter: usize,
-    ) -> Result<(Vec<Number>, Vec<Index>), SolverError> {
+    ) -> Result<(Vec<Number>, Vec<Index>, crate::boundcheck::RefineStop), SolverError> {
         let dx_full = self.parametric_step_full(pin_constraint_indices, deltas)?;
         let rhs_plain = self.parametric_rhs_full(pin_constraint_indices, deltas)?;
         let ctx = self.bound_context()?;
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
-        let (dx, pinned) = crate::boundcheck::refine_step_onto_bounds(
+        let (dx, pinned, stop) = crate::boundcheck::refine_step_onto_bounds(
             &state.backsolver,
             &dx_full,
             &ctx.x_curr,
@@ -693,6 +694,7 @@ impl Solver {
         Ok((
             dx[..ctx.n_x].to_vec(),
             pinned.into_iter().map(|p| p as Index).collect(),
+            stop,
         ))
     }
 
@@ -799,7 +801,7 @@ impl Solver {
         deltas: &[Number],
         max_iter: usize,
         held_var_rows: &[Index],
-    ) -> Result<(Vec<Number>, Vec<Index>), SolverError> {
+    ) -> Result<(Vec<Number>, Vec<Index>, crate::boundcheck::RefineStop), SolverError> {
         let weak = self.weakly_active_bounds()?;
         if weak.is_empty() {
             return self.parametric_step_bounded(pin_constraint_indices, deltas, max_iter);
@@ -817,7 +819,7 @@ impl Solver {
             &pinned_rows,
         )
         .map_err(SolverError::SensComputationFailed)?;
-        let (dx, pinned) = crate::boundcheck::refine_step_onto_bounds(
+        let (dx, pinned, stop) = crate::boundcheck::refine_step_onto_bounds(
             &state.backsolver,
             &d,
             &ctx.x_curr,
@@ -832,6 +834,7 @@ impl Solver {
         Ok((
             dx[..ctx.n_x].to_vec(),
             pinned.into_iter().map(|p| p as Index).collect(),
+            stop,
         ))
     }
 

--- a/crates/pounce-sensitivity/tests/parametric_cpp.rs
+++ b/crates/pounce-sensitivity/tests/parametric_cpp.rs
@@ -34,6 +34,7 @@ use pounce_nlp::tnlp::{
     BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
     TNLP,
 };
+use pounce_sensitivity::boundcheck::RefineStop;
 use pounce_sensitivity::{
     IndexSchurData, PdSensBacksolver, SensApplication, SensBacksolver, SensOptions,
 };
@@ -477,6 +478,15 @@ fn parametric_cpp_first_order_sensitivity_matches_finite_difference() {
 
 /// Solve at the nominal parameters and run `parametric_step_bounded`.
 fn run_bounded_step(delta_p: [Number; 2]) -> ([Number; 5], Vec<Index>) {
+    let (dx, pinned, _) = run_bounded_step_with_stop(delta_p, 8);
+    (dx, pinned)
+}
+
+/// `run_bounded_step` with the pass limit and the stop reason exposed.
+fn run_bounded_step_with_stop(
+    delta_p: [Number; 2],
+    max_iter: usize,
+) -> ([Number; 5], Vec<Index>, RefineStop) {
     use pounce_sensitivity::Solver;
 
     let mut app = IpoptApplication::new();
@@ -499,10 +509,10 @@ fn run_bounded_step(delta_p: [Number; 2]) -> ([Number; 5], Vec<Index>) {
         "nominal solve failed: {status:?}",
     );
 
-    let (dx, pinned) = solver
-        .parametric_step_bounded(&[2, 3], &delta_p, 8)
+    let (dx, pinned, stop) = solver
+        .parametric_step_bounded(&[2, 3], &delta_p, max_iter)
         .expect("parametric_step_bounded");
-    (std::array::from_fn(|i| dx[i]), pinned)
+    (std::array::from_fn(|i| dx[i]), pinned, stop)
 }
 
 #[test]
@@ -583,8 +593,13 @@ fn a_pin_beyond_the_degrees_of_freedom_is_refused() {
     // is singular and the second pin is refused. The refinement keeps
     // what it could achieve rather than returning the singular solve.
     let base = solve_at(5.0, 1.0);
-    let (fixed, pinned) = run_bounded_step([-2.0, -0.5]);
+    let (fixed, pinned, stop) = run_bounded_step_with_stop([-2.0, -0.5], 8);
     assert_eq!(pinned, vec![2], "only the first pin fits in one DOF");
+    assert_eq!(
+        stop,
+        RefineStop::DegreesOfFreedom,
+        "and the caller is told which limit that was, not that a budget          ran out",
+    );
 
     let x2 = base[2] + fixed[2];
     assert!(x2.abs() < 1e-7, "the pin that was accepted holds: {x2}");
@@ -740,8 +755,8 @@ fn three_free_solve_at(p: Number) -> [Number; 4] {
     captured.borrow().expect("on_converged fired")
 }
 
-#[test]
-fn fix_relax_pins_three_crossings_at_once() {
+/// The three-free model, solved at its nominal parameter.
+fn three_free_solver() -> pounce_sensitivity::Solver {
     use pounce_sensitivity::Solver;
 
     let mut app = IpoptApplication::new();
@@ -758,13 +773,24 @@ fn fix_relax_pins_three_crossings_at_once() {
         solver.solve(),
         ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
     ));
+    solver
+}
+
+#[test]
+fn fix_relax_pins_three_crossings_at_once() {
+    let solver = three_free_solver();
 
     let base = three_free_solve_at(1.0);
     let exact = three_free_solve_at(-1.0);
     let plain = solver.parametric_step(&[0], &[-2.0]).expect("plain step");
-    let (fixed, pinned) = solver
+    let (fixed, pinned, stop) = solver
         .parametric_step_bounded(&[0], &[-2.0], 8)
         .expect("bounded step");
+    assert_eq!(
+        stop,
+        RefineStop::Settled,
+        "the loop ends on an empty violation list, not on the pass limit",
+    );
 
     // dx/dp is (1, 2, 3), so the step drives all three below zero and
     // the worst violator is taken first
@@ -793,6 +819,36 @@ fn fix_relax_pins_three_crossings_at_once() {
         err(&fixed_x)
     );
     assert!(err(&fixed_x) <= err(&clamped));
+}
+
+#[test]
+fn the_pass_limit_no_longer_picks_the_answer() {
+    // gh#732. A pass used to take the single worst crossing, so the
+    // number of crossings repaired was whatever `max_iter` allowed and
+    // the answer moved with the budget. This model's step crosses three
+    // bounds at once: one pass now takes all three, and every budget
+    // from one pass up agrees to the last digit.
+    let solver = three_free_solver();
+    let at = |k| {
+        solver
+            .parametric_step_bounded(&[0], &[-2.0], k)
+            .expect("bounded step")
+    };
+    let (one, pins_one, stop_one) = at(1);
+    let (eight, pins_eight, stop_eight) = at(8);
+
+    assert_eq!(stop_one, RefineStop::Settled, "one pass settles it");
+    assert_eq!(stop_eight, RefineStop::Settled);
+    assert_eq!(pins_one, vec![2, 1, 0], "all three, worst first");
+    assert_eq!(pins_one, pins_eight, "and the budget does not change them");
+    for k in 0..4 {
+        assert!(
+            (one[k] - eight[k]).abs() < 1e-14,
+            "x[{k}] moved with the budget: {} vs {}",
+            one[k],
+            eight[k],
+        );
+    }
 }
 
 /// Walk the same perturbation the fix-relax tests use. Returns the

--- a/crates/pounce-sensitivity/tests/path_following.rs
+++ b/crates/pounce-sensitivity/tests/path_following.rs
@@ -191,7 +191,7 @@ fn both_steps(p0: Number, dp: Number) -> ([Number; 2], [Number; 2], usize) {
         "base solve failed: {status:?}",
     );
     let base = solver.converged().expect("converged state").x.clone();
-    let (fixed, _) = solver
+    let (fixed, _, _) = solver
         .parametric_step_bounded(&[0], &[dp], 8)
         .expect("parametric_step_bounded");
     let (walked, segs) = solver

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -258,6 +258,18 @@ crossings and takes a Schur row over it: that is the computation the
 release either way — their right-hand sides are re-measured against the
 re-solved base rather than the pin set being cleared.
 
+Releasing is the half that has to be careful about how much it does at
+once, and the asymmetry is worth stating. A pin ADDS a condition, so
+asking for too many shows up honestly as an augmented system that
+cannot be solved. A release REMOVES one: each bound taken out of the
+active set is stiffness that is no longer holding its variable there.
+Take too many at once and variables that were sitting on their bounds
+are carried off them, with no degrees of freedom left to pin them back
+— and no failed solve anywhere to say so. So a release batch is kept
+only when the step it produces is no further outside the bounds than
+the step in hand; otherwise the most negative multiplier goes alone and
+the next pass re-measures the rest under it.
+
 Three things stop it short of holding every bound. The pass limit,
 which a caller can raise. The problem's degrees of freedom, which no
 limit helps: pinning uses one degree of freedom each, and past that no

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -222,13 +222,24 @@ uncorrected step differs by 9e-6 at `tol = 1e-3` and by 2e-9 at
 `tol = 1e-8`. There is no option for it, since there is no reason to
 want the barrier problem's answer.
 
-Each pass rebuilds the Schur complement over the pins so far, so pass
-`k` costs one dense `k × k` solve and `k + 1` back-solves and the total
-grows quadratically. The default `max_iter` of 16 is 136 back-solves.
-A pin never rebuilds the factorization, which is what keeps it cheaper
-than re-solving. `max_iter` bounds that work and is a budget rather
-than a safeguard: the refinement is only worth running while it stays
-cheaper than the re-solve it replaces.
+A pass takes every crossing it can see, pins them together and
+re-solves, which is upstream's own loop: one violation list per pass,
+and `while (bounds_violated)` as the termination condition. Each pass
+rebuilds the Schur complement over the pins so far, so a pass carrying
+`k` of them costs one dense `k × k` solve and `k + 1` back-solves. A
+pin never rebuilds the factorization, which is what keeps it cheaper
+than re-solving.
+
+`max_iter` caps the passes, and is a safety limit rather than a budget.
+It was a budget while a pass took only the worst crossing, which needed
+as many passes as there were crossings — and on a model with more
+crossings than passes the limit, not the violations, decided where the
+loop stopped. On the CSTR of notebook 36 that put the pin count at
+exactly the budget for every budget tried, and at 100 pins (half that
+problem's degrees of freedom) the refined step came back 8.6 times
+worse than the unrefined one (gh#732). `estimate()`'s warning now names
+which stopping condition was reached rather than inferring it from the
+pin count.
 
 A **release** does re-factor, once per released set. It has to. An
 active bound contributes `sigma = z / s` to the KKT's `x` diagonal, and
@@ -240,15 +251,30 @@ was off by 2e-4 while at a looser `1e-6` it was off by 7e-9. Dropping
 the bound's `sigma` and re-factoring removes the dependence entirely.
 One factorization still sits an order of magnitude under the twenty to
 a hundred a re-solve runs, and a step that releases nothing pays
-nothing.
+nothing. This is the one place the loop departs from upstream, which
+puts the multiplier's row in the same violation list as the primal
+crossings and takes a Schur row over it: that is the computation the
+`eps · sigma` cancellation above is measuring. The pins survive a
+release either way — their right-hand sides are re-measured against the
+re-solved base rather than the pin set being cleared.
 
-Two things stop it short of holding every bound. The pass budget, which
-a caller can raise. And the problem's degrees of freedom, which no
-budget helps: pinning uses one degree of freedom each, and past that no
+Three things stop it short of holding every bound. The pass limit,
+which a caller can raise. The problem's degrees of freedom, which no
+limit helps: pinning uses one degree of freedom each, and past that no
 step holds every bound at once, so the pin is refused rather than
-returned from a singular system. In either case `estimate()` warns,
-names the variables still outside, and says which limit was reached.
-`clamp` then decides what happens to them, exactly as under `linear`.
+returned from a singular system. And the refinement ending further
+outside the bounds than the step it started from, which returns the
+unrefined step instead — repairing an active set has to beat not
+repairing it. In each case `estimate()` warns, names the variables
+still outside, and says which of the three it was. `clamp` then decides
+what happens to them, exactly as under `linear`.
+
+A pass is also refused when its correction is out of scale with the
+step it corrects, not only when a pinned row misses its target.
+Checking the pinned rows alone is what let gh#732's hundred pins each
+land within `1e-3` of where they were asked to go while the step as a
+whole came back unusable: hitting the pinned coordinates says nothing
+about what the correction did to the other thirteen hundred.
 
 What counts as outside a bound is not a tolerance you pass. It comes
 from the solve, which was willing to leave a converged point

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1155,12 +1155,13 @@ def estimate(model, perturb, clamp=True, mode="linear",
     change at the fraction where it happens. `active_set_changes()`
     returns the record of those changes.
 
-    max_iter bounds that work. Under "fix_relax" each pass costs a
-    dense solve whose size grows with the number of pins, and the
-    refinement is only worth running while it stays cheaper than a
-    re-solve. Under "path" it caps the number of active-set changes
-    applied, and past the cap the rest of the perturbation is taken
-    in one step under the active set reached.
+    max_iter bounds that work. Under "fix_relax" it caps the passes,
+    each of which pins every crossing it can see and costs a dense
+    solve whose size grows with the number of pins. It is a safety
+    limit there rather than a budget: the loop ends when nothing is
+    left outside a bound. Under "path" it caps the number of
+    active-set changes applied, and past the cap the rest of the
+    perturbation is taken in one step under the active set reached.
 
     degeneracy selects what happens when the base point itself sits at
     an active-set kink: a bound the classifier can call neither active
@@ -1179,7 +1180,7 @@ def estimate(model, perturb, clamp=True, mode="linear",
     clamp keeps its meaning in both modes: it clamps whatever is still
     outside a bound at the end. Under "fix_relax" the pins usually
     leave nothing to clamp, and when they do not, the warning says
-    whether the pass budget or the degrees of freedom stopped it.
+    which of the refinement's stopping conditions was reached.
 
     The perturbation is measured from the SOLVE point (the pin
     constraint's stored right-hand side, which is the value the Param
@@ -1229,7 +1230,7 @@ def estimate(model, perturb, clamp=True, mode="linear",
                 session.solver.parametric_step_directional(
                     pin_idx, deltas, degeneracy_iter))
             if mode == "fix_relax":
-                step, pinned = (
+                step, pinned, stop = (
                     session.solver.parametric_step_bounded_decided(
                         pin_idx, deltas, held_rows, max_iter))
             elif mode == "path":
@@ -1245,7 +1246,7 @@ def estimate(model, perturb, clamp=True, mode="linear",
             fell_back = True
     if degeneracy == "one_sided" or fell_back:
         if mode == "fix_relax":
-            step, pinned = session.solver.parametric_step_bounded(
+            step, pinned, stop = session.solver.parametric_step_bounded(
                 pin_idx, deltas, max_iter)
         elif mode == "path":
             step, segments = session.solver.parametric_step_path(
@@ -1277,16 +1278,29 @@ def estimate(model, perturb, clamp=True, mode="linear",
         if out.size:
             names = [session.var_names[i] for i in out]
             if mode == "fix_relax":
-                n_changes = len(pinned)
-                did = f"pinned {n_changes} variable(s)"
+                did = f"pinned {len(pinned)} variable(s)"
+                # The refinement says why it stopped rather than the
+                # count being read as a proxy for it: a pass pins every
+                # crossing it sees, so the number of pins says nothing
+                # about whether max_iter bound the work (gh#732).
+                why = {
+                    "iteration_limit":
+                        "the safety limit of %d pass(es) was reached, so "
+                        "raising max_iter may finish it" % max_iter,
+                    "degrees_of_freedom":
+                        "holding them all would need more pins than the "
+                        "problem has degrees of freedom, so no step does",
+                    "worse_than_plain":
+                        "the refinement ended further outside the bounds "
+                        "than the plain step, which was returned instead",
+                }.get(stop, "the refinement settled here")
             else:
                 n_changes = len(segments)
                 did = f"applied {n_changes} active-set change(s)"
-            why = ("the limit of %d was reached, so raising "
-                   "max_iter may finish it" % max_iter
-                   if n_changes >= max_iter else
-                   "holding them all would need more pins than the "
-                   "problem has degrees of freedom, so no step does")
+                why = ("the limit of %d was reached, so raising "
+                       "max_iter may finish it" % max_iter
+                       if n_changes >= max_iter else
+                       "the path settled the active set here")
             warnings.warn(
                 f"estimate: {mode} {did} and "
                 f"still leaves the bounds for {names}, because {why}."


### PR DESCRIPTION
Fixes #732

*Body kept current with the head; the numbers below are `7a5cfb8`'s. Reviewed by @devin-griff across two rounds — the [first](https://github.com/jkitchin/pounce/pull/734#issuecomment-5371441872) found a regression the first commit introduced, the [second](https://github.com/jkitchin/pounce/pull/734#issuecomment-5373330052) verified the fix on notebook 36's real CSTR, the double column and seven synthetic models, and recommends merging.*

## Problem

`refine_step_onto_bounds` pinned the single worst violation per pass, so
repairing `k` crossings took `k` passes and `max_iter` — documented as a cost
budget — was the loop's only termination condition on any model with more
crossings than passes. The budget then selected the answer.

Notebook 36 needs `pyomo_cvp`, which is not in this repo, so my own
measurements are on a CSTR built the same way with the piecewise-constant
controls written as explicit hold equalities instead of `cvp.parameterize`:
1806 variables, 202 degrees of freedom. Perturbing both initial conditions to
the steady state, `mode="linear"` is 0.8199; "err" is the largest relative
error against a warm re-solve, "rows" what the refinement constrained:

| `max_iter` | before: err / rows | after: err / rows |
|---|---|---|
| 16 | 0.9500 / 16 | 0.7293 / 244 |
| 30 | 0.9500 / 30 | 0.7293 / 244 |
| 60 | 0.9500 / 60 | 0.7293 / 244 |
| 100 | **4.8593** / 100 | 0.7293 / 244 |
| 200 | 0.9500 / 32 | 0.7293 / 244 |
| 400 | 0.9500 / 64 | 0.7293 / 244 |

The row count is exactly the budget at 16/30/60/100; at 100 rows the refined
step is six times worse than not refining at all; the drop to 32 rows at 200 is
the release wiping the pins.

@devin-griff's numbers on the real models are stronger. On the **double column**
(25,356 variables, 1963 required active-set changes, all releases), `main`
returns `rows == cap` at every budget and spends 77.72 s applying 200 of the
1963; this branch applies all 1963 in 0.79 s at every cap including 4. On
**notebook 36's CSTR**, all four perturbations are now flat in the budget:

| case | linear | main | this branch |
|---|---|---|---|
| A 25% out | 1.3007 | 0.2916 | 0.2916, 78 rows, `settled` |
| B quarter | 0.5637 | 0.1995 | 0.1995, 43 rows, `settled` |
| C halfway | 0.9197 | 0.4175 | 0.4175, 51 rows, `settled` |
| D steady state | 0.8329 | 0.9500 / 7.1554 / 0.7293 / 0.6258, = cap | **0.6258, 95 rows** |

Case D is the one #732 opens with. `main` reaches 0.6258 only at a cap of 400;
this reaches it at 16. Of seven synthetic models built to vary the structure,
`main` shows #732 on five; all seven settle here.

And `fix_relax` now agrees with `path` — a mode that decides the active set by
an entirely different route, walking the breakpoints instead of deciding at the
base point — at every case and every cap:

| case | gap before | gap on this branch |
|---|---|---|
| A | 7e-7 | 4.4e-6 |
| B | 1.1e-6 | 5.0e-7 |
| C | 1.8e-6 | 4.8e-15 |
| D | **7.6e-1** | **4.1e-7** |

## Cause

Four differences from `SensStdStepCalc.cpp`, as the issue lays out. Two of them
are what the tables above are:

* one violation per pass instead of the whole list, which makes the number of
  passes the number of crossings, so the budget binds and decides;
* a release clearing every pin and restarting, which is the discontinuity at
  200.

The guard that was meant to catch the 100-pin case checks only that each pinned
row landed where it was asked to. It does, to 1e-3, while the correction does
whatever it likes to the other 1300 coordinates.

## Fix

A pass now takes the whole violation list — every coordinate outside a bound
and every multiplier driven negative, collected together, ordered worst-first —
constrains all of it and re-solves. That is upstream's structure: one
`x_bound_violations_idx` per pass, `while (bounds_violated)` as the termination
condition. The loop ends when the list empties.

**Both batches back off, and the asymmetry between them is the subtle part.**
A pin ADDS a condition, so an over-large batch reports itself: the augmented
system cannot be solved, and the pass retries with the single worst of the new
crossings. A release REMOVES one — each bound taken out of the active set is
stiffness that is no longer holding its variable there — so a batch that takes
too many carries variables off bounds they were sitting on, with no degrees of
freedom left to pin them back and *nothing that fails* to say so. The first
commit here had a backoff only on the half that announces its own failure. On
the CSTR that was 56 releases where 41 were right, carrying five `v1` intervals
below the valve minimum, and cases B and C came back as the linear step.

A release batch of more than one is now kept only when the step it produces is
no further outside the bounds than the step in hand; otherwise the most
negative multiplier goes alone, unconditionally — refusing that too would leave
the loop with a negative multiplier and nothing to do about it — and the next
pass re-measures the rest under it. The batch is judged on the step *after* the
pins already placed are re-solved into the released system rather than on the
raw released base: it costs one Schur solve on a pass that already pays for a
factorization, and it is what lets case A settle in 16 passes instead of 60.
Backing off spends passes, which is the cost: on the double column it is about
9% (0.65 s → 0.71 s), and two of the seven synthetic models report
`iteration_limit` at a cap of 4 with identical answers.

**A release also survives a pin batch that cannot be solved**, and that is two
separable things — the released set, and the step it produced. Rolling back only
the first brings the released bounds back (case D: 0 rows → 95) while the answer
stays the unrefined step's, because `dx` is still restored from a snapshot taken
before any release happened; the snapshot has to sit below the release phase
too, and that is what turns 95 rows into 0.6258. Both are named at the snapshot
in the code (separated by @devin-griff's forward bisection from `a0358c5`, since
reverting from the fixed state shows nothing — the two fixes mask each other).

A bound whose release the factorization refuses is barred rather than asked for
again on every later pass, and its stop is `degrees_of_freedom`, which no budget
reaches, rather than the pass limit.

**A release keeps its re-factorization** rather than becoming a Schur row as
upstream has it. Computing a release from the held factor is what the
`eps · sigma` cancellation documented on `solve_released` measures: 2e-4 off at
`tol = 1e-10` against 7e-9 at `1e-6`, i.e. worse the better the solve converged.
The issue proposed the Schur row and withdrew it in review ("algebraically the
same, not the same in floating point"). What #732 correctly identifies about
releases is fixed — the pins now **survive** one, their right-hand sides
re-measured against the re-solved base instead of the pin set being cleared.

`max_iter` is a safety limit now and the refinement reports which stopping
condition fired. `parametric_step_bounded`, `parametric_step_bounded_decided`
and their Python bindings return `(dx, pinned, stop)` with `stop` one of
`settled` / `iteration_limit` / `degrees_of_freedom` / `worse_than_plain`.
`estimate()` names it in the warning rather than inferring the reason from
`len(pinned) >= max_iter`, which a batched pass makes meaningless.

Both guards from the issue, independent of the loop shape:

* a pass is refused when its correction is out of scale with the step it
  corrects (`CORRECTION_SCALE_LIMIT`, 1e4 — above the leverage a real pin can
  have, below the ~1e15 a dense LU returns for a singular system it does not
  report), not only when a pinned row misses its target;
* the unrefined step is returned when the refinement ends more than 10x further
  outside the bounds than it started (`WORSE_THAN_PLAIN_FACTOR`). This is the
  guard that caught the over-release above — working as intended, on a defect
  that should not have reached it.

Also fixed on the way: the refinement's augmented solves routed an *empty*
released set through `solve_released`, which a backsolver without release
support answers `false` to — such a backsolver could not pin at all. The real
backsolver already short-circuits an empty set to `solve`, so nothing that
worked before changes; it is what makes the guards testable against
`DenseLuBacksolver`.

## Blast radius

**Not a trajectory change: none of this runs during a solve.** The refinement
is post-convergence parametric-step machinery, so the fixture sweep does not
apply and no corpus number moves.

Signature change on `Solver::parametric_step_bounded` and
`parametric_step_bounded_decided` and on their `pounce` Python bindings, from
`(dx, pinned)` to `(dx, pinned, stop)`. In-tree callers are `pyomo-pounce`'s
`estimate()` and the CLI's `--sens-boundcheck`, both updated. #733 adds two more
call sites in its `estimate_report` dispatch; @devin-griff takes those on the
rebase, along with surfacing `stop` on `EstimateReport`.

Not touched: **notebook 36's stored outputs** for the `fix_relax` cells, which
are now stale — section 6 is the `max_iter` sweep this flattens, and the
`fix_relax`/`path` convergence above replaces prose in section 5 and in the
mode-comparison section. Re-running it needs `pyomo_cvp`, which isn't available
here; @devin-griff regenerates it on the #733 rebase.

I have no trustworthy wall-time comparison of my own: my before and after runs
straddle a change in machine load, and the re-solve I measure against moved by
the same factor. The column numbers above are @devin-griff's, measured in one
session on one machine. What is stable across every run is that the cost no
longer varies with `max_iter`.

Separately noticed while measuring, not from this change:
`estimate(mode="path", max_iter=400)` on my CSTR raises
`step_along_path: augmented solve failed (holds [...], released [...])`.
It reproduces identically on `main`. Say the word and I'll file it.

## Tests

`the_pass_limit_no_longer_picks_the_answer` (`parametric_cpp.rs`) is the
headline regression test: the three-free model crosses three bounds at once, and
`max_iter` of 1 and of 8 must agree. **Verified failing on `main`** in a
worktree, with the test back-ported to the two-tuple API so it compiles there:

```
assertion `left == right` failed: all three, worst first
  left: [2]
 right: [2, 1, 0]
```

which is the stated reason — one pin per pass at a budget of one.

Two unit tests on a scripted-release mock cover the release half, both
**verified failing on the first commit** (`a0358c5`) for the stated reason:

* `a_release_batch_that_makes_the_step_worse_backs_off_to_one` — `[2, 3, 0]`
  against `[2]`, which is the CSTR regression in miniature: it takes both
  releases and then has to pin the coordinate the batch carried out of bounds;
* `a_release_the_factorization_refuses_is_not_asked_for_twice` — 3 calls
  against 1, and `IterationLimit` where `DegreesOfFreedom` is the truth.

Writing the second of those turned up a real bug in the barring it tests: with
the refused row filtered out of the candidate list, the loop's own termination
check saw an empty list and called itself `settled` while a multiplier it had
given up on was still negative. Fixed in the same commit.

Two more unit tests pin the guards on a synthetic lever system:
`a_refinement_that_ends_further_out_returns_the_unrefined_step` and
`a_pass_whose_correction_is_out_of_scale_is_refused`. Being honest about these:
they cannot run on `main` at all, not merely fail — `RefineStop` does not exist
there, and the empty-released-set bug above means the refinement could not pin
with a `DenseLuBacksolver` in the first place. The behaviour they pin is new, so
there is no pre-fix version of them that bites.

`fix_relax_pins_three_crossings_at_once` keeps asserting `[2, 1, 0]` — batching
preserves worst-first ordering within a pass — and
`a_pin_beyond_the_degrees_of_freedom_is_refused` gains the
`RefineStop::DegreesOfFreedom` assertion, so the "which limit" answer is pinned
and not just its wording in a warning.

Green here: `cargo test -p pounce-sensitivity` (17 suites), the CLI's sens
tests, `python/tests/test_sensitivity.py` (10), `pyomo-pounce/tests` (320
passed; the 9 failures are `test_block_init_row_scale.py` needing `networkx`,
present before this branch). `cargo fmt --all -- --check` and CI's clippy gate
clean. @devin-griff independently ran the sensitivity suites and `pyomo-pounce`
(413 passed) on `abb43c7`.

---

- [x] Tests fail on the parent commit for the stated reason — the headline test
      and both release tests do, verbatim above; the two guard unit tests cannot
      exist on `main`, as noted
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`sensitivity.md`; no new page, so no
      `SUMMARY.md` change)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this body and in the code comments is true of the code as
      it stands now — rewritten at `abb43c7` and again at `7a5cfb8` rather than
      left describing an earlier commit