### PR TITLE
Stop the sens back-solve refining against a matrix it did not factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ changes.
 
 ## [Unreleased]
 
+- **The sensitivity back-solve no longer refines against a matrix its
+  factor does not decompose (gh#737 / gh#735 interaction).**
+
+  `may_refine` gates `PdFullSpaceSolver`'s iterative refinement, and its
+  own doc gives the rule: refinement measures its residual against the
+  system it thinks it is solving, which is this factor's system only
+  when no `SigmaOverride` is in play. It tested `declared.is_none()`
+  because crossover's declared frame was the only override that could
+  exist. gh#737's ceiling is a second one, and it fires on an ordinary
+  solve with no crossover, so refinement ran and escalated: on the
+  gh#737 fixture a step of `-0.21` came back as `7.97e22`. The test is
+  now on the override rather than on where it came from. Declared still
+  implies an override, so nothing changes where the gate was already
+  right.
+
+  Only reachable since both landed: the two changes merge without a
+  textual conflict and CI on each was green against a base without the
+  other.
+
 - **A barrier diagonal too stiff for the constraint rows it sits in no
   longer erases them (gh#737).**
 

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -466,8 +466,18 @@ impl PdSensBacksolver {
     /// the held factor does not decompose, the loop cannot converge,
     /// and it escalates instead of improving anything. Same reason the
     /// release path (`solve_released_inner`) never refines.
+    ///
+    /// So the test is on the override itself and not on where it came
+    /// from. It read `declared.is_none()` while crossover was the only
+    /// thing that could produce one; gh#737's ceiling is a second, and
+    /// it fires on an ordinary solve with `declared` empty. On the
+    /// gh#737 fixture that combination returned `7.97e22` for a step of
+    /// `-0.21` -- refinement escalating against the uncapped matrix,
+    /// exactly the failure this predicate exists to prevent. Declared
+    /// still implies an override, so this stays equivalent wherever it
+    /// was already right.
     fn may_refine(&self) -> bool {
-        self.declared.is_none()
+        self.sigma.x.is_none() && self.sigma.s.is_none()
     }
 
     /// The `x`-block barrier diagonal in the frame the held iterate

--- a/crates/pounce-sensitivity/tests/issue_737_pinned_to_bound_sigma.rs
+++ b/crates/pounce-sensitivity/tests/issue_737_pinned_to_bound_sigma.rs
@@ -76,12 +76,22 @@ const PIN: Number = 1.0;
 const DELTA: Number = -0.21;
 
 /// ```text
-/// min  ½(x − T)² + ½(w − 1)²
+/// min  ½(x − T)² + ½(w − 1)² + ½(u − 1)²
 /// s.t. g₀:  x − p = 0
 ///      g₁:      p = PIN     ← the parameter row, perturbed
 ///      g₂:  w − x = 0
-///      0 ≤ x ≤ PIN,  p and w free
+///      0 ≤ x ≤ PIN,  p, w and u free
 /// ```
+///
+/// `u` is in no constraint and nothing else reads it. It is here to
+/// keep the model **non-square**: at `n == m` the solve takes Ipopt's
+/// square-problem path (gh#508, ported in gh#735), which zeroes the
+/// bound multipliers because the equalities already determine every
+/// variable. That is the right answer for such a model and it makes
+/// `Σ = z/s` exactly zero -- so the three-variable version of this
+/// fixture stopped reproducing gh#737 the moment that path landed,
+/// while still passing every assertion below. One free variable puts
+/// the barrier back in play.
 ///
 /// `T > PIN` pulls `x` against the upper bound the equality already
 /// holds it on, so bound and equality bind together and the multiplier
@@ -102,10 +112,10 @@ struct PinnedToBound {
 impl TNLP for PinnedToBound {
     fn get_nlp_info(&mut self) -> Option<NlpInfo> {
         Some(NlpInfo {
-            n: 3,
+            n: 4,
             m: 3,
             nnz_jac_g: 5,
-            nnz_h_lag: 2,
+            nnz_h_lag: 3,
             index_style: IndexStyle::C,
         })
     }
@@ -117,6 +127,8 @@ impl TNLP for PinnedToBound {
         b.x_u[1] = 1.0e19;
         b.x_l[2] = -1.0e19;
         b.x_u[2] = 1.0e19;
+        b.x_l[3] = -1.0e19;
+        b.x_u[3] = 1.0e19;
         b.g_l[0] = 0.0;
         b.g_u[0] = 0.0;
         b.g_l[1] = PIN;
@@ -130,6 +142,7 @@ impl TNLP for PinnedToBound {
         sp.x[0] = 0.5;
         sp.x[1] = 0.5;
         sp.x[2] = 0.5;
+        sp.x[3] = 0.5;
         true
     }
 
@@ -139,13 +152,16 @@ impl TNLP for PinnedToBound {
     }
 
     fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
-        Some(0.5 * (x[0] - self.t).powi(2) + 0.5 * (x[2] - 1.0).powi(2))
+        Some(
+            0.5 * (x[0] - self.t).powi(2) + 0.5 * (x[2] - 1.0).powi(2) + 0.5 * (x[3] - 1.0).powi(2),
+        )
     }
 
     fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
         g[0] = x[0] - self.t;
         g[1] = 0.0;
         g[2] = x[2] - 1.0;
+        g[3] = x[3] - 1.0;
         true
     }
 
@@ -187,14 +203,14 @@ impl TNLP for PinnedToBound {
     ) -> bool {
         match mode {
             SparsityRequest::Structure { irow, jcol } => {
-                irow[0] = 0;
-                jcol[0] = 0;
-                irow[1] = 2;
-                jcol[1] = 2;
+                let rs: [Index; 3] = [0, 2, 3];
+                for (k, &r) in rs.iter().enumerate() {
+                    irow[k] = r;
+                    jcol[k] = r;
+                }
             }
             SparsityRequest::Values { values } => {
-                values[0] = obj_factor;
-                values[1] = obj_factor;
+                values.fill(obj_factor);
             }
         }
         true


### PR DESCRIPTION
**`main` is red.** #738 and #735 merge with no textual conflict, and CI on each was green against a base without the other. Together they turn a `-0.21` step into `7.97e22`. This fixes it.

## Problem

`the_barrier_diagonal_stays_under_the_ceiling` fails on `4617865`:

```
Sigma on the pinned variable is 0e0; the bound is still a bound, not a release
```

Two independent things went wrong in the merge, and the first hid the second.

## Cause 1 — the fixture stopped biting

#735 ported Ipopt's square-problem path (#508). The #737 fixture is square — three variables, three equalities — so it now takes that path, which zeroes the bound multipliers because the equalities already determine every variable.

That is the **right answer** for such a model. It also makes `Σ = z/s` exactly zero: no barrier, nothing to cap, and the fixture reproduced nothing at all while continuing to pass every assertion about the derivative. Only the one test that reads the diagonal rather than the answer noticed — it caught `Σ = 0`, and that is the only reason this was found.

The fixture gains a fourth variable, free and in no constraint row, whose only job is to keep the model non-square.

## Cause 2 — refinement against the wrong matrix

With the barrier back, the step came out at `7.97e22`.

`may_refine` gates `PdFullSpaceSolver`'s iterative refinement, and its own doc states the rule exactly:

> Refinement iterates `x += K^-1 r` and measures `r` against the system it thinks it is solving. That is only the system this factor factors when no `SigmaOverride` is in play […] the loop cannot converge, and it escalates instead of improving anything.

The implementation tested `declared.is_none()`, because crossover's declared frame was the only thing that could produce an override when it was written. #737's ceiling is a second one — and unlike crossover it fires on an **ordinary solve with `declared` empty**. So refinement ran, took its residual against the uncapped matrix, and escalated. Precisely the failure the predicate exists to prevent.

The gate is now on the override itself rather than on where it came from:

```rust
fn may_refine(&self) -> bool {
    self.sigma.x.is_none() && self.sigma.s.is_none()
}
```

`effective_sigma` gives every declared solve an override, so this is equivalent wherever the old test was already right, and strictly more conservative in the one case it was not.

## Blast radius

Refinement is lost only on a solve where the ceiling actually bound — which before #737 could not happen at all. Every other solve, refined or not, is unaffected. No trajectory moves: this is the sensitivity system only.

## Tests

The fixture discriminates again on the merged tree, three ways:

| | `d x` |
|---|---|
| ceiling disabled | `[0, -0.105, 0, 0]` — #737's own signature |
| ceiling + old `may_refine` | `7.97e22` |
| both as they now stand | `-0.21` in every coordinate that should move |

`Σ` on the pinned variable is back to `6.88e27` against a `7.04e13` ceiling. The new variable is the uncapped case by construction, which the caps vector shows directly: `[7.04e13, 7.04e13, 7.04e13, inf]`.

Verified: `cargo test --workspace --exclude pounce-hsl`; `cargo fmt --all --check`; `cargo clippy -p pounce-sensitivity --all-targets -D clippy::correctness -D clippy::suspicious`; `scripts/check-release-consistency.sh`; `scripts/check-docs-consistency.sh`.

## Note

Neither PR was wrong on its own, and neither review missed anything reachable at the time. The gap is that a merge of two green branches gets no CI run of its own until it is on `main`. Worth considering requiring branches to be up to date before merge on this repo, at least for `crates/pounce-sensitivity`.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — no user-visible behaviour change; the #737 docs already landed
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_015h7SEWNgcN8Q9nRCCZfrBN)_