### PR TITLE
fix(jax): thread traced bounds through the callback and the vjp (#740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ changes.
 
 ## [Unreleased]
 
+- **`pounce.jax.solve` composes with `jax.jit` when the bounds are built
+  inside the traced function** (#740).
+
+  `lb=jnp.full(n, -10.0)` written in the body of a jitted loss — which is
+  how the book's own examples write it — is a tracer, not an array. The
+  four bound arrays were closed over and then dereferenced inside the
+  `pure_callback` host body, which let the tracer escape its trace; JAX
+  reported the leak as a side effect *in the user's function*, naming a
+  line that had done nothing wrong. Under plain `jax.grad` the same
+  expression evaluates eagerly, because it does not depend on `p`, so
+  only the `jit` paths were affected and the eager examples looked fine.
+
+  The bounds are now split at the call: anything already concrete
+  (`None`, numpy, Python scalars, materialized `jax.Array`s) is closed
+  over exactly as before, and anything traced is threaded through
+  explicitly — as a `pure_callback` operand on the way to the host, and
+  as a `custom_vjp` argument so no rule closes over it either. The
+  second half matters on its own: `cl`/`cu` are read again in the
+  backward to tell equality rows from slack ones, and a closed-over
+  tracer there fails during lowering rather than in the callback.
+  `solve`, `solve_with_warm`, `vmap_solve` and `vmap_solve_parallel` all
+  route through the same split.
+
+  Bounds remain *constants* of the problem, so `jax.grad` still does not
+  produce `dx*/d(bound)`. Answering that with a plain zero would have
+  been a silent lie in one case — a bound derived from `p` that is
+  *active* at `x*` really does move `x*`, so dropping its term yields a
+  confidently wrong gradient where the old code at least crashed. The
+  bound cotangent is therefore `NaN` on exactly the active coordinates.
+  A constant bound is unaffected (its cotangent transposes into nothing
+  and is discarded, so the `jnp.full(n, -10.0)` idiom above is exempt
+  whether or not it binds), and a p-derived bound that stays slack keeps
+  its correct gradient. Fold a bound into a row of `g` if you need to
+  differentiate through it.
+
 - **The sensitivity back-solve no longer refines against a matrix its
   factor does not decompose (gh#737 / gh#735 interaction).**
 
@@ -101,7 +136,6 @@ changes.
   where it returned the baseline `1.000000` in all three before; the
   re-solve is `0.790000`. The rows away from a bound are unchanged to
   every digit printed.
-
 - **`corrector_iter` refines a step by Newton iterations on the barrier
   system, against the factorization the solve left behind.**
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -867,6 +867,21 @@ loss = lambda p: jnp.sum(x_star(p) ** 2)
 print(jax.grad(loss)(jnp.array([0.3, 0.7])))
 ```
 
+`lb` / `ub` / `cl` / `cu` may be built with `jnp.*` inside the traced
+function, as above, or passed as plain numpy — both compose with
+`jax.jit` (gh#740). They are treated as *constants* of the problem,
+though, so the implicit-diff rule does not produce `dx*/d(bound)`.
+
+That is exactly right for a fixed bound like the `jnp.full(2, -10.0)`
+above, and it costs nothing there. It is *not* right for a bound built
+out of `p` that ends up **active** at `x*`: the term being dropped is a
+genuine part of `dL/dp`. So `solve` returns `NaN` for those coordinates
+rather than a plausible-looking wrong number — a p-derived bound that
+merely stays slack keeps its correct gradient, and a fixed bound is
+unaffected whether or not it binds. If you need `dx*/d(bound)`, fold
+the bound into a constraint row of `g` instead, where the implicit-diff
+rule sees it.
+
 ### Warm-start across a parameter trajectory
 
 `solve_with_warm` returns the full primal-dual triple alongside `x*`,

--- a/python/pounce/jax/_diff.py
+++ b/python/pounce/jax/_diff.py
@@ -66,6 +66,118 @@ from .._pounce import Problem
 from .._ad_common import ACTIVE_TOL as _ACTIVE_TOL  # single source of truth (DiffHandoff contract)
 
 
+_BOUND_NAMES = ("lb", "ub", "cl", "cu")
+
+
+def _split_bounds(lb, ub, cl, cu):
+    """Split the four bound arrays into a static half and a traced half.
+
+    A bound built with ``jnp.*`` *inside* a traced function is a tracer,
+    not a concrete array — and that is exactly how the docs' examples
+    write them (``lb=jnp.full(n, -10.0)`` in the body of a jitted loss).
+    Closing such a value over and then dereferencing it inside a
+    ``pure_callback`` host body, or inside a ``custom_vjp`` rule, leaks
+    it out of the trace; JAX reports the leak as a side effect *in the
+    user's function*, which is near-undiagnosable from the message
+    (gh#740). Traced bounds are therefore threaded through explicitly —
+    as ``pure_callback`` operands on the way to the host, and as a
+    ``custom_vjp`` argument so nothing is closed over.
+
+    Everything else — ``None``, Python scalars, lists, numpy arrays,
+    already-concrete ``jax.Array`` values — stays static and is closed
+    over verbatim, so the common case keeps its old behaviour exactly.
+
+    Returns ``(static, dynamic)``: ``static`` is the 4-tuple with
+    ``None`` punched into every traced slot, and ``dynamic`` maps those
+    slot names to the arrays to thread through.
+    """
+    static = []
+    dynamic = {}
+    for name, b in zip(_BOUND_NAMES, (lb, ub, cl, cu)):
+        if isinstance(b, jax.core.Tracer):
+            static.append(None)
+            dynamic[name] = jnp.asarray(b, dtype=jnp.float64)
+        else:
+            static.append(b)
+    return tuple(static), dynamic
+
+
+def _merge_bounds(static, dynamic):
+    """Re-join :func:`_split_bounds`'s halves into ``(lb, ub, cl, cu)``.
+
+    Used both inside ``pure_callback`` host bodies (where ``dynamic``
+    holds the concrete numpy arrays JAX materialized) and inside the
+    backward rules (where it holds the residual's traced copies).
+    """
+    merged = dict(zip(_BOUND_NAMES, static))
+    merged.update(dynamic)
+    return tuple(merged[name] for name in _BOUND_NAMES)
+
+
+def _trip(b, mask):
+    """NaN where ``mask`` holds, zero elsewhere, shaped like the bound ``b``."""
+    zeros = jnp.zeros(jnp.shape(b), dtype=jnp.float64)
+    if jnp.shape(mask) != jnp.shape(b):
+        # A scalar (or otherwise broadcast) bound: the transpose of the
+        # broadcast sums the coordinates, so one tripped coordinate is
+        # enough to poison it.
+        mask = jnp.any(mask)
+    return jnp.where(mask, jnp.nan, zeros)
+
+
+def _active_bound_masks(need, g, m, cl, cu, p, x_star, lam, mult_xL, mult_xU):
+    """Per-bound mask: "the term we are dropping is nonzero here".
+
+    A variable bound's side is read straight off its multiplier — the
+    same ``_ACTIVE_TOL`` rule :func:`_kkt_implicit_backward` uses,
+    except split by side, since ``dx*/dlb`` is nonzero only where the
+    *lower* bound binds.
+
+    A constraint row needs its side too, and the multiplier's magnitude
+    does not carry it, so we evaluate ``g(x*, p)`` and ask which bound
+    it is sitting on. An equality row (``cl == cu``) reads as both,
+    which is right: it pins ``x*`` from either side. ``need`` holds the
+    bounds actually being asked about, so that extra ``g`` evaluation
+    only happens when a *constraint* bound was traced.
+    """
+    masks = {
+        "lb": mult_xL > _ACTIVE_TOL,
+        "ub": mult_xU > _ACTIVE_TOL,
+    }
+    if g is not None and m > 0 and ("cl" in need or "cu" in need):
+        gx = g(x_star, p)
+        cl_v = jnp.asarray(cl, dtype=jnp.float64)
+        cu_v = jnp.asarray(cu, dtype=jnp.float64)
+        active = (cl_v == cu_v) | (jnp.abs(lam) > _ACTIVE_TOL)
+        masks["cl"] = active & ((gx - cl_v) <= (cu_v - gx))
+        masks["cu"] = active & ((cu_v - gx) <= (gx - cl_v))
+    else:
+        masks["cl"] = jnp.zeros((m,), dtype=bool)
+        masks["cu"] = jnp.zeros((m,), dtype=bool)
+    return masks
+
+
+def _bound_cotangents(dyn_bounds, masks):
+    """Cotangent for the traced bounds: NaN exactly where the drop bites.
+
+    Bounds are constants of the problem, so ``solve`` has no gradient to
+    give back for them. Handing back a plain zero would be a silent lie
+    in one case: a bound *derived from* ``p`` that is active at ``x*``
+    genuinely moves ``x*``, so dropping its term yields a confidently
+    wrong ``jax.grad`` — the failure mode pounce#73 was filed for.
+
+    We cannot tell a p-derived bound from a constant one at trace time;
+    under ``jit`` both are tracers. We do not have to. A cotangent
+    handed back to a bound that *is* a constant transposes into nothing
+    and is discarded, so NaN on the coordinates where the dropped term
+    is nonzero is inert for the ordinary ``lb=jnp.full(n, -10.0)`` case
+    (gh#740) and unmissable for the case that would otherwise be wrong.
+    Slack coordinates keep an honest zero — there the dropped term
+    really is zero, so a p-derived slack bound still differentiates.
+    """
+    return {k: _trip(v, masks[k]) for k, v in dyn_bounds.items()}
+
+
 def _kkt_implicit_backward(f, g, n, m, cl, cu, p, x_star, lam, mult_xL, mult_xU, v):
     """Shared implicit-function-theorem backward for the NLP custom_vjp.
 
@@ -183,41 +295,51 @@ def _make_solve_custom_vjp(
     g: Callable | None,
     n: int,
     m: int,
-    lb,
-    ub,
-    cl,
-    cu,
+    static_bounds,
     options: dict | None,
 ):
     @jax.custom_vjp
-    def solve_fn(p, x0):
+    def solve_fn(p, x0, dyn_bounds):
         # Pure-callback to Python. The forward returns only x*; the
         # backward needs (x*, λ*, mult_x_L, mult_x_U) so we re-pack
         # them via the residual.
-        x_star, _info = _pure_callback_solve(f, g, p, x0, n, m, lb, ub, cl, cu, options)
+        x_star, _info = _pure_callback_solve(
+            f, g, p, x0, n, m, static_bounds, dyn_bounds, options
+        )
         return x_star
 
-    def fwd(p, x0):
-        x_star, info = _pure_callback_solve(f, g, p, x0, n, m, lb, ub, cl, cu, options)
+    def fwd(p, x0, dyn_bounds):
+        x_star, info = _pure_callback_solve(
+            f, g, p, x0, n, m, static_bounds, dyn_bounds, options
+        )
         lam = jnp.asarray(info["mult_g"]) if m > 0 else jnp.zeros(0)
         mult_xL = jnp.asarray(info["mult_x_L"])
         mult_xU = jnp.asarray(info["mult_x_U"])
-        return x_star, (p, x_star, lam, mult_xL, mult_xU)
+        return x_star, (p, x_star, lam, mult_xL, mult_xU, dyn_bounds)
 
     def bwd(residuals, cotangent_x):
-        p, x_star, lam, mult_xL, mult_xU = residuals
+        p, x_star, lam, mult_xL, mult_xU, dyn_bounds = residuals
+        _lb, _ub, cl, cu = _merge_bounds(static_bounds, dyn_bounds)
         dL_dp = _kkt_implicit_backward(
             f, g, n, m, cl, cu, p, x_star, lam, mult_xL, mult_xU, cotangent_x
         )
-        # The x0 input has no sensitivity through x* (the solver is
-        # deterministic at optimum); return zeros.
-        return dL_dp, jnp.zeros((n,), dtype=jnp.float64)
+        # x0 has no sensitivity through x* (the solver is deterministic
+        # at the optimum), so its cotangent is an exact zero. The bounds
+        # are held constant — see :func:`_bound_cotangents`.
+        masks = _active_bound_masks(
+            dyn_bounds, g, m, cl, cu, p, x_star, lam, mult_xL, mult_xU
+        )
+        return (
+            dL_dp,
+            jnp.zeros((n,), dtype=jnp.float64),
+            _bound_cotangents(dyn_bounds, masks),
+        )
 
     solve_fn.defvjp(fwd, bwd)
     return solve_fn
 
 
-def _pure_callback_solve(f, g, p, x0, n, m, lb, ub, cl, cu, options):
+def _pure_callback_solve(f, g, p, x0, n, m, static_bounds, dyn_bounds, options):
     """JAX pure_callback wrapper around :func:`_solve_once`.
 
     Returns ``(x_star, info)`` where ``info`` is a dict of arrays.
@@ -236,7 +358,8 @@ def _pure_callback_solve(f, g, p, x0, n, m, lb, ub, cl, cu, options):
         },
     )
 
-    def host_call(p_h, x0_h):
+    def host_call(p_h, x0_h, bounds_h):
+        lb, ub, cl, cu = _merge_bounds(static_bounds, bounds_h)
         x_np, info = _solve_once(
             f=f, g=g,
             p=jnp.asarray(p_h),
@@ -255,7 +378,7 @@ def _pure_callback_solve(f, g, p, x0, n, m, lb, ub, cl, cu, options):
         }
         return np.asarray(x_np, dtype=np.float64), info_out
 
-    return jax.pure_callback(host_call, result_shapes, p, x0)
+    return jax.pure_callback(host_call, result_shapes, p, x0, dyn_bounds)
 
 
 def solve(
@@ -275,12 +398,27 @@ def solve(
     """Parametric solve. ``x* = solve(p, f=..., g=..., x0=..., ...)``.
 
     Differentiable w.r.t. ``p`` via the implicit-function rule on the
-    KKT system at ``x*(p)``. Not differentiable w.r.t. ``x0``.
+    KKT system at ``x*(p)``. Not differentiable w.r.t. ``x0`` or the
+    bounds. ``x0``'s cotangent is an exact zero — the solver is
+    deterministic at the optimum. The bounds are treated as constants
+    of the problem, so building one out of ``p`` will *not* produce the
+    bound-sensitivity term; where such a bound is *active* at ``x*``
+    that term is a real part of ``dL/dp``, and rather than silently
+    drop it ``solve`` returns NaN for those coordinates. The gradient
+    goes visibly bad instead of quietly wrong. Fold the bound into a
+    row of ``g`` if you need to differentiate through it.
+
+    The bounds may be built with ``jnp.*`` inside a traced function —
+    they are threaded through the callback and the ``custom_vjp``
+    rather than closed over, so ``jax.jit`` works either way (gh#740).
+    A constant bound is unaffected by the NaN above: its cotangent
+    transposes into nothing and is discarded.
 
     ``f`` and ``g`` must take ``(x, p)`` and be JAX-traceable.
     """
-    fn = _make_solve_custom_vjp(f, g, n, m, lb, ub, cl, cu, options)
-    return fn(p, x0)
+    static_bounds, dyn_bounds = _split_bounds(lb, ub, cl, cu)
+    fn = _make_solve_custom_vjp(f, g, n, m, static_bounds, options)
+    return fn(p, x0, dyn_bounds)
 
 
 def _solve_once_warm(
@@ -348,7 +486,7 @@ def _solve_once_warm(
 
 
 def _pure_callback_warm_solve(
-    f, g, p, x0, n, m, lb, ub, cl, cu, options,
+    f, g, p, x0, n, m, static_bounds, dyn_bounds, options,
     lam_warm, zL_warm, zU_warm, mu_warm,
 ):
     """Pure-callback wrapper around :func:`_solve_once_warm`.
@@ -366,7 +504,8 @@ def _pure_callback_warm_solve(
         jax.ShapeDtypeStruct((), jnp.float64),
     )
 
-    def host_call(p_h, x0_h, lam_h, zL_h, zU_h, mu_h):
+    def host_call(p_h, x0_h, lam_h, zL_h, zU_h, mu_h, bounds_h):
+        lb, ub, cl, cu = _merge_bounds(static_bounds, bounds_h)
         x_np, lam_out, zL_out, zU_out, mu_out, _info = _solve_once_warm(
             f=f, g=g,
             p=jnp.asarray(p_h),
@@ -380,6 +519,7 @@ def _pure_callback_warm_solve(
 
     return jax.pure_callback(
         host_call, result_shapes, p, x0, lam_warm, zL_warm, zU_warm, mu_warm,
+        dyn_bounds,
     )
 
 
@@ -388,32 +528,30 @@ def _make_solve_with_warm_custom_vjp(
     g: Callable | None,
     n: int,
     m: int,
-    lb,
-    ub,
-    cl,
-    cu,
+    static_bounds,
     options: dict | None,
 ):
     @jax.custom_vjp
-    def solve_fn(p, x0, lam_warm, zL_warm, zU_warm, mu_warm):
+    def solve_fn(p, x0, lam_warm, zL_warm, zU_warm, mu_warm, dyn_bounds):
         x_star, lam_out, zL_out, zU_out, mu_out = _pure_callback_warm_solve(
-            f, g, p, x0, n, m, lb, ub, cl, cu, options,
+            f, g, p, x0, n, m, static_bounds, dyn_bounds, options,
             lam_warm, zL_warm, zU_warm, mu_warm,
         )
         return x_star, lam_out, zL_out, zU_out, mu_out
 
-    def fwd(p, x0, lam_warm, zL_warm, zU_warm, mu_warm):
+    def fwd(p, x0, lam_warm, zL_warm, zU_warm, mu_warm, dyn_bounds):
         x_star, lam_out, zL_out, zU_out, mu_out = _pure_callback_warm_solve(
-            f, g, p, x0, n, m, lb, ub, cl, cu, options,
+            f, g, p, x0, n, m, static_bounds, dyn_bounds, options,
             lam_warm, zL_warm, zU_warm, mu_warm,
         )
         return (
             (x_star, lam_out, zL_out, zU_out, mu_out),
-            (p, x_star, lam_out, zL_out, zU_out),
+            (p, x_star, lam_out, zL_out, zU_out, dyn_bounds),
         )
 
     def bwd(residuals, cotangents):
-        p, x_star, lam, mult_xL, mult_xU = residuals
+        p, x_star, lam, mult_xL, mult_xU, dyn_bounds = residuals
+        _lb, _ub, cl, cu = _merge_bounds(static_bounds, dyn_bounds)
         # Only the x* cotangent contributes a gradient w.r.t. p.
         # Cotangents on (lam_out, zL_out, zU_out, mu_out) are dropped —
         # same pattern existing `solve` uses for x0: warm dual / barrier
@@ -433,6 +571,12 @@ def _make_solve_with_warm_custom_vjp(
             jnp.zeros((n,), dtype=jnp.float64),
             jnp.zeros((n,), dtype=jnp.float64),
             jnp.zeros((), dtype=jnp.float64),
+            _bound_cotangents(
+                dyn_bounds,
+                _active_bound_masks(
+                    dyn_bounds, g, m, cl, cu, p, x_star, lam, mult_xL, mult_xU
+                ),
+            ),
         )
 
     solve_fn.defvjp(fwd, bwd)
@@ -513,9 +657,10 @@ def solve_with_warm(
             jnp.nan if mu_seed is None else mu_seed, dtype=jnp.float64
         )
 
-    fn = _make_solve_with_warm_custom_vjp(f, g, n, m, lb, ub, cl, cu, options)
+    static_bounds, dyn_bounds = _split_bounds(lb, ub, cl, cu)
+    fn = _make_solve_with_warm_custom_vjp(f, g, n, m, static_bounds, options)
     x_star, lam_out, zL_out, zU_out, mu_out = fn(
-        p, x0, lam_warm, zL_warm, zU_warm, mu_warm,
+        p, x0, lam_warm, zL_warm, zU_warm, mu_warm, dyn_bounds,
     )
     if want_mu:
         return x_star, (lam_out, zL_out, zU_out, mu_out)
@@ -606,46 +751,62 @@ def _make_vmap_solve_parallel_custom_vjp(
     g: Callable | None,
     n: int,
     m: int,
-    lb,
-    ub,
-    cl,
-    cu,
+    static_bounds,
     options: dict | None,
     workers: int | None,
 ):
     @jax.custom_vjp
-    def solve_fn(p_batch, x0_batch):
+    def solve_fn(p_batch, x0_batch, dyn_bounds):
         x_star, *_ = _pure_callback_parallel_solve(
-            f, g, p_batch, x0_batch, n, m, lb, ub, cl, cu, options, workers,
+            f, g, p_batch, x0_batch, n, m, static_bounds, dyn_bounds,
+            options, workers,
         )
         return x_star
 
-    def fwd(p_batch, x0_batch):
+    def fwd(p_batch, x0_batch, dyn_bounds):
         x_star, lam, mult_xL, mult_xU = _pure_callback_parallel_solve(
-            f, g, p_batch, x0_batch, n, m, lb, ub, cl, cu, options, workers,
+            f, g, p_batch, x0_batch, n, m, static_bounds, dyn_bounds,
+            options, workers,
         )
-        return x_star, (p_batch, x_star, lam, mult_xL, mult_xU)
-
-    def bwd_single(p, x_star, lam, mult_xL, mult_xU, v):
-        return _kkt_implicit_backward(
-            f, g, n, m, cl, cu, p, x_star, lam, mult_xL, mult_xU, v
-        )
+        return x_star, (p_batch, x_star, lam, mult_xL, mult_xU, dyn_bounds)
 
     def bwd(residuals, cotangent_x_batch):
-        p_batch, x_star_batch, lam_batch, mult_xL_batch, mult_xU_batch = residuals
+        (p_batch, x_star_batch, lam_batch, mult_xL_batch, mult_xU_batch,
+         dyn_bounds) = residuals
+        # The bounds are per-problem, not per-batch-element, so they stay
+        # in ``bwd_single``'s closure rather than joining the vmap.
+        _lb, _ub, cl, cu = _merge_bounds(static_bounds, dyn_bounds)
+
+        def bwd_single(p, x_star, lam, mult_xL, mult_xU, v):
+            return _kkt_implicit_backward(
+                f, g, n, m, cl, cu, p, x_star, lam, mult_xL, mult_xU, v
+            )
+
         dL_dp_batch = jax.vmap(bwd_single)(
             p_batch, x_star_batch, lam_batch, mult_xL_batch, mult_xU_batch,
             cotangent_x_batch,
         )
-        # x0_batch carries no gradient (matches `solve`).
-        return dL_dp_batch, jnp.zeros_like(x_star_batch)
+        # x0_batch carries no gradient (matches `solve`). The bounds are
+        # shared across the batch, so a coordinate trips if it is active
+        # in *any* element — that element's dropped term is nonzero.
+        masks_batch = jax.vmap(
+            lambda p_i, x_i, lam_i, zL_i, zU_i: _active_bound_masks(
+                dyn_bounds, g, m, cl, cu, p_i, x_i, lam_i, zL_i, zU_i
+            )
+        )(p_batch, x_star_batch, lam_batch, mult_xL_batch, mult_xU_batch)
+        masks = {k: jnp.any(v, axis=0) for k, v in masks_batch.items()}
+        return (
+            dL_dp_batch,
+            jnp.zeros_like(x_star_batch),
+            _bound_cotangents(dyn_bounds, masks),
+        )
 
     solve_fn.defvjp(fwd, bwd)
     return solve_fn
 
 
 def _pure_callback_parallel_solve(
-    f, g, p_batch, x0_batch, n, m, lb, ub, cl, cu, options, workers,
+    f, g, p_batch, x0_batch, n, m, static_bounds, dyn_bounds, options, workers,
 ):
     B = p_batch.shape[0]
     result_shapes = (
@@ -655,13 +816,16 @@ def _pure_callback_parallel_solve(
         jax.ShapeDtypeStruct((B, n), jnp.float64),
     )
 
-    def host_call(p_h, x0_h):
+    def host_call(p_h, x0_h, bounds_h):
+        lb, ub, cl, cu = _merge_bounds(static_bounds, bounds_h)
         return _solve_batch_threadpool(
             f, g, np.asarray(p_h), np.asarray(x0_h),
             n, m, lb, ub, cl, cu, options, workers,
         )
 
-    return jax.pure_callback(host_call, result_shapes, p_batch, x0_batch)
+    return jax.pure_callback(
+        host_call, result_shapes, p_batch, x0_batch, dyn_bounds,
+    )
 
 
 def vmap_solve_parallel(
@@ -704,7 +868,8 @@ def vmap_solve_parallel(
     x0_arr = jnp.asarray(x0)
     if x0_arr.ndim == 1:
         x0_arr = jnp.broadcast_to(x0_arr, (B, n))
+    static_bounds, dyn_bounds = _split_bounds(lb, ub, cl, cu)
     fn = _make_vmap_solve_parallel_custom_vjp(
-        f, g, n, m, lb, ub, cl, cu, options, workers,
+        f, g, n, m, static_bounds, options, workers,
     )
-    return fn(p_batch, x0_arr)
+    return fn(p_batch, x0_arr, dyn_bounds)

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -372,6 +372,261 @@ def test_implicit_diff_active_inequality_pounce_73():
     np.testing.assert_allclose(analytic, fd, atol=5e-6)
 
 
+# ---------------------------------------------------------------------
+# gh#740 — bounds built with jnp.* *inside* a traced function.
+#
+# `jnp.full(n, -10.0)` in the body of a jitted loss is a tracer, not a
+# concrete array. It used to be closed over and dereferenced inside the
+# pure_callback host body, which leaked it out of the trace; JAX then
+# blamed the *user's* function for a side effect. Under plain `jax.grad`
+# the same expression evaluates eagerly (it does not depend on `p`), so
+# only the `jit` paths were broken — which is why the docs' own examples
+# looked fine.
+# ---------------------------------------------------------------------
+
+
+def test_jit_solve_with_in_trace_jnp_bounds_gh_740():
+    """The issue's own reproduction: min ||x - p||² with slack bounds.
+
+    x*(p) = p, so sum(x*) = sum(p) = 3. Eager already worked; `jax.jit`
+    raised UnexpectedTracerError.
+    """
+    from pounce.jax import solve
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def loss(p):
+        x = solve(
+            p, f=f, x0=jnp.zeros(2), n=2,
+            lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+            options={"tol": 1e-10, "print_level": 0},
+        )
+        return jnp.sum(x)
+
+    p0 = jnp.array([1.0, 2.0])
+    assert float(loss(p0)) == pytest.approx(3.0, abs=1e-6)
+    assert float(jax.jit(loss)(p0)) == pytest.approx(3.0, abs=1e-6)
+
+
+@pytest.mark.parametrize("wrap", ["jit", "jit_of_grad", "grad_of_jit"])
+def test_jit_solve_bounds_flavours_agree_gh_740(wrap):
+    """In-trace `jnp` bounds must match `numpy` bounds under every
+    jit/grad composition — forward value *and* gradient.
+
+    `cl`/`cu` matter separately from `lb`/`ub`: they are read again in
+    the backward (to tell equality rows from slack ones), so a traced
+    constraint bound also has to reach the vjp without being closed over.
+    """
+    from pounce.jax import solve
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def g(x, p):  # x0 + x1 = p0  → one active equality row
+        return jnp.stack([x[0] + x[1] - p[0]])
+
+    def make_loss(full, zeros):
+        def loss(p):
+            x = solve(
+                p, f=f, g=g, x0=jnp.zeros(2), n=2, m=1,
+                lb=full(2, -10.0), ub=full(2, 10.0),
+                cl=zeros(1), cu=zeros(1),
+                options={"tol": 1e-10, "print_level": 0},
+            )
+            return jnp.sum(x ** 2)
+        return loss
+
+    def apply(loss, p):
+        if wrap == "jit":
+            return jax.jit(loss)(p)
+        if wrap == "jit_of_grad":
+            return jax.jit(jax.grad(loss))(p)
+        return jax.grad(jax.jit(loss))(p)
+
+    p0 = jnp.array([1.0, 2.0])
+    ref = np.asarray(apply(make_loss(np.full, np.zeros), p0))
+    got = np.asarray(apply(make_loss(jnp.full, jnp.zeros), p0))
+    np.testing.assert_allclose(got, ref, atol=1e-7)
+
+
+def test_jit_solve_with_warm_in_trace_jnp_bounds_gh_740():
+    """`solve_with_warm` carries the same closure, and the same fix."""
+    from pounce.jax import solve_with_warm
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def make_loss(full):
+        def loss(p):
+            x, _state = solve_with_warm(
+                p, f=f, x0=jnp.zeros(2), n=2, m=0,
+                lb=full(2, -10.0), ub=full(2, 10.0),
+                options={"tol": 1e-10, "print_level": 0},
+            )
+            return jnp.sum(x ** 2)
+        return loss
+
+    p0 = jnp.array([1.0, 2.0])
+    ref = np.asarray(jax.jit(jax.grad(make_loss(np.full)))(p0))
+    got = np.asarray(jax.jit(jax.grad(make_loss(jnp.full)))(p0))
+    np.testing.assert_allclose(got, ref, atol=1e-7)
+    np.testing.assert_allclose(got, 2.0 * np.asarray(p0), atol=1e-6)
+
+
+def test_jit_vmap_solve_parallel_in_trace_jnp_bounds_gh_740():
+    """The threadpool batch path routes bounds through the same split."""
+    from pounce.jax import vmap_solve_parallel
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def make_loss(full):
+        def loss(p_batch):
+            x = vmap_solve_parallel(
+                p_batch, f=f, x0=jnp.zeros(2), n=2, m=0,
+                lb=full(2, -10.0), ub=full(2, 10.0),
+                options={"tol": 1e-10, "print_level": 0},
+                workers=2,
+            )
+            return jnp.sum(x ** 2)
+        return loss
+
+    p_batch = jnp.array([[1.0, 2.0], [-0.5, 0.25]])
+    ref = np.asarray(jax.jit(jax.grad(make_loss(np.full)))(p_batch))
+    got = np.asarray(jax.jit(jax.grad(make_loss(jnp.full)))(p_batch))
+    np.testing.assert_allclose(got, ref, atol=1e-7)
+    np.testing.assert_allclose(got, 2.0 * np.asarray(p_batch), atol=1e-6)
+
+
+def _sq_loss_with_bounds(p, *, lb, ub, cl=None, cu=None, g=None, m=0):
+    """sum(x*²) for min ||x - p||² under the given bounds."""
+    from pounce.jax import solve
+
+    x = solve(
+        p,
+        f=lambda x, p: jnp.sum((x - p) ** 2),
+        g=g, x0=jnp.zeros(2), n=2, m=m,
+        lb=lb, ub=ub, cl=cl, cu=cu,
+        options={"tol": 1e-10, "print_level": 0},
+    )
+    return jnp.sum(x ** 2)
+
+
+def test_active_p_dependent_bound_trips_nan_gh_740():
+    """A p-derived bound that *binds* poisons the gradient with NaN.
+
+    `solve` holds the bounds constant, so dx*/d(bound) is dropped. That
+    is harmless for the ordinary `lb=jnp.full(n, -10.0)` idiom gh#740 is
+    about — a constant's cotangent transposes into nothing — but for a
+    bound built out of `p` the dropped term is a real part of dL/dp.
+    Before the fix that case raised UnexpectedTracerError; a plain zero
+    would have turned the crash into a *confidently wrong* number, so
+    the bound cotangent is NaN on exactly the active coordinates.
+    """
+    def loss(p):  # ub = p - 1 binds on every coordinate (x* wants x = p)
+        return _sq_loss_with_bounds(p, lb=jnp.full(2, -1e19), ub=p - 1.0)
+
+    p0 = jnp.array([1.0, 2.0])
+    grad = np.asarray(jax.jit(jax.grad(loss))(p0))
+    # True dL/dp = 2(p - 1) = (0, 2), and it arrives entirely through the
+    # bound. We cannot supply it, so we refuse to invent it.
+    assert np.all(np.isnan(grad)), grad
+
+
+def test_active_p_dependent_constraint_bound_trips_nan_gh_740():
+    """Same rule for `cu`, and only for the coordinates it feeds."""
+    def g(x, p):
+        return jnp.stack([x[0] + x[1]])
+
+    def loss(p):  # x0 + x1 <= p0 - 5 binds; only p[0] feeds the bound
+        return _sq_loss_with_bounds(
+            p, lb=jnp.full(2, -1e19), ub=jnp.full(2, 1e19),
+            cl=jnp.full(1, -1e19), cu=p[:1] - 5.0, g=g, m=1,
+        )
+
+    p0 = jnp.array([1.0, 2.0])
+    grad = np.asarray(jax.jit(jax.grad(loss))(p0))
+    assert np.isnan(grad[0]), grad
+    # p[1] never reaches the bound, so its gradient is untouched.
+    assert grad[1] == pytest.approx(1.0, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["constant_slack", "constant_active", "p_dependent_slack",
+     "constant_active_equality", "p_dependent_constraint_slack"],
+)
+def test_bound_tripwire_does_not_false_fire_gh_740(case):
+    """Everything except a binding p-derived bound keeps its gradient.
+
+    The tripwire is gated on the bound's own multiplier, so it stays
+    silent where the dropped term is genuinely zero — including the
+    gh#740 idiom itself, whether or not that constant bound is active.
+    """
+    def g(x, p):
+        return jnp.stack([x[0] + x[1] - p[0]])
+
+    def loss(p):
+        if case == "constant_slack":
+            return _sq_loss_with_bounds(
+                p, lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0))
+        if case == "constant_active":
+            # A jnp bound that binds -- the issue's own idiom, at a
+            # corner. Must not be mistaken for a p-derived bound.
+            return _sq_loss_with_bounds(
+                p, lb=jnp.full(2, -10.0), ub=jnp.full(2, 0.5))
+        if case == "p_dependent_slack":
+            return _sq_loss_with_bounds(
+                p, lb=jnp.full(2, -10.0), ub=p + 5.0)
+        if case == "constant_active_equality":
+            return _sq_loss_with_bounds(
+                p, lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+                cl=jnp.zeros(1), cu=jnp.zeros(1), g=g, m=1)
+        return _sq_loss_with_bounds(
+            p, lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+            cl=jnp.full(1, -1e19), cu=p[:1] + 50.0, g=g, m=1)
+
+    p0 = jnp.array([1.0, 2.0])
+    grad = np.asarray(jax.jit(jax.grad(loss))(p0))
+    assert np.all(np.isfinite(grad)), grad
+    fd = _finite_diff_jacobian(loss, p0).ravel()
+    np.testing.assert_allclose(grad, fd, atol=5e-6)
+
+
+def test_bound_tripwire_covers_warm_and_parallel_gh_740():
+    """The warm-start and threadpool backward rules carry it too."""
+    from pounce.jax import solve_with_warm, vmap_solve_parallel
+
+    f = lambda x, p: jnp.sum((x - p) ** 2)  # noqa: E731
+
+    def warm_loss(p):
+        x, _state = solve_with_warm(
+            p, f=f, x0=jnp.zeros(2), n=2, m=0,
+            lb=jnp.full(2, -1e19), ub=p - 1.0,
+            options={"tol": 1e-10, "print_level": 0},
+        )
+        return jnp.sum(x ** 2)
+
+    def par_loss(p_batch):
+        x = vmap_solve_parallel(
+            p_batch, f=f, x0=jnp.zeros(2), n=2, m=0,
+            lb=jnp.full(2, -1e19), ub=p_batch[0] - 1.0,
+            options={"tol": 1e-10, "print_level": 0},
+            workers=2,
+        )
+        return jnp.sum(x ** 2)
+
+    p0 = jnp.array([1.0, 2.0])
+    assert np.all(np.isnan(np.asarray(jax.jit(jax.grad(warm_loss))(p0))))
+
+    p_batch = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    # The bound is shared across the batch, so one active element is
+    # enough to poison it.
+    grad = np.asarray(jax.jit(jax.grad(par_loss))(p_batch))
+    assert np.all(np.isnan(grad[0])), grad
+
+
 def test_solve_with_warm_reduces_iterations_pounce_74():
     """`solve_with_warm` should consume the previous solve's duals and
     take fewer interior-point iterations on a small perturbation —


### PR DESCRIPTION
Fixes #740.

## The reported bug

`lb=jnp.full(n, -10.0)` written *inside* a jitted loss — which is how
`docs/src/python.md`'s own examples write it — is a tracer, not an array.
The four bound arrays were closed over and then dereferenced inside the
`pure_callback` host body, which let the tracer escape its trace. JAX
reported the leak as a side effect *in the user's function*, naming a line
that had done nothing wrong.

Under plain `jax.grad` the same expression evaluates eagerly (it does not
depend on `p`), so only the `jit` paths broke — which is why the eager
examples looked fine and this went unnoticed.

## A second defect the issue did not report

Fixing the forward surfaced a distinct failure under `jax.grad(jax.jit(...))`:
`TypeError: No constant handler for type: DynamicJaxprTracer`, raised during
MLIR lowering rather than in the callback. Cause: the `custom_vjp`-decorated
function itself closed over the `lb`/`ub` tracers. Confirmed by probing with
`m=0` (no `cl`/`cu` at all), which still failed.

## The fix

Bounds are split at the call site. Anything already concrete (`None`, numpy,
Python scalars, materialized `jax.Array`) is closed over exactly as before —
byte-identical behaviour and the same jit cache key for existing users.
Anything traced is threaded through explicitly: as a `pure_callback` operand
on the way to the host, and as a `custom_vjp` argument so no rule closes over
it either. `solve`, `solve_with_warm`, `vmap_solve` and `vmap_solve_parallel`
all route through the same split.

## The NaN tripwire

Routing traced bounds through the `custom_vjp` means JAX now asks for a
cotangent w.r.t. them. Bounds are constants of the problem, so there is no
`dx*/d(bound)` to give back — but answering with a plain **zero** would have
converted the old loud crash into a silently wrong gradient in one case: a
bound derived from `p` that is **active** at `x*` genuinely moves `x*`, so
its dropped term is a real part of `dL/dp`. Measured, with a zero cotangent:

```
ub = p - 1  (binds on both coordinates)
AD grad   : [-0.  -0.]
FD (truth): [ 0.   2.]
```

That is the shape of pounce#73, which `_diff.py`'s own module docstring
cites. So the bound cotangent is `NaN` on exactly the coordinates where the
dropped term is nonzero, gated on the matching multiplier (`mult_x_L` for
`lb`, `mult_x_U` for `ub`; row activity plus side for `cl`/`cu` — the
multiplier's magnitude does not carry the side, so `g(x*, p)` is evaluated to
find which bound the row sits on, and only when a constraint bound was
actually traced).

What makes this cost nothing in the common case: a cotangent handed back to a
bound that *is* a constant transposes into nothing and is discarded. So the
NaN is inert for the `jnp.full(n, -10.0)` idiom this issue is about, and
unmissable for the case that would otherwise be wrong.

Full case matrix under `jit(grad)`, AD vs central differences:

| case | AD | truth |
|---|---|---|
| `jnp.full` bounds, slack | `[2, 4]` | `[2, 4]` |
| `jnp.full` bounds, **active** | `[-0, -0]` | `[~0, ~0]` |
| p-dependent `ub`, slack | `[2, 4]` | `[2, 4]` |
| p-dependent `ub`, **active** | `[nan, nan]` | `[~0, 2]` |
| constant `cl == cu`, active | `[~0, 1]` | `[~0, 1]` |
| p-dependent `cu`, **active** | `[nan, 1]` | `[-7, 1]` |
| p-dependent `cu`, slack | `[2, 4]` | `[2, 4]` |

Row 6 is the point of the gating: only `p[0]` feeds that bound, so only
`p[0]` trips — `p[1]`'s gradient survives intact. Rows 2 and 5 are the
false-positive guards: a fixed bound is exempt whether or not it binds.

## Known limitation

NaN is a blunt signal. Someone who hits it sees a poisoned gradient with no
message explaining why, and has to reach the docs or the docstring to learn
that a `p`-derived bound is binding. A `debug_nans`-style checked variant
that raised with a real explanation would be friendlier, but it cannot run
under `jit` without a host callback on every backward pass. Recorded here so
the next reader does not have to rediscover the tradeoff.

## Testing

- 7 regression tests for the tracer leak (the issue's exact repro; a
  `["jit", "jit_of_grad", "grad_of_jit"]` parametrization comparing jnp
  against numpy bounds; warm-start and threadpool paths). All confirmed to
  **fail** on the pre-fix `_diff.py` and pass after.
- 4 tests for the tripwire: two proving it fires, a 5-case parametrization
  proving it never false-fires and matches finite differences, and one
  covering the `solve_with_warm` / `vmap_solve_parallel` backwards.
- Verified matrix: 4 APIs x 5 transforms (eager, jit, grad, jit(grad),
  grad(jit)) x 2 bound flavours (numpy, jnp) — all numerically identical.
- jax-adjacent suites 227 passed; rest of the Python suite 1002 passed.
- Ruff findings identical to baseline (6, all pre-existing).

**Not a trajectory change** — this is Python frontend plumbing; the same
bounds reach the same `Problem`. `scripts/sweep-fixtures.sh` is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9Tqn6nrW7B91fC1HpJsHp
