### PR TITLE
Implement reusable PSD certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ changes.
 
 ## [Unreleased]
 
+- **Sparse PSD certification is now a reusable Rust API.**
+
+  `pounce_convex::certify_psd_lower_triangle` (also available through
+  `pounce_rs::convex`) performs the safe classifier previously private to the
+  CLI: it sums duplicate lower-triangle triplets, keeps an expected-`O(nnz)`
+  diagonal fast path, and certifies coupled matrices from the inertia of a
+  tolerance-shifted sparse factorization supplied by the caller. Malformed
+  input, factorization failure, or a backend without inertia conservatively
+  returns `false`. `pounce_rs::linsol` now also re-exports
+  `ESymSolverStatus` and `EMatrixFormat`, so facade-only backend integrations
+  no longer need debug-string status comparisons or a direct
+  `pounce-linsol` dependency.
+
 - **`pounce.jax.solve` composes with `jax.jit` when the bounds are built
   inside the traced function** (#740).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ changes.
   CLI: it sums duplicate lower-triangle triplets, keeps an expected-`O(nnz)`
   diagonal fast path, and certifies coupled matrices from the inertia of a
   tolerance-shifted sparse factorization supplied by the caller. Malformed
-  input, factorization failure, or a backend without inertia conservatively
-  returns `false`. `pounce_rs::linsol` now also re-exports
+  input is reported as `PsdCertificateError`; factorization failure or a
+  backend without inertia conservatively returns `Ok(false)`.
+  `pounce_rs::linsol` now also re-exports
   `ESymSolverStatus` and `EMatrixFormat`, so facade-only backend integrations
   no longer need debug-string status comparisons or a direct
   `pounce-linsol` dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,6 @@ version = "0.10.0"
 dependencies = [
  "anstream",
  "anstyle",
- "feral",
  "nix",
  "pounce-algorithm",
  "pounce-common",

--- a/crates/pounce-cli/Cargo.toml
+++ b/crates/pounce-cli/Cargo.toml
@@ -54,7 +54,6 @@ pounce-convex.workspace = true
 # For the AntiCyclingChoice enum when forwarding sqp_qp_* to the active-set
 # engine; already a transitive dependency via pounce-convex.
 pounce-qp.workspace = true
-feral.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing.workspace = true

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -37,6 +37,7 @@
 
 use crate::nl_reader::NlProblem;
 use pounce_common::types::{lower_bound_present, upper_bound_present};
+use pounce_convex::{Triplet, certify_psd_lower_triangle};
 
 /// Tolerance for the smallest-eigenvalue sign test in the convexity
 /// check. A Hessian eigenvalue below `-PSD_TOL` is treated as a genuine
@@ -727,100 +728,16 @@ fn socp_reform_flops(h: &QuadHessian) -> u128 {
 
 /// Is the (symmetric, sparse) Hessian positive semidefinite?
 ///
-/// A purely diagonal Hessian is settled in `O(nnz)` by sign — its
-/// eigenvalues *are* its diagonal entries — with no factorization at all;
-/// this keeps large separable / least-squares QPs cheap. A *coupled*
-/// Hessian is certified by a sparse symmetric factorization (see
-/// [`coupled_hessian_is_psd`]): feral's LDLᵀ reports the matrix inertia in
-/// roughly `O(nnz · fill)`, so even the large but sparse coupled Hessians of
-/// the CVXQP family (n ≈ 1000) are classified in well under the solve cost —
-/// no dense `k×k` allocation and no `O(k³)` eigensolve. Returns `true` only
-/// when the smallest eigenvalue is `≥ -PSD_TOL`; an indefinite or
-/// inconclusive result returns `false`, routing to the safe (more general)
-/// class.
-fn hessian_is_psd(h: &QuadHessian, _n: usize) -> bool {
-    if h.is_empty() {
-        return true; // zero matrix is PSD (the linear case)
-    }
-    // Fast path: a diagonal Hessian is PSD iff every diagonal entry is
-    // `≥ -PSD_TOL`. No factorization — essential for large but separable
-    // objectives, where the answer is trivial.
-    if h.keys().all(|(i, j)| i == j) {
-        return h.values().all(|v| *v >= -PSD_TOL);
-    }
-    coupled_hessian_is_psd(h)
-}
-
-/// PSD certificate for a *coupled* Hessian via a sparse symmetric
-/// factorization.
-///
-/// The test is positive-definiteness of the `ε`-shifted matrix `H + ε·I`
-/// with `ε = PSD_TOL`. A genuinely-PSD `H` (smallest eigenvalue `λ_min ≥ 0`,
-/// even a singular one) becomes strictly positive definite after the shift,
-/// so feral factors it with no negative pivots (`inertia.negative == 0`); a
-/// truly indefinite `H` with `λ_min < -PSD_TOL` keeps a strictly-negative
-/// shifted eigenvalue and yields `negative > 0`. The `negative == 0` test on
-/// the shifted matrix is therefore exactly `λ_min ≥ -PSD_TOL` — the same
-/// tolerance the dense path used — and it scales to large sparse Hessians
-/// because the factorization cost tracks the nonzero/fill count, not a dense
-/// `k³`.
-///
-/// The Hessian is compressed to its active variable set so the factored
-/// dimension is `k` (the number of distinct variables in the form). The
-/// [`QuadHessian`] is upper-triangular (`i ≤ j`); feral wants the lower
-/// triangle (`row ≥ col`), so each entry `(i, j)` is emitted at
-/// `(row = j, col = i)`. Every active diagonal is seeded with `ε` (the shift;
-/// `from_triplets` sums it with any diagonal entry already in `H`), which
-/// also guarantees no structurally empty column. A non-`Success`
-/// factorization (singular/fatal — should not occur given the strictly-PD
-/// shift, but possible on a pathological form) is treated conservatively as
-/// not-provably-PSD.
-fn coupled_hessian_is_psd(h: &QuadHessian) -> bool {
-    use feral::{CscMatrix, FactorStatus, Solver};
-
-    // Compress to the active variable set so the factored dimension is `k`.
-    let mut active: Vec<usize> = Vec::with_capacity(2 * h.len());
-    for (i, j) in h.keys() {
-        active.push(*i);
-        active.push(*j);
-    }
-    active.sort_unstable();
-    active.dedup();
-    let k = active.len();
-    let idx = |v: usize| active.binary_search(&v).unwrap();
-
-    // Lower-triangle triplets: H's entry (i ≤ j) maps to (row = j, col = i).
-    // Capacity covers H's nonzeros plus one ε-shift per active diagonal.
-    let mut rows: Vec<usize> = Vec::with_capacity(h.len() + k);
-    let mut cols: Vec<usize> = Vec::with_capacity(h.len() + k);
-    let mut vals: Vec<f64> = Vec::with_capacity(h.len() + k);
-    for ((i, j), v) in h {
-        let (ri, rj) = (idx(*i), idx(*j));
-        // i ≤ j by the upper-tri convention, so rj ≥ ri ⇒ lower triangle.
-        rows.push(rj);
-        cols.push(ri);
-        vals.push(*v);
-    }
-    // εI shift: seed every active diagonal (summed with H's own diagonal).
-    for d in 0..k {
-        rows.push(d);
-        cols.push(d);
-        vals.push(PSD_TOL);
-    }
-
-    let mat = match CscMatrix::from_triplets(k, &rows, &cols, &vals) {
-        Ok(m) => m,
-        Err(_) => return false, // malformed ⇒ be conservative
-    };
-    let mut solver = Solver::new();
-    match solver.factor(&mat, None) {
-        FactorStatus::Success => {
-            // PD ⟺ no negative pivots in the LDLᵀ of the ε-shifted matrix.
-            solver.inertia().map(|i| i.negative == 0).unwrap_or(false)
-        }
-        // Singular / wrong-inertia / fatal: cannot certify ⇒ safe fallback.
-        _ => false,
-    }
+/// A diagonal Hessian is settled in `O(nnz)` by sign. A coupled Hessian is
+/// certified from the inertia of `H + PSD_TOL·I`.
+fn hessian_is_psd(h: &QuadHessian, n: usize) -> bool {
+    let lower: Vec<_> = h
+        .iter()
+        .map(|(&(row, col), &val)| Triplet::new(col, row, val))
+        .collect();
+    certify_psd_lower_triangle(n, &lower, PSD_TOL, || {
+        Box::new(pounce_feral::FeralSolverInterface::new())
+    })
 }
 
 #[cfg(test)]

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -745,6 +745,8 @@ fn hessian_is_psd(h: &QuadHessian, n: usize) -> bool {
 
     let lower: Vec<_> = h
         .iter()
+        // QuadHessian is upper-triangular (i <= j). The certificate wants the
+        // lower triangle, so (i, j) is emitted at (row = j, col = i).
         .map(|(&(i, j), &val)| Triplet::new(j, i, val))
         .collect();
     certify_psd_lower_triangle(n, &lower, PSD_TOL, || {

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -731,6 +731,10 @@ fn socp_reform_flops(h: &QuadHessian) -> u128 {
 /// A diagonal Hessian is settled in `O(nnz)` by sign before converting to the
 /// reusable triplet API. A coupled Hessian is certified from the inertia of
 /// `H + PSD_TOL·I`. An inconclusive certificate conservatively routes to NLP.
+/// The absolute shift is intentional and preserves the classifier's
+/// `lambda_min(H) >= -PSD_TOL` contract. On badly scaled, rank-deficient PSD
+/// matrices it can fall below floating-point resolution, in which case FERAL
+/// reports a zero pivot and this dispatch takes the slower NLP path.
 fn hessian_is_psd(h: &QuadHessian, n: usize) -> bool {
     if h.is_empty() {
         return true;
@@ -744,7 +748,9 @@ fn hessian_is_psd(h: &QuadHessian, n: usize) -> bool {
         .map(|(&(i, j), &val)| Triplet::new(j, i, val))
         .collect();
     certify_psd_lower_triangle(n, &lower, PSD_TOL, || {
-        Box::new(pounce_feral::FeralSolverInterface::new())
+        Box::new(pounce_feral::FeralSolverInterface::with_config(
+            pounce_feral::FeralConfig::default(),
+        ))
     })
     .unwrap_or(false)
 }

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -728,16 +728,25 @@ fn socp_reform_flops(h: &QuadHessian) -> u128 {
 
 /// Is the (symmetric, sparse) Hessian positive semidefinite?
 ///
-/// A diagonal Hessian is settled in `O(nnz)` by sign. A coupled Hessian is
-/// certified from the inertia of `H + PSD_TOL·I`.
+/// A diagonal Hessian is settled in `O(nnz)` by sign before converting to the
+/// reusable triplet API. A coupled Hessian is certified from the inertia of
+/// `H + PSD_TOL·I`. An inconclusive certificate conservatively routes to NLP.
 fn hessian_is_psd(h: &QuadHessian, n: usize) -> bool {
+    if h.is_empty() {
+        return true;
+    }
+    if h.keys().all(|(i, j)| i == j) {
+        return h.values().all(|value| *value >= -PSD_TOL);
+    }
+
     let lower: Vec<_> = h
         .iter()
-        .map(|(&(row, col), &val)| Triplet::new(col, row, val))
+        .map(|(&(i, j), &val)| Triplet::new(j, i, val))
         .collect();
     certify_psd_lower_triangle(n, &lower, PSD_TOL, || {
         Box::new(pounce_feral::FeralSolverInterface::new())
     })
+    .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -20,6 +20,8 @@
 //! Entry points:
 //! - [`solve_qp_ipm`] — solve a [`qp::QpProblem`] (covers LP via an empty
 //!   `P`).
+//! - [`certify_psd_lower_triangle`] — conservatively certify a sparse
+//!   symmetric matrix from a caller-supplied inertia-reporting backend.
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
@@ -36,6 +38,7 @@ pub mod hsde;
 pub mod hsde_nonsym;
 pub mod ipm;
 pub mod presolve;
+mod psd_certificate;
 pub mod qp;
 pub mod sensitivity;
 pub(crate) mod simplex;
@@ -51,6 +54,7 @@ pub use ipm::{
     QpFactorization, QpOptions, QpWarmStart, solve_qp_ipm, solve_qp_ipm_debug, solve_qp_ipm_warm,
     solve_socp_ipm, solve_socp_ipm_debug, solve_socp_ipm_warm,
 };
+pub use psd_certificate::certify_psd_lower_triangle;
 pub use qp::{NEG_INF, POS_INF, QpIterate, QpProblem, QpResiduals, QpSolution, QpStatus, Triplet};
 pub use sensitivity::{QpSensitivity, ReducedHessian, SensError};
 pub use sos::{

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -21,7 +21,8 @@
 //! - [`solve_qp_ipm`] — solve a [`qp::QpProblem`] (covers LP via an empty
 //!   `P`).
 //! - [`certify_psd_lower_triangle`] — conservatively certify a sparse
-//!   symmetric matrix from a caller-supplied inertia-reporting backend.
+//!   symmetric matrix from a caller-supplied inertia-reporting backend;
+//!   malformed input is returned as [`PsdCertificateError`].
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
@@ -54,7 +55,7 @@ pub use ipm::{
     QpFactorization, QpOptions, QpWarmStart, solve_qp_ipm, solve_qp_ipm_debug, solve_qp_ipm_warm,
     solve_socp_ipm, solve_socp_ipm_debug, solve_socp_ipm_warm,
 };
-pub use psd_certificate::certify_psd_lower_triangle;
+pub use psd_certificate::{PsdCertificateError, certify_psd_lower_triangle};
 pub use qp::{NEG_INF, POS_INF, QpIterate, QpProblem, QpResiduals, QpSolution, QpStatus, Triplet};
 pub use sensitivity::{QpSensitivity, ReducedHessian, SensError};
 pub use sos::{

--- a/crates/pounce-convex/src/psd_certificate.rs
+++ b/crates/pounce-convex/src/psd_certificate.rs
@@ -7,6 +7,31 @@ use pounce_linsol::{Factorization, SparseSymLinearSolverInterface};
 
 use crate::Triplet;
 
+/// An input error reported by [`certify_psd_lower_triangle`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PsdCertificateError {
+    /// `tolerance` was negative, NaN, or infinite.
+    InvalidTolerance,
+    /// A triplet coordinate is outside the declared `n × n` matrix.
+    OutOfBounds {
+        /// Zero-based row coordinate.
+        row: usize,
+        /// Zero-based column coordinate.
+        col: usize,
+        /// Declared matrix dimension.
+        dimension: usize,
+    },
+    /// The caller supplied an upper-triangle triplet to a lower-triangle API.
+    UpperTriangle { row: usize, col: usize },
+    /// A triplet value is not finite.
+    NonFiniteValue { row: usize, col: usize },
+    /// Summing duplicate triplets overflowed to a non-finite value.
+    NonFiniteSum { row: usize, col: usize },
+    /// The matrix pattern cannot be represented by the linear-solver index
+    /// type on this target.
+    DimensionTooLarge,
+}
+
 /// Certify that a sparse symmetric matrix is positive semidefinite within an
 /// absolute tolerance.
 ///
@@ -14,45 +39,74 @@ use crate::Triplet;
 /// coordinates (`row >= col`). Duplicate coordinates are summed. The
 /// diagonal fast path accepts an eigenvalue down to `-tolerance`, while coupled
 /// matrices are tested by factoring `A + tolerance * I` and inspecting its
-/// inertia. A coupled matrix exactly on that shifted singular boundary may be
-/// rejected conservatively when the backend cannot produce an inertia.
+/// inertia. At the exact boundary `lambda_min(A) = -tolerance`, the shifted
+/// matrix is singular, so a backend that rejects singular factors may return
+/// `Ok(false)` even though the eigenvalue is within the requested tolerance.
+/// A backend that reports no inertia, or a factorization that fails, likewise
+/// produces `Ok(false)` rather than a certificate.
+///
+/// For a symmetric matrix, shifting every eigenvalue by `tolerance` gives
+/// `lambda_min(A + tolerance I) = lambda_min(A) + tolerance`. Therefore a
+/// successful factorization with zero negative eigenvalues certifies exactly
+/// `lambda_min(A) >= -tolerance`; it does not require the original matrix to
+/// be nonsingular. The strict lower-triangle convention is important here:
+/// each off-diagonal is supplied once and the factorization layer mirrors it
+/// according to its symmetric-matrix contract.
 ///
 /// Empty and diagonal matrices are settled without constructing `make_backend`.
 /// A coupled matrix is compressed to the variables present in its nonzero
 /// pattern before it is factored, so structurally zero rows do not inflate the
 /// factorization.
+///
+/// The shift is deliberately absolute: it preserves the classifier's
+/// `lambda_min(A) >= -tolerance` contract. At very large matrix scales an
+/// absolute shift can be below floating-point resolution, and an exact
+/// rank-deficient PSD matrix may consequently be rejected as singular by a
+/// backend. That is a conservative dispatch fallback, not evidence of a
+/// negative eigenvalue; changing to a norm-relative tolerance would be a
+/// separate numerical-policy change.
 pub fn certify_psd_lower_triangle<F>(
     n: usize,
     triplets: &[Triplet],
     tolerance: f64,
     make_backend: F,
-) -> bool
+) -> Result<bool, PsdCertificateError>
 where
     F: FnOnce() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     if !tolerance.is_finite() || tolerance < 0.0 {
-        return false;
+        return Err(PsdCertificateError::InvalidTolerance);
     }
 
     let mut entries = HashMap::<(usize, usize), f64>::with_capacity(triplets.len());
     for &Triplet { row, col, val } in triplets {
-        if row >= n || col >= n || row < col || !val.is_finite() {
-            return false;
+        if row >= n || col >= n {
+            return Err(PsdCertificateError::OutOfBounds {
+                row,
+                col,
+                dimension: n,
+            });
+        }
+        if row < col {
+            return Err(PsdCertificateError::UpperTriangle { row, col });
+        }
+        if !val.is_finite() {
+            return Err(PsdCertificateError::NonFiniteValue { row, col });
         }
         let sum = entries.entry((row, col)).or_default();
         *sum += val;
         if !sum.is_finite() {
-            return false;
+            return Err(PsdCertificateError::NonFiniteSum { row, col });
         }
     }
     entries.retain(|_, value| *value != 0.0);
 
     if entries.is_empty() {
-        return true;
+        return Ok(true);
     }
 
     if entries.keys().all(|(row, col)| row == col) {
-        return entries.values().all(|value| *value >= -tolerance);
+        return Ok(entries.values().all(|value| *value >= -tolerance));
     }
 
     let mut active = Vec::with_capacity(2 * entries.len());
@@ -64,53 +118,54 @@ where
     active.dedup();
 
     let Ok(dim) = Index::try_from(active.len()) else {
-        return false;
+        return Err(PsdCertificateError::DimensionTooLarge);
     };
+    let active_index: HashMap<usize, usize> = active
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(compressed, original)| (original, compressed))
+        .collect();
     let mut shifted = BTreeMap::<(usize, usize), f64>::new();
     for ((row, col), value) in entries {
-        let Ok(compressed_row) = active.binary_search(&row) else {
-            return false;
-        };
-        let Ok(compressed_col) = active.binary_search(&col) else {
-            return false;
-        };
+        // Both coordinates were used to construct `active`, so these lookups
+        // are total for every entry in the validated map.
+        let compressed_row = active_index[&row];
+        let compressed_col = active_index[&col];
         shifted.insert((compressed_row, compressed_col), value);
     }
 
-    for diagonal in 0..active.len() {
+    for (diagonal, &original) in active.iter().enumerate() {
         let value = shifted.entry((diagonal, diagonal)).or_default();
         *value += tolerance;
         if !value.is_finite() {
-            return false;
+            return Err(PsdCertificateError::NonFiniteSum {
+                row: original,
+                col: original,
+            });
         }
     }
     if Index::try_from(shifted.len()).is_err() {
-        return false;
+        return Err(PsdCertificateError::DimensionTooLarge);
     }
 
     let mut rows = Vec::with_capacity(shifted.len());
     let mut cols = Vec::with_capacity(shifted.len());
     let mut values = Vec::with_capacity(shifted.len());
     for ((row, col), value) in shifted {
-        let Ok(row_1) = Index::try_from(row + 1) else {
-            return false;
-        };
-        let Ok(col_1) = Index::try_from(col + 1) else {
-            return false;
-        };
-        rows.push(row_1);
-        cols.push(col_1);
+        rows.push(row as Index + 1);
+        cols.push(col as Index + 1);
         values.push(value);
     }
 
     let backend = make_backend();
     if !backend.provides_inertia() {
-        return false;
+        return Ok(false);
     }
     let Ok(factor) = Factorization::new(dim, rows, cols, values, backend) else {
-        return false;
+        return Ok(false);
     };
-    factor.number_of_neg_evals() == Some(0)
+    Ok(factor.number_of_neg_evals() == Some(0))
 }
 
 #[cfg(test)]
@@ -129,19 +184,25 @@ mod tests {
         let no_backend = || -> Box<dyn SparseSymLinearSolverInterface> {
             panic!("the diagonal fast path must not construct a backend")
         };
-        assert!(certify_psd_lower_triangle(4, &[], 1e-9, no_backend));
+        assert!(certify_psd_lower_triangle(4, &[], 1e-9, no_backend).unwrap());
 
         let diagonal = [
             Triplet::new(0, 0, 3.0),
             Triplet::new(1, 1, -2.0),
             Triplet::new(1, 1, 2.0 - 5e-10),
         ];
-        assert!(certify_psd_lower_triangle(2, &diagonal, 1e-9, || {
-            panic!("the diagonal fast path must not construct a backend")
-        }));
-        assert!(!certify_psd_lower_triangle(2, &diagonal, 1e-11, || {
-            panic!("the diagonal fast path must not construct a backend")
-        }));
+        assert!(
+            certify_psd_lower_triangle(2, &diagonal, 1e-9, || {
+                panic!("the diagonal fast path must not construct a backend")
+            })
+            .unwrap()
+        );
+        assert!(
+            !certify_psd_lower_triangle(2, &diagonal, 1e-11, || {
+                panic!("the diagonal fast path must not construct a backend")
+            })
+            .unwrap()
+        );
     }
 
     #[test]
@@ -151,24 +212,14 @@ mod tests {
             Triplet::new(1, 0, 1.0),
             Triplet::new(1, 1, 1.0),
         ];
-        assert!(certify_psd_lower_triangle(
-            2,
-            &singular_psd,
-            1e-9,
-            feral_backend
-        ));
+        assert!(certify_psd_lower_triangle(2, &singular_psd, 1e-9, feral_backend).unwrap());
 
         let indefinite = [
             Triplet::new(0, 0, 2.0),
             Triplet::new(1, 0, 0.25),
             Triplet::new(1, 1, -1e-4),
         ];
-        assert!(!certify_psd_lower_triangle(
-            2,
-            &indefinite,
-            1e-9,
-            feral_backend
-        ));
+        assert!(!certify_psd_lower_triangle(2, &indefinite, 1e-9, feral_backend).unwrap());
     }
 
     #[test]
@@ -184,18 +235,14 @@ mod tests {
                 Triplet::new(1, 1, 1.0),
             ]
         };
-        assert!(certify_psd_lower_triangle(
-            2,
-            &matrix(0.5 * TOLERANCE),
-            TOLERANCE,
-            feral_backend
-        ));
-        assert!(!certify_psd_lower_triangle(
-            2,
-            &matrix(2.0 * TOLERANCE),
-            TOLERANCE,
-            feral_backend
-        ));
+        assert!(
+            certify_psd_lower_triangle(2, &matrix(0.5 * TOLERANCE), TOLERANCE, feral_backend)
+                .unwrap()
+        );
+        assert!(
+            !certify_psd_lower_triangle(2, &matrix(2.0 * TOLERANCE), TOLERANCE, feral_backend)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -207,9 +254,12 @@ mod tests {
             Triplet::new(1, 0, -4.0),
             Triplet::new(1, 1, 1.0),
         ];
-        assert!(certify_psd_lower_triangle(2, &matrix, 0.0, || {
-            panic!("cancelled coupling should use the diagonal fast path")
-        }));
+        assert!(
+            certify_psd_lower_triangle(2, &matrix, 0.0, || {
+                panic!("cancelled coupling should use the diagonal fast path")
+            })
+            .unwrap()
+        );
     }
 
     #[test]
@@ -222,10 +272,19 @@ mod tests {
             (vec![Triplet::new(0, 0, 1.0)], f64::INFINITY),
         ];
         for (matrix, tolerance) in cases {
-            assert!(!certify_psd_lower_triangle(2, &matrix, tolerance, || {
-                panic!("invalid input must not construct a backend")
-            }));
+            assert!(
+                certify_psd_lower_triangle(2, &matrix, tolerance, || {
+                    panic!("invalid input must not construct a backend")
+                })
+                .is_err()
+            );
         }
+        assert!(matches!(
+            certify_psd_lower_triangle(2, &[Triplet::new(0, 1, 1.0)], 1e-9, || {
+                panic!("upper-triangle input must not construct a backend")
+            }),
+            Err(PsdCertificateError::UpperTriangle { row: 0, col: 1 })
+        ));
     }
 
     struct MockBackend {
@@ -361,12 +420,15 @@ mod tests {
         let record = Rc::new(RefCell::new(BackendRecord::default()));
         let backend_record = Rc::clone(&record);
 
-        assert!(certify_psd_lower_triangle(8, &matrix, 0.5, move || {
-            Box::new(RecordingBackend {
-                values: Vec::new(),
-                record: backend_record,
+        assert!(
+            certify_psd_lower_triangle(8, &matrix, 0.5, move || {
+                Box::new(RecordingBackend {
+                    values: Vec::new(),
+                    record: backend_record,
+                })
             })
-        }));
+            .unwrap()
+        );
 
         let record = record.borrow();
         assert_eq!(record.dim, Some(3));
@@ -395,17 +457,23 @@ mod tests {
                 })
             }
         };
-        assert!(!certify_psd_lower_triangle(
-            2,
-            &coupled_matrix(),
-            1e-9,
-            make_mock(ESymSolverStatus::Success, None),
-        ));
-        assert!(!certify_psd_lower_triangle(
-            2,
-            &coupled_matrix(),
-            1e-9,
-            make_mock(ESymSolverStatus::Singular, Some(0)),
-        ));
+        assert!(
+            !certify_psd_lower_triangle(
+                2,
+                &coupled_matrix(),
+                1e-9,
+                make_mock(ESymSolverStatus::Success, None),
+            )
+            .unwrap()
+        );
+        assert!(
+            !certify_psd_lower_triangle(
+                2,
+                &coupled_matrix(),
+                1e-9,
+                make_mock(ESymSolverStatus::Singular, Some(0)),
+            )
+            .unwrap()
+        );
     }
 }

--- a/crates/pounce-convex/src/psd_certificate.rs
+++ b/crates/pounce-convex/src/psd_certificate.rs
@@ -1,0 +1,411 @@
+//! Conservative positive-semidefiniteness certificates for sparse matrices.
+
+use std::collections::{BTreeMap, HashMap};
+
+use pounce_common::types::Index;
+use pounce_linsol::{Factorization, SparseSymLinearSolverInterface};
+
+use crate::Triplet;
+
+/// Certify that a sparse symmetric matrix is positive semidefinite within an
+/// absolute tolerance.
+///
+/// `triplets` supplies the matrix's lower triangle in zero-based
+/// coordinates (`row >= col`). Duplicate coordinates are summed. The
+/// diagonal fast path accepts an eigenvalue down to `-tolerance`, while coupled
+/// matrices are tested by factoring `A + tolerance * I` and inspecting its
+/// inertia. A coupled matrix exactly on that shifted singular boundary may be
+/// rejected conservatively when the backend cannot produce an inertia.
+///
+/// Empty and diagonal matrices are settled without constructing `make_backend`.
+/// A coupled matrix is compressed to the variables present in its nonzero
+/// pattern before it is factored, so structurally zero rows do not inflate the
+/// factorization.
+pub fn certify_psd_lower_triangle<F>(
+    n: usize,
+    triplets: &[Triplet],
+    tolerance: f64,
+    make_backend: F,
+) -> bool
+where
+    F: FnOnce() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    if !tolerance.is_finite() || tolerance < 0.0 {
+        return false;
+    }
+
+    let mut entries = HashMap::<(usize, usize), f64>::with_capacity(triplets.len());
+    for &Triplet { row, col, val } in triplets {
+        if row >= n || col >= n || row < col || !val.is_finite() {
+            return false;
+        }
+        let sum = entries.entry((row, col)).or_default();
+        *sum += val;
+        if !sum.is_finite() {
+            return false;
+        }
+    }
+    entries.retain(|_, value| *value != 0.0);
+
+    if entries.is_empty() {
+        return true;
+    }
+
+    if entries.keys().all(|(row, col)| row == col) {
+        return entries.values().all(|value| *value >= -tolerance);
+    }
+
+    let mut active = Vec::with_capacity(2 * entries.len());
+    for &(row, col) in entries.keys() {
+        active.push(row);
+        active.push(col);
+    }
+    active.sort_unstable();
+    active.dedup();
+
+    let Ok(dim) = Index::try_from(active.len()) else {
+        return false;
+    };
+    let mut shifted = BTreeMap::<(usize, usize), f64>::new();
+    for ((row, col), value) in entries {
+        let Ok(compressed_row) = active.binary_search(&row) else {
+            return false;
+        };
+        let Ok(compressed_col) = active.binary_search(&col) else {
+            return false;
+        };
+        shifted.insert((compressed_row, compressed_col), value);
+    }
+
+    for diagonal in 0..active.len() {
+        let value = shifted.entry((diagonal, diagonal)).or_default();
+        *value += tolerance;
+        if !value.is_finite() {
+            return false;
+        }
+    }
+    if Index::try_from(shifted.len()).is_err() {
+        return false;
+    }
+
+    let mut rows = Vec::with_capacity(shifted.len());
+    let mut cols = Vec::with_capacity(shifted.len());
+    let mut values = Vec::with_capacity(shifted.len());
+    for ((row, col), value) in shifted {
+        let Ok(row_1) = Index::try_from(row + 1) else {
+            return false;
+        };
+        let Ok(col_1) = Index::try_from(col + 1) else {
+            return false;
+        };
+        rows.push(row_1);
+        cols.push(col_1);
+        values.push(value);
+    }
+
+    let backend = make_backend();
+    if !backend.provides_inertia() {
+        return false;
+    }
+    let Ok(factor) = Factorization::new(dim, rows, cols, values, backend) else {
+        return false;
+    };
+    factor.number_of_neg_evals() == Some(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pounce_linsol::{EMatrixFormat, ESymSolverStatus};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn feral_backend() -> Box<dyn SparseSymLinearSolverInterface> {
+        Box::new(pounce_feral::FeralSolverInterface::serial())
+    }
+
+    #[test]
+    fn empty_and_diagonal_matrices_do_not_construct_a_backend() {
+        let no_backend = || -> Box<dyn SparseSymLinearSolverInterface> {
+            panic!("the diagonal fast path must not construct a backend")
+        };
+        assert!(certify_psd_lower_triangle(4, &[], 1e-9, no_backend));
+
+        let diagonal = [
+            Triplet::new(0, 0, 3.0),
+            Triplet::new(1, 1, -2.0),
+            Triplet::new(1, 1, 2.0 - 5e-10),
+        ];
+        assert!(certify_psd_lower_triangle(2, &diagonal, 1e-9, || {
+            panic!("the diagonal fast path must not construct a backend")
+        }));
+        assert!(!certify_psd_lower_triangle(2, &diagonal, 1e-11, || {
+            panic!("the diagonal fast path must not construct a backend")
+        }));
+    }
+
+    #[test]
+    fn coupled_psd_and_indefinite_matrices_are_distinguished() {
+        let singular_psd = [
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, 1.0),
+        ];
+        assert!(certify_psd_lower_triangle(
+            2,
+            &singular_psd,
+            1e-9,
+            feral_backend
+        ));
+
+        let indefinite = [
+            Triplet::new(0, 0, 2.0),
+            Triplet::new(1, 0, 0.25),
+            Triplet::new(1, 1, -1e-4),
+        ];
+        assert!(!certify_psd_lower_triangle(
+            2,
+            &indefinite,
+            1e-9,
+            feral_backend
+        ));
+    }
+
+    #[test]
+    fn coupled_tolerance_boundary_is_applied_to_the_spectrum() {
+        const TOLERANCE: f64 = 1e-6;
+
+        // [[1, 1 + delta], [1 + delta, 1]] has eigenvalues
+        // -delta and 2 + delta.
+        let matrix = |delta| {
+            [
+                Triplet::new(0, 0, 1.0),
+                Triplet::new(1, 0, 1.0 + delta),
+                Triplet::new(1, 1, 1.0),
+            ]
+        };
+        assert!(certify_psd_lower_triangle(
+            2,
+            &matrix(0.5 * TOLERANCE),
+            TOLERANCE,
+            feral_backend
+        ));
+        assert!(!certify_psd_lower_triangle(
+            2,
+            &matrix(2.0 * TOLERANCE),
+            TOLERANCE,
+            feral_backend
+        ));
+    }
+
+    #[test]
+    fn duplicate_off_diagonals_are_summed_before_factorization() {
+        // The off-diagonal duplicates cancel, leaving diag(1, 1).
+        let matrix = [
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(1, 0, 4.0),
+            Triplet::new(1, 0, -4.0),
+            Triplet::new(1, 1, 1.0),
+        ];
+        assert!(certify_psd_lower_triangle(2, &matrix, 0.0, || {
+            panic!("cancelled coupling should use the diagonal fast path")
+        }));
+    }
+
+    #[test]
+    fn malformed_inputs_are_not_certified() {
+        let cases = [
+            (vec![Triplet::new(0, 1, 1.0)], 1e-9),
+            (vec![Triplet::new(2, 0, 1.0)], 1e-9),
+            (vec![Triplet::new(0, 0, f64::NAN)], 1e-9),
+            (vec![Triplet::new(0, 0, 1.0)], -1.0),
+            (vec![Triplet::new(0, 0, 1.0)], f64::INFINITY),
+        ];
+        for (matrix, tolerance) in cases {
+            assert!(!certify_psd_lower_triangle(2, &matrix, tolerance, || {
+                panic!("invalid input must not construct a backend")
+            }));
+        }
+    }
+
+    struct MockBackend {
+        values: Vec<f64>,
+        solve_status: ESymSolverStatus,
+        inertia: Option<Index>,
+        panic_on_initialize: bool,
+    }
+
+    impl SparseSymLinearSolverInterface for MockBackend {
+        fn initialize_structure(
+            &mut self,
+            _dim: Index,
+            nonzeros: Index,
+            _ia: &[Index],
+            _ja: &[Index],
+        ) -> ESymSolverStatus {
+            assert!(
+                !self.panic_on_initialize,
+                "a backend without inertia must not be initialized"
+            );
+            self.values.resize(nonzeros as usize, 0.0);
+            ESymSolverStatus::Success
+        }
+
+        fn values_array_mut(&mut self) -> &mut [f64] {
+            &mut self.values
+        }
+
+        fn multi_solve(
+            &mut self,
+            _new_matrix: bool,
+            _ia: &[Index],
+            _ja: &[Index],
+            _nrhs: Index,
+            _rhs_vals: &mut [f64],
+            _check_neg_evals: bool,
+            _number_of_neg_evals: Index,
+        ) -> ESymSolverStatus {
+            self.solve_status
+        }
+
+        fn number_of_neg_evals(&self) -> Index {
+            self.inertia.unwrap_or_default()
+        }
+
+        fn increase_quality(&mut self) -> bool {
+            false
+        }
+
+        fn provides_inertia(&self) -> bool {
+            self.inertia.is_some()
+        }
+
+        fn matrix_format(&self) -> EMatrixFormat {
+            EMatrixFormat::TripletFormat
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct BackendRecord {
+        dim: Option<Index>,
+        rows: Vec<Index>,
+        cols: Vec<Index>,
+        values: Vec<f64>,
+    }
+
+    struct RecordingBackend {
+        values: Vec<f64>,
+        record: Rc<RefCell<BackendRecord>>,
+    }
+
+    impl SparseSymLinearSolverInterface for RecordingBackend {
+        fn initialize_structure(
+            &mut self,
+            dim: Index,
+            nonzeros: Index,
+            ia: &[Index],
+            ja: &[Index],
+        ) -> ESymSolverStatus {
+            self.values.resize(nonzeros as usize, 0.0);
+            let mut record = self.record.borrow_mut();
+            record.dim = Some(dim);
+            record.rows = ia.to_vec();
+            record.cols = ja.to_vec();
+            ESymSolverStatus::Success
+        }
+
+        fn values_array_mut(&mut self) -> &mut [f64] {
+            &mut self.values
+        }
+
+        fn multi_solve(
+            &mut self,
+            _new_matrix: bool,
+            _ia: &[Index],
+            _ja: &[Index],
+            _nrhs: Index,
+            _rhs_vals: &mut [f64],
+            _check_neg_evals: bool,
+            _number_of_neg_evals: Index,
+        ) -> ESymSolverStatus {
+            self.record.borrow_mut().values = self.values.clone();
+            ESymSolverStatus::Success
+        }
+
+        fn number_of_neg_evals(&self) -> Index {
+            0
+        }
+
+        fn increase_quality(&mut self) -> bool {
+            false
+        }
+
+        fn provides_inertia(&self) -> bool {
+            true
+        }
+
+        fn matrix_format(&self) -> EMatrixFormat {
+            EMatrixFormat::TripletFormat
+        }
+    }
+
+    #[test]
+    fn coupled_matrix_is_normalized_compressed_shifted_and_one_based() {
+        let matrix = [
+            Triplet::new(4, 4, 3.0),
+            Triplet::new(4, 1, 0.75),
+            Triplet::new(7, 7, 4.0),
+            Triplet::new(1, 1, 2.0),
+            Triplet::new(4, 1, 0.25),
+        ];
+        let record = Rc::new(RefCell::new(BackendRecord::default()));
+        let backend_record = Rc::clone(&record);
+
+        assert!(certify_psd_lower_triangle(8, &matrix, 0.5, move || {
+            Box::new(RecordingBackend {
+                values: Vec::new(),
+                record: backend_record,
+            })
+        }));
+
+        let record = record.borrow();
+        assert_eq!(record.dim, Some(3));
+        assert_eq!(record.rows, [1, 2, 2, 3]);
+        assert_eq!(record.cols, [1, 1, 2, 3]);
+        assert_eq!(record.values, [2.5, 1.0, 3.5, 4.5]);
+    }
+
+    fn coupled_matrix() -> [Triplet; 3] {
+        [
+            Triplet::new(0, 0, 2.0),
+            Triplet::new(1, 0, 0.1),
+            Triplet::new(1, 1, 2.0),
+        ]
+    }
+
+    #[test]
+    fn missing_inertia_and_factorization_failures_are_inconclusive() {
+        let make_mock = |solve_status, inertia| {
+            move || -> Box<dyn SparseSymLinearSolverInterface> {
+                Box::new(MockBackend {
+                    values: vec![],
+                    solve_status,
+                    inertia,
+                    panic_on_initialize: inertia.is_none(),
+                })
+            }
+        };
+        assert!(!certify_psd_lower_triangle(
+            2,
+            &coupled_matrix(),
+            1e-9,
+            make_mock(ESymSolverStatus::Success, None),
+        ));
+        assert!(!certify_psd_lower_triangle(
+            2,
+            &coupled_matrix(),
+            1e-9,
+            make_mock(ESymSolverStatus::Singular, Some(0)),
+        ));
+    }
+}

--- a/crates/pounce-convex/src/psd_certificate.rs
+++ b/crates/pounce-convex/src/psd_certificate.rs
@@ -39,11 +39,19 @@ pub enum PsdCertificateError {
 /// coordinates (`row >= col`). Duplicate coordinates are summed. The
 /// diagonal fast path accepts an eigenvalue down to `-tolerance`, while coupled
 /// matrices are tested by factoring `A + tolerance * I` and inspecting its
-/// inertia. At the exact boundary `lambda_min(A) = -tolerance`, the shifted
-/// matrix is singular, so a backend that rejects singular factors may return
-/// `Ok(false)` even though the eigenvalue is within the requested tolerance.
-/// A backend that reports no inertia, or a factorization that fails, likewise
-/// produces `Ok(false)` rather than a certificate.
+/// inertia. These branches differ at the exact boundary: the diagonal test is
+/// inclusive (`lambda_min(A) >= -tolerance`), but the coupled route must first
+/// accept the shifted matrix as a nonsingular factorization and is therefore
+/// effectively strict (`lambda_min(A) > -tolerance`) with the current FERAL
+/// backend.
+///
+/// At `lambda_min(A) = -tolerance`, the shifted matrix has a zero eigenvalue.
+/// FERAL reports that zero pivot as `Singular`; `Factorization::new` converts
+/// that status to an error, so the certificate returns `Ok(false)` before
+/// `number_of_neg_evals` is consulted. This is separate from the later
+/// `provides_inertia()` guard: a backend that reports no inertia, or any other
+/// factorization failure, likewise produces `Ok(false)` rather than a
+/// certificate.
 ///
 /// For a symmetric matrix, shifting every eigenvalue by `tolerance` gives
 /// `lambda_min(A + tolerance I) = lambda_min(A) + tolerance`. Therefore a

--- a/crates/pounce-convex/src/psd_certificate.rs
+++ b/crates/pounce-convex/src/psd_certificate.rs
@@ -53,6 +53,30 @@ pub enum PsdCertificateError {
 /// each off-diagonal is supplied once and the factorization layer mirrors it
 /// according to its symmetric-matrix contract.
 ///
+/// More explicitly, the factorization is an `L D L^T` factorization of the
+/// shifted symmetric matrix, up to the backend's permutation. The factor is a
+/// congruence, so Sylvester's law of inertia makes the reported negative-pivot
+/// count equal to the shifted matrix's number of negative eigenvalues. Since
+/// every eigenvalue is shifted by the same `tolerance`, `negative == 0` is
+/// equivalent to `lambda_min(A) + tolerance >= 0`. A singular PSD matrix has
+/// `lambda_min(A) = 0`, so the shift moves its zero eigenvalue to the strictly
+/// positive value `tolerance` and it is certified just like an SPD matrix
+/// (subject to the backend's finite-precision singularity policy).
+///
+/// The diagonal branch is intentionally separate: once duplicate entries have
+/// been summed, a diagonal matrix's eigenvalues are its diagonal entries, so a
+/// single sign scan settles it in `O(nnz)` without constructing or factoring a
+/// backend. That cost matters for the large separable and least-squares QP
+/// shapes, whose Hessians can contain tens of thousands of diagonal entries
+/// even though their convexity is trivial.
+///
+/// Coupled Hessians use the sparse factorization instead of a dense Jacobi or
+/// eigensolve. The latter allocates a dense `k × k` matrix and costs
+/// `O(k^3)` for the `k` active variables; sparse inertia follows the nonzero
+/// pattern and its fill. This is what makes the coupled, sparse Hessians in
+/// the CVXQP family (typically around `k = 1000`) practical to classify
+/// without paying a dense cubic eigenvalue computation before the solve.
+///
 /// Empty and diagonal matrices are settled without constructing `make_backend`.
 /// A coupled matrix is compressed to the variables present in its nonzero
 /// pattern before it is factored, so structurally zero rows do not inflate the

--- a/crates/pounce-rs/src/convex.rs
+++ b/crates/pounce-rs/src/convex.rs
@@ -101,12 +101,12 @@
 pub use pounce_convex::{
     ActiveSetOverrides, ConeSpec, NEG_INF, POS_INF, PolyProblem, Polynomial, QpFactorization,
     QpIterate, QpOptions, QpProblem, QpResiduals, QpSensitivity, QpSolution, QpStatus, QpWarmStart,
-    ReducedHessian, SensError, SosBound, SosSolution, Triplet, solve_qp_active_set, solve_qp_batch,
-    solve_qp_batch_parallel, solve_qp_batch_parallel_warm, solve_qp_ipm, solve_qp_ipm_debug,
-    solve_qp_ipm_warm, solve_qp_multi_rhs, solve_qp_multi_rhs_parallel, solve_socp_ipm,
-    solve_socp_ipm_debug, solve_socp_ipm_warm, sos_constrained_lower_bound,
-    sos_constrained_lower_bound_opts, sos_lower_bound, sos_lower_bound_opts, sos_minimize,
-    sos_minimize_opts, sos_opts,
+    ReducedHessian, SensError, SosBound, SosSolution, Triplet, certify_psd_lower_triangle,
+    solve_qp_active_set, solve_qp_batch, solve_qp_batch_parallel, solve_qp_batch_parallel_warm,
+    solve_qp_ipm, solve_qp_ipm_debug, solve_qp_ipm_warm, solve_qp_multi_rhs,
+    solve_qp_multi_rhs_parallel, solve_socp_ipm, solve_socp_ipm_debug, solve_socp_ipm_warm,
+    sos_constrained_lower_bound, sos_constrained_lower_bound_opts, sos_lower_bound,
+    sos_lower_bound_opts, sos_minimize, sos_minimize_opts, sos_opts,
 };
 
 /// The underlying crate, for anything not surfaced above.

--- a/crates/pounce-rs/src/convex.rs
+++ b/crates/pounce-rs/src/convex.rs
@@ -99,14 +99,14 @@
 //! without adding a dependency.
 
 pub use pounce_convex::{
-    ActiveSetOverrides, ConeSpec, NEG_INF, POS_INF, PolyProblem, Polynomial, QpFactorization,
-    QpIterate, QpOptions, QpProblem, QpResiduals, QpSensitivity, QpSolution, QpStatus, QpWarmStart,
-    ReducedHessian, SensError, SosBound, SosSolution, Triplet, certify_psd_lower_triangle,
-    solve_qp_active_set, solve_qp_batch, solve_qp_batch_parallel, solve_qp_batch_parallel_warm,
-    solve_qp_ipm, solve_qp_ipm_debug, solve_qp_ipm_warm, solve_qp_multi_rhs,
-    solve_qp_multi_rhs_parallel, solve_socp_ipm, solve_socp_ipm_debug, solve_socp_ipm_warm,
-    sos_constrained_lower_bound, sos_constrained_lower_bound_opts, sos_lower_bound,
-    sos_lower_bound_opts, sos_minimize, sos_minimize_opts, sos_opts,
+    ActiveSetOverrides, ConeSpec, NEG_INF, POS_INF, PolyProblem, Polynomial, PsdCertificateError,
+    QpFactorization, QpIterate, QpOptions, QpProblem, QpResiduals, QpSensitivity, QpSolution,
+    QpStatus, QpWarmStart, ReducedHessian, SensError, SosBound, SosSolution, Triplet,
+    certify_psd_lower_triangle, solve_qp_active_set, solve_qp_batch, solve_qp_batch_parallel,
+    solve_qp_batch_parallel_warm, solve_qp_ipm, solve_qp_ipm_debug, solve_qp_ipm_warm,
+    solve_qp_multi_rhs, solve_qp_multi_rhs_parallel, solve_socp_ipm, solve_socp_ipm_debug,
+    solve_socp_ipm_warm, sos_constrained_lower_bound, sos_constrained_lower_bound_opts,
+    sos_lower_bound, sos_lower_bound_opts, sos_minimize, sos_minimize_opts, sos_opts,
 };
 
 /// The underlying crate, for anything not surfaced above.

--- a/crates/pounce-rs/src/linsol.rs
+++ b/crates/pounce-rs/src/linsol.rs
@@ -13,7 +13,10 @@
 //! Available whenever the `convex` or `qp` feature is on.
 
 pub use pounce_feral::FeralSolverInterface;
-pub use pounce_linsol::{Factorization, FactorizationError, SparseSymLinearSolverInterface};
+pub use pounce_linsol::{
+    EMatrixFormat, ESymSolverStatus, Factorization, FactorizationError,
+    SparseSymLinearSolverInterface,
+};
 
 /// The default backend: FERAL's sparse symmetric indefinite (LDLᵀ)
 /// factorization, parallel inside a single factor.

--- a/crates/pounce-rs/tests/convex_surface.rs
+++ b/crates/pounce-rs/tests/convex_surface.rs
@@ -6,10 +6,10 @@
 #![cfg(feature = "convex")]
 
 use pounce_rs::convex::{
-    QpFactorization, QpOptions, QpProblem, QpStatus, Triplet, solve_qp_batch,
-    solve_qp_batch_parallel, solve_qp_ipm,
+    QpFactorization, QpOptions, QpProblem, QpStatus, Triplet, certify_psd_lower_triangle,
+    solve_qp_batch, solve_qp_batch_parallel, solve_qp_ipm,
 };
-use pounce_rs::linsol::{backend, serial_backend};
+use pounce_rs::linsol::{EMatrixFormat, ESymSolverStatus, backend, serial_backend};
 
 /// `min ‖x − t‖²` over the box `[0, 1]ⁿ`, written as `½ xᵀ(2I)x − 2tᵀx`.
 /// The unconstrained optimum is `t`, clamped componentwise to `[0, 1]`.
@@ -26,6 +26,19 @@ fn boxed_qp(t: &[f64]) -> QpProblem {
         lb: vec![0.0; n],
         ub: vec![1.0; n],
     }
+}
+
+#[test]
+fn sparse_psd_certificate_and_linsol_enums_are_available_through_the_facade() {
+    let lower = [
+        Triplet::new(0, 0, 2.0),
+        Triplet::new(1, 0, 1.0),
+        Triplet::new(1, 1, 2.0),
+    ];
+    assert!(certify_psd_lower_triangle(2, &lower, 1e-9, backend));
+
+    assert_eq!(ESymSolverStatus::Success, ESymSolverStatus::Success);
+    assert_eq!(backend().matrix_format(), EMatrixFormat::TripletFormat);
 }
 
 #[test]

--- a/crates/pounce-rs/tests/convex_surface.rs
+++ b/crates/pounce-rs/tests/convex_surface.rs
@@ -9,7 +9,7 @@ use pounce_rs::convex::{
     QpFactorization, QpOptions, QpProblem, QpStatus, Triplet, certify_psd_lower_triangle,
     solve_qp_batch, solve_qp_batch_parallel, solve_qp_ipm,
 };
-use pounce_rs::linsol::{EMatrixFormat, ESymSolverStatus, backend, serial_backend};
+use pounce_rs::linsol::{EMatrixFormat, backend, serial_backend};
 
 /// `min ‖x − t‖²` over the box `[0, 1]ⁿ`, written as `½ xᵀ(2I)x − 2tᵀx`.
 /// The unconstrained optimum is `t`, clamped componentwise to `[0, 1]`.
@@ -35,9 +35,8 @@ fn sparse_psd_certificate_and_linsol_enums_are_available_through_the_facade() {
         Triplet::new(1, 0, 1.0),
         Triplet::new(1, 1, 2.0),
     ];
-    assert!(certify_psd_lower_triangle(2, &lower, 1e-9, backend));
+    assert!(certify_psd_lower_triangle(2, &lower, 1e-9, backend).unwrap());
 
-    assert_eq!(ESymSolverStatus::Success, ESymSolverStatus::Success);
     assert_eq!(backend().matrix_format(), EMatrixFormat::TripletFormat);
 }
 


### PR DESCRIPTION
## Problem

The sparse PSD classifier currently lives in pounce-cli and it is not reusable.

## Fix

- Extract the CLI’s sparse PSD classifier into pounce-convex 
- Check inertia support before initializing or factoring the backend.
- Re-export EMatrixFormat and ESymSolverStatus through pounce-rs::linsol.

## Blast radius

End users of pounce that do not go through the CLI. Easier to add to oximo.

## Tests

- [ ] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now — no test named that does not exist, no doc describing a
      design that was revised mid-review, no measurement whose baseline has
      since moved

> The changelog and CLI were updated using codex