### PR TITLE
Route convex structure detection under scipy's jac=True spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ changes.
 
 ## [Unreleased]
 
+- **`pounce.minimize`: `jac=True` no longer defeats convex structure
+  detection** (#750).
+
+  The convex routers probe `fun` as a bare `f(x) -> float` and `jac` as
+  `g(x) -> vector`. Under scipy's `jac=True` spelling — where `fun(x)`
+  returns the pair `(f, grad)` — they were handed a tuple-returning `fun`
+  and the bare bool `True` instead, so every probe raised and the routers'
+  catch-all ("a probe failure never becomes a wrong solver choice") reported
+  "not convex". On a textbook convex QP that meant
+  `solver_selection="qp-ipm"` (or `lp-ipm` / `qp-active-set` / `socp`)
+  raised `ValueError` rejecting a problem that satisfies its documented
+  precondition, while `solver_selection="auto"` silently fell back to the
+  general NLP solver and never took the convex fast path. The answer stayed
+  correct under `auto`; the routing did not.
+
+  `minimize` now splits the `(f, grad)` pair into the two plain callables the
+  routers expect, through a per-point cache so the user's `fun` is still
+  evaluated once per probe point, and copies the returned gradient so a
+  reused output buffer cannot poison cached probe data. The same block also
+  maps `jac=False` (scipy's explicit "no analytic gradient") to `None`, which
+  is the spelling `_route._grad_fn` reads as "finite-difference `fun`" —
+  `False is not None`, so that spelling failed every probe for the same
+  reason. Detection is unchanged otherwise: a genuinely nonconvex objective
+  spelled `jac=True` is still refused by a forced convex selector.
+
+  Same defect class as the `args`-binding fix that precedes it in the routing
+  block: a user input the convex route did not honor.
+
 - **Sparse PSD certification is now a reusable Rust API.**
 
   `pounce_convex::certify_psd_lower_triangle` (also available through

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -599,6 +599,16 @@ QP), a quadratic *equality*, or a quadratic inequality whose feasible set is
 nonconvex (a non-PSD constraint Hessian) all fall back to the NLP solver.
 **You never get a wrong "optimum" from a misclassification.**
 
+Because detection reads the callables, it is spelled-input agnostic: `args`
+are bound before probing, and every gradient spelling `minimize` accepts —
+a separate `jac=` callable, scipy's `jac=True` (`fun(x)` returning
+`(f, grad)`), or an omitted / `jac=False` gradient — describes the same
+problem and routes the same way. Under `jac=True` the pair is evaluated once
+per probe point, so the packed spelling costs no extra forward passes.
+Derivative-*free* detection is still weaker in one place: recovering a
+*constraint* Hessian from finite-differenced Jacobians is too noisy to
+confirm a quadratic, so a QCQP wants analytic constraint `jac`s (see below).
+
 #### Forcing the solver
 
 The `solver_selection` option (passed in `options=`) overrides the automatic

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -1162,14 +1162,58 @@ def minimize(
             return f
         return lambda x, _f=f, _a=args: _f(x, *_a)
 
+    # Normalize the *spelling* of the gradient for the routers, which probe
+    # `fun` as a bare `f(x) -> float` and `jac` as `g(x) -> vector`. Two scipy
+    # spellings do not fit that shape:
+    #
+    #   * `jac=True` — `fun(x, *args)` returns the pair `(f, grad)`, and `jac`
+    #     is the bare bool. Handing those to the routers makes both probes
+    #     blow up (a tuple where a float belongs; a non-callable `True`), and
+    #     the routers' catch-all turns any probe failure into "not convex".
+    #   * `jac=False` — scipy's "no gradient, use finite differences" spelling.
+    #     `False` is not `None`, so it too would reach the routers as a
+    #     non-callable and fail every probe.
+    #
+    # Either way the same convex QP that routes fine under `jac=callable` is
+    # wrongly rejected: `solver_selection="auto"` silently falls back to the
+    # NLP solver, and a forced convex selector raises `ValueError` on a problem
+    # that satisfies its documented precondition. Same defect class as the
+    # `args` binding above — a user input the convex route does not honor.
+    # (#750)
+    def _split_fun_and_grad():
+        """Router `(fun, jac)` for `jac=True`, splitting the cached pair."""
+        pair_cache: dict[bytes, tuple[float, np.ndarray]] = {}
+
+        def pair(x):
+            key = np.asarray(x, dtype=np.float64).tobytes()
+            hit = pair_cache.get(key)
+            if hit is None:
+                f, g = fun(x, *args)
+                # Copy the gradient: a `fun` that reuses one output buffer
+                # across calls would otherwise mutate earlier cache entries in
+                # place (same hazard `_point_cache` guards against).
+                hit = (float(f), _to_array(g).ravel().copy())
+                pair_cache[key] = hit
+            return hit
+
+        return lambda x: pair(x)[0], lambda x: pair(x)[1]
+
+    if jac is True:
+        route_fun, route_jac = _split_fun_and_grad()
+    else:
+        route_fun = _bind_args(fun)
+        # `jac=False`/`None` both mean "no analytic gradient"; the routers
+        # finite-difference `fun` when `jac is None`.
+        route_jac = _bind_args(jac) if callable(jac) else None
+
     # Wrap router callables in one shared point-cache (M34): the LP/QP and SOCP
     # routers probe an identical point set (same seed), so caching makes the
     # second router's probes cache hits instead of re-evaluating the objective.
     # Only these router copies are cached; the NLP fallback below still calls
     # the original `fun`/`jac`/… so the actual solve is unaffected.
     route_kw = dict(
-        fun=_point_cache(_bind_args(fun)),
-        jac=_point_cache(_bind_args(jac)),
+        fun=_point_cache(route_fun),
+        jac=_point_cache(route_jac),
         hess=_point_cache(_bind_args(hess)),
         lb=lb,
         ub=ub,

--- a/python/tests/test_minimize_autoroute.py
+++ b/python/tests/test_minimize_autoroute.py
@@ -369,3 +369,111 @@ def test_solver_selection_values_match_rust():
         f"Python whitelist {sorted(_SOLVER_SELECTION_VALUES)} != "
         f"Rust registry {sorted(rust_values)}"
     )
+
+
+def test_jac_true_routes_like_a_separate_gradient_callable():
+    # scipy's `jac=True` spelling: `fun(x)` returns `(f, grad)`. The routers
+    # probe `fun` for a float and call `jac(x)` for a vector, so before the fix
+    # they were handed a tuple-returning `fun` and the bare bool `True`; every
+    # probe raised, the routers' catch-all read that as "not convex", and the
+    # same convex QP that routes under `jac=callable` was rejected. (#750)
+    #
+    # min ½‖x‖² − x0 − 2x1 on [−5, 5]²  → x* = (1, 2), interior to the box.
+    P, c = np.eye(2), np.array([-1.0, -2.0])
+    f = lambda x: float(0.5 * x @ P @ x + c @ x)
+    g = lambda x: P @ x + c
+    fg = lambda x: (f(x), g(x))
+    bounds = [(-5.0, 5.0)] * 2
+
+    separate = minimize(f, np.zeros(2), jac=g, bounds=bounds,
+                        options={"solver_selection": "qp-ipm"})
+    packed = minimize(fg, np.zeros(2), jac=True, bounds=bounds,
+                      options={"solver_selection": "qp-ipm"})
+
+    assert _routed_to(separate) == _routed_to(packed) == "qp-ipm"
+    np.testing.assert_allclose(packed.x, [1.0, 2.0], atol=1e-6)
+    np.testing.assert_allclose(packed.x, separate.x, atol=1e-8)
+    assert packed.fun == pytest.approx(separate.fun, abs=1e-8)
+
+    # `auto` must take the convex fast path too, not fall through to NLP.
+    auto = minimize(fg, np.zeros(2), jac=True, bounds=bounds,
+                    options={"solver_selection": "auto"})
+    assert _routed_to(auto) == "qp-ipm"
+    np.testing.assert_allclose(auto.x, [1.0, 2.0], atol=1e-6)
+
+
+def test_jac_true_lp_routes_to_lp_selector():
+    # The same spelling on an LP: min −x0 + x1 on [−5, 5]² → x* = (5, −5).
+    c = np.array([-1.0, 1.0])
+    fg = lambda x: (float(c @ x), c.copy())
+    res = minimize(fg, np.zeros(2), jac=True, bounds=[(-5.0, 5.0)] * 2,
+                   options={"solver_selection": "lp-ipm"})
+
+    assert _routed_to(res) == "lp-ipm"
+    np.testing.assert_allclose(res.x, [5.0, -5.0], atol=1e-6)
+
+
+def test_jac_true_pair_is_evaluated_once_per_probe_point():
+    # The pair is cached per point (and shared with the SOCP router on `auto`),
+    # so splitting `(f, grad)` must not double the user's forward passes.
+    P, c = np.eye(2), np.array([-1.0, -2.0])
+    calls = {"n": 0, "points": set()}
+
+    def fg(x):
+        calls["n"] += 1
+        calls["points"].add(np.asarray(x, dtype=float).tobytes())
+        return float(0.5 * x @ P @ x + c @ x), P @ x + c
+
+    minimize(fg, np.zeros(2), jac=True, bounds=[(-5.0, 5.0)] * 2,
+             options={"solver_selection": "qp-ipm"})
+
+    assert calls["n"] == len(calls["points"])
+
+
+def test_jac_true_gradient_buffer_reuse_does_not_poison_probes():
+    # A `fun` that returns one reused gradient buffer must not corrupt cached
+    # probe data (the hazard `_point_cache` guards against, on the pair cache).
+    P, c = np.eye(2), np.array([-1.0, -2.0])
+    buf = np.empty(2)
+
+    def fg(x):
+        buf[:] = P @ x + c
+        return float(0.5 * x @ P @ x + c @ x), buf
+
+    res = minimize(fg, np.zeros(2), jac=True, bounds=[(-5.0, 5.0)] * 2,
+                   options={"solver_selection": "qp-ipm"})
+
+    assert _routed_to(res) == "qp-ipm"
+    np.testing.assert_allclose(res.x, [1.0, 2.0], atol=1e-6)
+
+
+def test_jac_true_with_args_routes():
+    # `args` binding and the `(f, grad)` split have to compose.
+    fun = lambda x, k: ((x[0] - k) ** 2 + x[1] ** 2,
+                        np.array([2 * (x[0] - k), 2 * x[1]]))
+    res = minimize(fun, [0.0, 0.0], args=(3.0,), jac=True,
+                   bounds=[(-10, 10), (-10, 10)],
+                   options={"solver_selection": "qp-ipm"})
+
+    assert _routed_to(res) == "qp-ipm"
+    np.testing.assert_allclose(res.x, [3.0, 0.0], atol=1e-6)
+
+
+def test_jac_false_routes_like_an_omitted_jac():
+    # scipy's explicit "no gradient" spelling. `False is not None`, so it too
+    # reached the routers as a non-callable and failed every probe. (#750)
+    a = np.array([0.3, 0.7])
+    fun = lambda x: float((x[0] - a[0]) ** 2 + (x[1] - a[1]) ** 2)
+    res = minimize(fun, [0.0, 0.0], jac=False, bounds=[(0, 1), (0, 1)],
+                   options={"solver_selection": "qp-ipm"})
+
+    assert _routed_to(res) == "qp-ipm"
+    np.testing.assert_allclose(res.x, a, atol=1e-5)
+
+
+def test_jac_true_still_rejected_when_genuinely_not_convex():
+    # The fix must not weaken detection: a quartic objective spelled `jac=True`
+    # is still refused by a forced convex selector.
+    fg = lambda x: (x[0] ** 4 + x[1] ** 2, np.array([4 * x[0] ** 3, 2 * x[1]]))
+    with pytest.raises(ValueError):
+        minimize(fg, [1.0, 1.0], jac=True, options={"solver_selection": "qp-ipm"})

--- a/python/tests/test_minimize_socp_autoroute.py
+++ b/python/tests/test_minimize_socp_autoroute.py
@@ -177,3 +177,23 @@ def test_plain_qp_still_routes_to_qp_not_socp():
                    options={"solver_selection": "auto"})
 
     assert _routed_to(res) == "qp-ipm"
+
+
+def test_jac_true_qcqp_routes_to_socp():
+    # scipy's `jac=True` spelling reached the SOCP router as a tuple-returning
+    # `fun` plus the bare bool `True`, so every probe failed and a convex QCQP
+    # was rejected by `solver_selection="socp"` / skipped by `auto`. (#750)
+    # min −x0 + 2x1  s.t.  x0² + x1² ≤ 1  →  x* = (1, −2)/√5.
+    c = np.array([-1.0, 2.0])
+    fg = lambda x: (float(c @ x), c.copy())
+    expected = -c / np.linalg.norm(c)
+
+    forced = minimize(fg, [0.1, 0.1], jac=True, constraints=[_ball_constraint()],
+                      options={"solver_selection": "socp"})
+    assert _routed_to(forced) == "socp"
+    np.testing.assert_allclose(forced.x, expected, atol=1e-5)
+
+    auto = minimize(fg, [0.1, 0.1], jac=True, constraints=[_ball_constraint()],
+                    options={"solver_selection": "auto"})
+    assert _routed_to(auto) == "socp"
+    np.testing.assert_allclose(auto.x, expected, atol=1e-5)


### PR DESCRIPTION
## Problem

`pounce.minimize`'s convex structure detection only worked when the objective's
gradient was a separate **callable**. With scipy's standard `jac=True` spelling
— where `fun(x, *args)` returns `(f, grad)` — detection always reported "not
convex", on a problem that *is* a convex QP.

Reproduction from the issue: `min ½‖x‖² − x0 − 2x1` on `[−5, 5]²`, whose
closed-form optimum is `x* = (1, 2)`, interior to the box.

| selector | `jac=callable` (before & after) | `jac=True` before | `jac=True` after |
|---|---|---|---|
| `lp-ipm` | `ValueError` (correct — it is a QP, not an LP) | `ValueError` | `ValueError` |
| `qp-ipm` | `x = [1, 2]`, `solver=qp-ipm` | **`ValueError`** | `x = [1, 2]`, `solver=qp-ipm` |
| `qp-active-set` | `x = [1, 2]`, `solver=qp-active-set` | **`ValueError`** | `x = [1, 2]`, `solver=qp-active-set` |
| `auto` | `solver=qp-ipm` | **`solver=None`** (fell back to NLP) | `solver=qp-ipm` |

Oracle: closed form, `x* = −c = (1, 2)`. Same split on an LP under `lp-ipm`
(`x* = [−5, 5]`) and on a convex QCQP under `socp` (`x* = −c/‖c‖`); both now
match the `jac=callable` column exactly.

Two user-visible consequences, both routing/interface defects rather than a
wrong optimum:

1. A forced convex `solver_selection` raised `ValueError` rejecting a problem
   that satisfies its documented precondition — same math, same gradient,
   different spelling.
2. `solver_selection="auto"` silently fell back to the general NLP solver, so
   the documented convex fast path never fired.

## Cause

The routers (`pounce._route`) probe opaque callables: they call `fun` expecting
a bare `f(x) -> float` and `jac` expecting `g(x) -> vector`. Under `jac=True`
they were handed the tuple-returning `fun` and the bare bool `True`, so both
probes raised — a tuple where a float belongs, and a call on a non-callable.

`classify_and_extract` deliberately swallows any probe failure
(`except Exception: return None`) so that a probe blowing up can never become a
*wrong* solver choice. That safety net is what converted the interface mismatch
into a silent "not convex" verdict, which is why the failure looked like a
detection result rather than an error.

`jac=False` — scipy's explicit "no analytic gradient" — was broken the same
way: `False is not None`, so it too reached the routers as a non-callable and
failed every probe. (`_route._grad_fn` treats only `None` as "finite-difference
`fun`".)

This is the same defect class as the `args`-binding fix that immediately
precedes it in the routing block, whose comment already describes this exact
failure mode for a sibling input: a user input the convex route does not honor.

## Fix

In `python/pounce/_minimize.py`, normalize the *spelling* of the gradient
before building `route_kw`:

- `jac is True` → split the `(f, grad)` pair into the two plain callables the
  routers expect. The split goes through a per-point cache keyed on the point's
  float64 bytes, so the user's `fun` is still evaluated **once per probe point**
  — the packed spelling costs no extra forward passes, and the pair cache
  composes with the existing shared `_point_cache` across the LP/QP and SOCP
  routers.
- The cached gradient is **copied**, so a `fun` that reuses one output buffer
  across calls cannot mutate earlier cache entries in place. This is the same
  hazard `_point_cache` already guards against (M34); the new pair cache sits
  upstream of it and needs its own copy.
- `jac is False` → mapped to `None`, the spelling `_route._grad_fn` reads as
  "finite-difference `fun`".

Rejected alternative: reusing `_FunAndGradCache` (the NLP path's `jac=True`
helper). It memoizes only the *most recent* `x`, which is right for Ipopt's
objective/gradient pair at one iterate but wrong here — the routers evaluate
`fun` across a probe set and then the gradient across the same set, so a
last-point cache would double the user's forward passes on exactly the input
this PR is meant to make cheap. Hence the small dict cache instead.

Detection strictness is unchanged, and the NLP path is untouched: a genuinely
nonconvex objective spelled `jac=True` is still refused by a forced convex
selector (pinned by a test).

## Blast radius

Python facade only — no Rust changed, so no solver trajectory moves and the
fixture sweep does not apply.

Within the facade, the change is confined to the router copies of
`fun`/`jac` built inside `minimize`. The NLP fallback still calls the original
`fun`/`jac`, so any solve that reaches the NLP backend is bit-identical. The
default `solver_selection="nlp"` never runs the routers at all, so the default
path is untouched.

Behaviour changes only where routing was previously wrong: a convex LP/QP/QCQP
spelled `jac=True` or `jac=False` now routes where before it was rejected or
silently sent to NLP. Problems that were correctly *not* routed still are not.
Full Python suite: 956 passed, 1 failure
(`test_continuation.py::test_step_controller_is_what_the_jax_follower_uses`),
which is pre-existing and environmental — JAX is not installed in this
container, and it reproduces identically with this diff stashed.

## Tests

8 new tests, all confirmed to **fail on the parent commit** except the negative
one (noted below):

`python/tests/test_minimize_autoroute.py`

- `test_jac_true_routes_like_a_separate_gradient_callable` — the issue's QP; the
  packed and separate spellings must agree on selector, `x`, and objective, and
  `auto` must take the convex path. Pre-fix: `ValueError`.
- `test_jac_true_lp_routes_to_lp_selector` — same spelling on an LP under
  `lp-ipm`. Pre-fix: `ValueError`.
- `test_jac_true_pair_is_evaluated_once_per_probe_point` — pins the cache: call
  count must equal the number of distinct probe points. Pre-fix: fails at the
  `ValueError` before it can count.
- `test_jac_true_gradient_buffer_reuse_does_not_poison_probes` — a `fun`
  returning one reused buffer still routes and lands `x*`.
- `test_jac_true_with_args_routes` — `args` binding and the pair split compose.
- `test_jac_false_routes_like_an_omitted_jac` — scipy's explicit "no gradient".
- `test_jac_true_still_rejected_when_genuinely_not_convex` — a quartic spelled
  `jac=True` is still refused by `qp-ipm`. **This one passes pre-fix**, by
  design: it is a guard against the fix weakening detection, not a regression
  test for the bug.

`python/tests/test_minimize_socp_autoroute.py`

- `test_jac_true_qcqp_routes_to_socp` — the conic route, forced and under
  `auto`. Pre-fix: `ValueError` / silent NLP fallback.

Verified by stashing the `_minimize.py` change and re-running: 7 failed, 1
passed (the negative test above), for the stated reason in each case.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`python.md`, the "Solver routing in
      `minimize`" section — existing page, no `SUMMARY.md` change needed)
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — **not
      run: no Rust source is touched by this diff.** The Python suite was run
      instead (result above).
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

Fixes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgJQkhirymSfKBB52YaGMk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgJQkhirymSfKBB52YaGMk)_