### PR TITLE
Move convex options out of the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ changes.
 
 ## [Unreleased]
 
+- **Convex `OptionsList` parsing is now a reusable library API.**
+
+  `pounce_convex::QpOptions::try_from_options_list`,
+  `ConvexPresolveOptions::try_from_options_list`, and
+  `ActiveSetOverrides::try_from_options_list` now own the names, conversions,
+  validation, and precedence rules for the convex `qp_*` and `sqp_qp_*`
+  controls. The CLI delegates to those typed readers instead of maintaining
+  private copies, so another frontend can materialize the same configuration
+  without reproducing CLI logic. Existing explicit-only handling for shared
+  `tol` / iteration / wall-time controls, `qp_tau_max` precedence, and the
+  `qp_presolve`-over-`presolve` rule is unchanged.
+
+  `qp_gondzio_corr` is also covered by the core library guard that refuses a
+  non-default convex-only option on an entry point unable to run the convex
+  solver, closing the one remaining silent-ignore case in that option family.
+
 - **`pounce.minimize`: `jac=True` no longer defeats convex structure
   detection** (#750).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,6 @@ dependencies = [
  "pounce-nlp",
  "pounce-observability",
  "pounce-presolve",
- "pounce-qp",
  "pounce-restoration",
  "pounce-sensitivity",
  "pounce-solve-report",

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1333,6 +1333,7 @@ impl IpoptApplication {
             "qp_tau",
             "qp_tau_max",
             "qp_reg",
+            "qp_gondzio_corr",
             "qp_infeas_tol",
             "qp_hsde",
             "qp_equilibrate",

--- a/crates/pounce-algorithm/tests/solver_selection_library_option.rs
+++ b/crates/pounce-algorithm/tests/solver_selection_library_option.rs
@@ -201,7 +201,7 @@ fn solver_selection_and_qp_presolve_are_registered() {
 // that reads them (gh#604).
 // ---------------------------------------------------------------------
 
-/// All eight convex knobs live in the core registry, so every frontend
+/// All convex knobs live in the core registry, so every frontend
 /// *parses* them. Until gh#604 the seven `qp_tau`-family names were
 /// registered by `pounce-cli` at startup instead, which made setting one
 /// from Python or the C interface fail with `Unknown option "qp_tau"` —
@@ -222,6 +222,11 @@ fn every_convex_knob_is_registered_core_side() {
             "`{name}` should be a registered library option"
         );
     }
+    assert!(
+        o.set_integer_value("qp_gondzio_corr", 2, true, true)
+            .is_ok(),
+        "`qp_gondzio_corr` should be a registered library option"
+    );
     for name in ["qp_hsde", "qp_equilibrate", "qp_crossover", "qp_presolve"] {
         assert!(
             o.set_string_value(name, "no", true, true).is_ok(),
@@ -231,6 +236,10 @@ fn every_convex_knob_is_registered_core_side() {
     // The registered ranges still bite: τ ∈ (0,1) open at both ends.
     assert!(o.set_numeric_value("qp_tau", 1.0, true, true).is_err());
     assert!(o.set_numeric_value("qp_reg", -1.0, true, true).is_err());
+    assert!(
+        o.set_integer_value("qp_gondzio_corr", 11, true, true)
+            .is_err()
+    );
     assert!(o.set_string_value("qp_hsde", "maybe", true, true).is_err());
 }
 
@@ -256,6 +265,16 @@ fn a_convex_knob_is_refused_on_a_library_solve() {
         .expect("a non-default convex knob must be refused");
     assert!(msg.contains("qp_crossover"), "{msg}");
     assert!(msg.contains("604"), "message should name the issue: {msg}");
+
+    let mut app = IpoptApplication::new();
+    app.initialize().unwrap();
+    app.options_mut()
+        .set_integer_value("qp_gondzio_corr", 2, true, true)
+        .unwrap();
+    let msg = app
+        .unhonored_convex_option()
+        .expect("qp_gondzio_corr must be guarded like every convex-only knob");
+    assert!(msg.contains("qp_gondzio_corr"), "{msg}");
 }
 
 /// The same default gate the rest of the refusals use: an `ipopt.opt`

--- a/crates/pounce-cli/Cargo.toml
+++ b/crates/pounce-cli/Cargo.toml
@@ -51,9 +51,6 @@ pounce-observability.workspace = true
 # Specialized convex LP/QP interior-point solver, dispatched to for
 # classified LP / convex-QP `.nl` inputs.
 pounce-convex.workspace = true
-# For the AntiCyclingChoice enum when forwarding sqp_qp_* to the active-set
-# engine; already a transitive dependency via pounce-convex.
-pounce-qp.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing.workspace = true

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1036,13 +1036,18 @@ pub fn main() -> ExitCode {
                     };
                     (p, args.json_detail, input)
                 });
-                // Build the convex IPM options from the registered CLI knobs.
-                // Each tunable forwards only when the user *explicitly* set it
-                // (the `true` flag from `get_*_value`); otherwise the convex
-                // driver keeps its own tuned `QpOptions` default. `max_iter` in
-                // particular must not be silently raised to the (far larger)
-                // Ipopt default, so it too is forwarded only when set.
-                let convex_opts = convex_cli_opts(&app);
+                // Materialize the convex controls in pounce-convex, which owns
+                // their typed representation and precedence rules. In
+                // particular, unset shared NLP options must not replace the
+                // convex driver's independently tuned defaults.
+                let convex_opts =
+                    match pounce_convex::QpOptions::try_from_options_list(app.options()) {
+                        Ok(options) => options,
+                        Err(error) => {
+                            eprintln!("pounce: convex option setup failed: {error}");
+                            return ExitCode::from(2);
+                        }
+                    };
                 // When the convex attempt declines (gh #535 / `socp_nlp_fallback`)
                 // the NLP solve below opens its own `Deadline` from the *option
                 // value*, which still names the full budget — so a run that spent
@@ -1052,14 +1057,15 @@ pub fn main() -> ExitCode {
                 // the deduction below the block.
                 let convex_t0 = std::time::Instant::now();
                 // Resolve the convex-path presolve switch (#139) once, above
-                // the driver split: both convex drivers honour it. See
-                // `resolve_convex_presolve` for the aliasing rationale.
-                let presolve_on = {
-                    let opts = app.options();
-                    resolve_convex_presolve(
-                        opts.get_string_value("qp_presolve", "").ok(),
-                        opts.get_string_value("presolve", "").ok(),
-                    )
+                // the driver split: both convex drivers honour it.
+                let presolve_on = match pounce_convex::ConvexPresolveOptions::try_from_options_list(
+                    app.options(),
+                ) {
+                    Ok(options) => options.enabled,
+                    Err(error) => {
+                        eprintln!("pounce: convex presolve setup failed: {error}");
+                        return ExitCode::from(2);
+                    }
                 };
                 if matches!(choice, SolverChoice::SocpIpm) {
                     // `None` means the conic solve came back without a verified
@@ -1086,13 +1092,19 @@ pub fn main() -> ExitCode {
                     // the-boundary). The active-set engine is a different
                     // algorithm with no such hook, so a `--debug*` request would
                     // otherwise silently no-op. Say so explicitly.
-                    // Forward the `sqp_qp_*` family to the inner engine. These knobs
-                    // named the QP subproblem *of the SQP outer loop*, which this
-                    // path no longer goes through, so every one of them silently
-                    // became a no-op when the dispatch moved to the convex driver.
-                    // The names are kept because they are the documented, in-use
-                    // spelling; only the delivery route changed.
-                    let engine_overrides = active_set_overrides(&app);
+                    // Forward the `sqp_qp_*` family to the inner engine. Only
+                    // explicit settings materialize as overrides, leaving the
+                    // direct driver's tuned defaults intact otherwise.
+                    let engine_overrides =
+                        match pounce_convex::ActiveSetOverrides::try_from_options_list(
+                            app.options(),
+                        ) {
+                            Ok(options) => options,
+                            Err(error) => {
+                                eprintln!("pounce: active-set option setup failed: {error}");
+                                return ExitCode::from(2);
+                            }
+                        };
                     if matches!(choice, SolverChoice::QpActiveSet) && debug_hook.is_some() {
                         eprintln!(
                             "pounce: note: the interactive debugger is IPM-only and does \
@@ -2413,130 +2425,6 @@ fn convex_status_report(s: pounce_convex::QpStatus) -> (&'static str, bool, i32)
     }
 }
 
-/// Read the `sqp_qp_*` option family into inner-engine overrides for the
-/// active-set QP driver.
-///
-/// Only options the user set **explicitly** are forwarded (the `true` flag from
-/// the `OptionsList` accessors), so the driver keeps its own tuned defaults
-/// otherwise — it deliberately picks a size-scaled `max_iter` and enables Schur
-/// updates, and must be able to tell "unset" from "set to the default value".
-///
-/// These knobs were introduced for the QP subproblem of the active-set *SQP*
-/// outer loop. `solver_selection=qp-active-set` used to reach the engine that
-/// way, so they applied; it now drives the engine directly through the convex
-/// path, and without this they would all be silent no-ops. The `sqp_qp_`
-/// spelling is retained because it is the documented, already-in-use name.
-fn active_set_overrides(app: &IpoptApplication) -> pounce_convex::ActiveSetOverrides {
-    use pounce_qp::AntiCyclingChoice;
-    let mut o = pounce_convex::ActiveSetOverrides::default();
-    let opt = app.options();
-    if let Ok((v, true)) = opt.get_integer_value("sqp_qp_max_iter", "") {
-        if v >= 0 {
-            o.max_iter = Some(v as u32);
-        }
-    }
-    if let Ok((v, true)) = opt.get_string_value("sqp_qp_anti_cycling", "") {
-        o.anti_cycling = match v.as_str() {
-            "bland" => Some(AntiCyclingChoice::Bland),
-            "expand" => Some(AntiCyclingChoice::Expand),
-            "none" => Some(AntiCyclingChoice::None),
-            _ => None,
-        };
-    }
-    if let Ok((v, true)) = opt.get_numeric_value("sqp_qp_feas_tol", "") {
-        o.feas_tol = Some(v);
-    }
-    if let Ok((v, true)) = opt.get_numeric_value("sqp_qp_opt_tol", "") {
-        o.opt_tol = Some(v);
-    }
-    if let Ok((v, true)) = opt.get_numeric_value("sqp_qp_elastic_gamma", "") {
-        o.elastic_gamma = Some(v);
-    }
-    if let Ok((v, true)) = opt.get_string_value("sqp_qp_use_schur_updates", "") {
-        o.use_schur_updates = Some(v == "yes");
-    }
-    if let Ok((v, true)) = opt.get_string_value("sqp_qp_use_homotopy", "") {
-        o.use_homotopy = Some(v == "yes");
-    }
-    if let Ok((v, true)) = opt.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "") {
-        if v >= 0 {
-            o.max_schur_updates_before_refactor = Some(v as u32);
-        }
-    }
-    o
-}
-
-/// Build the convex IPM [`pounce_convex::QpOptions`] from the registered CLI
-/// knobs.
-///
-/// Every field is overridden only when the user *explicitly* set the option
-/// (the `true` flag returned by the `OptionsList` accessors); otherwise the
-/// `QpOptions` default is kept. The standard `tol` / `max_iter` options feed
-/// the convex solve alongside the `qp_*` knobs registered in `main`.
-/// `max_iter` is forwarded only when set so the convex driver's own (smaller)
-/// cap is never silently raised to the much larger Ipopt default.
-fn convex_cli_opts(app: &IpoptApplication) -> pounce_convex::QpOptions {
-    let mut o = pounce_convex::QpOptions::default();
-    let opt = app.options();
-    if let Ok((v, true)) = opt.get_integer_value("max_iter", "") {
-        // Forward `max_iter=0` too: AMPL/Ipopt semantics make it a
-        // "take no iterations" request that must not reach optimality
-        // (pounce#186). Only a negative value (invalid) is ignored so the
-        // usize cast can't wrap.
-        if v >= 0 {
-            o.max_iter = v as usize;
-        }
-    }
-    if let Ok((v, true)) = opt.get_numeric_value("tol", "") {
-        o.tol = v;
-    }
-    // `max_wall_time`, honoured only when the user set it explicitly (the `true`
-    // flag) — Ipopt's default is 1e20, i.e. "no limit", and turning that into a
-    // `Duration` would put a nonsensical deadline on every solve.
-    //
-    // A value `Duration` cannot represent is *not* clamped to something huge:
-    // it means no limit, and it says so. `try_from_secs_f64` rejects exactly
-    // the values with no honest deadline — NaN, and anything past ~5.8e11
-    // years including `f64::INFINITY` and Ipopt's own 1e20 sentinel should a
-    // user type it out. Negative is invalid and likewise ignored. `0.0` is
-    // kept as a real (immediate) deadline: "take no time" is the wall-clock
-    // twin of `max_iter=0`, which pounce#186 requires to stop before solving.
-    if let Ok((v, true)) = opt.get_numeric_value("max_wall_time", "")
-        && v >= 0.0
-        && let Ok(d) = std::time::Duration::try_from_secs_f64(v)
-    {
-        o.time_limit = Some(d);
-    }
-    if let Ok((v, true)) = opt.get_numeric_value("qp_tau", "") {
-        o.tau = v;
-        // A raised floor lifts the default ceiling with it, so `qp_tau` alone
-        // still means "use this τ"; an explicit `qp_tau_max` below wins.
-        o.tau_max = o.tau_max.max(v);
-    }
-    if let Ok((v, true)) = opt.get_numeric_value("qp_tau_max", "") {
-        o.tau_max = v;
-    }
-    if let Ok((v, true)) = opt.get_numeric_value("qp_reg", "") {
-        o.reg = v;
-    }
-    if let Ok((v, true)) = opt.get_integer_value("qp_gondzio_corr", "") {
-        o.gondzio_max_corr = v.max(0) as usize;
-    }
-    if let Ok((v, true)) = opt.get_numeric_value("qp_infeas_tol", "") {
-        o.infeas_tol = v;
-    }
-    if let Ok((v, true)) = opt.get_string_value("qp_hsde", "") {
-        o.use_hsde = v != "no";
-    }
-    if let Ok((v, true)) = opt.get_string_value("qp_equilibrate", "") {
-        o.equilibrate = v != "no";
-    }
-    if let Ok((v, true)) = opt.get_string_value("qp_crossover", "") {
-        o.crossover = v != "no";
-    }
-    o
-}
-
 fn convex_opts_with_remaining(
     mut opts: pounce_convex::QpOptions,
     started: std::time::Instant,
@@ -2579,30 +2467,6 @@ fn charge_wall_budget(
     if let Ok((limit, true)) = opts.get_numeric_value("max_wall_time", "") {
         let left = (limit - spent.as_secs_f64()).max(WALL_BUDGET_FLOOR);
         let _ = opts.set_numeric_value("max_wall_time", left, true, false);
-    }
-}
-
-/// Resolve the convex LP/QP presolve switch (#139).
-///
-/// The convex driver is gated by the `qp_presolve` option, but `presolve` is
-/// the spelling users carry over from the NLP path; on the convex path it used
-/// to be silently ignored. Honor whichever the user *explicitly* set, with the
-/// more specific `qp_presolve` winning when both are given; when neither is set
-/// keep the driver's default (on).
-///
-/// Each argument is `Some((value, explicitly_set))` as returned by
-/// `OptionsList::get_string_value(..).ok()`, or `None` if the lookup failed.
-fn resolve_convex_presolve(
-    qp_presolve: Option<(String, bool)>,
-    presolve: Option<(String, bool)>,
-) -> bool {
-    match (qp_presolve, presolve) {
-        // `qp_presolve` explicitly set → authoritative.
-        (Some((v, true)), _) => v != "no",
-        // else alias an explicitly-set `presolve` onto this path.
-        (_, Some((v, true))) => v != "no",
-        // neither set → keep the driver's default (on).
-        _ => true,
     }
 }
 
@@ -4051,55 +3915,5 @@ mod nlp_exit_code_tests {
                 "{s:?} must not count as a successful solve"
             );
         }
-    }
-}
-
-#[cfg(test)]
-mod convex_presolve_tests {
-    //! #139: the convex LP/QP driver is gated by `qp_presolve`, but `presolve`
-    //! (the NLP-path spelling) used to be silently ignored on this path. These
-    //! lock the aliasing: `presolve` is honored, `qp_presolve` wins ties, and
-    //! only explicit settings count.
-    use super::resolve_convex_presolve;
-
-    // Helpers mirroring `OptionsList::get_string_value(..).ok()`:
-    //   set(v)   → user explicitly set the option to `v`
-    //   unset(v) → option carries its default `v`, not user-set
-    fn set(v: &str) -> Option<(String, bool)> {
-        Some((v.to_string(), true))
-    }
-    fn unset(v: &str) -> Option<(String, bool)> {
-        Some((v.to_string(), false))
-    }
-
-    #[test]
-    fn defaults_on_when_nothing_set() {
-        assert!(resolve_convex_presolve(None, None));
-        assert!(resolve_convex_presolve(unset("yes"), unset("yes")));
-    }
-
-    #[test]
-    fn explicit_presolve_is_honored() {
-        // The crux of #139: a bare `presolve no` must turn it off here.
-        assert!(!resolve_convex_presolve(unset("yes"), set("no")));
-        assert!(resolve_convex_presolve(unset("yes"), set("yes")));
-    }
-
-    #[test]
-    fn explicit_qp_presolve_is_honored() {
-        assert!(!resolve_convex_presolve(set("no"), None));
-        assert!(resolve_convex_presolve(set("yes"), None));
-    }
-
-    #[test]
-    fn qp_presolve_wins_when_both_explicit() {
-        // More specific spelling is authoritative when the two conflict.
-        assert!(!resolve_convex_presolve(set("no"), set("yes")));
-        assert!(resolve_convex_presolve(set("yes"), set("no")));
-    }
-
-    #[test]
-    fn explicit_presolve_overrides_unset_qp_presolve() {
-        assert!(!resolve_convex_presolve(unset("yes"), set("no")));
     }
 }

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -38,6 +38,7 @@ pub(crate) mod equilibrate;
 pub mod hsde;
 pub mod hsde_nonsym;
 pub mod ipm;
+mod options;
 pub mod presolve;
 mod psd_certificate;
 pub mod qp;
@@ -55,6 +56,7 @@ pub use ipm::{
     QpFactorization, QpOptions, QpWarmStart, solve_qp_ipm, solve_qp_ipm_debug, solve_qp_ipm_warm,
     solve_socp_ipm, solve_socp_ipm_debug, solve_socp_ipm_warm,
 };
+pub use options::ConvexPresolveOptions;
 pub use psd_certificate::{PsdCertificateError, certify_psd_lower_triangle};
 pub use qp::{NEG_INF, POS_INF, QpIterate, QpProblem, QpResiduals, QpSolution, QpStatus, Triplet};
 pub use sensitivity::{QpSensitivity, ReducedHessian, SensError};

--- a/crates/pounce-convex/src/options.rs
+++ b/crates/pounce-convex/src/options.rs
@@ -1,0 +1,415 @@
+//! Typed materialization of the convex solver's [`OptionsList`] controls.
+//!
+//! Registration lives in `pounce-algorithm` because that registry is present
+//! even when the optional `pounce-convex` dependency is not. Interpretation,
+//! however, belongs beside the types being configured: callers should not
+//! have to reproduce option names, conversions, or precedence rules.
+
+use std::time::Duration;
+
+use pounce_common::{ExceptionKind, Index, OptionsList, SolverException};
+use pounce_qp::AntiCyclingChoice;
+
+use crate::{ActiveSetOverrides, QpOptions};
+
+fn invalid(name: &str, message: impl std::fmt::Display) -> SolverException {
+    SolverException::new(
+        ExceptionKind::OPTION_INVALID,
+        format!("Option \"{name}\": {message}."),
+        file!(),
+        line!() as Index,
+    )
+}
+
+impl QpOptions {
+    /// Build convex-IPM options from a registered [`OptionsList`].
+    ///
+    /// Shared NLP controls (`tol`, `max_iter`, and `max_wall_time`) are applied
+    /// only when explicitly set, so their registry defaults do not replace the
+    /// convex solver's independently tuned defaults. The same explicit-only
+    /// rule preserves the precedence of `qp_tau` and `qp_tau_max`.
+    pub fn try_from_options_list(options: &OptionsList) -> Result<Self, SolverException> {
+        let mut parsed = Self::default();
+
+        let (max_iter, explicitly_set) = options.get_integer_value("max_iter", "")?;
+        if explicitly_set {
+            parsed.max_iter = usize::try_from(max_iter)
+                .map_err(|_| invalid("max_iter", "must be nonnegative and fit in usize"))?;
+        }
+
+        let (tol, explicitly_set) = options.get_numeric_value("tol", "")?;
+        if explicitly_set {
+            if tol <= 0.0 || tol.is_nan() {
+                return Err(invalid("tol", "must be greater than zero"));
+            }
+            parsed.tol = tol;
+        }
+
+        let (wall_time, explicitly_set) = options.get_numeric_value("max_wall_time", "")?;
+        if explicitly_set {
+            if wall_time.is_nan() || wall_time < 0.0 {
+                return Err(invalid("max_wall_time", "must be nonnegative"));
+            }
+            // Values outside Duration's honest range, including Ipopt's 1e20
+            // sentinel and infinity, mean "no deadline" rather than an
+            // arbitrary clamped deadline. Zero remains an immediate deadline.
+            parsed.time_limit = Duration::try_from_secs_f64(wall_time).ok();
+        }
+
+        let (tau, explicitly_set) = options.get_numeric_value("qp_tau", "")?;
+        if explicitly_set {
+            if !(tau > 0.0 && tau < 1.0) {
+                return Err(invalid("qp_tau", "must lie strictly between zero and one"));
+            }
+            parsed.tau = tau;
+            // A raised floor lifts the default ceiling; an explicit
+            // qp_tau_max is read afterwards and remains authoritative.
+            parsed.tau_max = parsed.tau_max.max(tau);
+        }
+
+        let (tau_max, explicitly_set) = options.get_numeric_value("qp_tau_max", "")?;
+        if explicitly_set {
+            if !(tau_max > 0.0 && tau_max < 1.0) {
+                return Err(invalid(
+                    "qp_tau_max",
+                    "must lie strictly between zero and one",
+                ));
+            }
+            parsed.tau_max = tau_max;
+        }
+
+        let (reg, explicitly_set) = options.get_numeric_value("qp_reg", "")?;
+        if explicitly_set {
+            if reg < 0.0 || reg.is_nan() {
+                return Err(invalid("qp_reg", "must be nonnegative"));
+            }
+            parsed.reg = reg;
+        }
+
+        let (correctors, explicitly_set) = options.get_integer_value("qp_gondzio_corr", "")?;
+        if explicitly_set {
+            if !(0..=10).contains(&correctors) {
+                return Err(invalid("qp_gondzio_corr", "must be between 0 and 10"));
+            }
+            parsed.gondzio_max_corr = correctors as usize;
+        }
+
+        let (infeas_tol, explicitly_set) = options.get_numeric_value("qp_infeas_tol", "")?;
+        if explicitly_set {
+            if infeas_tol <= 0.0 || infeas_tol.is_nan() {
+                return Err(invalid("qp_infeas_tol", "must be greater than zero"));
+            }
+            parsed.infeas_tol = infeas_tol;
+        }
+
+        let (_, explicitly_set) = options.get_string_value("qp_hsde", "")?;
+        if explicitly_set {
+            parsed.use_hsde = options.get_bool_value("qp_hsde", "")?.0;
+        }
+        let (_, explicitly_set) = options.get_string_value("qp_equilibrate", "")?;
+        if explicitly_set {
+            parsed.equilibrate = options.get_bool_value("qp_equilibrate", "")?.0;
+        }
+        let (_, explicitly_set) = options.get_string_value("qp_crossover", "")?;
+        if explicitly_set {
+            parsed.crossover = options.get_bool_value("qp_crossover", "")?.0;
+        }
+
+        Ok(parsed)
+    }
+}
+
+/// Convex-path presolve settings materialized from an [`OptionsList`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConvexPresolveOptions {
+    /// Whether convex QP/conic presolve is enabled.
+    pub enabled: bool,
+}
+
+impl Default for ConvexPresolveOptions {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+impl ConvexPresolveOptions {
+    /// Resolve the convex presolve switch and its NLP-path alias.
+    ///
+    /// An explicit `qp_presolve` is authoritative. Otherwise an explicit
+    /// `presolve` setting is honored; when neither is set, convex presolve
+    /// keeps its default-on behavior.
+    pub fn try_from_options_list(options: &OptionsList) -> Result<Self, SolverException> {
+        let (_, qp_explicit) = options.get_string_value("qp_presolve", "")?;
+        let qp_presolve = if qp_explicit {
+            Some(options.get_bool_value("qp_presolve", "")?.0)
+        } else {
+            None
+        };
+        let (_, nlp_explicit) = options.get_string_value("presolve", "")?;
+        let nlp_presolve = if nlp_explicit {
+            Some(options.get_bool_value("presolve", "")?.0)
+        } else {
+            None
+        };
+        Ok(Self {
+            enabled: qp_presolve.or(nlp_presolve).unwrap_or(true),
+        })
+    }
+}
+
+impl ActiveSetOverrides {
+    /// Read explicitly set `sqp_qp_*` controls for the direct convex
+    /// active-set driver.
+    ///
+    /// Unset values remain `None`, allowing the driver to retain its tuned,
+    /// size-dependent defaults rather than inheriting the SQP subproblem
+    /// defaults from the option registry.
+    pub fn try_from_options_list(options: &OptionsList) -> Result<Self, SolverException> {
+        let mut parsed = Self::default();
+
+        let (max_iter, explicitly_set) = options.get_integer_value("sqp_qp_max_iter", "")?;
+        if explicitly_set {
+            let value = u32::try_from(max_iter)
+                .map_err(|_| invalid("sqp_qp_max_iter", "must be positive and fit in u32"))?;
+            if value == 0 {
+                return Err(invalid("sqp_qp_max_iter", "must be positive"));
+            }
+            parsed.max_iter = Some(value);
+        }
+
+        let (anti_cycling, explicitly_set) = options.get_string_value("sqp_qp_anti_cycling", "")?;
+        if explicitly_set {
+            parsed.anti_cycling = Some(match anti_cycling.as_str() {
+                "bland" => AntiCyclingChoice::Bland,
+                "expand" => AntiCyclingChoice::Expand,
+                "none" => AntiCyclingChoice::None,
+                _ => {
+                    return Err(invalid(
+                        "sqp_qp_anti_cycling",
+                        format_args!("unknown value \"{anti_cycling}\""),
+                    ));
+                }
+            });
+        }
+
+        let (feas_tol, explicitly_set) = options.get_numeric_value("sqp_qp_feas_tol", "")?;
+        if explicitly_set {
+            if feas_tol <= 0.0 || feas_tol.is_nan() {
+                return Err(invalid("sqp_qp_feas_tol", "must be greater than zero"));
+            }
+            parsed.feas_tol = Some(feas_tol);
+        }
+
+        let (opt_tol, explicitly_set) = options.get_numeric_value("sqp_qp_opt_tol", "")?;
+        if explicitly_set {
+            if opt_tol <= 0.0 || opt_tol.is_nan() {
+                return Err(invalid("sqp_qp_opt_tol", "must be greater than zero"));
+            }
+            parsed.opt_tol = Some(opt_tol);
+        }
+
+        let (elastic_gamma, explicitly_set) =
+            options.get_numeric_value("sqp_qp_elastic_gamma", "")?;
+        if explicitly_set {
+            if elastic_gamma <= 0.0 || elastic_gamma.is_nan() {
+                return Err(invalid("sqp_qp_elastic_gamma", "must be greater than zero"));
+            }
+            parsed.elastic_gamma = Some(elastic_gamma);
+        }
+
+        let (_, explicitly_set) = options.get_string_value("sqp_qp_use_schur_updates", "")?;
+        if explicitly_set {
+            parsed.use_schur_updates =
+                Some(options.get_bool_value("sqp_qp_use_schur_updates", "")?.0);
+        }
+        let (_, explicitly_set) = options.get_string_value("sqp_qp_use_homotopy", "")?;
+        if explicitly_set {
+            parsed.use_homotopy = Some(options.get_bool_value("sqp_qp_use_homotopy", "")?.0);
+        }
+
+        let (updates, explicitly_set) =
+            options.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "")?;
+        if explicitly_set {
+            let value = u32::try_from(updates).map_err(|_| {
+                invalid(
+                    "sqp_qp_max_schur_updates_before_refactor",
+                    "must be positive and fit in u32",
+                )
+            })?;
+            if value == 0 {
+                return Err(invalid(
+                    "sqp_qp_max_schur_updates_before_refactor",
+                    "must be positive",
+                ));
+            }
+            parsed.max_schur_updates_before_refactor = Some(value);
+        }
+
+        Ok(parsed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_num(options: &mut OptionsList, name: &str, value: f64) {
+        options.set_numeric_value(name, value, true, true).unwrap();
+    }
+
+    fn set_int(options: &mut OptionsList, name: &str, value: Index) {
+        options.set_integer_value(name, value, true, true).unwrap();
+    }
+
+    fn set_str(options: &mut OptionsList, name: &str, value: &str) {
+        options.set_string_value(name, value, true, true).unwrap();
+    }
+
+    #[test]
+    fn qp_defaults_do_not_inherit_unset_registry_values() {
+        let parsed = QpOptions::try_from_options_list(&OptionsList::new()).unwrap();
+        let defaults = QpOptions::default();
+        assert_eq!(parsed.time_limit, defaults.time_limit);
+        assert_eq!(parsed.tol, defaults.tol);
+        assert_eq!(parsed.max_iter, defaults.max_iter);
+        assert_eq!(parsed.tau, defaults.tau);
+        assert_eq!(parsed.tau_max, defaults.tau_max);
+        assert_eq!(parsed.reg, defaults.reg);
+        assert_eq!(parsed.infeas_tol, defaults.infeas_tol);
+        assert_eq!(parsed.use_hsde, defaults.use_hsde);
+        assert_eq!(parsed.equilibrate, defaults.equilibrate);
+        assert_eq!(parsed.crossover, defaults.crossover);
+        assert_eq!(parsed.gondzio_max_corr, defaults.gondzio_max_corr);
+    }
+
+    #[test]
+    fn qp_explicit_controls_materialize_typed_values() {
+        let mut options = OptionsList::new();
+        set_int(&mut options, "max_iter", 0);
+        set_num(&mut options, "tol", 2e-7);
+        set_num(&mut options, "max_wall_time", 1.25);
+        set_num(&mut options, "qp_tau", 0.9);
+        set_num(&mut options, "qp_tau_max", 0.98);
+        set_num(&mut options, "qp_reg", 2e-9);
+        set_int(&mut options, "qp_gondzio_corr", 7);
+        set_num(&mut options, "qp_infeas_tol", 3e-6);
+        set_str(&mut options, "qp_hsde", "no");
+        set_str(&mut options, "qp_equilibrate", "no");
+        set_str(&mut options, "qp_crossover", "yes");
+
+        let parsed = QpOptions::try_from_options_list(&options).unwrap();
+        assert_eq!(parsed.max_iter, 0);
+        assert_eq!(parsed.tol, 2e-7);
+        assert_eq!(parsed.time_limit, Some(Duration::from_secs_f64(1.25)));
+        assert_eq!(parsed.tau, 0.9);
+        assert_eq!(parsed.tau_max, 0.98);
+        assert_eq!(parsed.reg, 2e-9);
+        assert_eq!(parsed.gondzio_max_corr, 7);
+        assert_eq!(parsed.infeas_tol, 3e-6);
+        assert!(!parsed.use_hsde);
+        assert!(!parsed.equilibrate);
+        assert!(parsed.crossover);
+    }
+
+    #[test]
+    fn explicit_tau_max_wins_and_an_unset_ceiling_tracks_a_raised_floor() {
+        let mut floor_only = OptionsList::new();
+        set_num(&mut floor_only, "qp_tau", 1.0 - 5e-13);
+        let parsed = QpOptions::try_from_options_list(&floor_only).unwrap();
+        assert_eq!(parsed.tau_max, 1.0 - 5e-13);
+
+        set_num(&mut floor_only, "qp_tau_max", 0.9);
+        let parsed = QpOptions::try_from_options_list(&floor_only).unwrap();
+        assert_eq!(parsed.tau_max, 0.9);
+    }
+
+    #[test]
+    fn an_unrepresentable_wall_time_means_no_deadline() {
+        let mut options = OptionsList::new();
+        set_num(&mut options, "max_wall_time", 1e20);
+        assert_eq!(
+            QpOptions::try_from_options_list(&options)
+                .unwrap()
+                .time_limit,
+            None
+        );
+    }
+
+    #[test]
+    fn presolve_alias_and_specific_precedence_are_typed() {
+        let defaults = ConvexPresolveOptions::try_from_options_list(&OptionsList::new()).unwrap();
+        assert!(defaults.enabled);
+
+        let mut options = OptionsList::new();
+        set_str(&mut options, "presolve", "no");
+        assert!(
+            !ConvexPresolveOptions::try_from_options_list(&options)
+                .unwrap()
+                .enabled
+        );
+
+        set_str(&mut options, "qp_presolve", "yes");
+        assert!(
+            ConvexPresolveOptions::try_from_options_list(&options)
+                .unwrap()
+                .enabled
+        );
+
+        set_str(&mut options, "presolve", "yes");
+        set_str(&mut options, "qp_presolve", "no");
+        assert!(
+            !ConvexPresolveOptions::try_from_options_list(&options)
+                .unwrap()
+                .enabled
+        );
+
+        let mut alias_only = OptionsList::new();
+        set_str(&mut alias_only, "presolve", "yes");
+        assert!(
+            ConvexPresolveOptions::try_from_options_list(&alias_only)
+                .unwrap()
+                .enabled
+        );
+    }
+
+    #[test]
+    fn active_set_controls_materialize_only_explicit_overrides() {
+        let defaults = ActiveSetOverrides::try_from_options_list(&OptionsList::new()).unwrap();
+        assert!(defaults.is_empty());
+
+        let mut options = OptionsList::new();
+        set_int(&mut options, "sqp_qp_max_iter", 37);
+        set_str(&mut options, "sqp_qp_anti_cycling", "bland");
+        set_num(&mut options, "sqp_qp_feas_tol", 1e-7);
+        set_num(&mut options, "sqp_qp_opt_tol", 2e-7);
+        set_num(&mut options, "sqp_qp_elastic_gamma", 1e4);
+        set_str(&mut options, "sqp_qp_use_schur_updates", "yes");
+        set_str(&mut options, "sqp_qp_use_homotopy", "no");
+        set_int(&mut options, "sqp_qp_max_schur_updates_before_refactor", 12);
+
+        let parsed = ActiveSetOverrides::try_from_options_list(&options).unwrap();
+        assert_eq!(parsed.max_iter, Some(37));
+        assert_eq!(parsed.anti_cycling, Some(AntiCyclingChoice::Bland));
+        assert_eq!(parsed.feas_tol, Some(1e-7));
+        assert_eq!(parsed.opt_tol, Some(2e-7));
+        assert_eq!(parsed.elastic_gamma, Some(1e4));
+        assert_eq!(parsed.use_schur_updates, Some(true));
+        assert_eq!(parsed.use_homotopy, Some(false));
+        assert_eq!(parsed.max_schur_updates_before_refactor, Some(12));
+    }
+
+    #[test]
+    fn malformed_unregistered_values_are_rejected() {
+        let mut options = OptionsList::new();
+        set_num(&mut options, "qp_tau", 1.0);
+        assert!(QpOptions::try_from_options_list(&options).is_err());
+
+        let mut options = OptionsList::new();
+        set_str(&mut options, "qp_hsde", "maybe");
+        assert!(QpOptions::try_from_options_list(&options).is_err());
+
+        let mut options = OptionsList::new();
+        set_int(&mut options, "sqp_qp_max_iter", 0);
+        assert!(ActiveSetOverrides::try_from_options_list(&options).is_err());
+    }
+}


### PR DESCRIPTION
## Problem

Convex solver option parsing currently lives in `pounce-cli`. Library consumers have to reproduce the  qp_* and sqp_qp_* names, types, bounds, defaults, and precedence rules. 

`qp_gondzio_corr` was also missing from the guard that rejects convex-only options on library paths unable to use them.

## Fix

Moved all convex parsing and validation out of the CLI.

## Blast radius

Just options.

## Tests

- [ ] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now — no test named that does not exist, no doc describing a
      design that was revised mid-review, no measurement whose baseline has
      since moved

> Implemented using Codex