### PR TITLE
options: one reader for the sqp_qp_* family, and a drift guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,14 +551,27 @@ changes.
 - **Convex `OptionsList` parsing is now a reusable library API.**
 
   `pounce_convex::QpOptions::try_from_options_list`,
-  `ConvexPresolveOptions::try_from_options_list`, and
-  `ActiveSetOverrides::try_from_options_list` now own the names, conversions,
-  validation, and precedence rules for the convex `qp_*` and `sqp_qp_*`
-  controls. The CLI delegates to those typed readers instead of maintaining
-  private copies, so another frontend can materialize the same configuration
-  without reproducing CLI logic. Existing explicit-only handling for shared
-  `tol` / iteration / wall-time controls, `qp_tau_max` precedence, and the
-  `qp_presolve`-over-`presolve` rule is unchanged.
+  `pounce_convex::ConvexPresolveOptions::try_from_options_list`, and
+  `pounce_qp::ActiveSetOverrides::try_from_options_list` now own the names,
+  conversions, validation, and precedence rules for the convex `qp_*` and
+  `sqp_qp_*` controls. The CLI delegates to those typed readers instead of
+  maintaining private copies, so another frontend can materialize the same
+  configuration without reproducing CLI logic. Existing explicit-only handling
+  for shared `tol` / iteration / wall-time controls, `qp_tau_max` precedence,
+  and the `qp_presolve`-over-`presolve` rule is unchanged.
+
+  `ActiveSetOverrides` lives in `pounce-qp`, beside the `QpOptions` it
+  overlays, so that it is genuinely the only reader of the `sqp_qp_*` family:
+  the SQP subproblem path in `pounce-algorithm` — which has no `pounce-convex`
+  dependency, and until now kept a second copy of the same eight names —
+  reads through it too. `pounce_convex::ActiveSetOverrides` is unchanged as a
+  public path; it re-exports the type.
+
+  The bounds these readers re-check duplicate the registered ones on purpose,
+  for callers who build an `OptionsList` with no registry attached. A new test,
+  `pounce-cli`'s `convex_option_readers_match_the_registry`, derives the
+  registry's verdict at run time and fails if a reader is narrower than the
+  registration it mirrors, so the two copies cannot drift apart silently.
 
   `qp_gondzio_corr` is also covered by the core library guard that refuses a
   non-default convex-only option on an entry point unable to run the convex

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -4999,50 +4999,33 @@ fn apply_sqp_options(options: &OptionsList, opts: &mut crate::sqp::SqpOptions) {
 /// options ([`crate::sqp::SqpOptions`]); this one feeds the inner QP
 /// solver that `SqpAlgorithm` delegates each subproblem to. Consulted
 /// only on the `ActiveSetSqp` path. Each knob is forwarded only when
-/// the user explicitly set it (the `true` flag), so the `pounce_qp`
-/// defaults stand otherwise.
+/// the user explicitly set it, so the `pounce_qp` defaults stand
+/// otherwise.
+///
+/// The reading itself is [`pounce_qp::ActiveSetOverrides`], shared with
+/// `pounce_convex`'s direct active-set driver, which overlays the same
+/// eight names onto the same `QpOptions` type. This function had its own
+/// copy until then, and the two had drifted: this one silently ignored a
+/// `sqp_qp_max_iter` of 0 and an unknown `sqp_qp_anti_cycling` value where
+/// the other rejected them. Neither divergence was reachable — the
+/// registry bounds `sqp_qp_max_iter` at 1 and restricts `anti_cycling` to
+/// three values — but two readers of one option family is how a
+/// reachable one starts.
 fn apply_qp_subproblem_options(options: &OptionsList, opts: &mut pounce_qp::QpOptions) {
-    use pounce_qp::AntiCyclingChoice;
-
-    if let Ok((v, true)) = options.get_integer_value("sqp_qp_max_iter", "") {
-        if v >= 0 {
-            opts.max_iter = v as u32;
-        }
-    }
-    if let Ok((v, true)) = options.get_numeric_value("sqp_qp_feas_tol", "") {
-        opts.feas_tol = v;
-    }
-    if let Ok((v, true)) = options.get_numeric_value("sqp_qp_opt_tol", "") {
-        opts.opt_tol = v;
-    }
-    if let Ok((v, true)) = options.get_numeric_value("sqp_qp_elastic_gamma", "") {
-        opts.elastic_gamma = v;
-    }
-    if let Ok((v, true)) = options.get_bool_value("sqp_qp_use_schur_updates", "") {
-        opts.use_schur_updates = v;
-    }
-    // Registered by the homotopy work but never read here, so the knob was a
-    // no-op on the SQP path: `pounce_qp`'s own default is `false`, and only
-    // `pounce_convex::active_set` set it (in Rust, not through options). The
-    // inverse of gh #360 — registered-but-unread rather than
-    // read-but-unregistered — and invisible to that issue's guard test, which
-    // only checked one direction.
-    if let Ok((v, true)) = options.get_bool_value("sqp_qp_use_homotopy", "") {
-        opts.use_homotopy = v;
-    }
-    if let Ok((v, true)) = options.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "")
-    {
-        if v >= 1 {
-            opts.max_schur_updates_before_refactor = v as u32;
-        }
-    }
-    if let Ok((s, true)) = options.get_string_value("sqp_qp_anti_cycling", "") {
-        opts.anti_cycling = match s.as_str() {
-            "expand" => AntiCyclingChoice::Expand,
-            "bland" => AntiCyclingChoice::Bland,
-            "none" => AntiCyclingChoice::None,
-            _ => opts.anti_cycling,
-        };
+    match pounce_qp::ActiveSetOverrides::try_from_options_list(options) {
+        Ok(overrides) => overrides.apply(opts),
+        // Unreachable from here: this runs after `initialize()`, so every
+        // value present has already been validated against the registered
+        // bound that the reader re-checks. Say so out loud anyway rather
+        // than solving with a configuration the user did not ask for —
+        // silently dropping the whole family is exactly the failure mode
+        // `tests/no_silent_options.rs` exists to prevent.
+        Err(error) => tracing::error!(
+            target: "pounce::options",
+            %error,
+            "sqp_qp_* options were rejected after the registry accepted them; \
+             the QP subproblem is running on pounce-qp defaults"
+        ),
     }
 }
 

--- a/crates/pounce-cli/tests/convex_option_readers_match_the_registry.rs
+++ b/crates/pounce-cli/tests/convex_option_readers_match_the_registry.rs
@@ -1,0 +1,281 @@
+//! The convex option readers must not be narrower than the registry.
+//!
+//! `pounce_convex::{QpOptions, ConvexPresolveOptions}` and
+//! `pounce_qp::ActiveSetOverrides` re-check the bounds that
+//! `pounce_algorithm::upstream_options` registers. That duplication is
+//! deliberate — a caller may hand a reader an `OptionsList` with no registry
+//! attached, and then the reader is the only thing standing between a bad
+//! value and the solver — but it is duplication, and nothing else compares the
+//! two copies.
+//!
+//! That is the shape of defect this repository keeps paying for. #677:
+//! `limited_memory_initialization` was registered with one default and read
+//! with another, and no layer of testing compared the registry against
+//! behaviour. #551 caution 1: "re-derive the classification mechanically; do
+//! not trust a hand-maintained list."
+//!
+//! So this test derives the registry's verdict at run time rather than
+//! restating any bound. For every probe value it asks the *registry* whether
+//! the value is legal, and where the answer is yes it requires the reader to
+//! accept it too. A bound widened in `upstream_options.rs` and not widened in
+//! the reader fails here, naming the option and the value.
+//!
+//! The converse — a reader more permissive than the registry — is not an
+//! error and is not asserted. `max_wall_time` is the live example: the
+//! registry bounds it strictly above zero, while the reader accepts `0.0` as
+//! an immediate deadline for the no-registry caller. A reader can only be
+//! reached with a registry-rejected value when there is no registry, and then
+//! its own rule is the whole contract.
+//!
+//! This crate is the test's home because it is the only one that depends on
+//! both `pounce-algorithm` (which owns the registry) and `pounce-convex`
+//! (which owns the readers, and re-exports `pounce-qp`'s).
+
+use pounce_algorithm::IpoptApplication;
+use pounce_common::OptionsList;
+// `ActiveSetOverrides` is defined in `pounce-qp` and re-exported here; reach
+// it by the public path a CLI-side caller would.
+use pounce_convex::{ActiveSetOverrides, ConvexPresolveOptions, QpOptions};
+
+/// Run all three readers; `Err` from any of them is a rejection.
+fn readers_accept(options: &OptionsList) -> Result<(), String> {
+    QpOptions::try_from_options_list(options).map_err(|e| format!("QpOptions: {e}"))?;
+    ConvexPresolveOptions::try_from_options_list(options)
+        .map_err(|e| format!("ConvexPresolveOptions: {e}"))?;
+    ActiveSetOverrides::try_from_options_list(options)
+        .map_err(|e| format!("ActiveSetOverrides: {e}"))?;
+    Ok(())
+}
+
+fn app() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.initialize().expect("registry initializes");
+    app
+}
+
+#[derive(Clone, Copy)]
+enum Probe {
+    Num(f64),
+    Int(i32),
+    Str(&'static str),
+}
+
+impl std::fmt::Display for Probe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Probe::Num(v) => write!(f, "{v}"),
+            Probe::Int(v) => write!(f, "{v}"),
+            Probe::Str(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+/// Boundary and just-past-boundary values for every option the three readers
+/// re-validate. Whether each is legal is *not* stated here — the registry is
+/// asked at run time. The list only has to be wide enough to straddle each
+/// registered bound.
+const PROBES: &[(&str, &[Probe])] = &[
+    (
+        "qp_tau",
+        &[
+            Probe::Num(0.0),
+            Probe::Num(1e-12),
+            Probe::Num(0.5),
+            Probe::Num(1.0 - 1e-12),
+            Probe::Num(1.0),
+        ],
+    ),
+    (
+        "qp_tau_max",
+        &[
+            Probe::Num(0.0),
+            Probe::Num(0.5),
+            Probe::Num(1.0 - 1e-12),
+            Probe::Num(1.0),
+        ],
+    ),
+    (
+        "qp_reg",
+        &[Probe::Num(-1.0), Probe::Num(0.0), Probe::Num(1e-10)],
+    ),
+    (
+        "qp_infeas_tol",
+        &[Probe::Num(0.0), Probe::Num(1e-12), Probe::Num(1.0)],
+    ),
+    (
+        "qp_gondzio_corr",
+        &[
+            Probe::Int(-1),
+            Probe::Int(0),
+            Probe::Int(3),
+            Probe::Int(10),
+            Probe::Int(11),
+        ],
+    ),
+    (
+        "tol",
+        &[Probe::Num(0.0), Probe::Num(1e-14), Probe::Num(1.0)],
+    ),
+    (
+        "max_iter",
+        &[
+            Probe::Int(-1),
+            Probe::Int(0),
+            Probe::Int(1),
+            Probe::Int(3000),
+        ],
+    ),
+    (
+        "max_wall_time",
+        &[Probe::Num(1e-9), Probe::Num(1.0), Probe::Num(1e20)],
+    ),
+    (
+        "qp_hsde",
+        &[Probe::Str("yes"), Probe::Str("no"), Probe::Str("maybe")],
+    ),
+    ("qp_equilibrate", &[Probe::Str("yes"), Probe::Str("no")]),
+    ("qp_crossover", &[Probe::Str("yes"), Probe::Str("no")]),
+    ("qp_presolve", &[Probe::Str("yes"), Probe::Str("no")]),
+    ("presolve", &[Probe::Str("yes"), Probe::Str("no")]),
+    (
+        "sqp_qp_max_iter",
+        &[
+            Probe::Int(0),
+            Probe::Int(1),
+            Probe::Int(200),
+            Probe::Int(5000),
+        ],
+    ),
+    (
+        "sqp_qp_max_schur_updates_before_refactor",
+        &[Probe::Int(0), Probe::Int(1), Probe::Int(50)],
+    ),
+    (
+        "sqp_qp_feas_tol",
+        &[Probe::Num(0.0), Probe::Num(1e-14), Probe::Num(1.0)],
+    ),
+    (
+        "sqp_qp_opt_tol",
+        &[Probe::Num(0.0), Probe::Num(1e-14), Probe::Num(1.0)],
+    ),
+    (
+        "sqp_qp_elastic_gamma",
+        &[Probe::Num(0.0), Probe::Num(1e-14), Probe::Num(1e6)],
+    ),
+    (
+        "sqp_qp_anti_cycling",
+        &[
+            Probe::Str("expand"),
+            Probe::Str("bland"),
+            Probe::Str("none"),
+            Probe::Str("maybe"),
+        ],
+    ),
+    (
+        "sqp_qp_use_schur_updates",
+        &[Probe::Str("yes"), Probe::Str("no")],
+    ),
+    (
+        "sqp_qp_use_homotopy",
+        &[Probe::Str("yes"), Probe::Str("no")],
+    ),
+];
+
+#[test]
+fn a_value_the_registry_accepts_is_never_rejected_by_a_reader() {
+    let mut app = app();
+    let mut checked = 0usize;
+
+    for (name, probes) in PROBES {
+        for probe in *probes {
+            let options = app.options_mut();
+            options.unset_value(name);
+            let registry_accepts = match probe {
+                Probe::Num(v) => options.set_numeric_value(name, *v, true, true).is_ok(),
+                Probe::Int(v) => options.set_integer_value(name, *v, true, true).is_ok(),
+                Probe::Str(v) => options.set_string_value(name, v, true, true).is_ok(),
+            };
+            if !registry_accepts {
+                continue;
+            }
+            checked += 1;
+            if let Err(why) = readers_accept(app.options()) {
+                panic!(
+                    "the registry accepts `{name} = {probe}` but a convex option reader \
+                     refuses it: {why}\n\n\
+                     The reader's hardcoded bound has drifted from the one \
+                     `pounce_algorithm::upstream_options` registers. Widen the reader to \
+                     match, or tighten the registration — but do not leave a value that \
+                     validates at set time and then fails when it is read."
+                );
+            }
+            app.options_mut().unset_value(name);
+        }
+    }
+
+    // A typo in `PROBES` that names no registered option would otherwise make
+    // this test pass by checking nothing.
+    assert!(
+        checked >= PROBES.len(),
+        "only {checked} probe values were accepted by the registry across \
+         {} options — the probe table is not reaching the registry",
+        PROBES.len()
+    );
+}
+
+#[test]
+fn an_untouched_registry_yields_exactly_the_rust_defaults() {
+    // The other half of the drift guard, and the reason the readers gate every
+    // field on the `explicitly_set` flag: a registered default must never be
+    // read as a request. `max_iter` is the one that bites — Ipopt's default is
+    // far larger than the convex driver's, and silently adopting it would turn
+    // a tuned cap into no cap at all.
+    let app = app();
+
+    let qp = QpOptions::try_from_options_list(app.options()).expect("defaults must parse");
+    let expected = QpOptions::default();
+    assert_eq!(qp.max_iter, expected.max_iter);
+    assert_eq!(qp.tol, expected.tol);
+    assert_eq!(qp.time_limit, expected.time_limit);
+    assert_eq!(qp.tau, expected.tau);
+    assert_eq!(qp.tau_max, expected.tau_max);
+    assert_eq!(qp.reg, expected.reg);
+    assert_eq!(qp.gondzio_max_corr, expected.gondzio_max_corr);
+    assert_eq!(qp.infeas_tol, expected.infeas_tol);
+    assert_eq!(qp.use_hsde, expected.use_hsde);
+    assert_eq!(qp.equilibrate, expected.equilibrate);
+    assert_eq!(qp.crossover, expected.crossover);
+
+    assert_eq!(
+        ConvexPresolveOptions::try_from_options_list(app.options()).expect("defaults must parse"),
+        ConvexPresolveOptions::default()
+    );
+
+    assert!(
+        ActiveSetOverrides::try_from_options_list(app.options())
+            .expect("defaults must parse")
+            .is_empty(),
+        "an untouched registry must produce no active-set overrides"
+    );
+}
+
+/// The registered defaults are also the *values* the readers would apply if
+/// the explicit-set gate ever broke — so pin the two that a reader would
+/// otherwise silently disagree with.
+#[test]
+fn an_explicitly_set_default_still_reads_as_that_default() {
+    let mut app = app();
+    app.options_mut()
+        .set_numeric_value("qp_tau", 0.95, true, true)
+        .unwrap();
+    app.options_mut()
+        .set_integer_value("qp_gondzio_corr", 3, true, true)
+        .unwrap();
+
+    let qp = QpOptions::try_from_options_list(app.options()).unwrap();
+    assert_eq!(qp.tau, 0.95);
+    assert_eq!(qp.gondzio_max_corr, 3);
+    // `qp_tau` lifts the ceiling with the floor, and 0.95 is below the
+    // default ceiling, so an unset `qp_tau_max` must stay put.
+    assert_eq!(qp.tau_max, QpOptions::default().tau_max);
+}

--- a/crates/pounce-common/src/exception.rs
+++ b/crates/pounce-common/src/exception.rs
@@ -152,6 +152,29 @@ impl fmt::Display for SolverException {
 
 impl std::error::Error for SolverException {}
 
+/// Build an `OPTION_INVALID` exception rejecting `name`'s value,
+/// attributed to the **caller's** source location.
+///
+/// Every option reader that validates a value it read out of an
+/// [`crate::OptionsList`] wants the same shape of error, but a shared
+/// constructor that captured `file!()`/`line!()` of its own body would
+/// point every such message at one line in this file — and that pair is
+/// what [`SolverException`]'s `Display` prints to the user. `#[track_caller]`
+/// keeps the attribution on the read site that actually rejected the value.
+///
+/// The message reads `Option "<name>": <message>.` — the trailing period is
+/// supplied here, so `message` should not carry one.
+#[track_caller]
+pub fn option_invalid(name: &str, message: impl fmt::Display) -> SolverException {
+    let loc = std::panic::Location::caller();
+    SolverException::new(
+        ExceptionKind::OPTION_INVALID,
+        format!("Option \"{name}\": {message}."),
+        loc.file(),
+        loc.line() as Index,
+    )
+}
+
 /// Macro replacement for Ipopt's `THROW_EXCEPTION(kind, msg)`. Produces
 /// a `Result::Err(SolverException)` using `file!()`/`line!()`.
 #[macro_export]

--- a/crates/pounce-common/src/lib.rs
+++ b/crates/pounce-common/src/lib.rs
@@ -25,7 +25,7 @@ pub mod utils;
 pub use cached::Cache;
 pub use diagnostics::{DiagCategory, DiagnosticsConfig, DiagnosticsState, DumpFormat, IterSpec};
 pub use exact::{add_is_exact, is_live, mul_is_exact};
-pub use exception::{ExceptionKind, SolverException};
+pub use exception::{ExceptionKind, SolverException, option_invalid};
 pub use journalist::{
     FileJournal, Journal, JournalCategory, JournalLevel, Journalist, StringJournal,
 };

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -64,78 +64,19 @@
 use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
 use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
 use pounce_linsol::SparseSymLinearSolverInterface;
+// `ActiveSetOverrides` is `pounce-qp`'s: it overlays the `sqp_qp_*` family
+// onto a `QpOptions` base, which the SQP subproblem path in
+// `pounce-algorithm` needs too, and `pounce-qp` is the only crate both of
+// them depend on. Re-exported from this crate's root, so the public path
+// callers already use is unchanged.
 use pounce_qp::{
-    AntiCyclingChoice, BoundStatus, ConsStatus, HessianInertia, ParametricActiveSetSolver,
+    ActiveSetOverrides, BoundStatus, ConsStatus, HessianInertia, ParametricActiveSetSolver,
     QpOptions as ActiveSetOptions, QpProblem as ActiveSetProblem, QpSolver,
     QpStatus as ActiveSetStatus, QpWarmStart, WorkingSet,
 };
 
 use crate::ipm::{FARKAS_RESID_TOL, QpOptions, dot, finite_or_failed, inf_norm};
 use crate::qp::{BoxScreen, QpProblem, QpSolution, QpStatus, screen_variable_box};
-
-/// Caller-supplied overrides for the inner `pounce-qp` engine.
-///
-/// Every field is `None` unless the user set the corresponding option
-/// explicitly, so this driver can tell "left at the default" from "asked for
-/// the default value" — a distinction it needs, because it deliberately
-/// overrides two of these itself (a size-scaled `max_iter` and
-/// `use_schur_updates: true`) and an explicit request must win over that.
-///
-/// Exists because these knobs became unreachable when `qp-active-set` moved off
-/// the SQP outer loop: the `sqp_qp_*` option family fed the SQP's QP
-/// subproblem, and with no SQP in the picture all seven silently became no-ops.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ActiveSetOverrides {
-    pub max_iter: Option<u32>,
-    pub anti_cycling: Option<AntiCyclingChoice>,
-    pub feas_tol: Option<f64>,
-    pub opt_tol: Option<f64>,
-    pub elastic_gamma: Option<f64>,
-    pub use_schur_updates: Option<bool>,
-    pub use_homotopy: Option<bool>,
-    pub max_schur_updates_before_refactor: Option<u32>,
-}
-
-impl ActiveSetOverrides {
-    /// True when the caller set nothing.
-    pub fn is_empty(&self) -> bool {
-        self.max_iter.is_none()
-            && self.anti_cycling.is_none()
-            && self.feas_tol.is_none()
-            && self.opt_tol.is_none()
-            && self.elastic_gamma.is_none()
-            && self.use_schur_updates.is_none()
-            && self.use_homotopy.is_none()
-            && self.max_schur_updates_before_refactor.is_none()
-    }
-
-    fn apply(&self, o: &mut ActiveSetOptions) {
-        if let Some(v) = self.max_iter {
-            o.max_iter = v;
-        }
-        if let Some(v) = self.anti_cycling {
-            o.anti_cycling = v;
-        }
-        if let Some(v) = self.feas_tol {
-            o.feas_tol = v;
-        }
-        if let Some(v) = self.opt_tol {
-            o.opt_tol = v;
-        }
-        if let Some(v) = self.elastic_gamma {
-            o.elastic_gamma = v;
-        }
-        if let Some(v) = self.use_schur_updates {
-            o.use_schur_updates = v;
-        }
-        if let Some(v) = self.use_homotopy {
-            o.use_homotopy = v;
-        }
-        if let Some(v) = self.max_schur_updates_before_refactor {
-            o.max_schur_updates_before_refactor = v;
-        }
-    }
-}
 
 /// Clamp a convex lower-bound value to pounce-qp's `±1e19` free convention.
 fn to_qp_lower(lb: f64) -> f64 {

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -46,7 +46,7 @@ pub mod sensitivity;
 pub(crate) mod simplex;
 pub mod sos;
 
-pub use active_set::{ActiveSetOverrides, solve_qp_active_set};
+pub use active_set::solve_qp_active_set;
 pub use batch::{
     solve_qp_batch, solve_qp_batch_parallel, solve_qp_batch_parallel_warm, solve_qp_multi_rhs,
     solve_qp_multi_rhs_parallel,
@@ -57,6 +57,10 @@ pub use ipm::{
     solve_socp_ipm, solve_socp_ipm_debug, solve_socp_ipm_warm,
 };
 pub use options::ConvexPresolveOptions;
+// Defined in `pounce-qp` alongside the `QpOptions` it overlays, and shared
+// with the SQP subproblem reader there; re-exported so the public path is
+// unchanged for callers who reach it through this crate.
+pub use pounce_qp::ActiveSetOverrides;
 pub use psd_certificate::{PsdCertificateError, certify_psd_lower_triangle};
 pub use qp::{NEG_INF, POS_INF, QpIterate, QpProblem, QpResiduals, QpSolution, QpStatus, Triplet};
 pub use sensitivity::{QpSensitivity, ReducedHessian, SensError};

--- a/crates/pounce-convex/src/options.rs
+++ b/crates/pounce-convex/src/options.rs
@@ -7,22 +7,20 @@
 
 use std::time::Duration;
 
-use pounce_common::{ExceptionKind, Index, OptionsList, SolverException};
-use pounce_qp::AntiCyclingChoice;
+use pounce_common::{OptionsList, SolverException, option_invalid};
 
-use crate::{ActiveSetOverrides, QpOptions};
-
-fn invalid(name: &str, message: impl std::fmt::Display) -> SolverException {
-    SolverException::new(
-        ExceptionKind::OPTION_INVALID,
-        format!("Option \"{name}\": {message}."),
-        file!(),
-        line!() as Index,
-    )
-}
+use crate::QpOptions;
 
 impl QpOptions {
     /// Build convex-IPM options from a registered [`OptionsList`].
+    ///
+    /// The bounds re-checked here duplicate the ones
+    /// `pounce_algorithm::upstream_options` registers, so on any path that
+    /// went through the registry they are unreachable — the registry rejects
+    /// the value at *set* time. They exist for the caller who builds an
+    /// `OptionsList` with no registry attached, where nothing else would.
+    /// `pounce-cli`'s `convex_option_readers_match_the_registry` test pins the
+    /// two sets of bounds together so the pair cannot drift.
     ///
     /// Shared NLP controls (`tol`, `max_iter`, and `max_wall_time`) are applied
     /// only when explicitly set, so their registry defaults do not replace the
@@ -34,13 +32,13 @@ impl QpOptions {
         let (max_iter, explicitly_set) = options.get_integer_value("max_iter", "")?;
         if explicitly_set {
             parsed.max_iter = usize::try_from(max_iter)
-                .map_err(|_| invalid("max_iter", "must be nonnegative and fit in usize"))?;
+                .map_err(|_| option_invalid("max_iter", "must be nonnegative and fit in usize"))?;
         }
 
         let (tol, explicitly_set) = options.get_numeric_value("tol", "")?;
         if explicitly_set {
             if tol <= 0.0 || tol.is_nan() {
-                return Err(invalid("tol", "must be greater than zero"));
+                return Err(option_invalid("tol", "must be greater than zero"));
             }
             parsed.tol = tol;
         }
@@ -48,7 +46,7 @@ impl QpOptions {
         let (wall_time, explicitly_set) = options.get_numeric_value("max_wall_time", "")?;
         if explicitly_set {
             if wall_time.is_nan() || wall_time < 0.0 {
-                return Err(invalid("max_wall_time", "must be nonnegative"));
+                return Err(option_invalid("max_wall_time", "must be nonnegative"));
             }
             // Values outside Duration's honest range, including Ipopt's 1e20
             // sentinel and infinity, mean "no deadline" rather than an
@@ -59,7 +57,10 @@ impl QpOptions {
         let (tau, explicitly_set) = options.get_numeric_value("qp_tau", "")?;
         if explicitly_set {
             if !(tau > 0.0 && tau < 1.0) {
-                return Err(invalid("qp_tau", "must lie strictly between zero and one"));
+                return Err(option_invalid(
+                    "qp_tau",
+                    "must lie strictly between zero and one",
+                ));
             }
             parsed.tau = tau;
             // A raised floor lifts the default ceiling; an explicit
@@ -70,7 +71,7 @@ impl QpOptions {
         let (tau_max, explicitly_set) = options.get_numeric_value("qp_tau_max", "")?;
         if explicitly_set {
             if !(tau_max > 0.0 && tau_max < 1.0) {
-                return Err(invalid(
+                return Err(option_invalid(
                     "qp_tau_max",
                     "must lie strictly between zero and one",
                 ));
@@ -81,7 +82,7 @@ impl QpOptions {
         let (reg, explicitly_set) = options.get_numeric_value("qp_reg", "")?;
         if explicitly_set {
             if reg < 0.0 || reg.is_nan() {
-                return Err(invalid("qp_reg", "must be nonnegative"));
+                return Err(option_invalid("qp_reg", "must be nonnegative"));
             }
             parsed.reg = reg;
         }
@@ -89,7 +90,10 @@ impl QpOptions {
         let (correctors, explicitly_set) = options.get_integer_value("qp_gondzio_corr", "")?;
         if explicitly_set {
             if !(0..=10).contains(&correctors) {
-                return Err(invalid("qp_gondzio_corr", "must be between 0 and 10"));
+                return Err(option_invalid(
+                    "qp_gondzio_corr",
+                    "must be between 0 and 10",
+                ));
             }
             parsed.gondzio_max_corr = correctors as usize;
         }
@@ -97,11 +101,16 @@ impl QpOptions {
         let (infeas_tol, explicitly_set) = options.get_numeric_value("qp_infeas_tol", "")?;
         if explicitly_set {
             if infeas_tol <= 0.0 || infeas_tol.is_nan() {
-                return Err(invalid("qp_infeas_tol", "must be greater than zero"));
+                return Err(option_invalid("qp_infeas_tol", "must be greater than zero"));
             }
             parsed.infeas_tol = infeas_tol;
         }
 
+        // Two lookups rather than a bare `get_bool_value`, and deliberately
+        // so: with no registry attached `get_string_value` answers "" /
+        // not-found for an unset name, and `get_bool_value` would reject that
+        // "" as a non-boolean instead of reporting it unset. Read the presence
+        // flag first, and only decode a value that is actually there.
         let (_, explicitly_set) = options.get_string_value("qp_hsde", "")?;
         if explicitly_set {
             parsed.use_hsde = options.get_bool_value("qp_hsde", "")?.0;
@@ -139,6 +148,8 @@ impl ConvexPresolveOptions {
     /// `presolve` setting is honored; when neither is set, convex presolve
     /// keeps its default-on behavior.
     pub fn try_from_options_list(options: &OptionsList) -> Result<Self, SolverException> {
+        // Two lookups per name, for the reason given in
+        // [`QpOptions::try_from_options_list`].
         let (_, qp_explicit) = options.get_string_value("qp_presolve", "")?;
         let qp_presolve = if qp_explicit {
             Some(options.get_bool_value("qp_presolve", "")?.0)
@@ -156,102 +167,10 @@ impl ConvexPresolveOptions {
         })
     }
 }
-
-impl ActiveSetOverrides {
-    /// Read explicitly set `sqp_qp_*` controls for the direct convex
-    /// active-set driver.
-    ///
-    /// Unset values remain `None`, allowing the driver to retain its tuned,
-    /// size-dependent defaults rather than inheriting the SQP subproblem
-    /// defaults from the option registry.
-    pub fn try_from_options_list(options: &OptionsList) -> Result<Self, SolverException> {
-        let mut parsed = Self::default();
-
-        let (max_iter, explicitly_set) = options.get_integer_value("sqp_qp_max_iter", "")?;
-        if explicitly_set {
-            let value = u32::try_from(max_iter)
-                .map_err(|_| invalid("sqp_qp_max_iter", "must be positive and fit in u32"))?;
-            if value == 0 {
-                return Err(invalid("sqp_qp_max_iter", "must be positive"));
-            }
-            parsed.max_iter = Some(value);
-        }
-
-        let (anti_cycling, explicitly_set) = options.get_string_value("sqp_qp_anti_cycling", "")?;
-        if explicitly_set {
-            parsed.anti_cycling = Some(match anti_cycling.as_str() {
-                "bland" => AntiCyclingChoice::Bland,
-                "expand" => AntiCyclingChoice::Expand,
-                "none" => AntiCyclingChoice::None,
-                _ => {
-                    return Err(invalid(
-                        "sqp_qp_anti_cycling",
-                        format_args!("unknown value \"{anti_cycling}\""),
-                    ));
-                }
-            });
-        }
-
-        let (feas_tol, explicitly_set) = options.get_numeric_value("sqp_qp_feas_tol", "")?;
-        if explicitly_set {
-            if feas_tol <= 0.0 || feas_tol.is_nan() {
-                return Err(invalid("sqp_qp_feas_tol", "must be greater than zero"));
-            }
-            parsed.feas_tol = Some(feas_tol);
-        }
-
-        let (opt_tol, explicitly_set) = options.get_numeric_value("sqp_qp_opt_tol", "")?;
-        if explicitly_set {
-            if opt_tol <= 0.0 || opt_tol.is_nan() {
-                return Err(invalid("sqp_qp_opt_tol", "must be greater than zero"));
-            }
-            parsed.opt_tol = Some(opt_tol);
-        }
-
-        let (elastic_gamma, explicitly_set) =
-            options.get_numeric_value("sqp_qp_elastic_gamma", "")?;
-        if explicitly_set {
-            if elastic_gamma <= 0.0 || elastic_gamma.is_nan() {
-                return Err(invalid("sqp_qp_elastic_gamma", "must be greater than zero"));
-            }
-            parsed.elastic_gamma = Some(elastic_gamma);
-        }
-
-        let (_, explicitly_set) = options.get_string_value("sqp_qp_use_schur_updates", "")?;
-        if explicitly_set {
-            parsed.use_schur_updates =
-                Some(options.get_bool_value("sqp_qp_use_schur_updates", "")?.0);
-        }
-        let (_, explicitly_set) = options.get_string_value("sqp_qp_use_homotopy", "")?;
-        if explicitly_set {
-            parsed.use_homotopy = Some(options.get_bool_value("sqp_qp_use_homotopy", "")?.0);
-        }
-
-        let (updates, explicitly_set) =
-            options.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "")?;
-        if explicitly_set {
-            let value = u32::try_from(updates).map_err(|_| {
-                invalid(
-                    "sqp_qp_max_schur_updates_before_refactor",
-                    "must be positive and fit in u32",
-                )
-            })?;
-            if value == 0 {
-                return Err(invalid(
-                    "sqp_qp_max_schur_updates_before_refactor",
-                    "must be positive",
-                ));
-            }
-            parsed.max_schur_updates_before_refactor = Some(value);
-        }
-
-        Ok(parsed)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pounce_common::Index;
 
     fn set_num(options: &mut OptionsList, name: &str, value: f64) {
         options.set_numeric_value(name, value, true, true).unwrap();
@@ -373,32 +292,6 @@ mod tests {
     }
 
     #[test]
-    fn active_set_controls_materialize_only_explicit_overrides() {
-        let defaults = ActiveSetOverrides::try_from_options_list(&OptionsList::new()).unwrap();
-        assert!(defaults.is_empty());
-
-        let mut options = OptionsList::new();
-        set_int(&mut options, "sqp_qp_max_iter", 37);
-        set_str(&mut options, "sqp_qp_anti_cycling", "bland");
-        set_num(&mut options, "sqp_qp_feas_tol", 1e-7);
-        set_num(&mut options, "sqp_qp_opt_tol", 2e-7);
-        set_num(&mut options, "sqp_qp_elastic_gamma", 1e4);
-        set_str(&mut options, "sqp_qp_use_schur_updates", "yes");
-        set_str(&mut options, "sqp_qp_use_homotopy", "no");
-        set_int(&mut options, "sqp_qp_max_schur_updates_before_refactor", 12);
-
-        let parsed = ActiveSetOverrides::try_from_options_list(&options).unwrap();
-        assert_eq!(parsed.max_iter, Some(37));
-        assert_eq!(parsed.anti_cycling, Some(AntiCyclingChoice::Bland));
-        assert_eq!(parsed.feas_tol, Some(1e-7));
-        assert_eq!(parsed.opt_tol, Some(2e-7));
-        assert_eq!(parsed.elastic_gamma, Some(1e4));
-        assert_eq!(parsed.use_schur_updates, Some(true));
-        assert_eq!(parsed.use_homotopy, Some(false));
-        assert_eq!(parsed.max_schur_updates_before_refactor, Some(12));
-    }
-
-    #[test]
     fn malformed_unregistered_values_are_rejected() {
         let mut options = OptionsList::new();
         set_num(&mut options, "qp_tau", 1.0);
@@ -407,9 +300,5 @@ mod tests {
         let mut options = OptionsList::new();
         set_str(&mut options, "qp_hsde", "maybe");
         assert!(QpOptions::try_from_options_list(&options).is_err());
-
-        let mut options = OptionsList::new();
-        set_int(&mut options, "sqp_qp_max_iter", 0);
-        assert!(ActiveSetOverrides::try_from_options_list(&options).is_err());
     }
 }

--- a/crates/pounce-qp/src/lib.rs
+++ b/crates/pounce-qp/src/lib.rs
@@ -63,7 +63,7 @@ pub use kkt::{
     assemble_equality_plus_bounds, h_times_x, is_all_equality_constraints, is_pure_box,
     is_pure_equality_no_bounds, rhs_equality_only,
 };
-pub use options::{AntiCyclingChoice, QpAlgorithm, QpOptions};
+pub use options::{ActiveSetOverrides, AntiCyclingChoice, QpAlgorithm, QpOptions};
 pub use problem::{HessianInertia, QpProblem, QpSolution, QpStats, QpWarmStart};
 pub use qps::{QpsModel, parse_qps};
 pub use solver::{ParametricActiveSetSolver, QpSolver};

--- a/crates/pounce-qp/src/options.rs
+++ b/crates/pounce-qp/src/options.rs
@@ -2,7 +2,7 @@
 //! values from the design note so the SQP-side wiring can forward
 //! `OptionsList` entries straight through without translation.
 
-use pounce_common::Number;
+use pounce_common::{Number, OptionsList, SolverException, option_invalid};
 use std::time::Duration;
 
 /// Active-set QP algorithm variant. Phase 5a ships only the sparse
@@ -196,5 +196,294 @@ impl Default for QpOptions {
             expand_tol_max: 1e-7,
             certify_recession_ray: true,
         }
+    }
+}
+
+/// Explicitly-set `sqp_qp_*` overrides for a [`QpOptions`] base.
+///
+/// Every field is `None` unless the user set the corresponding option
+/// *explicitly*, so a caller can tell "left at the default" from "asked for
+/// the default value". Both consumers need that distinction, and for the same
+/// reason: each starts from a base that is not [`QpOptions::default`] and an
+/// explicit request has to win over it. `pounce-convex`'s direct active-set
+/// driver picks a size-scaled `max_iter` and turns Schur updates on;
+/// `pounce-algorithm`'s SQP path starts from the plain defaults but must not
+/// overwrite them with zeros for options nobody set.
+///
+/// The type exists because these knobs became unreachable when
+/// `solver_selection=qp-active-set` moved off the SQP outer loop: the
+/// `sqp_qp_*` family was introduced for the QP subproblem *of that loop*, and
+/// with no SQP in the picture every one of them silently became a no-op on the
+/// direct convex route. The spelling is kept because it is the documented,
+/// already-in-use name; only the delivery route changed.
+///
+/// This lives in `pounce-qp` because [`QpOptions`] does: it is the one crate
+/// both readers already depend on (`pounce-algorithm` has no `pounce-convex`
+/// dependency), so it is the only place a single copy can serve both. It was
+/// two copies until then — `pounce_convex::ActiveSetOverrides` for the direct
+/// driver and `pounce_algorithm::application::apply_qp_subproblem_options` for
+/// the SQP subproblem — reading the same eight registered names into the same
+/// struct, and they had already drifted apart on how they treat a value the
+/// registry would have rejected.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct ActiveSetOverrides {
+    pub max_iter: Option<u32>,
+    pub anti_cycling: Option<AntiCyclingChoice>,
+    pub feas_tol: Option<Number>,
+    pub opt_tol: Option<Number>,
+    pub elastic_gamma: Option<Number>,
+    pub use_schur_updates: Option<bool>,
+    pub use_homotopy: Option<bool>,
+    pub max_schur_updates_before_refactor: Option<u32>,
+}
+
+impl ActiveSetOverrides {
+    /// True when the caller set nothing.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Overlay the explicitly-set values onto `o`, leaving the rest alone.
+    pub fn apply(&self, o: &mut QpOptions) {
+        if let Some(v) = self.max_iter {
+            o.max_iter = v;
+        }
+        if let Some(v) = self.anti_cycling {
+            o.anti_cycling = v;
+        }
+        if let Some(v) = self.feas_tol {
+            o.feas_tol = v;
+        }
+        if let Some(v) = self.opt_tol {
+            o.opt_tol = v;
+        }
+        if let Some(v) = self.elastic_gamma {
+            o.elastic_gamma = v;
+        }
+        if let Some(v) = self.use_schur_updates {
+            o.use_schur_updates = v;
+        }
+        if let Some(v) = self.use_homotopy {
+            o.use_homotopy = v;
+        }
+        if let Some(v) = self.max_schur_updates_before_refactor {
+            o.max_schur_updates_before_refactor = v;
+        }
+    }
+
+    /// Read the explicitly-set `sqp_qp_*` controls out of a registered
+    /// [`OptionsList`].
+    ///
+    /// The bounds re-checked here duplicate the ones
+    /// `pounce_algorithm::upstream_options` registers, so on any path that
+    /// went through the registry they are unreachable — the registry rejects
+    /// the value at *set* time. They exist for the caller who builds an
+    /// `OptionsList` with no registry attached, where nothing else would.
+    /// `pounce-cli`'s `convex_option_readers_match_the_registry` test pins the
+    /// two sets of bounds together so the pair cannot drift.
+    pub fn try_from_options_list(options: &OptionsList) -> Result<Self, SolverException> {
+        let mut parsed = Self::default();
+
+        let (max_iter, explicitly_set) = options.get_integer_value("sqp_qp_max_iter", "")?;
+        if explicitly_set {
+            let value = u32::try_from(max_iter).map_err(|_| {
+                option_invalid("sqp_qp_max_iter", "must be positive and fit in u32")
+            })?;
+            if value == 0 {
+                return Err(option_invalid("sqp_qp_max_iter", "must be positive"));
+            }
+            parsed.max_iter = Some(value);
+        }
+
+        let (anti_cycling, explicitly_set) = options.get_string_value("sqp_qp_anti_cycling", "")?;
+        if explicitly_set {
+            parsed.anti_cycling = Some(match anti_cycling.as_str() {
+                "bland" => AntiCyclingChoice::Bland,
+                "expand" => AntiCyclingChoice::Expand,
+                "none" => AntiCyclingChoice::None,
+                _ => {
+                    return Err(option_invalid(
+                        "sqp_qp_anti_cycling",
+                        format_args!("unknown value \"{anti_cycling}\""),
+                    ));
+                }
+            });
+        }
+
+        let (feas_tol, explicitly_set) = options.get_numeric_value("sqp_qp_feas_tol", "")?;
+        if explicitly_set {
+            if feas_tol <= 0.0 || feas_tol.is_nan() {
+                return Err(option_invalid(
+                    "sqp_qp_feas_tol",
+                    "must be greater than zero",
+                ));
+            }
+            parsed.feas_tol = Some(feas_tol);
+        }
+
+        let (opt_tol, explicitly_set) = options.get_numeric_value("sqp_qp_opt_tol", "")?;
+        if explicitly_set {
+            if opt_tol <= 0.0 || opt_tol.is_nan() {
+                return Err(option_invalid(
+                    "sqp_qp_opt_tol",
+                    "must be greater than zero",
+                ));
+            }
+            parsed.opt_tol = Some(opt_tol);
+        }
+
+        let (elastic_gamma, explicitly_set) =
+            options.get_numeric_value("sqp_qp_elastic_gamma", "")?;
+        if explicitly_set {
+            if elastic_gamma <= 0.0 || elastic_gamma.is_nan() {
+                return Err(option_invalid(
+                    "sqp_qp_elastic_gamma",
+                    "must be greater than zero",
+                ));
+            }
+            parsed.elastic_gamma = Some(elastic_gamma);
+        }
+
+        // Two lookups rather than a bare `get_bool_value`, and deliberately so:
+        // with no registry attached `get_string_value` answers "" / not-found
+        // for an unset name, and `get_bool_value` would reject that "" as a
+        // non-boolean instead of reporting it unset. Read the presence flag
+        // first, and only decode a value that is actually there.
+        let (_, explicitly_set) = options.get_string_value("sqp_qp_use_schur_updates", "")?;
+        if explicitly_set {
+            parsed.use_schur_updates =
+                Some(options.get_bool_value("sqp_qp_use_schur_updates", "")?.0);
+        }
+        let (_, explicitly_set) = options.get_string_value("sqp_qp_use_homotopy", "")?;
+        if explicitly_set {
+            parsed.use_homotopy = Some(options.get_bool_value("sqp_qp_use_homotopy", "")?.0);
+        }
+
+        let (updates, explicitly_set) =
+            options.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "")?;
+        if explicitly_set {
+            let value = u32::try_from(updates).map_err(|_| {
+                option_invalid(
+                    "sqp_qp_max_schur_updates_before_refactor",
+                    "must be positive and fit in u32",
+                )
+            })?;
+            if value == 0 {
+                return Err(option_invalid(
+                    "sqp_qp_max_schur_updates_before_refactor",
+                    "must be positive",
+                ));
+            }
+            parsed.max_schur_updates_before_refactor = Some(value);
+        }
+
+        Ok(parsed)
+    }
+}
+
+#[cfg(test)]
+mod option_reader_tests {
+    use super::*;
+    use pounce_common::Index;
+
+    fn set_num(options: &mut OptionsList, name: &str, value: Number) {
+        options.set_numeric_value(name, value, true, true).unwrap();
+    }
+
+    fn set_int(options: &mut OptionsList, name: &str, value: Index) {
+        options.set_integer_value(name, value, true, true).unwrap();
+    }
+
+    fn set_str(options: &mut OptionsList, name: &str, value: &str) {
+        options.set_string_value(name, value, true, true).unwrap();
+    }
+
+    #[test]
+    fn active_set_controls_materialize_only_explicit_overrides() {
+        let defaults = ActiveSetOverrides::try_from_options_list(&OptionsList::new()).unwrap();
+        assert!(defaults.is_empty());
+
+        let mut options = OptionsList::new();
+        set_int(&mut options, "sqp_qp_max_iter", 37);
+        set_str(&mut options, "sqp_qp_anti_cycling", "bland");
+        set_num(&mut options, "sqp_qp_feas_tol", 1e-7);
+        set_num(&mut options, "sqp_qp_opt_tol", 2e-7);
+        set_num(&mut options, "sqp_qp_elastic_gamma", 1e4);
+        set_str(&mut options, "sqp_qp_use_schur_updates", "yes");
+        set_str(&mut options, "sqp_qp_use_homotopy", "no");
+        set_int(&mut options, "sqp_qp_max_schur_updates_before_refactor", 12);
+
+        let parsed = ActiveSetOverrides::try_from_options_list(&options).unwrap();
+        assert_eq!(parsed.max_iter, Some(37));
+        assert_eq!(parsed.anti_cycling, Some(AntiCyclingChoice::Bland));
+        assert_eq!(parsed.feas_tol, Some(1e-7));
+        assert_eq!(parsed.opt_tol, Some(2e-7));
+        assert_eq!(parsed.elastic_gamma, Some(1e4));
+        assert_eq!(parsed.use_schur_updates, Some(true));
+        assert_eq!(parsed.use_homotopy, Some(false));
+        assert_eq!(parsed.max_schur_updates_before_refactor, Some(12));
+    }
+
+    /// `apply` is the half both consumers share: an empty set must leave a
+    /// non-default base untouched, and an explicit value must beat it. That
+    /// is the whole reason the type carries `Option`s — the direct convex
+    /// driver seeds a size-scaled `max_iter` and turns Schur updates on, and
+    /// a user who asked for neither must keep the seed.
+    #[test]
+    fn apply_overlays_only_what_was_set() {
+        let seeded = QpOptions {
+            max_iter: 4242,
+            use_schur_updates: true,
+            ..QpOptions::default()
+        };
+
+        let mut untouched = seeded.clone();
+        ActiveSetOverrides::default().apply(&mut untouched);
+        assert_eq!(untouched.max_iter, 4242);
+        assert!(untouched.use_schur_updates);
+
+        let mut overridden = seeded.clone();
+        ActiveSetOverrides {
+            max_iter: Some(9),
+            ..ActiveSetOverrides::default()
+        }
+        .apply(&mut overridden);
+        assert_eq!(overridden.max_iter, 9);
+        // Untouched fields keep the seed, not `QpOptions::default()`.
+        assert!(overridden.use_schur_updates);
+    }
+
+    /// Without a registry attached nothing validates at set time, so the
+    /// reader is the only thing standing between a bad value and the solver.
+    #[test]
+    fn malformed_unregistered_values_are_rejected() {
+        let mut options = OptionsList::new();
+        set_int(&mut options, "sqp_qp_max_iter", 0);
+        assert!(ActiveSetOverrides::try_from_options_list(&options).is_err());
+
+        let mut options = OptionsList::new();
+        set_str(&mut options, "sqp_qp_anti_cycling", "maybe");
+        assert!(ActiveSetOverrides::try_from_options_list(&options).is_err());
+
+        let mut options = OptionsList::new();
+        set_num(&mut options, "sqp_qp_feas_tol", 0.0);
+        assert!(ActiveSetOverrides::try_from_options_list(&options).is_err());
+
+        let mut options = OptionsList::new();
+        set_int(&mut options, "sqp_qp_max_schur_updates_before_refactor", 0);
+        assert!(ActiveSetOverrides::try_from_options_list(&options).is_err());
+    }
+
+    /// The shared constructor is `#[track_caller]`, so a rejection points at
+    /// the read site rather than at one line inside `pounce-common`.
+    #[test]
+    fn a_rejection_is_attributed_to_this_reader() {
+        let mut options = OptionsList::new();
+        set_int(&mut options, "sqp_qp_max_iter", 0);
+        let err = ActiveSetOverrides::try_from_options_list(&options).unwrap_err();
+        assert!(
+            err.to_string().contains("options.rs"),
+            "expected the reader's own file, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #754, which moved the convex option readers out of `pounce-cli`
into `pounce-convex`. That PR named two things it did not finish.

Rebased onto #751 (`00dbc40`); all measurements below are from the rebased head.

## Problem

**Two readers of the `sqp_qp_*` family, already diverged.** #754 removed the
CLI's copy but left `pounce_algorithm::application::apply_qp_subproblem_options`,
which hand-parsed the same eight registered names into the same
`pounce_qp::QpOptions` that `ActiveSetOverrides` overlays. The two had drifted
on how they treat a value the registry would have rejected:

| | `sqp_qp_max_iter = 0` | `sqp_qp_anti_cycling = "maybe"` |
|---|---|---|
| `apply_qp_subproblem_options` | silently ignored, keeps `pounce-qp` default | silently ignored, keeps current value |
| `ActiveSetOverrides::try_from_options_list` | `Err(OPTION_INVALID)` | `Err(OPTION_INVALID)` |

Neither divergence is reachable — `upstream_options.rs` bounds
`sqp_qp_max_iter` at 1 and restricts `sqp_qp_anti_cycling` to three values — so
nothing was broken. But two readers of one option family is how a reachable one
starts, and #754's own CHANGELOG entry claimed the new readers owned the
`sqp_qp_*` names when they owned half of them.

**Duplicated bounds with nothing comparing the copies.** The readers re-check
bounds that `upstream_options.rs` also registers — `qp_tau ∈ (0,1)`,
`qp_gondzio_corr ∈ 0..=10`, `sqp_qp_max_iter ≥ 1`, and five more. That
duplication is deliberate: a caller may hand a reader an `OptionsList` with no
registry attached, and then the reader is the only thing between a bad value
and the solver. But nothing asserted the two copies agree, so a bound widened
in the registry and not in the reader would silently narrow it back — the #677
shape (registered with one value, read with another, no layer comparing them)
and the #551 caution against hand-maintained lists.

## Cause

`pounce-convex` cannot be the shared home for the `sqp_qp_*` reader:
`pounce-algorithm` depends on `pounce-qp` but **not** on `pounce-convex`
(`crates/pounce-algorithm/Cargo.toml`), so the algorithm-side reader had no way
to reach it there. #754 put the type one crate too high.

## Fix

**`ActiveSetOverrides` moves to `pounce-qp`**, beside the `QpOptions` it
overlays. `pounce-qp` is the one crate both readers already depend on, and it
already has `pounce-common` for `OptionsList`, so this adds no dependency and
creates no cycle. `apply_qp_subproblem_options` becomes a call to
`ActiveSetOverrides::try_from_options_list(options)?.apply(opts)`.
`pounce_convex::ActiveSetOverrides` re-exports the type, so `pounce-py`,
`pounce-rs`, the CLI, the examples, and the existing tests reach it by the same
path as before.

Rejected: threading the reader's `Result` up through
`IpoptApplication::algorithm_builder_snapshot`. That function returns a plain
`AlgorithmBuilder`, and neither caller above it (`optimize_sqp_tnlp`,
`maybe_crossover`) returns `Result` either, so propagation meant a new failure
mode in the solve path for a branch the registry makes unreachable.
`apply_qp_subproblem_options` logs at `tracing::error!` and keeps the
`pounce-qp` defaults instead — strictly better than the silent-ignore it
replaces, but it is a swallow, and worth revisiting if that chain ever becomes
fallible for other reasons.

**A drift guard that derives the registry's verdict at run time.** The new test
restates no bound. For each probe value it asks the registry whether the value
is legal, and where the answer is yes it requires the readers to accept it too.

The converse is not asserted, deliberately: a reader more permissive than the
registry is not a bug, and there is a live case — `max_wall_time` is registered
strictly above zero while the reader accepts `0.0` as an immediate deadline for
the no-registry caller. That is written into the test's module header rather
than hidden behind an exceptions list.

**Also:** `pounce_common::option_invalid` replaces the per-crate helper and is
`#[track_caller]`, so an `OPTION_INVALID` names the read site that rejected the
value rather than one line inside the helper. The deliberate
`get_string_value` → `get_bool_value` pair is commented at both sites —
collapsing it to a bare `get_bool_value` looks equivalent and breaks the
no-registry case, where `""` reads as a non-boolean instead of as unset.
The #754 CHANGELOG entry is corrected to claim only what now holds.

## Blast radius

**No behavior change on any registry-backed path**, which is every path a user
reaches. The only semantic differences between the removed
`apply_qp_subproblem_options` and the shared reader are the two rows in the
table above, and both are values `initialize()` rejects before the reader runs.

Not a trajectory change, so no fixture sweep: nothing reroutes a correction or
rescales a step. The `sqp_qp_*` values that reach `pounce_qp::QpOptions` are
identical for every input the registry accepts, and
`application_sqp_qp_subproblem_options_are_registered_and_propagate` pins that
end-to-end through `IpoptApplication`.

**Interaction with #751, checked after the rebase:** that PR edits
`upstream_options.rs`, which is the registry this PR's guard compares against.
Its additions are `adaptive_mu_max_free_returns`,
`adaptive_mu_budget_pin_fraction`, and the `mu_strategy_fallback` default flip
— none of them a name any of these readers touches, so the two do not interact.
The drift guard passes on the rebased head.

No public path changes. `ActiveSetOverrides` gains `PartialEq` (used by
`is_empty`); every existing import site is unchanged.

## Tests

`crates/pounce-cli/tests/convex_option_readers_match_the_registry.rs` — three
tests: registry-accepted values are never reader-rejected; an untouched
registry yields exactly the Rust defaults; an explicitly-set default reads back
as that default.

**How I know it bites.** This is a guard against future drift, not a regression
test — there is no regression, the bounds agree today — so it does *not* fail
on the parent commit, and saying otherwise would be the exact claim the last
checklist box is about. Verified by mutation instead: narrowing
`qp_gondzio_corr`'s reader bound to `0..=5` fails it with the option, the
value, and the read site named:

```
the registry accepts `qp_gondzio_corr = 10` but a convex option reader refuses it:
QpOptions: Exception of type: OPTION_INVALID in file "crates/pounce-convex/src/options.rs"
at line 93: Option "qp_gondzio_corr": must be between 0 and 10.
```

That output doubles as the check on `#[track_caller]`: pre-change it would have
named `pounce-common/src/exception.rs`.

`crates/pounce-qp/src/options.rs` — four unit tests, relocated from
`pounce-convex` with two added: `apply_overlays_only_what_was_set` (the half
both consumers share — an empty override set must leave a *non-default* base
untouched, which is the whole reason the type carries `Option`s) and
`a_rejection_is_attributed_to_this_reader`.

**A gap, stated:** `cargo test --workspace` cannot complete in a container
without CoinHSL — `pounce-hsl`'s `t_sym_solver_ma57` fails to link with
`COINHSL_DIR` unset, aborting the run before any test executes. The green
signal below is from per-crate runs, not one workspace run.

Measured on the rebased head:

- Full suites green: `pounce-common`, `pounce-qp`, `pounce-convex`,
  `pounce-algorithm` (57 test binaries), `pounce-cli` / `pounce-rs` /
  `pounce-py` (104 test binaries — the three added ones are #751's).
- `cargo fmt --all -- --check` clean. `cargo build --workspace --exclude
  pounce-hsl` clean. `cargo clippy --all-targets` clean over the five crates
  this PR touches (`pounce-common`, `pounce-qp`, `pounce-convex`,
  `pounce-algorithm`, `pounce-cli`); the pre-rebase run was `--workspace` and
  showed nothing beyond a pre-existing unused import in `pounce-restoration`.

---

- [ ] Tests fail on the parent commit for the stated reason — **no, and
      deliberately so**: this is a drift guard, not a regression test. Shown to
      bite by mutation instead; see Tests.
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — **not needed**:
      `docs/src/lp-qp-routing.md` already describes this behavior, and no
      user-visible option, default, or bound moves here.
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — with
      the `pounce-hsl` linking gap and the clippy scope noted above.
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now — re-checked against the rebased head, which is what
      moved the test counts above.