### PR TITLE
chore(sweep): record the engine per fixture, and stop the convex-arm myth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,33 @@ initial Hessian scalar used `scalar2` where Ipopt uses `scalar1`, because
 a rare opt-in — the Python frontend and the CasADi plugin both select it
 automatically when no exact Lagrangian Hessian is available.
 
+**The convex arm is covered — do not skip the sweep for a convex-path
+change.** Both legs run at the default `solver_selection=auto`, which routes
+to the most specialized engine available, so 40 of the 71 fixtures never touch
+the NLP arm at all: 35 reach the convex QP interior-point and 5 the convex
+QCQP conic one. gh#760 is the case for saying so explicitly — `4c02817d`
+skipped the sweep on the reasoning that "this is a trajectory change on the
+convex path, not the NLP path, so `scripts/sweep-fixtures.sh` does not cover
+it", and substituted an objective-parity check over the convex corpus.
+Objective parity is blind to trajectory by construction. Run across that
+commit the sweep moves 52 fixture-legs and flips `scaled_feasible_a` on the
+lbfgs leg from `MaximumIterationsExceeded`/199 to `SolveSucceeded`/69.
+
+Each line also records **which engine solved the model** (`cvx-qp`,
+`cvx-qcqp`, `nlp`). Status, objective and iteration count can all be unchanged
+while a model silently changes arms, and the JSON report does not name the
+engine, so a routing regression used to leave no trace in the diff. A line
+whose only moving field is the engine is a routing change, and is as
+reportable as a moved iteration count.
+
+What the corpus still cannot give you is **magnitude on large degenerate
+models**. Every convex fixture is 1–32 variables while the substantial models
+(`deb7`, `eigena2`/`eigenb2`, `pooling_rt2stp`) are all NLP class — see
+`dev-notes/convex-fixture-corpus.md`. Nothing in the corpus predicted the 4.4×
+iteration cost `4c02817d` carried on the Maros-Meszaros QSCFXM family
+(38 → 168). A moved convex line is a signal to go measure `benchmarks/qp`, not
+a bound on what you will find there.
+
 "It cannot produce a wrong answer" is **not** the relevant safety property
 here, and that exact argument is what shipped gh#544 in 0.10.0: a trajectory
 regression produces the *right* answer, slowly — or a differently-wrong

--- a/scripts/sweep-fixtures.sh
+++ b/scripts/sweep-fixtures.sh
@@ -34,6 +34,37 @@
 # Lagrangian Hessian is available, so it is what an embedder gets by
 # default -- reached without any user ever typing the option.
 #
+# THE CONVEX ARM IS COVERED. DO NOT SKIP THIS SWEEP FOR A CONVEX-PATH CHANGE.
+# Both legs run at the default `solver_selection=auto`, and `auto` routes to
+# the most specialized engine it can, so the corpus splits three ways: 35
+# fixtures reach the convex QP interior-point, 5 the convex QCQP conic
+# interior-point, and 31 the NLP filter line-search. Forty of seventy-one
+# fixtures never touch the NLP arm at all.
+#
+# This is written in capitals because the reasoning it refutes has already
+# shipped once. gh#760: `4c02817d` applied `bound_relax_factor` on the convex
+# arm and justified not sweeping with "this is a trajectory change on the
+# convex path, not the NLP path, so scripts/sweep-fixtures.sh does not cover
+# it", substituting an objective-parity check over the convex corpus. Objective
+# parity cannot see a trajectory change -- that is the entire premise of this
+# script -- and the sweep was never blind: run across that commit it moves
+# about thirty fixture-legs and flips `scaled_feasible_a` on the lbfgs leg from
+# `MaximumIterationsExceeded`/199 to `SolveSucceeded`/69. The signal was there
+# for the asking.
+#
+# WHAT THE CORPUS STILL CANNOT TELL YOU is magnitude on large degenerate
+# models: every fixture here is small, so nothing in it predicted the 4.4x
+# iteration cost the same commit carried on the Maros-Meszaros QSCFXM family
+# (38 -> 168 iterations). A moved convex line is a signal to go measure
+# `benchmarks/qp`, not a bound on what you will find there.
+#
+# THE ENGINE COLUMN (gh#760). Each line records which engine solved the model.
+# Status, objective and iteration count can all three be unchanged while a
+# model silently changes arms -- the JSON report does not name the engine, so
+# before this column a routing regression left no trace in the diff. A line
+# whose only moving field is the engine is a routing change and is exactly as
+# reportable as a moved iteration count.
+#
 # Usage:
 #   scripts/sweep-fixtures.sh <pounce-binary> <outfile> [extra solver opts...]
 #
@@ -72,17 +103,32 @@ sweep_leg() {
     n=$(basename "$f" .nl)
     # A fixture that hangs must not hang the sweep; it shows up as NO_JSON.
     timeout 300 "$BIN" "$f" "$W/$n.sol" --json-output "$W/$n.json" "$@" \
-      >/dev/null 2>&1
+      > "$W/$n.out" 2>&1
+    # Which arm solved it. The JSON does not carry this, so it comes off the
+    # banner line: "Problem class: LP. Selected solver: convex QP
+    # interior-point (pounce-convex) [solver_selection=auto]." An unrecognised
+    # engine is reported verbatim rather than bucketed, so a newly added one
+    # shows up as a diff instead of hiding under "other".
+    eng=$(sed -n 's/.*Selected solver: \(.*\) \[solver_selection.*/\1/p' \
+          "$W/$n.out" | head -1)
+    case "$eng" in
+      *"QCQP conic"*)  eng=cvx-qcqp ;;
+      *"convex QP"*)   eng=cvx-qp   ;;
+      *"NLP filter"*)  eng=nlp      ;;
+      "")              eng=unknown  ;;
+      *)               eng=$(printf '%s' "$eng" | tr ' ' '-') ;;
+    esac
     if [ -f "$W/$n.json" ]; then
-      python3 - "$W/$n.json" "$n" "$leg" >> "$OUT" <<'PY'
+      python3 - "$W/$n.json" "$n" "$leg" "$eng" >> "$OUT" <<'PY'
 import json, sys
 d = json.load(open(sys.argv[1]))
 s = d.get("solution", {})
 st = d.get("statistics", {})
 obj = s.get("objective")
-print("%-6s %-40s %-32s it=%-6s obj=%s" % (
+print("%-6s %-40s %-9s %-32s it=%-6s obj=%s" % (
     sys.argv[3],
     sys.argv[2],
+    sys.argv[4],
     s.get("status"),
     st.get("iteration_count", "?"),
     "%.10g" % obj if obj is not None else "none",
@@ -92,8 +138,9 @@ PY
       # previous leg would otherwise be reported as this leg's result.
       rm -f "$W/$n.json"
     else
-      printf '%-6s %-40s NO_JSON\n' "$leg" "$n" >> "$OUT"
+      printf '%-6s %-40s %-9s NO_JSON\n' "$leg" "$n" "$eng" >> "$OUT"
     fi
+    rm -f "$W/$n.out"
   done
 }
 


### PR DESCRIPTION
chore(sweep): record the engine per fixture, and stop the convex-arm myth

gh#760 found `4c02817d` had skipped the fixture sweep on the reasoning that
"this is a trajectory change on the convex path, not the NLP path, so
scripts/sweep-fixtures.sh does not cover it", substituting an objective-parity
check over the convex corpus.

Both halves of that are wrong. Objective parity is blind to trajectory by
construction -- that is the premise the script is built on. And the sweep was
never blind to the convex arm: both legs run at the default
`solver_selection=auto`, which routes to the most specialized engine
available, so 40 of 71 fixtures never touch the NLP arm at all (35 convex QP,
5 convex QCQP, 31 NLP). Run across that commit the existing sweep moves 52
fixture-legs and flips `scaled_feasible_a` on the lbfgs leg from
`MaximumIterationsExceeded`/199 to `SolveSucceeded`/69. The signal was there
for the asking.

So the fix is not a new leg -- a convex leg would duplicate what `exact`
already does. It is to say so where it gets read, in the script header and in
CLAUDE.md.

One real hole is closed. Each line now records which engine solved the model
(`cvx-qp` / `cvx-qcqp` / `nlp`). Status, objective and iteration count can all
three be unchanged while a model silently changes arms, and the JSON report
does not name the engine, so before this a routing regression left no trace in
the diff. Verified live rather than cosmetic: forcing `solver_selection=nlp`
moves all 71 fixtures to `nlp` and differs from `auto` on exactly the 40
convex-routed lines. An unrecognised engine string is reported verbatim rather
than bucketed, so a newly added engine shows up as a diff.

This widens the output by one column, so a baseline captured with the old
script will diff dirty against a new one. Re-capture the baseline.

Also recorded, in both places: what the corpus still cannot tell you. Every
convex fixture is 1-32 variables while the substantial models are all NLP
class (dev-notes/convex-fixture-corpus.md), so nothing here predicted the 4.4x
cost the same commit carried on the Maros-Meszaros QSCFXM family. A moved
convex line is a signal to go measure benchmarks/qp, not a bound on what is
there.



Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N9Tqn6nrW7B91fC1HpJsHp

## Validation

Both binaries built from `4c02817d` and its parent `a798ae1b`:

- engine distribution on the exact leg: 35 `cvx-qp`, 5 `cvx-qcqp`, 31 `nlp` —
  matches an independent routing survey of the corpus
- 52 fixture-legs move across `4c02817d` with the existing checks
- routing itself is unchanged across that commit, so the new column correctly
  reports no false positive there
- negative control: `solver_selection=nlp` moves all 71 to `nlp`, differing
  from `auto` on exactly the 40 convex-routed lines

No Rust changed; this is a script and two docs.

Refs #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9Tqn6nrW7B91fC1HpJsHp
