### PR TITLE
fix(py): jacobianstructure is optional, and means a dense (m, n) Jacobian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+- **`jacobianstructure` is optional again on the Python `Problem`, as
+  cyipopt documents it** (#765). A constrained `problem_obj` that omits the
+  callback declares a dense `(m, n)` Jacobian; `Problem.solve()` and
+  `solve_nlp_batch()` used to call the method unconditionally and raise a
+  bare `AttributeError: 'O' object has no attribute 'jacobianstructure'`.
+
+  The asymmetry was the tell: `hessianstructure` *is* feature-detected
+  (`has_hessian` is a `hasattr` probe, and the Hessian block is gated on
+  it) — only the Jacobian block called blind. So did POUNCE's own entry
+  points: `pounce.preflight` implements the dense fallback in
+  `_preflight.py` and reported `ok: True` for the very object `solve()`
+  then rejected.
+
+  The synthesized pattern is `np.divmod(np.arange(m * n), n)` — the same
+  row-major order `_preflight.py` uses and the order a `jacobian(x)`
+  written against the dense default returns. A model whose `m * n`
+  overflows the signed-32-bit nonzero count is refused with a message
+  naming `jacobianstructure`, rather than wrapping to a truncated count.
+  Nothing changes for an object that supplies the callback: it takes the
+  same branch as before and the trajectory is bit-for-bit identical.
+
+  Also on this path: a `jacobian(x)` whose length is not `nele_jac` now
+  logs the mismatch instead of discarding the error and ending the solve
+  in a bare `Invalid_Number_Detected`. With the dense default that is a
+  realistic user error — returning only the structural nonzeros while
+  declaring no pattern.
+
 - **The default-on `mu_strategy_fallback` retry now takes
   `Solved_To_Acceptable_Level`, when the caller left the convergence
   configuration alone** (#757). `cho_parmest` recovers its certificate:

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -1051,10 +1051,30 @@ impl PyProblem {
     ) -> PyResult<PyTnlpInit> {
         let n = self.n as usize;
         let m = self.m as usize;
+        // Jacobian sparsity. `jacobianstructure` is *optional* in the
+        // cyipopt interface we advertise: an object that omits it declares a
+        // dense `(m, n)` Jacobian, whose `jacobian(x)` returns all `m * n`
+        // entries row-major. Feature-detect it the way the Hessian block
+        // below does. Calling it unconditionally raised a bare
+        // `AttributeError` out of `Problem.solve()` / `solve_nlp_batch()` for
+        // every object that took that documented default — while
+        // `pounce.preflight`, which implements the fallback in
+        // `_preflight.py`, accepted the very same object and reported
+        // `ok: True` (gh#765).
         let (jac_rows, jac_cols, nele_jac) = if m > 0 {
-            let s = call0(&self.problem_obj, "jacobianstructure")?;
-            let (rows, cols) = decode_structure_inferred(&s)?;
-            (rows.clone(), cols.clone(), rows.len() as Index)
+            let has_structure = self
+                .problem_obj
+                .bind(py)
+                .hasattr("jacobianstructure")
+                .unwrap_or(false);
+            if has_structure {
+                let s = call0(&self.problem_obj, "jacobianstructure")?;
+                let (rows, cols) = decode_structure_inferred(&s)?;
+                let nnz = rows.len() as Index;
+                (rows, cols, nnz)
+            } else {
+                dense_jacobian_structure(m, n)?
+            }
         } else {
             (Vec::new(), Vec::new(), 0)
         };
@@ -1341,6 +1361,41 @@ pub(crate) fn build_info_dict<'py>(
     )?;
     info.set_item("active_tol", pounce_sensitivity::DEFAULT_ACTIVE_TOL)?;
     Ok(info)
+}
+
+/// The dense `(m, n)` Jacobian pattern, row-major — the same index pairs
+/// `np.divmod(np.arange(m * n), n)` produces in `_preflight.py`, and the
+/// order in which a `jacobian(x)` written against the dense default returns
+/// its values. Used when the user object omits the optional
+/// `jacobianstructure` callback (gh#765).
+///
+/// `m * n` is computed in `usize` and range-checked before it is narrowed:
+/// `nele_jac` is a signed 32-bit `Index`, so a large dense pattern (m = n =
+/// 50 000 is already 2.5e9 entries) would otherwise wrap to a negative or
+/// truncated count and mis-size every structure buffer downstream. Such a
+/// problem cannot be meant to be dense anyway, so the message points at the
+/// callback that declares the real pattern.
+fn dense_jacobian_structure(m: usize, n: usize) -> PyResult<(Vec<Index>, Vec<Index>, Index)> {
+    let nnz = m
+        .checked_mul(n)
+        .filter(|&nnz| nnz <= Index::MAX as usize)
+        .ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "problem_obj has no jacobianstructure(), so the Jacobian is taken \
+                 to be dense (m, n) = ({m}, {n}) -- but m*n exceeds the solver's \
+                 signed-32-bit nonzero count. Add a jacobianstructure() method \
+                 returning the (rows, cols) of the actual sparse pattern."
+            ))
+        })?;
+    let mut rows = Vec::with_capacity(nnz);
+    let mut cols = Vec::with_capacity(nnz);
+    for i in 0..m {
+        for j in 0..n {
+            rows.push(i as Index);
+            cols.push(j as Index);
+        }
+    }
+    Ok((rows, cols, nnz as Index))
 }
 
 /// Variant of `decode_structure` that infers `nnz` from the input

--- a/crates/pounce-py/src/tnlp_bridge.rs
+++ b/crates/pounce-py/src/tnlp_bridge.rs
@@ -9,11 +9,18 @@
 //!     def gradient(self, x):            -> array(n)
 //!     def constraints(self, x):         -> array(m)             # if m > 0
 //!     def jacobian(self, x):            -> array(nnz_jac)       # if m > 0
-//!     def jacobianstructure(self):      -> (rows, cols)         # called once
+//!     def jacobianstructure(self):      -> (rows, cols)         # optional
 //!     def hessian(self, x, lam, obj_f): -> array(nnz_hess)      # if exact-hess
 //!     def hessianstructure(self):       -> (rows, cols)         # called once
 //!     def intermediate(self, *stats):   -> bool | None          # optional
 //! ```
+//!
+//! Both structure callbacks are resolved once, in `build_tnlp_init`, and
+//! both are optional. Omitting `jacobianstructure` declares a dense
+//! `(m, n)` Jacobian whose `jacobian(x)` returns all `m * n` entries
+//! row-major (cyipopt's documented default, gh#765); omitting `hessian` /
+//! `hessianstructure` runs the solve with `hessian_approximation =
+//! limited-memory`.
 //!
 //! Bounds (`lb`, `ub`, `cl`, `cu`) and starting point come through
 //! [`PyTnlpInit`], populated by the `Problem.solve` wrapper.
@@ -290,7 +297,20 @@ impl TNLP for PyTnlp {
                         return false;
                     }
                 };
-                copy_pyarray_into(&res, values, "jacobian").is_ok()
+                // Log the copy failure rather than dropping it. The only
+                // way to get here is a `jacobian(x)` whose length is not
+                // `nele_jac`, and since gh#765 that is a realistic user
+                // error: an object with no `jacobianstructure` declares a
+                // dense `(m, n)` Jacobian, so returning only the structural
+                // nonzeros mismatches. Without this line the solve just ends
+                // in `Invalid_Number_Detected` with nothing said about why.
+                match copy_pyarray_into(&res, values, "jacobian") {
+                    Ok(()) => true,
+                    Err(e) => {
+                        tracing::error!(target: "pounce::py", "pounce-py: jacobian(): {e}");
+                        false
+                    }
+                }
             }
         }
     }

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -57,6 +57,20 @@ x, info = prob.solve(x0=np.array([1.0, 5.0, 5.0, 1.0]))
 print(info['status_msg'], info['obj_val'], x)
 ```
 
+`objective` is required; `gradient` is required for any real solve.
+Everything else is conditional or optional, on cyipopt's rules:
+
+| method | when |
+| --- | --- |
+| `constraints` / `jacobian` | required when `m > 0` |
+| `jacobianstructure` | **optional.** Omit it and the Jacobian is dense `(m, n)`: `jacobian(x)` then returns all `m*n` entries, row-major. Supply it to declare a sparse pattern — worth doing for anything but a small dense block. |
+| `hessian` + `hessianstructure` | **optional, both or neither.** Without them the solve runs `hessian_approximation=limited-memory` (L-BFGS). |
+| `intermediate` | optional per-iteration callback; return `False` to stop. |
+
+`pounce.preflight(problem_obj, x0, ...)` evaluates the same object once
+and reports what the solver's first iteration will see, under exactly
+these rules.
+
 ### Verifying convergence / trustworthy duals
 
 `info` carries the final KKT residuals so a consumer can independently

--- a/python/tests/test_problem.py
+++ b/python/tests/test_problem.py
@@ -551,3 +551,191 @@ def test_add_option_large_but_in_range_solves():
     x, info = prob.solve(x0=np.array([1.0, 1.0]))
     assert info["status_msg"] == "Solve_Succeeded"
     np.testing.assert_allclose(x, [0.0, 0.0], atol=1e-6)
+
+
+# --- gh#765: jacobianstructure is optional --------------------------------
+#
+# In the cyipopt interface POUNCE advertises, `jacobianstructure` is an
+# *optional* callback: an object that omits it declares a dense (m, n)
+# Jacobian, and its `jacobian(x)` returns all m*n entries row-major.
+# `Problem.solve()` used to call the method unconditionally and die with a
+# bare AttributeError, while `pounce.preflight` -- which implements the
+# fallback in `_preflight.py` -- accepted the very same object.
+#
+# Each test below is run against *both* branches of the new feature
+# detection: the structure-less object and an otherwise identical one that
+# supplies the pattern explicitly. A green run on the fallback alone would
+# say nothing about the path every existing model takes, and vice versa.
+
+
+class HS071Dense:
+    """HS071 with the (already dense) `jacobianstructure` omitted.
+
+    Delegates to an `HS071` rather than subclassing it: an inherited
+    `jacobianstructure` is still `hasattr`-visible, so a subclass that
+    merely deletes the name from its own dict would keep taking the
+    explicit-structure branch and test nothing.
+
+    `jacobian` is unchanged -- the 8 entries it returns are exactly the
+    dense (m, n) = (2, 4) block in row-major order, which is what the
+    fallback pattern addresses.
+    """
+
+    def __init__(self):
+        self._inner = HS071()
+
+    def objective(self, x):
+        return self._inner.objective(x)
+
+    def gradient(self, x):
+        return self._inner.gradient(x)
+
+    def constraints(self, x):
+        return self._inner.constraints(x)
+
+    def jacobian(self, x):
+        return self._inner.jacobian(x)
+
+
+class SumToOne:
+    """The issue's reproduction: min x·x s.t. x0 + x1 == 1, optimum
+    x = [0.5, 0.5], obj = 0.5. No `jacobianstructure`."""
+
+    def objective(self, x):
+        return float(np.asarray(x, float) @ np.asarray(x, float))
+
+    def gradient(self, x):
+        return 2 * np.asarray(x, float)
+
+    def constraints(self, x):
+        return np.array([float(np.sum(x))])
+
+    def jacobian(self, x):
+        return np.ones(2)  # dense (m=1, n=2), row-major
+
+
+class SumToOneWithStructure(SumToOne):
+    def jacobianstructure(self):
+        return (np.array([0, 0]), np.array([0, 1]))
+
+
+def _sum_to_one_problem(obj):
+    p = pounce.Problem(
+        n=2, m=1, problem_obj=obj, lb=[-10.0] * 2, ub=[10.0] * 2, cl=[1.0], cu=[1.0]
+    )
+    p.add_option("print_level", 0)
+    return p
+
+
+@pytest.mark.parametrize("obj", [SumToOne(), SumToOneWithStructure()])
+def test_missing_jacobianstructure_solves_as_dense(obj):
+    """The filed repro, plus the explicit-structure control."""
+    x, info = _sum_to_one_problem(obj).solve(x0=np.array([0.0, 0.0]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x, [0.5, 0.5], atol=1e-7)
+    np.testing.assert_allclose(info["obj_val"], 0.5, atol=1e-9)
+
+
+def test_missing_jacobianstructure_matches_explicit_structure():
+    """Same model, same answer, whichever branch resolves the sparsity.
+
+    HS071 rather than the 2-variable repro: it has m = 2 and a genuinely
+    dense 2x4 block, so a fallback that transposed the row-major order
+    (`np.divmod(k, m)` instead of `np.divmod(k, n)`) would still solve the
+    1-row model and fail here.
+    """
+    kw = dict(n=4, m=2, lb=[1.0] * 4, ub=[5.0] * 4, cl=[25.0, 40.0], cu=[2e19, 40.0])
+    out = []
+    for obj in (HS071Dense(), HS071()):
+        p = pounce.Problem(problem_obj=obj, **kw)
+        p.add_option("tol", 1e-8)
+        p.add_option("print_level", 0)
+        out.append(p.solve(x0=np.array([1.0, 5.0, 5.0, 1.0])))
+    (x_dense, info_dense), (x_sparse, info_sparse) = out
+    assert info_dense["status_msg"] == "Solve_Succeeded"
+    # The published HS071 optimum, from the issue's third oracle.
+    np.testing.assert_allclose(info_dense["obj_val"], 17.0140173, rtol=1e-8)
+    np.testing.assert_allclose(x_dense, [1.0, 4.7430, 3.8211, 1.3794], atol=1e-3)
+    # ... and bit-for-bit the same trajectory as the explicit pattern: the
+    # fallback declares the same (rows, cols), so nothing downstream moves.
+    np.testing.assert_array_equal(x_dense, x_sparse)
+    assert info_dense["iter_count"] == info_sparse["iter_count"]
+    assert info_dense["obj_val"] == info_sparse["obj_val"]
+
+
+@pytest.mark.parametrize("obj", [SumToOne(), SumToOneWithStructure()])
+def test_missing_jacobianstructure_solves_in_batch(obj):
+    """`solve_nlp_batch` builds its `PyTnlpInit` through the same helper."""
+    (x, info), = pounce.solve_nlp_batch([_sum_to_one_problem(obj)], [np.zeros(2)])
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x, [0.5, 0.5], atol=1e-7)
+
+
+@pytest.mark.parametrize("obj", [SumToOne(), SumToOneWithStructure()])
+def test_preflight_and_solve_agree_on_the_same_object(obj):
+    """The internal inconsistency the issue reports: `preflight` accepted
+    an object `solve` rejected. Whatever preflight calls solvable, solve
+    must solve."""
+    report = pounce.preflight(
+        obj, np.zeros(2), lb=[-10.0] * 2, ub=[10.0] * 2, cl=[1.0], cu=[1.0]
+    )
+    assert not report.fatal
+    _, info = _sum_to_one_problem(obj).solve(x0=np.zeros(2))
+    assert info["status_msg"] == "Solve_Succeeded"
+
+
+def test_missing_jacobianstructure_unaffected_when_m_is_zero():
+    """m = 0 skips the Jacobian block entirely; no dense pattern is
+    synthesized and `jacobian` is never called."""
+
+    class Unconstrained:
+        def objective(self, x):
+            return float(np.asarray(x, float) @ np.asarray(x, float))
+
+        def gradient(self, x):
+            return 2 * np.asarray(x, float)
+
+    p = pounce.Problem(n=2, m=0, problem_obj=Unconstrained(), lb=[-10.0] * 2, ub=[10.0] * 2)
+    p.add_option("print_level", 0)
+    x, info = p.solve(x0=np.array([1.0, 1.0]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x, [0.0, 0.0], atol=1e-6)
+
+
+def test_dense_jacobian_fallback_rejects_an_out_of_range_pattern():
+    """The dense pattern is m*n entries, and `nele_jac` is a signed 32-bit
+    count. A problem big enough to overflow it is not one that meant to be
+    dense, so the message names the callback that declares the real
+    pattern -- rather than wrapping to a negative or truncated nonzero
+    count and mis-sizing every structure buffer downstream.
+
+    No callback is ever invoked: the check runs while the sparsity is
+    being resolved, so the bogus object below is never asked for values.
+    """
+
+    class Big:
+        def objective(self, x):
+            return 0.0
+
+        def gradient(self, x):
+            return np.zeros(len(x))
+
+        def constraints(self, x):
+            return np.zeros(100_000)
+
+        def jacobian(self, x):
+            raise AssertionError("must not be reached")
+
+    n = m = 100_000  # m*n = 1e10 > i32::MAX
+    p = pounce.Problem(
+        n=n,
+        m=m,
+        problem_obj=Big(),
+        lb=[-1.0] * n,
+        ub=[1.0] * n,
+        cl=[-1.0] * m,
+        cu=[1.0] * m,
+    )
+    p.add_option("print_level", 0)
+    with pytest.raises(ValueError, match="jacobianstructure"):
+        p.solve(x0=np.zeros(n))


### PR DESCRIPTION
## Problem

`jacobianstructure` is **optional** in the cyipopt interface POUNCE
advertises: an object that omits it declares a dense `(m, n)` Jacobian, and
`jacobian(x)` then returns all `m * n` entries row-major. `Problem.solve()`
and `solve_nlp_batch()` called the method unconditionally whenever `m > 0`
and died with a bare `AttributeError`.

The issue's 12-line repro — `min x·x` s.t. `x0 + x1 == 1`:

| | status | objective | x | iters |
|---|---|---|---|---|
| before | `AttributeError: 'O' object has no attribute 'jacobianstructure'` | — | — | — |
| after | `Solve_Succeeded` | 0.5 | `[0.5, 0.5]` | 5 |
| oracle (closed form) | — | 0.5 | `[0.5, 0.5]` | — |

The docs' own HS071 with `jacobianstructure` deleted — its Jacobian is an
already-dense 2×4 block, so the values callback is unchanged:

| | status | objective | NLP error | iters |
|---|---|---|---|---|
| before | `AttributeError` | — | — | — |
| after | `Solve_Succeeded` | 17.01401714521598 | 2.506e-09 | 10 |
| same object, callback restored | `Solve_Succeeded` | 17.01401714521598 | 2.506e-09 | 10 |
| published optimum | — | 17.0140173 | — | — |

`m = 0` is unaffected (the branch is skipped), and the CLI cannot reproduce
it — an `.nl` model always carries its own Jacobian sparsity.

## Cause

`build_tnlp_init` (`crates/pounce-py/src/problem.rs`) resolved the two
sparsity patterns side by side, and only one of them was feature-detected:

```rust
let (jac_rows, jac_cols, nele_jac) = if m > 0 {
    let s = call0(&self.problem_obj, "jacobianstructure")?;   // <-- unconditional
    ...
let (hess_rows, hess_cols, nele_hess) = if self.has_hessian {  // <-- hasattr probe
    let s = call0(&self.problem_obj, "hessianstructure")?;
```

That asymmetry is the whole defect. Three places in POUNCE already treat a
structure-less `problem_obj` as a supported shape, so this was an omission on
one path rather than a contract the project had declined to implement:

- `_preflight.py` implements the fallback explicitly (`hasattr` guard +
  `np.divmod(np.arange(jac_vals.size), n)`) and reported `ok: True` for the
  very object `solve()` then rejected — the internal inconsistency the issue
  leads with;
- `_starts._jacobian_coo` `hasattr`-guards and reshapes the dense row-major
  block when the method is absent;
- `_warm_start_schema._structure_digest` names "a dense-jacobian
  `problem_obj`" in its docstring as a case it must report as unverifiable.

## Fix

Mirror the Hessian block's detection and synthesize the dense pattern when
the method is absent — `np.divmod(np.arange(m * n), n)`, i.e. the same
row-major order `_preflight.py` uses and the order in which a `jacobian(x)`
written against the dense default returns its values.

`m * n` is computed in `usize` and range-checked before it is narrowed:
`nele_jac` is a signed 32-bit `Index`, so a large dense pattern (m = n =
50 000 is already 2.5e9 entries) would otherwise wrap to a truncated count
and mis-size every structure buffer downstream. Such a model is not meant to
be dense, so it is refused with a message naming the callback that declares
the real pattern. No Jacobian evaluation happens before that check.

**Rejected: probing `jacobian(x0)` at build time to validate its length.**
`build_tnlp_init` has `x0` in hand, so it could compare `len(jacobian(x0))`
against `m * n` and raise something far more specific than what a mismatch
produces today. Two things ruled it out: it spends a user callback
evaluation on every solve of every structure-less object, and it converts an
exception raised inside `jacobian` at `x0` — for reasons having nothing to do
with sparsity — into a setup-time failure instead of the
`Invalid_Number_Detected` such an object gets now. cyipopt does not probe
either.

What shipped instead is the cheap half of that: `eval_jac_g` was discarding
the `Err` from the values copy (`copy_pyarray_into(...).is_ok()`), so a
length mismatch ended the solve in a bare `Invalid_Number_Detected` with
nothing said anywhere. It now logs, the way every other callback failure in
the bridge already does. That mismatch goes from exotic to realistic with
this PR — an object that declares no pattern but returns only the structural
nonzeros — which is why the line is in this diff and not a separate one.

## Blast radius

**Bit-identical except the targeted case.** An object that supplies
`jacobianstructure` takes the same branch as before, and
`test_missing_jacobianstructure_matches_explicit_structure` pins that
against the fallback: same `x` by `assert_array_equal`, same iteration count,
same objective bit pattern (table above).

No corpus sweep. `scripts/sweep-fixtures.sh` drives `.nl` models through the
CLI, and the CLI never enters this code — the callback API is the only way to
reach it. Nothing in the workspace depends on `pounce-py`; it is a
`publish = false` pyo3 crate that appears in the root `Cargo.toml` only as a
member.

The only behaviour change for existing working code is the new log line on a
Jacobian length mismatch. The status such a solve ends in is unchanged.

## Tests

Nine cases in `python/tests/test_problem.py`, each run against **both**
branches of the new feature detection — a green fallback leg says nothing
about the path every existing model takes:

- the filed repro and an explicit-structure control (parametrized);
- HS071 with and without the callback, asserted equal to the iteration. It
  has `m = 2` and a genuinely dense 2×4 block, so a fallback that transposed
  the row-major order (`divmod(k, m)` for `divmod(k, n)`) would still solve
  the 1-row repro and fail here;
- `solve_nlp_batch`, which mints its `PyTnlpInit` through the same helper;
- `preflight`/`solve` agreement on one object — the inconsistency the issue
  reports, stated as a test;
- the `m = 0` control, where no pattern is synthesized and `jacobian` is
  never called;
- the overflow refusal, whose `problem_obj` raises from `jacobian` to prove
  the check runs before the Jacobian is ever evaluated.

**They bite.** Built against the parent commit (20be289) with this test file
in place, five fail — the four fallback legs and the overflow refusal — each
with the issue's exact `AttributeError: '<X>' object has no attribute
'jacobianstructure'`. The explicit-structure legs and the `m = 0` control
stay green, which is what makes the fallback legs evidence rather than noise.

`HS071Dense` delegates to an `HS071` instance rather than subclassing it: an
inherited `jacobianstructure` is still `hasattr`-visible, so a subclass that
deleted the name from its own dict would keep taking the explicit-structure
branch and test nothing. The first draft of this PR did exactly that, and the
parent-commit run is what caught it.

**Deliberately not pinned:** the new `tracing::error!` on a Jacobian length
mismatch. Asserting it would need a tracing subscriber wired into the Python
test process, and none of the bridge's sibling callback-failure logs are
pinned either. The observable behaviour around it — `Invalid_Number_Detected`
for a mismatched `jacobian(x)` — is unchanged and is what the log explains.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated — `python.md` gains a table of which
      callbacks are required, conditional, and optional, since the reason this
      shipped is that the page's HS071 example was the whole contract anyone
      could read. Existing page, already in `SUMMARY.md`.
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

`cargo test --workspace --exclude pounce-hsl`: 3501 passed across 284
suites, 0 failed. Full Python suite: 1183 passed, 21 skipped. `cargo clippy
-p pounce-py --all-targets -- -D clippy::correctness -D clippy::suspicious`
(the CI gate) is clean; the warnings it prints under the broader lint set are
all pre-existing and in untouched code. `scripts/check-release-consistency.sh`
and `scripts/check-docs-consistency.sh` both OK.

Fixes #765

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjyraQkaVv64XSapu6ToHN)_