### PR TITLE
fix(convex): timing statistics, an EXIT/Status verdict, and the upstream status spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,50 @@ changes.
   in a bare `Invalid_Number_Detected`. With the dense default that is a
   realistic user error — returning only the structural nonzeros while
   declaring no pattern.
+- **The convex path now presents the same end-of-run contract as the NLP
+  path**: timing statistics when asked for, an `EXIT:` banner, and a
+  machine-readable `Status:` line (#767).
+
+  All three gaps were found while instrumenting the Mittelmann suite, where
+  2 of 47 instances route convex.
+
+  `print_timing_statistics=yes` was accepted on the convex path, reported
+  `(used)` by `print_user_options`, and emitted nothing — so a tool
+  attributing solve cost by phase read 0% for *every* phase of a
+  convex-routed instance, which reads as "already fast" rather than "not
+  measured". `bearing_400` ran 9.8 s and printed no timer at all. The convex
+  drivers now emit a phase report in the same row layout the NLP path uses:
+  `OverallAlgorithm` and the three `LinearSystem*` rows carry the same labels
+  because they are the same quantities, beside `ProblemExtraction`,
+  `Presolve`, `ConvexSolve` and `SolutionRecovery` for the stages this path
+  actually has. The linear-algebra rows are charged from inside
+  `pounce-linsol` (both interior-point engines) and `pounce-qp` (the
+  parametric active-set engine), so no engine reports a solve it spent real
+  time in as costing nothing in the linear system.
+
+  The log also ended after the residual block, with no `EXIT:` banner and no
+  terminal status. `benchmarks/scripts/run_nl_bench.sh` already prefers a
+  `Status:` line and only falls back to its ladder of convex-specific stdout
+  scrapes because nothing emitted one; every other consumer of the CLI had to
+  reimplement that ladder. Both blocks are gated exactly as the NLP path's
+  are — `print_level >= 1`, and no `Status:` line under `--debug-json` — and a
+  convex attempt that declines to the NLP path (gh #535, `socp_nlp_fallback`)
+  still prints no verdict, so a run has exactly one.
+
+- **The JSON solve report carries the verdict in IPOPT's own enumerator
+  spelling**, as `solution.status_upstream` (#767).
+
+  `solution.status` is the Rust variant name (`SolveSucceeded`) — on both
+  paths, not just the convex one — while the spelling every IPOPT-facing
+  consumer keys off is `Solve_Succeeded`: CUTEst status tables, the reference
+  JSONs under `benchmarks/*/ipopt_ma57.json`, and pounce's own `Status:` line.
+  A consumer comparing `solution.status == "Solve_Succeeded"` matched nothing
+  and silently classified every solve as a failure. The new field is derived
+  from `status` in `ReportBuilder::finish`, so the two cannot disagree, and
+  `status` keeps its documented meaning — existing consumers are unaffected.
+  It is an added field, which the schema documents as non-breaking, so
+  `pounce.solve-report/v1` is unchanged; reports written by pounce ≤ 0.10.0
+  do not carry it.
 
 - **The default-on `mu_strategy_fallback` retry now takes
   `Solved_To_Acceptable_Level`, when the caller left the convergence

--- a/benchmarks/cblib/run_cblib.py
+++ b/benchmarks/cblib/run_cblib.py
@@ -36,8 +36,18 @@ VENDORED = os.path.join(
 
 
 def status_underscored(s: str) -> str:
-    """`SolveSucceeded` -> `Solve_Succeeded` (the composite-report form)."""
+    """`SolveSucceeded` -> `Solve_Succeeded` (the composite-report form).
+
+    Fallback only: since gh #767 the report carries that spelling itself as
+    `solution.status_upstream`, which `report_status` prefers. Kept for
+    reports written by an older binary, where the field is absent.
+    """
     return re.sub(r"(?<!^)(?=[A-Z])", "_", s)
+
+
+def report_status(solution: dict) -> str:
+    """The solve's verdict in IPOPT's enumerator spelling."""
+    return solution.get("status_upstream") or status_underscored(solution["status"])
 
 
 def build_binary() -> None:
@@ -82,7 +92,7 @@ def run_one(name, path, detail):
             "name": name,
             "n": r["problem"]["n_variables"],
             "m": r["problem"]["n_constraints"],
-            "status": status_underscored(r["solution"]["status"]),
+            "status": report_status(r["solution"]),
             "objective": r["solution"]["objective"],
             "iterations": r["statistics"]["iteration_count"],
             "solve_time": r["statistics"]["total_wallclock_time_secs"],

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1087,6 +1087,7 @@ pub fn main() -> ExitCode {
                         bound_relax,
                         presolve_on,
                         socp_nlp_fallback,
+                        convex_console(&app, json_dbg),
                     ) {
                         return code;
                     }
@@ -1135,6 +1136,7 @@ pub fn main() -> ExitCode {
                         matches!(choice, SolverChoice::QpActiveSet),
                         engine_overrides,
                         lp_nlp_fallback,
+                        convex_console(&app, json_dbg),
                     ) {
                         return code;
                     }
@@ -2459,6 +2461,86 @@ fn convex_bound_relax(app: &IpoptApplication) -> pounce_cli::qp_extract::BoundRe
     }
 }
 
+/// The console-contract knobs the convex drivers need from the options list.
+///
+/// Resolved once at the dispatch site because neither driver carries the
+/// [`IpoptApplication`] the options live on, and both must answer the same
+/// questions: may they print the end-of-run verdict, and were they asked for
+/// timing statistics (gh #767).
+#[derive(Debug, Clone, Copy, Default)]
+struct ConvexConsole {
+    /// `print_level >= 1` — gates the `EXIT:` / `POUNCE:` / `Status:` block,
+    /// exactly as `Application::emit_end_summary` gates the NLP path's. At
+    /// print_level 0 the console is silent by request.
+    verdict: bool,
+    /// `--json-debug`: stdout is a pure protocol channel there, so the
+    /// machine-readable `Status:` line stays off it — the same carve-out the
+    /// NLP path makes.
+    json_debug: bool,
+    /// `timing_statistics` or `print_timing_statistics` (which implies it) —
+    /// run the detailed per-phase timers.
+    collect_timing: bool,
+    /// `print_timing_statistics` — emit the timing block after the verdict.
+    print_timing: bool,
+}
+
+/// Read [`ConvexConsole`] off the application's options list.
+///
+/// gh #767: `print_timing_statistics` was registered, accepted, and reported
+/// `(used)` by `print_user_options` on this path while emitting nothing —
+/// so a tool attributing solve cost by phase read 0% for every phase of a
+/// convex-routed instance, which is indistinguishable from "already fast".
+fn convex_console(app: &IpoptApplication, json_dbg: bool) -> ConvexConsole {
+    let opt = app.options();
+    let yes = |name: &str| {
+        opt.get_bool_value(name, "")
+            .ok()
+            .and_then(|(v, found)| found.then_some(v))
+            .unwrap_or(false)
+    };
+    let print_timing = yes("print_timing_statistics");
+    ConvexConsole {
+        verdict: opt
+            .get_integer_value("print_level", "")
+            .map(|(v, _found)| v >= 1)
+            .unwrap_or(true),
+        json_debug: json_dbg,
+        // `print_timing_statistics=yes` implies `timing_statistics=yes` per
+        // its own option help, so either one arms the detailed timers.
+        collect_timing: print_timing || yes("timing_statistics"),
+        print_timing,
+    }
+}
+
+/// Emit the convex path's end-of-run verdict: the `EXIT:` banner block and
+/// the machine-readable `Status:` line, under the same gates the NLP path
+/// applies to its own (see [`ConvexConsole`]). Shared by both convex drivers
+/// so the two cannot drift.
+fn print_convex_verdict(
+    console: ConvexConsole,
+    status: pounce_convex::QpStatus,
+    timing: &pounce_common::timing::ConvexTimingStatistics,
+) {
+    if !console.verdict {
+        return;
+    }
+    if console.print_timing {
+        print!("{}", timing.report());
+    }
+    // One status vocabulary across both engines: the convex verdict mapped
+    // onto the NLP-side enumerator, which is what `status_message` phrases
+    // and what `upstream_name` spells the way CUTEst tables and the
+    // reference JSONs do.
+    let ars = qp_status_to_ars(status);
+    // The same quantity the NLP path prints on this line: the driver's own
+    // `OverallAlgorithm` total, not the solve-only figure the one-line result
+    // above already carries.
+    print::print_convex_end(ars, timing.overall_alg.total_wallclock_time());
+    if !console.json_debug {
+        println!("Status: {}", ars.upstream_name());
+    }
+}
+
 fn convex_opts_with_remaining(
     mut opts: pounce_convex::QpOptions,
     started: std::time::Instant,
@@ -2532,13 +2614,25 @@ fn run_convex_qp(
     engine_overrides: pounce_convex::ActiveSetOverrides,
     // gh #535: may an uncertified LP solve be handed back to the NLP path?
     allow_nlp_fallback: bool,
+    // Verdict / timing-statistics switches read off the options list.
+    console: ConvexConsole,
 ) -> Option<ExitCode> {
     let t0 = std::time::Instant::now();
     use pounce_convex::active_set::solve_qp_active_set;
     use pounce_convex::presolve::{FixpointExit, PresolveOutcome, presolve};
     use pounce_convex::{QpOptions, QpStatus, solve_qp_ipm, solve_qp_ipm_debug};
 
-    let (qp, con_map, obj_nl_const) =
+    // gh #767: per-phase wall clock for the convex path. The struct is always
+    // built (it costs nothing when the detailed timers are off) and the sink
+    // is always installed, so `pounce-linsol` can charge the factorization and
+    // back-solve rows from several crates below this driver.
+    let timing = Rc::new(pounce_common::timing::ConvexTimingStatistics::new());
+    timing.set_detailed_enabled(console.collect_timing);
+    timing.overall_alg.start();
+    let _timing_scope = pounce_common::timing::ConvexTimingScope::open(&timing);
+
+    let (qp, con_map, obj_nl_const) = {
+        let _t = timing.extraction.guard();
         match pounce_cli::qp_extract::extract_qp_with_map(prob, bound_relax) {
             Some(q) => q,
             None => {
@@ -2548,7 +2642,8 @@ fn run_convex_qp(
                 );
                 return Some(ExitCode::from(2));
             }
-        };
+        }
+    };
 
     // The reported objective must include *both* constant sources: the
     // `.nl` linear-section constant (`obj_constant`) and any degree-0 term
@@ -2635,9 +2730,14 @@ fn run_convex_qp(
         // user selected. The caller has already printed the note explaining
         // the debugger does not engage; fall through and solve normally.
         let mut h = hook.borrow_mut();
+        let _t = timing.solve.guard();
         solve_qp_ipm_debug(&qp, &solve_opts(), &mut *h, backend)
     } else if presolve_on {
-        match presolve(&qp) {
+        let outcome = {
+            let _t = timing.presolve.guard();
+            presolve(&qp)
+        };
+        match outcome {
             PresolveOutcome::Reduced(ps) => {
                 // A screen claimed infeasibility and the re-derivation without
                 // the speculative fixings would not reproduce it, so presolve
@@ -2686,17 +2786,23 @@ fn run_convex_qp(
                         exit,
                     ));
                 }
-                let red = if use_active_set {
-                    let mut mk = backend;
-                    solve_qp_active_set(
-                        &ps.reduced,
-                        &solve_opts_offset(ps.obj_offset()),
-                        &engine_overrides,
-                        &mut mk,
-                    )
-                } else {
-                    solve_qp_ipm(&ps.reduced, &solve_opts_offset(ps.obj_offset()), backend)
+                let red = {
+                    let _t = timing.solve.guard();
+                    if use_active_set {
+                        let mut mk = backend;
+                        solve_qp_active_set(
+                            &ps.reduced,
+                            &solve_opts_offset(ps.obj_offset()),
+                            &engine_overrides,
+                            &mut mk,
+                        )
+                    } else {
+                        solve_qp_ipm(&ps.reduced, &solve_opts_offset(ps.obj_offset()), backend)
+                    }
                 };
+                // The postsolve lift is presolve's other half, so it is
+                // charged to the same row.
+                let _t = timing.presolve.guard();
                 ps.postsolve(&red)
             }
             PresolveOutcome::Infeasible(trigger) => {
@@ -2710,8 +2816,10 @@ fn run_convex_qp(
         }
     } else if use_active_set {
         let mut mk = backend;
+        let _t = timing.solve.guard();
         solve_qp_active_set(&qp, &solve_opts(), &engine_overrides, &mut mk)
     } else {
+        let _t = timing.solve.guard();
         solve_qp_ipm(&qp, &solve_opts(), backend)
     };
     let elapsed = t0.elapsed().as_secs_f64();
@@ -2793,6 +2901,7 @@ fn run_convex_qp(
     // Recover per-constraint duals once (mapped from the QP multipliers back
     // to per-`.nl`-constraint order); used by both the `.sol` and the JSON
     // report.
+    let recovery = timing.solution_recovery.guard();
     let lambda = pounce_cli::qp_extract::recover_duals(prob, &con_map, &sol.y, &sol.z);
 
     // Bound multipliers (`ipopt_zL_out`/`ipopt_zU_out`). The QP extractor puts
@@ -2819,6 +2928,14 @@ fn run_convex_qp(
             values: nl_writer::SolSuffixValues::Real(z_u_suffix),
         },
     ];
+    recovery.stop();
+
+    // The end-of-run verdict, in the shape the NLP path emits it (gh #767).
+    // After the residual block and the dual recovery so the timing rows cover
+    // the whole driver, and before the `.sol` / JSON writes, which report
+    // nothing to stdout.
+    timing.overall_alg.end();
+    print_convex_verdict(console, sol.status, &timing);
 
     // Write a `.sol` if requested: primal x and recovered constraint duals in
     // the AMPL `.sol` convention.
@@ -2927,12 +3044,21 @@ fn run_convex_socp(
     presolve_on: bool,
     // gh #535: may an unverified conic solve be handed back to the NLP path?
     allow_nlp_fallback: bool,
+    // Verdict / timing-statistics switches read off the options list.
+    console: ConvexConsole,
 ) -> Option<ExitCode> {
     let t0 = std::time::Instant::now();
     use pounce_convex::presolve::{PresolveOutcome, presolve_conic};
     use pounce_convex::{QpOptions, solve_socp_ipm, solve_socp_ipm_debug};
 
-    let (qp, con_map, obj_nl_const, cones) =
+    // Per-phase wall clock; see the same block in `run_convex_qp` (gh #767).
+    let timing = Rc::new(pounce_common::timing::ConvexTimingStatistics::new());
+    timing.set_detailed_enabled(console.collect_timing);
+    timing.overall_alg.start();
+    let _timing_scope = pounce_common::timing::ConvexTimingScope::open(&timing);
+
+    let (qp, con_map, obj_nl_const, cones) = {
+        let _t = timing.extraction.guard();
         match pounce_cli::qp_extract::extract_socp_with_map(prob, bound_relax) {
             Some(q) => q,
             None => {
@@ -2942,7 +3068,8 @@ fn run_convex_socp(
                 );
                 return Some(ExitCode::from(2));
             }
-        };
+        }
+    };
 
     // Reported objective includes both constant sources (the `.nl` linear
     // section and the degree-0 term folded into the nonlinear objective tree),
@@ -2989,6 +3116,7 @@ fn run_convex_socp(
         // so the debugger's blocks correspond to the user's rows rather than
         // a reduced set. Same carve-out as the QP path.
         let mut h = hook.borrow_mut();
+        let _t = timing.solve.guard();
         solve_socp_ipm_debug(&qp, &cones, &solve_opts(), &mut *h, backend)
     } else if presolve_on {
         // **`presolve_conic`, never `presolve`.** The orthant entry point
@@ -3003,7 +3131,11 @@ fn run_convex_socp(
         // `presolve_conic` protects every non-orthant row, which is what
         // makes this call safe; §7 of `dev-notes/quadratic-structure-
         // exploitation.md` is the validity table.
-        match presolve_conic(&qp, &cones) {
+        let outcome = {
+            let _t = timing.presolve.guard();
+            presolve_conic(&qp, &cones)
+        };
+        match outcome {
             PresolveOutcome::Reduced(ps) => {
                 if let Some(trigger) = ps.discarded_infeasibility() {
                     presolve_log.push(format!(
@@ -3038,7 +3170,12 @@ fn run_convex_socp(
                 // row indices, so `con_map`'s `z_row0`/`z_row1` — and hence
                 // `recover_socp_duals` below — need no remapping.
                 let red_cones = ps.reduced_cones(&cones);
-                let red = solve_socp_ipm(&ps.reduced, &red_cones, &solve_opts(), backend);
+                let red = {
+                    let _t = timing.solve.guard();
+                    solve_socp_ipm(&ps.reduced, &red_cones, &solve_opts(), backend)
+                };
+                // The postsolve lift is presolve's other half.
+                let _t = timing.presolve.guard();
                 ps.postsolve(&red)
             }
             PresolveOutcome::Infeasible(trigger) => {
@@ -3048,6 +3185,7 @@ fn run_convex_socp(
             PresolveOutcome::Unbounded => trivial(pounce_convex::QpStatus::DualInfeasible),
         }
     } else {
+        let _t = timing.solve.guard();
         solve_socp_ipm(&qp, &cones, &solve_opts(), backend)
     };
     let elapsed = t0.elapsed().as_secs_f64();
@@ -3117,6 +3255,7 @@ fn run_convex_socp(
     // Per-constraint duals, mapped from the cone multipliers back to `.nl`
     // constraint order (best-effort for the quadratic rows; see
     // `recover_socp_duals`).
+    let recovery = timing.solution_recovery.guard();
     let lambda = pounce_cli::qp_extract::recover_socp_duals(prob, &con_map, &sol.y, &sol.z);
 
     // Bound multipliers (`ipopt_zL_out`/`ipopt_zU_out`). As on the QP path the
@@ -3140,6 +3279,12 @@ fn run_convex_socp(
             values: nl_writer::SolSuffixValues::Real(z_u_suffix),
         },
     ];
+    recovery.stop();
+
+    // The end-of-run verdict, in the shape the NLP path emits it (gh #767);
+    // see the same call in `run_convex_qp` for the placement.
+    timing.overall_alg.end();
+    print_convex_verdict(console, sol.status, &timing);
 
     if let Some(path) = sol_path {
         let payload = nl_writer::SolutionFile {

--- a/crates/pounce-cli/tests/issue_767_convex_path_reports_like_nlp.rs
+++ b/crates/pounce-cli/tests/issue_767_convex_path_reports_like_nlp.rs
@@ -1,0 +1,306 @@
+//! gh #767: the convex path must present the same end-of-run contract as the
+//! NLP path — timing statistics when asked for them, an `EXIT:` banner and a
+//! machine-readable `Status:` line, and a JSON `solution` a consumer can
+//! compare against Ipopt's own enumerator spelling.
+//!
+//! All three gaps were found while instrumenting the Mittelmann suite, where
+//! two of 47 instances route convex and the other 45 do not:
+//!
+//! 1. `print_timing_statistics=yes` was accepted, reported `(used)` by
+//!    `print_user_options`, and emitted nothing. A tool attributing solve cost
+//!    by phase then read 0% for *every* phase of a convex-routed instance,
+//!    which reads as "already fast" rather than "not measured" — `bearing_400`
+//!    ran 9.8 s and printed no timer at all.
+//! 2. The log ended after the residual block: no `EXIT:`, no `Status:`. Every
+//!    consumer of the CLI other than `benchmarks/scripts/run_nl_bench.sh` — which
+//!    carries its own ladder of convex-specific stdout scrapes — had to
+//!    reimplement that ladder.
+//! 3. The JSON report's `solution.status` is the Rust variant name
+//!    (`SolveSucceeded`) on *both* paths, while the spelling every Ipopt-facing
+//!    consumer keys off is `Solve_Succeeded`. A consumer comparing against the
+//!    latter matched nothing and silently classified every solve as a failure,
+//!    and only noticed on the convex path because that path printed no
+//!    `Status:` line to compare with. The report now carries both spellings.
+//!
+//! The tests run every convex arm the router can reach — the QP/LP
+//! interior-point engine, the parametric active-set engine, and the conic
+//! (QCQP) engine — because each has its own driver and its own linear algebra,
+//! and a green leg on one says nothing about the others.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use pounce_cli::solve_report::SolveReport;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn run(name: &str, args: &[&str]) -> String {
+    let out = Command::new(pounce_exe())
+        .arg(fixture(name))
+        .arg("--no-sol")
+        .args(args)
+        .output()
+        .expect("spawn pounce");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Solve `name` and return `(stdout, report)`.
+fn run_with_report(name: &str, args: &[&str]) -> (String, SolveReport) {
+    let json = std::env::temp_dir().join(format!(
+        "pounce_767_{}_{}_{}.json",
+        std::process::id(),
+        name.replace('.', "-"),
+        args.join("_").replace(['=', '.', '/'], "-")
+    ));
+    let out = Command::new(pounce_exe())
+        .arg(fixture(name))
+        .arg("--no-sol")
+        .arg("--json-output")
+        .arg(&json)
+        .args(args)
+        .output()
+        .expect("spawn pounce");
+    let report: SolveReport =
+        serde_json::from_str(&std::fs::read_to_string(&json).expect("read JSON report"))
+            .expect("parse JSON report");
+    let _ = std::fs::remove_file(&json);
+    (String::from_utf8_lossy(&out.stdout).into_owned(), report)
+}
+
+fn status_lines(stdout: &str) -> Vec<&str> {
+    stdout
+        .lines()
+        .filter(|l| l.starts_with("Status:"))
+        .collect()
+}
+
+/// The convex arms, one fixture each. `solver_selection` is pinned rather than
+/// left at `auto` so a routing change cannot quietly turn one of these legs
+/// into a second copy of another.
+const CONVEX_ARMS: &[(&str, &str, &str)] = &[
+    (
+        "lp_afiro.nl",
+        "solver_selection=qp-ipm",
+        "LP, interior-point",
+    ),
+    (
+        "convex_qp_share1b.nl",
+        "solver_selection=qp-ipm",
+        "convex QP, interior-point",
+    ),
+    (
+        "boxed_qp_min.nl",
+        "solver_selection=qp-active-set",
+        "convex QP, active-set",
+    ),
+    (
+        "qcqp_ball.nl",
+        "solver_selection=socp",
+        "convex QCQP, conic",
+    ),
+];
+
+/// Item 2. Every convex arm ends its log the way the NLP path does.
+#[test]
+fn every_convex_arm_ends_with_an_exit_banner_and_a_status_line() {
+    for (fixture, selection, arm) in CONVEX_ARMS {
+        let stdout = run(fixture, &[selection]);
+        assert!(
+            stdout.contains("EXIT: Optimal Solution Found."),
+            "{arm}: no EXIT: banner; stdout=\n{stdout}"
+        );
+        assert_eq!(
+            status_lines(&stdout),
+            vec!["Status: Solve_Succeeded"],
+            "{arm}: expected exactly one machine-readable status line; stdout=\n{stdout}"
+        );
+    }
+}
+
+/// Item 3, and the half of item 2 that matters to a machine: the spelling on
+/// the `Status:` line and the spelling in the JSON report agree, on both
+/// paths, so a consumer can compare one literal against either surface.
+#[test]
+fn the_printed_status_and_the_json_report_agree_on_both_paths() {
+    // `hs13_bigstart.nl` is an NLP; the others route convex.
+    for (fixture, selection) in [
+        ("hs13_bigstart.nl", "solver_selection=nlp"),
+        ("convex_qp_share1b.nl", "solver_selection=qp-ipm"),
+        ("qcqp_ball.nl", "solver_selection=socp"),
+    ] {
+        let (stdout, report) = run_with_report(fixture, &[selection]);
+        let printed = status_lines(&stdout)
+            .first()
+            .map(|l| l.trim_start_matches("Status:").trim().to_string())
+            .unwrap_or_else(|| panic!("{fixture}: no Status: line; stdout=\n{stdout}"));
+        assert_eq!(
+            report.solution.status_upstream, printed,
+            "{fixture}: the report's upstream status must be the printed one"
+        );
+        assert_eq!(
+            printed, "Solve_Succeeded",
+            "{fixture}: expected the upstream spelling, not the Rust variant name"
+        );
+        // The pre-existing field keeps its documented meaning — the Rust
+        // variant name — so a consumer reading it does not break.
+        assert_eq!(format!("{:?}", report.solution.status), "SolveSucceeded");
+    }
+}
+
+/// Item 1. `print_timing_statistics=yes` produces a phase breakdown on every
+/// convex arm, and the phases nest the way the labels claim — a block of
+/// structural zeros, or one whose parts exceed their whole, would be the same
+/// defect with more output.
+///
+/// The magnitude claim is made only where the report can resolve it: rows
+/// print three decimals, so a sub-millisecond fixture legitimately shows
+/// `0.000s` everywhere and asserting otherwise would flake on a fast machine.
+/// That the instrumentation exists at all is pinned deterministically, per
+/// engine, by `pounce-linsol`'s `a_convex_timing_scope_charges_each_phase_to_
+/// its_own_row` and `pounce-qp`'s `tests/convex_timing_rows.rs`, which read
+/// the raw nanosecond totals instead of the printed rows.
+#[test]
+fn print_timing_statistics_attributes_the_solve_on_every_convex_arm() {
+    /// Ten times the report's display quantum: below this a zero row says
+    /// "too fast to print", above it a zero row says "never measured".
+    const RESOLVABLE: f64 = 0.005;
+
+    for (fixture, selection, arm) in CONVEX_ARMS {
+        let stdout = run(fixture, &[selection, "print_timing_statistics=yes"]);
+        assert!(
+            stdout.contains("\nTiming Statistics:\n"),
+            "{arm}: no timing block; stdout=\n{stdout}"
+        );
+
+        // The dot leader is part of the match: `Presolve` alone also prefixes
+        // the reduction line presolve logs above the summary.
+        let seconds = |label: &str| -> f64 {
+            let leader = format!("{label}.");
+            let row = stdout
+                .lines()
+                .find(|l| l.trim_start().starts_with(&leader))
+                .unwrap_or_else(|| panic!("{arm}: no `{label}` row; stdout=\n{stdout}"));
+            row.rsplit_once(' ')
+                .and_then(|(_, v)| v.trim().trim_end_matches('s').parse::<f64>().ok())
+                .unwrap_or_else(|| panic!("{arm}: unparsable row {row:?}"))
+        };
+
+        let overall = seconds("OverallAlgorithm");
+        let solve = seconds("ConvexSolve");
+        // Every driver stage has a row, whether or not it did anything.
+        for stage in ["ProblemExtraction", "Presolve", "SolutionRecovery"] {
+            let _ = seconds(stage);
+        }
+        // The linear-algebra split is the reason a phase report is worth
+        // printing, and it is engine-specific: the interior-point drivers
+        // factor through `pounce_linsol::Factorization`, the active-set engine
+        // through `pounce_qp`'s own `LinearSolver`.
+        let linear = seconds("LinearSystemSymbolicFactorization")
+            + seconds("LinearSystemFactorization")
+            + seconds("LinearSystemBackSolve");
+
+        // Rounding can only move a row by half a quantum in each direction.
+        const SLACK: f64 = 0.001;
+        assert!(
+            solve <= overall + SLACK,
+            "{arm}: ConvexSolve {solve}s exceeds OverallAlgorithm {overall}s"
+        );
+        assert!(
+            linear <= solve + SLACK,
+            "{arm}: the LinearSystem* rows ({linear}s) exceed the solve they \
+             happen inside ({solve}s)"
+        );
+
+        if solve >= RESOLVABLE {
+            assert!(
+                overall > 0.0,
+                "{arm}: OverallAlgorithm read {overall}s — the option must \
+                 measure something"
+            );
+            assert!(
+                linear > 0.0,
+                "{arm}: the LinearSystem* rows sum to {linear}s beside a \
+                 {solve}s solve — an uninstrumented engine reports 0% for every \
+                 phase, which reads as `already fast` rather than `not \
+                 measured` (gh #767)"
+            );
+        }
+    }
+}
+
+/// The block is opt-in: a default solve keeps its old output.
+#[test]
+fn the_timing_block_is_absent_without_the_option() {
+    let stdout = run("convex_qp_share1b.nl", &["solver_selection=qp-ipm"]);
+    assert!(
+        !stdout.contains("Timing Statistics:"),
+        "timing must stay opt-in; stdout=\n{stdout}"
+    );
+    // …but the verdict is not opt-in.
+    assert!(stdout.contains("EXIT:"), "stdout=\n{stdout}");
+}
+
+/// `timing_statistics=yes` alone arms the detailed timers without printing
+/// them, exactly as it does on the NLP path (`print_timing_statistics`
+/// implies it, not the other way round).
+#[test]
+fn timing_statistics_alone_does_not_print() {
+    let stdout = run(
+        "convex_qp_share1b.nl",
+        &["solver_selection=qp-ipm", "timing_statistics=yes"],
+    );
+    assert!(
+        !stdout.contains("Timing Statistics:"),
+        "only print_timing_statistics prints; stdout=\n{stdout}"
+    );
+}
+
+/// The verdict block is gated on `print_level` the same way
+/// `Application::emit_end_summary` gates the NLP path's: at print_level 0 the
+/// console is silent by request, and adding a status line would break that.
+#[test]
+fn print_level_zero_suppresses_the_convex_verdict() {
+    let stdout = run(
+        "convex_qp_share1b.nl",
+        &["solver_selection=qp-ipm", "print_level=0"],
+    );
+    assert!(
+        !stdout.contains("EXIT:") && status_lines(&stdout).is_empty(),
+        "print_level=0 must not print a verdict; stdout=\n{stdout}"
+    );
+}
+
+/// `--debug-json` makes stdout a pure protocol channel, so the machine-readable
+/// status line stays off it — the same carve-out the NLP path makes.
+#[test]
+fn json_debug_keeps_the_status_line_off_stdout() {
+    let stdout = run("convex_qp.nl", &["--debug-json"]);
+    assert!(
+        status_lines(&stdout).is_empty(),
+        "--debug-json owns stdout; stdout=\n{stdout}"
+    );
+}
+
+/// One run, one verdict. gh #535 hands an uncertified LP back to the NLP path,
+/// and the convex attempt that declined must not have left a status line
+/// behind — a log with two `Status:` lines is exactly the ambiguity the
+/// machine-readable line exists to remove.
+#[test]
+fn a_convex_attempt_that_declines_leaves_no_status_line() {
+    let stdout = run("lp_afiro.nl", &["solver_selection=auto", "tol=1e-20"]);
+    assert_eq!(
+        status_lines(&stdout).len(),
+        1,
+        "a rerouted run must print exactly one status line; stdout=\n{stdout}"
+    );
+}

--- a/crates/pounce-common/src/timing.rs
+++ b/crates/pounce-common/src/timing.rs
@@ -5,7 +5,7 @@
 
 use crate::types::Number;
 use crate::utils::{cpu_time, sys_time, wallclock_time};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 /// Which time budget a [`Deadline`] check found crossed.
@@ -567,6 +567,209 @@ impl TimingStatistics {
         self.eval_constr_jac.reset();
         self.eval_lag_hess.reset();
     }
+}
+
+/// Which linear-system phase a [`ConvexTimingStatistics`] row is charging.
+/// Named after the rows [`TimingStatistics::report`] already prints, so a
+/// tool that attributes cost by phase reads one vocabulary across both
+/// solver paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinearSystemPhase {
+    /// Pattern analysis / ordering (`Factorization::new`'s structure pass).
+    SymbolicFactorization,
+    /// Numeric factorization of the KKT matrix.
+    Factorization,
+    /// Triangular back-substitution against an existing factor.
+    BackSolve,
+}
+
+/// Wall-clock phase accumulator for the dedicated convex (LP / QP / conic)
+/// path, the counterpart of [`TimingStatistics`] for a solve that has no
+/// callbacks, no Hessian updates and no filter line search to attribute time
+/// to.
+///
+/// gh #767: `print_timing_statistics=yes` was accepted on the convex path,
+/// reported `(used)` by `print_user_options`, and emitted nothing — so a tool
+/// attributing cost by phase read 0% everywhere on a convex-routed instance,
+/// which is indistinguishable from "already fast" rather than "not measured".
+/// A 9.8 s `bearing_400` printed no timer at all.
+///
+/// The rows this reports are the phases the convex path actually has. Four of
+/// them — `OverallAlgorithm` and the three `LinearSystem*` rows — carry the
+/// *same* labels [`TimingStatistics::report`] prints, because they are the
+/// same quantities; the rest are named for the convex driver's own stages
+/// rather than reusing NLP row names that would always read zero.
+#[derive(Debug, Default)]
+pub struct ConvexTimingStatistics {
+    /// The whole convex driver: extraction through solution recovery.
+    /// Reported regardless of the detailed-timer switch, matching
+    /// [`TimingStatistics::overall_alg`].
+    pub overall_alg: TimedTask,
+    /// Reading the `.nl` model into the standard-form convex problem.
+    pub extraction: TimedTask,
+    /// Convex presolve plus the matching postsolve lift.
+    pub presolve: TimedTask,
+    /// The engine call itself (interior-point or active-set iterations).
+    pub solve: TimedTask,
+    /// Recovering per-constraint duals and bound multipliers in the
+    /// original model's ordering.
+    pub solution_recovery: TimedTask,
+
+    pub linear_system_symbolic_factorization: TimedTask,
+    pub linear_system_factorization: TimedTask,
+    pub linear_system_back_solve: TimedTask,
+}
+
+impl ConvexTimingStatistics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Format the per-phase report, in the row layout
+    /// [`TimingStatistics::report`] uses (label padded to 42 columns, wall
+    /// seconds right-aligned). Returns a multi-line string ending in a
+    /// trailing newline so callers can `print!` it directly.
+    pub fn report(&self) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::new();
+        let row = |s: &mut String, label: &str, t: &TimedTask| {
+            let _ = writeln!(
+                s,
+                "{label:<42} {wall:>10.3}s",
+                wall = t.total_wallclock_time()
+            );
+        };
+        s.push_str("\nTiming Statistics:\n");
+        row(
+            &mut s,
+            "OverallAlgorithm....................:",
+            &self.overall_alg,
+        );
+        row(
+            &mut s,
+            " ProblemExtraction..................:",
+            &self.extraction,
+        );
+        row(
+            &mut s,
+            " Presolve...........................:",
+            &self.presolve,
+        );
+        row(&mut s, " ConvexSolve........................:", &self.solve);
+        row(
+            &mut s,
+            " SolutionRecovery...................:",
+            &self.solution_recovery,
+        );
+        row(
+            &mut s,
+            "LinearSystemSymbolicFactorization...:",
+            &self.linear_system_symbolic_factorization,
+        );
+        row(
+            &mut s,
+            "LinearSystemFactorization...........:",
+            &self.linear_system_factorization,
+        );
+        row(
+            &mut s,
+            "LinearSystemBackSolve...............:",
+            &self.linear_system_back_solve,
+        );
+        s
+    }
+
+    /// Enable or disable the *detailed* per-phase timers, mirroring
+    /// [`TimingStatistics::set_detailed_enabled`] and therefore upstream
+    /// Ipopt's `timing_statistics` gating: with the option off, every
+    /// `start()` / `end()` on these tasks is a no-op and the solve pays no
+    /// clock syscalls for them.
+    ///
+    /// [`Self::overall_alg`] is deliberately left enabled, for the same
+    /// reason it is on the NLP path — upstream's help text is explicit that
+    /// the overall algorithm time is unaffected by this option.
+    pub fn set_detailed_enabled(&self, on: bool) {
+        let set = |t: &TimedTask| {
+            if on {
+                t.enable();
+            } else {
+                t.disable();
+            }
+        };
+        set(&self.extraction);
+        set(&self.presolve);
+        set(&self.solve);
+        set(&self.solution_recovery);
+        set(&self.linear_system_symbolic_factorization);
+        set(&self.linear_system_factorization);
+        set(&self.linear_system_back_solve);
+    }
+
+    fn phase(&self, phase: LinearSystemPhase) -> &TimedTask {
+        match phase {
+            LinearSystemPhase::SymbolicFactorization => &self.linear_system_symbolic_factorization,
+            LinearSystemPhase::Factorization => &self.linear_system_factorization,
+            LinearSystemPhase::BackSolve => &self.linear_system_back_solve,
+        }
+    }
+}
+
+thread_local! {
+    /// The convex-path sink, when a [`ConvexTimingScope`] is open.
+    /// Thread-local rather than threaded through the drivers because the
+    /// factorization and back-solve rows are charged from inside
+    /// `pounce-linsol`, several crates below the driver that wants them —
+    /// the same reason `pounce-convex`'s solve deadline is thread-local.
+    static CONVEX_TIMING: RefCell<Option<Rc<ConvexTimingStatistics>>> =
+        const { RefCell::new(None) };
+}
+
+/// RAII installation of a convex-path timing sink: [`ConvexTimingScope::open`]
+/// makes `stats` the active sink, and dropping the returned guard restores
+/// whatever was installed before it.
+///
+/// A guard rather than a `with(…, closure)` wrapper because the driver that
+/// opens the scope is a long function with several early returns, and each of
+/// those must still restore the previous sink.
+///
+/// The tasks inside `stats` carry their own enabled flag, so a solve that was
+/// not asked for timing statistics pays one thread-local read per
+/// [`time_linear_system`] call and no clock syscalls at all.
+///
+/// Thread-local means exactly that: work a scope-holding thread hands to
+/// worker threads (`pounce_convex::solve_qp_batch_parallel`) is not charged,
+/// because those threads have no scope. The convex CLI driver — the only
+/// caller that opens one — solves on the thread that opened it.
+#[must_use = "the scope ends when the guard is dropped; bind it to a variable"]
+pub struct ConvexTimingScope {
+    previous: Option<Rc<ConvexTimingStatistics>>,
+}
+
+impl ConvexTimingScope {
+    pub fn open(stats: &Rc<ConvexTimingStatistics>) -> Self {
+        let previous = CONVEX_TIMING.with(|slot| slot.borrow_mut().replace(Rc::clone(stats)));
+        Self { previous }
+    }
+}
+
+impl Drop for ConvexTimingScope {
+    fn drop(&mut self) {
+        CONVEX_TIMING.with(|slot| *slot.borrow_mut() = self.previous.take());
+    }
+}
+
+/// Charge the wall time `f` takes against `phase` of the active convex-path
+/// sink. A no-op wrapper when no [`ConvexTimingScope`] is open.
+///
+/// Phases never nest (a factorization does not run inside a back-solve), so
+/// the guard cannot clobber an outer start on the same task.
+pub fn time_linear_system<T>(phase: LinearSystemPhase, f: impl FnOnce() -> T) -> T {
+    let Some(stats) = CONVEX_TIMING.with(|slot| slot.borrow().clone()) else {
+        return f();
+    };
+    let task = stats.phase(phase);
+    let _guard = task.guard();
+    f()
 }
 
 #[cfg(test)]

--- a/crates/pounce-linsol/src/factorization.rs
+++ b/crates/pounce-linsol/src/factorization.rs
@@ -31,6 +31,7 @@
 use crate::error::FactorizationError;
 use crate::sparse_sym_iface::SparseSymLinearSolverInterface;
 use crate::t_sym_solver::TSymLinearSolver;
+use pounce_common::timing::{LinearSystemPhase, time_linear_system};
 use pounce_common::types::{Index, Number};
 
 /// Value-typed handle holding a sparse symmetric factorization.
@@ -98,7 +99,15 @@ impl Factorization {
         assert_eq!(values.len(), airn.len(), "values must match nnz");
         let nnz = airn.len() as Index;
         let mut inner = TSymLinearSolver::new(backend, None, false);
-        FactorizationError::from_status(inner.initialize_structure(dim, &airn, &ajcn))?;
+        // Charged as the symbolic phase whenever a convex-path timing scope
+        // is open (gh #767); a no-op otherwise. Backends differ in how much
+        // analysis they do here versus fold into the first numeric factor —
+        // feral defers its ordering, so this row reads near zero for it, the
+        // same way it does in the NLP path's report.
+        let structure = time_linear_system(LinearSystemPhase::SymbolicFactorization, || {
+            inner.initialize_structure(dim, &airn, &ajcn)
+        });
+        FactorizationError::from_status(structure)?;
 
         let mut me = Self {
             inner,
@@ -134,14 +143,16 @@ impl Factorization {
             self.dim as usize * nrhs,
             "rhs length must equal dim * nrhs"
         );
-        let status = self.inner.multi_solve(
-            &self.values,
-            false, // new_matrix = false: pure back-substitution
-            nrhs as Index,
-            rhs,
-            false,
-            0,
-        );
+        let status = time_linear_system(LinearSystemPhase::BackSolve, || {
+            self.inner.multi_solve(
+                &self.values,
+                false, // new_matrix = false: pure back-substitution
+                nrhs as Index,
+                rhs,
+                false,
+                0,
+            )
+        });
         FactorizationError::from_status(status)
     }
 
@@ -196,14 +207,16 @@ impl Factorization {
     /// Internal helper: issue a factor (and discard the back-solve).
     fn do_factor(&mut self) -> Result<(), FactorizationError> {
         let mut dummy_rhs = vec![0.0; self.dim as usize];
-        let status = self.inner.multi_solve(
-            &self.values,
-            true, // new_matrix = true: factor now
-            1,
-            &mut dummy_rhs,
-            false,
-            0,
-        );
+        let status = time_linear_system(LinearSystemPhase::Factorization, || {
+            self.inner.multi_solve(
+                &self.values,
+                true, // new_matrix = true: factor now
+                1,
+                &mut dummy_rhs,
+                false,
+                0,
+            )
+        });
         FactorizationError::from_status(status)?;
         self.inertia_known = true;
         Ok(())
@@ -486,6 +499,89 @@ mod tests {
         let r1 = rhs[0] + 5.0 * rhs[1] - 6.0;
         assert!(r0.abs() < 1e-10);
         assert!(r1.abs() < 1e-10);
+    }
+
+    /// gh #767: with a convex-path timing scope open, each operation charges
+    /// its own row — and the three rows are distinguishable, so a report
+    /// cannot attribute a back-solve to the factorization or vice versa.
+    ///
+    /// Asserted on the raw wall-clock totals rather than the printed report:
+    /// `Instant` resolves nanoseconds, so any real work is strictly positive
+    /// even when the report's three-decimal row rounds it to `0.000s`.
+    #[test]
+    fn a_convex_timing_scope_charges_each_phase_to_its_own_row() {
+        use pounce_common::timing::{ConvexTimingScope, ConvexTimingStatistics};
+        use std::rc::Rc;
+
+        let stats = Rc::new(ConvexTimingStatistics::new());
+        let scope = ConvexTimingScope::open(&stats);
+
+        let mut f = Factorization::new(
+            2,
+            vec![1, 2, 2],
+            vec![1, 1, 2],
+            vec![2.0, 1.0, 3.0],
+            Box::new(DenseLuBackend::new()),
+        )
+        .unwrap();
+        // `new` charges the structure pass and the initial numeric factor;
+        // nothing has back-substituted through `solve` yet.
+        assert!(
+            stats
+                .linear_system_symbolic_factorization
+                .total_wallclock_time()
+                > 0.0,
+            "construction must charge the symbolic row"
+        );
+        assert!(
+            stats.linear_system_factorization.total_wallclock_time() > 0.0,
+            "construction must charge the factorization row"
+        );
+        assert_eq!(
+            stats.linear_system_back_solve.total_wallclock_time(),
+            0.0,
+            "no `solve` has run yet, so the back-solve row must be untouched"
+        );
+
+        let after_construction = stats.linear_system_factorization.total_wallclock_time();
+        let mut rhs = vec![5.0, 6.0];
+        f.solve_one(&mut rhs).unwrap();
+        assert!(
+            stats.linear_system_back_solve.total_wallclock_time() > 0.0,
+            "`solve` must charge the back-solve row"
+        );
+        assert_eq!(
+            stats.linear_system_factorization.total_wallclock_time(),
+            after_construction,
+            "a pure back-substitution must not be charged as a factorization"
+        );
+
+        let before_refactor = stats.linear_system_back_solve.total_wallclock_time();
+        f.refactor(&[4.0, 1.0, 5.0]).unwrap();
+        assert!(
+            stats.linear_system_factorization.total_wallclock_time() > after_construction,
+            "`refactor` must charge the factorization row"
+        );
+        assert_eq!(
+            stats.linear_system_back_solve.total_wallclock_time(),
+            before_refactor,
+            "`refactor`'s discarded no-op back-solve is factorization cost, not \
+             back-solve cost"
+        );
+
+        // Outside the scope nothing is charged at all — the NLP path runs
+        // through this same type and keeps its own timers.
+        drop(scope);
+        let totals = || {
+            (
+                stats.linear_system_factorization.total_wallclock_time(),
+                stats.linear_system_back_solve.total_wallclock_time(),
+            )
+        };
+        let before = totals();
+        f.refactor(&[4.0, 1.0, 5.0]).unwrap();
+        f.solve_one(&mut [5.0, 6.0]).unwrap();
+        assert_eq!(totals(), before, "a closed scope must record nothing");
     }
 
     /// Singular matrix → Singular error.

--- a/crates/pounce-qp/src/factor.rs
+++ b/crates/pounce-qp/src/factor.rs
@@ -29,6 +29,7 @@
 
 use crate::error::QpError;
 use crate::kkt::KktTriplet;
+use pounce_common::timing::{LinearSystemPhase, time_linear_system};
 use pounce_common::{Index, Number};
 use pounce_linsol::status::ESymSolverStatus;
 use pounce_linsol::{EMatrixFormat, SparseSymLinearSolverInterface};
@@ -95,9 +96,15 @@ impl LinearSolver {
         let dim = kkt.dim as Index;
         let nnz = kkt.irn.len() as Index;
 
-        let st = self
-            .backend
-            .initialize_structure(dim, nnz, &kkt.irn, &kkt.jcn);
+        // Charged to the convex path's timing sink when one is open (gh
+        // #767); a no-op otherwise. Without this the active-set engine's
+        // three `LinearSystem*` rows read 0.000s beside a `ConvexSolve` row
+        // carrying the whole solve — the same "0% everywhere" report the
+        // issue is about, one engine down.
+        let st = time_linear_system(LinearSystemPhase::SymbolicFactorization, || {
+            self.backend
+                .initialize_structure(dim, nnz, &kkt.irn, &kkt.jcn)
+        });
         if st != ESymSolverStatus::Success {
             return Err(QpError::LinearSolverFailure(format!(
                 "initialize_structure → {st:?}"
@@ -113,10 +120,12 @@ impl LinearSolver {
             None => (false, 0),
         };
 
-        let st = self.backend.multi_solve(
-            true, // new_matrix
-            &kkt.irn, &kkt.jcn, 1, rhs, check, expected,
-        );
+        let st = time_linear_system(LinearSystemPhase::Factorization, || {
+            self.backend.multi_solve(
+                true, // new_matrix
+                &kkt.irn, &kkt.jcn, 1, rhs, check, expected,
+            )
+        });
         match st {
             ESymSolverStatus::Success => {
                 self.cached_irn = Some(kkt.irn.clone());
@@ -163,10 +172,12 @@ impl LinearSolver {
         }
         let irn = self.cached_irn.as_ref().expect("factored ⇒ cache present");
         let jcn = self.cached_jcn.as_ref().expect("factored ⇒ cache present");
-        let st = self.backend.multi_solve(
-            false, // new_matrix=false ⇒ reuse cached factor
-            irn, jcn, 1, rhs, false, 0,
-        );
+        let st = time_linear_system(LinearSystemPhase::BackSolve, || {
+            self.backend.multi_solve(
+                false, // new_matrix=false ⇒ reuse cached factor
+                irn, jcn, 1, rhs, false, 0,
+            )
+        });
         match st {
             ESymSolverStatus::Success => Ok(()),
             other => Err(QpError::LinearSolverFailure(format!(

--- a/crates/pounce-qp/tests/convex_timing_rows.rs
+++ b/crates/pounce-qp/tests/convex_timing_rows.rs
@@ -1,0 +1,86 @@
+//! gh #767: the active-set engine's linear algebra charges the convex path's
+//! timing rows.
+//!
+//! The convex driver's `print_timing_statistics` report splits the solve into
+//! symbolic factorization / numeric factorization / back-solve, and it draws
+//! those three rows from whichever linear-algebra layer actually ran. The
+//! interior-point engines go through `pounce_linsol::Factorization`; the
+//! parametric active-set engine goes through this crate's [`LinearSolver`]
+//! instead, and an uninstrumented one would report a solve it spent every
+//! second of as costing nothing in the linear system — the same "0% for every
+//! phase" report the issue is about, one engine down.
+//!
+//! Asserted on the raw wall-clock totals, not the printed rows: `Instant`
+//! resolves nanoseconds, so any real work is strictly positive even when the
+//! report's three-decimal row rounds it to `0.000s`.
+
+use pounce_common::timing::{ConvexTimingScope, ConvexTimingStatistics};
+use pounce_qp::LinearSolver;
+use pounce_qp::kkt::KktTriplet;
+use std::rc::Rc;
+
+/// `[[4, 1], [1, 3]]` in 1-based lower-triangle triplets — symmetric positive
+/// definite, so the factor succeeds and `resolve` has something to reuse.
+fn spd_2x2() -> KktTriplet {
+    KktTriplet {
+        dim: 2,
+        irn: vec![1, 2, 2],
+        jcn: vec![1, 1, 2],
+        vals: vec![4.0, 1.0, 3.0],
+    }
+}
+
+#[test]
+fn the_active_set_linear_solver_charges_each_convex_timing_row() {
+    let stats = Rc::new(ConvexTimingStatistics::new());
+    let scope = ConvexTimingScope::open(&stats);
+
+    let mut solver = LinearSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let kkt = spd_2x2();
+
+    let mut rhs = vec![1.0, 2.0];
+    solver
+        .factorize_and_solve(&kkt, &mut rhs, None)
+        .expect("SPD KKT factors");
+    assert!(
+        stats
+            .linear_system_symbolic_factorization
+            .total_wallclock_time()
+            > 0.0,
+        "the structure pass must charge the symbolic row"
+    );
+    assert!(
+        stats.linear_system_factorization.total_wallclock_time() > 0.0,
+        "the numeric factor must charge the factorization row"
+    );
+    assert_eq!(
+        stats.linear_system_back_solve.total_wallclock_time(),
+        0.0,
+        "`factorize_and_solve`'s substitution is part of the factor call, not a \
+         separate back-solve — no `resolve` has run yet"
+    );
+
+    let after_factor = stats.linear_system_factorization.total_wallclock_time();
+    let mut rhs2 = vec![3.0, 4.0];
+    solver.resolve(&mut rhs2).expect("cached factor resolves");
+    assert!(
+        stats.linear_system_back_solve.total_wallclock_time() > 0.0,
+        "`resolve` must charge the back-solve row"
+    );
+    assert_eq!(
+        stats.linear_system_factorization.total_wallclock_time(),
+        after_factor,
+        "reusing the cached factor must not be charged as a factorization"
+    );
+
+    // Outside a scope nothing is charged: this type is also reached from the
+    // NLP-side SQP subproblem reader, which keeps its own timers.
+    drop(scope);
+    let before = stats.linear_system_back_solve.total_wallclock_time();
+    solver.resolve(&mut [5.0, 6.0]).expect("resolve");
+    assert_eq!(
+        stats.linear_system_back_solve.total_wallclock_time(),
+        before,
+        "a closed scope must record nothing"
+    );
+}

--- a/crates/pounce-solve-report/src/console.rs
+++ b/crates/pounce-solve-report/src/console.rs
@@ -607,6 +607,35 @@ pub fn print_convex_summary(
     println!();
 }
 
+/// The end-of-run verdict block for the convex path: wall-clock total,
+/// `EXIT:` banner, and the `POUNCE <version>:` line — the same three lines,
+/// in the same order and spelling, that [`print_summary`] ends the NLP
+/// path's log with.
+///
+/// gh #767: the convex log stopped after the residual block, with no `EXIT:`
+/// banner and no terminal status of any kind. `benchmarks/scripts/run_nl_bench.sh`
+/// already compensates with a ladder of convex-specific stdout scrapes, so
+/// every *other* consumer of the CLI had to reimplement that ladder to learn
+/// how a convex-routed solve ended. The phrases come from [`status_message`],
+/// the table the NLP path prints from, so a consumer that recognises Ipopt's
+/// end-of-run vocabulary needs no convex-specific case at all.
+///
+/// The caller supplies the status already mapped onto the NLP-side
+/// [`ApplicationReturnStatus`] (the CLI's `qp_status_to_ars`), for the same
+/// reason: one status vocabulary across both engines.
+pub fn print_convex_end(status: ApplicationReturnStatus, total_seconds: f64) {
+    println!();
+    println!("Total seconds in POUNCE                              = {total_seconds:.3}");
+    println!();
+    println!("EXIT: {}", status_message(status));
+    println!();
+    println!(
+        "POUNCE {}: {}",
+        env!("CARGO_PKG_VERSION"),
+        status_message(status)
+    );
+}
+
 /// Format a number in Ipopt's scientific notation: 16-digit mantissa,
 /// signed 2-digit exponent (e.g. `3.7952009505566139e+03`). Rust's
 /// `{:.16e}` is close but emits a 1-digit exponent without leading

--- a/crates/pounce-solve-report/src/lib.rs
+++ b/crates/pounce-solve-report/src/lib.rs
@@ -292,6 +292,24 @@ pub struct SolutionInfo {
     /// `SolveSucceeded`, `MaximumIterationsExceeded`, etc. The string
     /// form is the Rust enum variant name verbatim.
     pub status: ApplicationReturnStatus,
+    /// The same verdict in upstream Ipopt's C enumerator spelling —
+    /// `Solve_Succeeded`, `Infeasible_Problem_Detected` — from
+    /// `IpReturnCodes_inc.h`.
+    ///
+    /// [`Self::status`] carries the Rust variant name, which is *not* the
+    /// name any Ipopt-facing consumer already keys off: CUTEst status
+    /// tables, `benchmarks/scripts/run_nl_bench.sh`, the reference JSONs
+    /// under `benchmarks/*/ipopt_ma57.json` and the CLI's own `Status:`
+    /// line all spell it with separators. A consumer comparing
+    /// `solution.status == "Solve_Succeeded"` against the report matched
+    /// nothing and silently classified every solve as a failure (gh #767).
+    /// This field is that spelling, so the comparison can be literal.
+    ///
+    /// Derived from [`Self::status`] by [`ReportBuilder::finish`] — never
+    /// set by a caller, so the two cannot disagree. Empty when read back
+    /// from a pre-#767 report.
+    #[serde(default)]
+    pub status_upstream: String,
     /// AMPL-style solve-result code (Gay 2005, §5 p. 23 table).
     pub solve_result_num: i32,
     /// Final unscaled objective value (mirrors
@@ -421,6 +439,8 @@ impl ReportBuilder {
             },
             solution: SolutionInfo {
                 status: ApplicationReturnStatus::InternalError,
+                // Overwritten from `status` by `finish`; see the field docs.
+                status_upstream: String::new(),
                 solve_result_num: 500,
                 // 0.0 (not NaN) so JSON round-trips. Callers that
                 // need "unknown objective" semantics check
@@ -476,6 +496,12 @@ impl ReportBuilder {
             .elapsed()
             .map(|d| d.as_secs_f64())
             .unwrap_or(0.0);
+        // Derived here rather than at each call site: every producer of a
+        // report (CLI, C interface, Python bindings, the CBF driver) sets
+        // `solution.status` and none of them can forget the upstream
+        // spelling, nor set one that disagrees with the other (gh #767).
+        let mut solution = self.solution;
+        solution.status_upstream = solution.status.upstream_name().to_string();
         let result_id = format!("{}-{}", self.started_unix_nanos, std::process::id());
         let created_at_iso = unix_nanos_to_iso(self.started_unix_nanos);
 
@@ -497,7 +523,7 @@ impl ReportBuilder {
                 environment: capture_solve_env_overrides(),
             },
             problem: self.problem,
-            solution: self.solution,
+            solution,
             statistics: self.stats,
             iterations: self.iterations,
             linear_solver: self.linear_solver,
@@ -741,6 +767,49 @@ mod tests {
             back.solution.status,
             ApplicationReturnStatus::SolveSucceeded,
         ));
+    }
+
+    /// gh #767: the report is the FAIR-aligned machine surface, and a
+    /// consumer keyed on Ipopt's own enumerator spelling — which is what
+    /// CUTEst tables, the reference JSONs and the CLI's `Status:` line all
+    /// use — must be able to compare a field literally. `status` carries
+    /// the Rust variant name (`SolveSucceeded`); `status_upstream` carries
+    /// `Solve_Succeeded`. A consumer that compared the former against the
+    /// latter's spelling matched nothing and read every solve as a failure.
+    #[test]
+    fn report_carries_the_upstream_status_spelling_beside_the_rust_one() {
+        let mut b = ReportBuilder::new(
+            ReportDetail::Summary,
+            InputDescriptor::Builtin {
+                name: "rosenbrock".into(),
+            },
+        );
+        b.solution.status = ApplicationReturnStatus::SolveSucceeded;
+        let json = serde_json::to_value(b.finish()).expect("serialize");
+        assert_eq!(json["solution"]["status"], "SolveSucceeded");
+        assert_eq!(json["solution"]["status_upstream"], "Solve_Succeeded");
+    }
+
+    /// The derived field tracks whatever `status` was last set to — it is
+    /// computed in `finish`, so a caller cannot leave it stale or set the
+    /// two to different verdicts.
+    #[test]
+    fn upstream_status_spelling_is_derived_not_stored() {
+        for status in [
+            ApplicationReturnStatus::MaximumIterationsExceeded,
+            ApplicationReturnStatus::InfeasibleProblemDetected,
+            ApplicationReturnStatus::SolvedToAcceptableLevel,
+        ] {
+            let mut b = ReportBuilder::new(
+                ReportDetail::Summary,
+                InputDescriptor::Builtin { name: "x".into() },
+            );
+            // Deliberately wrong; `finish` must overwrite it.
+            b.solution.status_upstream = "Solve_Succeeded".to_string();
+            b.solution.status = status;
+            let report = b.finish();
+            assert_eq!(report.solution.status_upstream, status.upstream_name());
+        }
     }
 
     #[test]

--- a/docs/src/schema/solve-report-v1.md
+++ b/docs/src/schema/solve-report-v1.md
@@ -36,7 +36,7 @@ verified via Crossref on 2026-05-14):
 |---|---|
 | **F**indable | `result_id` (`<unix_nanos>-<pid>`, globally unique and time-ordered), `created_at_iso`, `created_at_unix_nanos`. |
 | **A**ccessible | Plain-text JSON on disk; no protocol gating; UTF-8. Same trust model as the `.sol` file. |
-| **I**nteroperable | Schema-versioned (`pounce.solve-report/v1`); JSON primitives only (no binary blobs); units documented per-field below; `solution.status` is the enum-variant string for cross-language consumption. |
+| **I**nteroperable | Schema-versioned (`pounce.solve-report/v1`); JSON primitives only (no binary blobs); units documented per-field below; `solution.status` is the enum-variant string for cross-language consumption, beside `solution.status_upstream` in IPOPT's own enumerator spelling. |
 | **R**eusable | `solver` (name + version + git commit + target triple), `license`, `input` (kind + path + size), and `environment` (solve-affecting env-var overrides in force) capture enough provenance to reproduce a solve. |
 
 ## Versioning policy
@@ -162,6 +162,7 @@ Problem dimensions reported by the TNLP at `get_nlp_info()`.
 | Field | Type | Notes |
 |---|---|---|
 | `status` | string | `ApplicationReturnStatus` enum variant name verbatim (e.g. `"SolveSucceeded"`, `"MaximumIterationsExceeded"`). |
+| `status_upstream` | string | The same verdict in upstream IPOPT's C enumerator spelling from `IpReturnCodes_inc.h` (e.g. `"Solve_Succeeded"`, `"Infeasible_Problem_Detected"`) — the spelling CUTEst status tables, the CLI's own `Status:` line and the reference JSONs under `benchmarks/*/ipopt_ma57.json` all use. Derived from `status`, so the two can never disagree. Compare against this field, not `status`, when your consumer already keys off IPOPT's names. Added after `pounce.solve-report/v1` shipped; absent from reports written by pounce ≤ 0.10.0. |
 | `solve_result_num` | integer | AMPL-style solve-result code (Gay 2005, "Hooking Your Solver to AMPL" §5, p. 23 table): 0 = solved, 100-range = warning, 200-range = infeasible, 400-range = limit reached, 500-range = failure. Within the solved range, `0` is `SolveSucceeded` and `1` is `SolvedToAcceptableLevel` — IPOPT's codes ([solution output](../solution-output.md#solved-strict-vs-acceptable)). Identical to the `objno` code in the `.sol`. |
 | `objective` | float | Final unscaled objective value. `0.0` (not NaN) when the solve never completed; check `statistics.iteration_count > 0` to distinguish. |
 | `x` | array of float \| empty | Primal vector, length `problem.n_variables`. Empty when the binary doesn't capture the final iterate (currently: `pounce` on the `newton_driver` fast-path). Omitted from JSON when empty. |
@@ -319,6 +320,7 @@ Levels map to verbosity in the same spirit as upstream's `print_level`
   "problem": { "n_variables": 5, "n_constraints": 4, "n_objectives": 1, "minimize": true },
   "solution": {
     "status": "SolveSucceeded",
+    "status_upstream": "Solve_Succeeded",
     "solve_result_num": 0,
     "objective": 0.5510204081632656,
     "x":      [0.6326530575201161, 0.3877551079678144, 0.020408165487930466, 5.0, 1.0],

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -354,6 +354,14 @@ shipped — if you are parsing pounce's output, read `Status:` and ignore the
 banners. It carries the upstream IPOPT enumerator spelling
 (`Infeasible_Problem_Detected`, `Maximum_Iterations_Exceeded`, …).
 
+The specialized convex engines (LP / QP interior-point, the parametric
+active-set QP engine, and the conic QCQP engine) print the same `EXIT:` block
+and the same `Status:` line, in the same spelling, so a parser needs no
+convex-specific case. If you are reading the JSON report rather than the log,
+compare against `solution.status_upstream`, which carries that spelling;
+`solution.status` is the Rust enum-variant name (`Solve_Succeeded` vs
+`SolveSucceeded`) and does not match IPOPT's tables.
+
 The two rungs probe different things, and the distinction matters when
 you are reading a log:
 

--- a/python/tests/test_gams_link.py
+++ b/python/tests/test_gams_link.py
@@ -271,6 +271,10 @@ def test_solve_view_writes_solve_report(tmp_path):
     doc = json.loads(report.read_text())
     assert doc["schema"] == "pounce.solve-report/v1"
     assert doc["solution"]["status"] == "SolveSucceeded"
+    # gh #767: every producer of a report derives the upstream spelling in
+    # `ReportBuilder::finish`, so the Python route carries it too — a GAMS
+    # consumer comparing against IPOPT's own enumerator names matches.
+    assert doc["solution"]["status_upstream"] == "Solve_Succeeded"
     assert doc["problem"]["n_variables"] == 4
     assert doc["problem"]["n_constraints"] == 2
     # `full` detail carries the per-iteration trace the studio/MCP post-mortem


### PR DESCRIPTION
Fixes #767

## Problem

Three ways the convex path's end-of-run reporting differs from the NLP path's, all found while instrumenting the Mittelmann suite (2 of 47 instances route convex).

Same model, same options, before and after — `convex_qp_share1b.nl` at `solver_selection=qp-ipm print_timing_statistics=yes`:

| | timing block | `EXIT:` banner | `Status:` line | `solution.status_upstream` |
|---|---|---|---|---|
| before (`1b719e8`) | absent | absent | absent | absent |
| after | 8 rows, 0.371 s attributed | `Optimal Solution Found.` | `Solve_Succeeded` | `Solve_Succeeded` |

Status, objective and iteration count are identical across that pair; only the reporting moved.

1. **`print_timing_statistics=yes` was accepted, reported `(used)` by `print_user_options`, and emitted nothing.** A tool attributing solve cost by phase then read 0% for *every* phase of a convex-routed instance — which reads as "already fast", not "not measured". `bearing_400` ran 9.8 s and printed no timer at all.
2. **The log ended after the residual block** — no `EXIT:`, no terminal status. `benchmarks/scripts/run_nl_bench.sh` already prefers a `Status:` line and falls back to its ladder of convex-specific stdout scrapes only because nothing emitted one; every other consumer of the CLI had to reimplement that ladder.
3. **The JSON report's status spelling matches nothing an IPOPT-facing consumer keys off.** The issue describes this as the two paths disagreeing — `pounce-nlp` writing `Solve_Succeeded` and `pounce-convex` writing `SolveSucceeded`. That is not what happens: there is one `SolutionInfo` and one serializer, and both paths write `"SolveSucceeded"`. What differed was the *surface* — the NLP path printed a `Status: Solve_Succeeded` line and the convex path printed nothing, so on a convex-routed solve the JSON was the only status visible. The underlying complaint stands either way: CUTEst status tables, the reference JSONs under `benchmarks/*/ipopt_ma57.json` and our own `Status:` line all spell it `Solve_Succeeded`, so a consumer comparing against that matched nothing and silently classified every solve as a failure.

## Cause

Items 1 and 2 are the same absence: `run_convex_qp` / `run_convex_socp` never had the reporting `Application::emit_end_summary` does for the NLP path. Nothing consumed `print_timing_statistics` on this path, and no code emitted a banner or a status line — the drivers returned straight from the residual block into the `.sol` / JSON writes.

Item 3 is that `SolutionInfo::status` serializes through `ApplicationReturnStatus`'s serde derive, i.e. the Rust variant name. `upstream_name()` — the spelling the CLI prints — existed but was never reflected into the report.

## Fix

**Timing.** Both convex drivers build a `ConvexTimingStatistics` (new, in `pounce-common`, beside `TimingStatistics`) and print it in the NLP path's row layout. `OverallAlgorithm` and the three `LinearSystem*` rows keep the NLP labels because they are the same quantities; the rest are the stages this path actually has — `ProblemExtraction`, `Presolve` (including the postsolve lift), `ConvexSolve`, `SolutionRecovery`.

Reusing the NLP `TimingStatistics` struct was the first thing tried and rejected: most of its rows are eval-callback and Hessian-update counters the convex path has no analogue for, so a shared struct would print a screenful of structural zeros — the same "0% everywhere" reading this PR exists to remove, just with more output.

The linear-algebra rows are charged through a thread-local sink (`ConvexTimingScope`), because the crates that do the factoring sit several layers below the driver that wants the numbers and neither takes a timing argument. That is the shape `pounce_convex`'s solve deadline already uses. Threading a parameter down instead would have touched every `Factorization` and `LinearSolver` signature and every caller on both paths, for a number only the convex CLI driver reads.

**Both** engines are instrumented at their own choke point — `pounce_linsol::Factorization` for the interior-point drivers, `pounce_qp::LinearSolver` for the parametric active-set engine. The second one is not optional: with only the first done, an active-set solve of `convex_qp_share1b` spent 51.7 s in `ConvexSolve` and reported `LinearSystemFactorization: 0.000s` — this issue's exact failure mode, one engine down.

**Verdict.** `print_convex_end` in `pounce-solve-report` emits the same three lines `print_summary` ends the NLP log with, phrased from the same `status_message` table via the CLI's `qp_status_to_ars`, so there is one status vocabulary across both engines. Gated exactly as the NLP path gates its own: `print_level >= 1`, and no `Status:` line under `--debug-json` (stdout is a protocol channel there). A convex attempt that declines to the NLP path (#535, `socp_nlp_fallback`) returns before this point, so a rerouted run still prints exactly one verdict, not two.

**Report.** `solution.status_upstream`, derived from `status` in `ReportBuilder::finish` rather than at each call site, so no producer (CLI, C interface, Python bindings, the CBF driver) can forget it or set the two to different verdicts. `status` keeps its documented meaning.

## Blast radius

`scripts/sweep-fixtures.sh`, both legs, against `1b719e8`: **empty diff over all 142 fixture-legs** — status, objective, iteration count and engine all bit-identical. The corpus covers all three arms this PR touches (70 legs `cvx-qp`, 10 `cvx-qcqp`, 62 `nlp`). That is the expected result for a change that adds instrumentation and output without touching a step computation, and it is worth having because the fix does restructure both convex drivers' control flow to scope the timing guards.

Adding a field to the JSON report is non-breaking by the schema's own rules, so `pounce.solve-report/v1` is unchanged. Nothing in the tree deserializes reports with `deny_unknown_fields`, so existing consumers — `python/tests/test_gams_link.py`, `benchmarks/cblib/run_cblib.py`, `pounce-studio-core` — are unaffected; `run_cblib.py`'s hand-rolled `status_underscored` now prefers the field and keeps the regex as a fallback for older reports.

When no timing scope is open — every non-CLI caller of these crates, and the whole NLP path — `time_linear_system` is one thread-local read and no clock syscalls.

## Tests

`crates/pounce-cli/tests/issue_767_convex_path_reports_like_nlp.rs` runs every convex arm the router can reach (QP/LP interior-point, active-set, conic QCQP), pinning `solver_selection` per arm so a routing change cannot silently turn one leg into a copy of another.

Run against `1b719e8` with the `status_upstream` reference removed so the rest compiles, 3 of 7 fail, each for its own stated reason:

- `print_timing_statistics_attributes_the_solve_on_every_convex_arm` — *"LP, interior-point: no timing block"* (item 1)
- `every_convex_arm_ends_with_an_exit_banner_and_a_status_line` — *"LP, interior-point: no EXIT: banner"* (item 2)
- `the_timing_block_is_absent_without_the_option` — its second assertion, that a default solve still prints `EXIT:` (item 2)

The remaining four (`timing_statistics_alone_does_not_print`, `print_level_zero_suppresses_the_convex_verdict`, `json_debug_keeps_the_status_line_off_stdout`, `a_convex_attempt_that_declines_leaves_no_status_line`) pass on the parent, and are meant to: they assert an *absence*, which is trivially true where nothing is printed at all. They are guards on the new output's gating, not regression pins, and they bite on any future change that prints a verdict where one is not wanted. Item 3's test does not compile on the parent (`no field status_upstream on type SolutionInfo`), as does `pounce-qp/tests/convex_timing_rows.rs` (`unresolved import ConvexTimingScope`).

The CLI test's magnitude claims are deliberately conditional: rows print three decimals, so a sub-millisecond fixture legitimately reads `0.000s` and asserting otherwise would flake on a faster machine. That the instrumentation exists at all is pinned per engine, on raw nanosecond totals rather than printed rows, by `pounce-linsol`'s `a_convex_timing_scope_charges_each_phase_to_its_own_row` and `pounce-qp`'s `tests/convex_timing_rows.rs` — each of which also checks that a back-solve is not charged as a factorization, and that a closed scope records nothing.

`python/tests/test_gams_link.py` gains one line asserting the Python route carries `status_upstream` too. It is the only assertion here I could not run locally (no maturin in this container); the mechanism is the shared `ReportBuilder::finish` the Rust tests cover.

Not pinned, and a known gap: the rest of the convex console (the class/solver banner, the one-line result, the residual block) still ignores `print_level` entirely. That is pre-existing; only the new lines are gated.

`cargo test --workspace --exclude pounce-hsl`: 3513 passed, 0 failed. `cargo fmt --all --check`, CI's clippy gate, and `scripts/check-release-consistency.sh` all clean.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new — `docs/src/schema/solve-report-v1.md` documents `status_upstream`; `docs/src/troubleshooting.md` says the convex path prints the same `Status:` line. Both are existing pages, no `SUMMARY.md` change.
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLV6tfq2aXN4ykUBQ3oDzT)_