### PR TITLE
convex: escalate the primal (x,x) regularization on wrong inertia, and budget the gh #293 LP retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,73 @@ changes.
   It is an added field, which the schema documents as non-breaking, so
   `pounce.solve-report/v1` is unchanged; reports written by pounce ≤ 0.10.0
   do not carry it.
+- **The convex arm now escalates the primal `(x,x)` regularization when the
+  factorization reports wrong inertia**, which is what Ipopt's Algorithm IC
+  does and what POUNCE was missing. LP+QP corpus (509 problems, no NLP
+  fallback): **1261.3 s -> 605.7 s (-52.0%), 4 verdicts gained, 0 lost, 0
+  objective moves above 1e-6 relative.** `gen` and `gen1` go from 174 s at the
+  199-iteration cap (`Solved to acceptable level`) to 2.8 s in 18 iterations
+  (`Optimal`); `df2177` from 78 s at the cap to 0.66 s in 9; `dsbmip` from the
+  cap to `Optimal`.
+
+  `KktStructure::build` wrote `P + reg*I` into the `(x,x)` block once and
+  nothing ever rewrote it — `update_blocks` touches only the cone blocks,
+  `update_eq_reg` only the `y` diagonal. For an LP `P = 0`, so that block *is*
+  the regularization, frozen at the 1e-10 static default for the life of the
+  solve. Against a Jacobian with entries O(1) that leaves the x-pivots on the
+  roundoff floor and LDL^T loses their signs. The driver read the result back
+  as a wrong-inertia deficit and escalated `delta_c` and the `(z,z)`
+  regularization — neither of which can repair a defect living in `(x,x)` — so
+  it refactored, saw the same deficit, and escalated again until the try budget
+  was gone. On `gen`: 4.19 refactorizations per iteration, a mean first-try
+  deficit of 134.8 eigenvalues, 376 of 400 iterations starting wrong. Pinning
+  `(x,x)` alone at 1e-6 takes that solve from 176.04 s to 1.69 s; moving only
+  `delta_c` and `(z,z)` gets 113.02 s.
+
+  Escalated, not raised statically. A static 1e-6 fixes `gen` and looks
+  spectacular in isolation, but costs 48 verdicts across the corpus and shifts
+  `pilot.we`'s objective by 12% while still certifying `Optimal` — the
+  regularized problem is a different problem. And `delta_w` is staged *ahead
+  of* `delta_c`/`(z,z)` rather than raised alongside them: bumping all three
+  together drags `delta_c` up on iterates that never needed it, which is the
+  #218 ratchet (`delta_c*||dy||` biases the equality residual and floors
+  `pres` permanently) and cost `cq5` and `maros` their `Optimal` verdict in a
+  first draft. Problems without the defect pay nothing — `pilot.we`, `forplan`,
+  `greenbea` and `pilot87` return bit-identical objectives.
+
+  `scripts/sweep-fixtures.sh` moves exactly one line, identically on both legs:
+  `lp_degen2`, the corpus's one degenerate LP on this arm, 20 -> 18 iterations
+  with the objective agreeing to 10 significant figures (-1435.178018 ->
+  -1435.178017, relative 2.1e-10). It crosses the termination threshold two
+  iterations earlier rather than settling to a worse point; both exits are
+  `Optimal`. The ~20 other LP/QP/QCQP fixtures on the same arm are
+  byte-identical.
+
+- **The gh #293 equilibrated retry is capped at half the budget for a pure LP
+  whose first solve merely failed to converge.** The retry re-solves with Ruiz
+  equilibration and re-runs the full `max_iter`; for an LP that is almost
+  always wasted, since every accepted LP retry in the corpus converged by
+  iteration 78 while every one that ran to the 199-iteration cap was
+  discarded.
+
+  Two gates, both load-bearing. `P = 0`, because equilibration exists to
+  surface curvature the NT scaling cannot see and a QP retry genuinely needs
+  the room — `QSCFXM1/2/3` and `Q25FV47` are accepted at 131-168 iterations and
+  a flat cap would demote four clean `Optimal` results. And
+  `IterationLimit | OptimalInaccurate` rather than `NumericalFailure`, because a
+  `NumericalFailure` first solve accepts a retry on status alone, so a cap
+  there could *manufacture* an `IterationLimit` and have it accepted —
+  reporting "Maximum iterations exceeded" where the honest answer is "Numerical
+  failure". `issue_535_lp_falls_back_to_nlp` pins that.
+
+  Measured on its own against the previous behaviour this was worth 124.6 s,
+  concentrated in `gen` -47.9, `gen1` -47.5, `df2177` -19.8, `complex` -9.6.
+  **Stacked on the `(x,x)` regularization fix above it is worth -0.4 s (-0.1%),
+  which is the noise floor**: `gen`, `gen1` and `df2177` now converge on the
+  first solve and never reach the retry at all. What survives is `complex`
+  -9.2 s and `pilot.ja` -1.1 s, the two LPs that still hit the cap on the first
+  solve and still pay for a rejected retry. It is kept for those and for the
+  correctness of the two gates, not for the original headline number.
 
 - **The default-on `mu_strategy_fallback` retry now takes
   `Solved_To_Acceptable_Level`, when the caller left the convergence

--- a/crates/pounce-convex/src/hsde.rs
+++ b/crates/pounce-convex/src/hsde.rs
@@ -98,6 +98,23 @@ const DYN_REG_RES_TOL: f64 = 1e-8;
 /// new primal residual at `δ_c·‖dy‖`, and as `μ → 0` both `δ_c` and `dy`
 /// shrink, so that residual drives to zero (Ipopt's convergence argument on
 /// degenerate equality systems).
+/// Primal `(x, x)` regularization δ_w, escalated on wrong inertia — Ipopt's
+/// Algorithm IC knob, which the HSDE loop previously had no way to move.
+/// For an LP the `(x, x)` block *is* δ_w (`P = 0`), so at the 1e-10 static
+/// default its pivots sit at the roundoff floor and the factorization loses
+/// their signs; escalating `δ_c` / `(z, z)` cannot repair a defect that lives
+/// in `(x, x)`. Measured on NETLIB `gen`: 4.19 extra refactorizations per
+/// iteration and a 134-eigenvalue mean inertia deficit at the static default,
+/// both going to zero once δ_w reaches ~1e-6.
+///
+/// Escalated, not raised statically: a static 1e-6 fixes `gen` (199 → 16
+/// iterations) but biases `pilot.we`'s objective by 12% while still
+/// certifying Optimal — the regularized problem is a different problem. Only
+/// the iterates that actually show a deficit should pay.
+const DELTA_W_INIT: f64 = 1e-8;
+const DELTA_W_FACTOR: f64 = 10.0;
+const DELTA_W_MAX: f64 = 1e-4;
+
 const DELTA_C_INIT: f64 = 1e-8;
 const DELTA_C_FACTOR: f64 = 10.0;
 const DELTA_C_MAX: f64 = 1e-1;
@@ -416,6 +433,12 @@ where
     // record at the converged iterate (α = 0).
     let mut trace: Vec<QpIterate> = Vec::new();
 
+    // Latched once δ_w has climbed to its cap without curing the defect: on
+    // that solve the rank loss is not in `(x, x)`, so re-probing the whole
+    // δ_w ladder every subsequent iteration is pure wasted factorization.
+    // Only the *decision* is carried across iterations — the δ values
+    // themselves still reset, unlike a regularization warm start.
+    let mut dw_exhausted = false;
     for it in 0..opts.max_iter {
         iters = it;
         if crate::deadline::expired() {
@@ -663,6 +686,10 @@ where
         // slack block keeps `reg_eff`, whose iterate-norm scaling is correct
         // for full-rank large-dual problems (LISWET).
         let mut delta_c = crate::ipm::adaptive_eq_reg(mu, opts.reg);
+        // δ_w on the (x,x) primal block. Starts at the static `opts.reg` — no
+        // change from the previous behaviour on a healthy iterate — and is
+        // escalated below only when the factorization reports a defect.
+        let mut delta_w = opts.reg;
         // Correct KKT inertia has one negative eigenvalue per equality and per
         // inequality row; the SOC auxiliary variables contribute positives
         // only. Too few negatives ⇒ the factor is an indefinite saddle.
@@ -672,19 +699,33 @@ where
         loop {
             kkt.update_blocks(cone, &s, &z, reg_eff, &mut kkt_vals);
             kkt.update_eq_reg(delta_c, &mut kkt_vals);
+            kkt.update_primal_reg(delta_w, &mut kkt_vals);
 
             // Escalation budget (tries + per-block ceilings) and the bump that
             // raises δ_c (equality/Jacobian reg) and the (z,z) reg together.
             // `macro` would be cleaner, but inlined to keep the borrow trivial.
-            let budget =
-                tries < INERTIA_MAX_TRIES && (delta_c < DELTA_C_MAX || reg_eff < DYN_REG_MAX);
+            let budget = tries < INERTIA_MAX_TRIES
+                && (delta_c < DELTA_C_MAX || reg_eff < DYN_REG_MAX || delta_w < DELTA_W_MAX);
 
             match fact.refactor(&kkt_vals) {
                 Err(_) => {
                     // Singular factorization: rank-deficient KKT. Escalate.
                     if budget {
-                        delta_c = (delta_c.max(DELTA_C_INIT) * DELTA_C_FACTOR).min(DELTA_C_MAX);
-                        reg_eff = (reg_eff * DYN_REG_FACTOR).min(DYN_REG_MAX);
+                        // Staged ladder: δ_w answers wrong inertia (Ipopt
+                        // Algorithm IC). Only once δ_w has saturated without
+                        // curing it does the defect look like something other
+                        // than a (x,x) rank loss, and the older δ_c / (z,z)
+                        // knobs take over. Bumping all three together drags
+                        // δ_c up on iterates that never needed it — the gh
+                        // #218 ratchet — which costs cq5 and maros their
+                        // Optimal verdict.
+                        if dw_exhausted || delta_w >= DELTA_W_MAX {
+                            dw_exhausted = true;
+                            delta_c = (delta_c.max(DELTA_C_INIT) * DELTA_C_FACTOR).min(DELTA_C_MAX);
+                            reg_eff = (reg_eff * DYN_REG_FACTOR).min(DYN_REG_MAX);
+                        } else {
+                            delta_w = (delta_w.max(DELTA_W_INIT) * DELTA_W_FACTOR).min(DELTA_W_MAX);
+                        }
                         tries += 1;
                         continue;
                     }
@@ -697,8 +738,21 @@ where
                     let wrong_inertia =
                         matches!(fact.number_of_neg_evals(), Some(n) if n < expected_neg);
                     if wrong_inertia && budget {
-                        delta_c = (delta_c.max(DELTA_C_INIT) * DELTA_C_FACTOR).min(DELTA_C_MAX);
-                        reg_eff = (reg_eff * DYN_REG_FACTOR).min(DYN_REG_MAX);
+                        // Staged ladder: δ_w answers wrong inertia (Ipopt
+                        // Algorithm IC). Only once δ_w has saturated without
+                        // curing it does the defect look like something other
+                        // than a (x,x) rank loss, and the older δ_c / (z,z)
+                        // knobs take over. Bumping all three together drags
+                        // δ_c up on iterates that never needed it — the gh
+                        // #218 ratchet — which costs cq5 and maros their
+                        // Optimal verdict.
+                        if dw_exhausted || delta_w >= DELTA_W_MAX {
+                            dw_exhausted = true;
+                            delta_c = (delta_c.max(DELTA_C_INIT) * DELTA_C_FACTOR).min(DELTA_C_MAX);
+                            reg_eff = (reg_eff * DYN_REG_FACTOR).min(DYN_REG_MAX);
+                        } else {
+                            delta_w = (delta_w.max(DELTA_W_INIT) * DELTA_W_FACTOR).min(DELTA_W_MAX);
+                        }
                         tries += 1;
                         continue;
                     }

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -3518,6 +3518,19 @@ pub(crate) struct KktStructure {
     /// converge below `tol` instead of flooring the primal residual at
     /// `δ·‖dy‖`. Empty when there are no equality rows.
     y_diag_pos: Vec<usize>,
+    /// Value-array positions of the `(x, x)` diagonal, one per column, and
+    /// the `P` diagonal that sits under the regularization. Seeded with
+    /// `P + reg` in [`Self::build`] and overwritten each iteration with
+    /// `P + δ_w` by [`Self::update_primal_reg`].
+    ///
+    /// For an LP `P = 0`, so this block *is* the regularization: at the
+    /// 1e-10 static default the x-pivots sit at the roundoff floor and LDLᵀ
+    /// loses their signs, which reads out as a wrong-inertia deficit that no
+    /// amount of `δ_c` / `(z, z)` escalation can repair — those bumps are on
+    /// the wrong blocks. Ipopt's Algorithm IC escalates exactly this δ_w for
+    /// wrong inertia; `δ_c` answers a rank-deficient equality Jacobian.
+    x_diag_pos: Vec<usize>,
+    x_diag_base: Vec<f64>,
 }
 
 impl KktStructure {
@@ -3536,9 +3549,15 @@ impl KktStructure {
             *entries.entry((r, c)).or_insert(0.0) += v;
         };
 
-        // (x,x): P + δI.
+        // (x,x): P + δ_w I. The P diagonal is captured before the
+        // regularization is folded in so `update_primal_reg` can rewrite δ_w
+        // each iteration without losing P.
+        let mut x_diag_base = vec![0.0f64; n];
         for t in &prob.p_lower {
             add(t.row, t.col, t.val);
+            if t.row == t.col {
+                x_diag_base[t.row] += t.val;
+            }
         }
         for i in 0..n {
             add(i, i, reg);
@@ -3644,6 +3663,7 @@ impl KktStructure {
         // per-iteration adaptive regularization. Built unconditionally; the
         // `-reg` seed is already in `values` from the loop above.
         let y_diag_pos: Vec<usize> = (0..m_eq).map(|i| coord_to_pos[&(n + i, n + i)]).collect();
+        let x_diag_pos: Vec<usize> = (0..n).map(|i| coord_to_pos[&(i, i)]).collect();
 
         KktStructure {
             airn,
@@ -3652,6 +3672,8 @@ impl KktStructure {
             dim,
             z_blocks,
             y_diag_pos,
+            x_diag_pos,
+            x_diag_base,
         }
     }
 
@@ -3717,6 +3739,15 @@ impl KktStructure {
     pub(crate) fn update_eq_reg(&self, delta_c: f64, out: &mut [Number]) {
         for &p in &self.y_diag_pos {
             out[p] = -delta_c;
+        }
+    }
+
+    /// Overwrite the `(x, x)` diagonal with `P + δ_w` for the current primal
+    /// regularization. Call once per iteration, on the same `out` buffer as
+    /// [`Self::update_blocks`] / [`Self::update_eq_reg`].
+    pub(crate) fn update_primal_reg(&self, delta_w: f64, out: &mut [Number]) {
+        for (&p, &base) in self.x_diag_pos.iter().zip(&self.x_diag_base) {
+            out[p] = base + delta_w;
         }
     }
 }

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -463,7 +463,51 @@ where
         if crate::deadline::expired() {
             return mark_timed_out(sol);
         }
-        let retry = equilibrated_solve(prob, opts, /* use_hsde */ true, &mut make_backend);
+        // Budget the retry on a *pure LP*, where its premise does not apply.
+        //
+        // Everything above justifies this retry by Hessian curvature that NT
+        // scaling cannot see: `P = diag(1e-12)` with the optimum at `‖x*‖ ~
+        // 1e12`, where Ruiz lifts `P̂` to O(1) and the same driver then
+        // converges. That is a QP story. A pure LP has `P = 0` — there is no
+        // curvature term for equilibration to surface — so an LP retry is only
+        // ever fixing row/column scaling, and when that works, it works fast.
+        //
+        // Measured over the LP, QP and lpopt corpora (513 problems, 24 retries):
+        // every *accepted* LP retry converged by iteration 78 (24, 30, 32, 32,
+        // 33, 34, 34, 34, 46, 78), while every LP retry that ran to the cap was
+        // discarded — `gen`, `gen1`, `complex`, `df2177`, `dsbmip`, `pilot.ja`,
+        // `de063155`, `irish-electricity`, all 199 iterations, all rejected, all
+        // paying a second full budget to learn nothing. `gen` and `gen1` alone
+        // are 347 s of that corpus and end up on the NLP arm regardless, which
+        // solves them in ~1 s. The `P = 0` gate is why this is not applied
+        // globally: `QSCFXM1/2/3` and `Q25FV47` are accepted at 131–168
+        // iterations, and a flat cap would demote four clean `Optimal` results.
+        //
+        // Half the first solve's budget clears the longest observed LP success
+        // by 22 iterations and scales with a user-set `max_iter`. If an unseen
+        // LP needs more, the failure mode is soft: the retry is rejected, the
+        // first solve's honest non-converged status stands, and under
+        // `solver_selection=auto` gh #535 routes it to the NLP arm — where
+        // these LPs were already going.
+        //
+        // Gated to the two statuses whose acceptance below demands a *certified*
+        // `Optimal`. That restriction is load-bearing, not tidiness: a
+        // first-solve `NumericalFailure` accepts any non-failing retry status as
+        // an improvement on a breakdown, so capping the budget there lets the
+        // cap *manufacture* an `IterationLimit` and have it accepted — reporting
+        // "Maximum iterations exceeded", with the capped retry's iterate, where
+        // the honest answer is "Numerical failure". `lp_afiro` at `qp_tau=0.99`
+        // does exactly this; `issue_535_lp_falls_back_to_nlp` pins it. Under
+        // `IterationLimit`/`OptimalInaccurate` a capped retry can only fail to
+        // certify and be discarded — which is the outcome the cap wants sooner.
+        let mut retry_opts = opts.clone();
+        retry_opts.max_iter = equilibrated_retry_budget(prob, sol.status, opts.max_iter);
+        let retry = equilibrated_solve(
+            prob,
+            &retry_opts,
+            /* use_hsde */ true,
+            &mut make_backend,
+        );
         // An `Optimal` from this retry has to earn the same way the one in
         // [`verify_or_repair_optimum`] does (gh #712). This retry runs *inside*
         // the equilibrated metric, so its own absolute convergence test is
@@ -578,6 +622,23 @@ where
         return sol;
     }
     sol
+}
+
+/// Iteration budget for the gh #293 equilibrated retry — `max_iter` in
+/// general, half that for a pure LP whose first solve merely failed to
+/// converge. See the call site in [`solve_qp_ipm_core`] for the full rationale
+/// and the corpus measurements behind the halving.
+fn equilibrated_retry_budget(prob: &QpProblem, first: QpStatus, max_iter: usize) -> usize {
+    let is_lp = prob.p_lower.iter().all(|t| t.val == 0.0);
+    let certify_or_reject = matches!(
+        first,
+        QpStatus::IterationLimit | QpStatus::OptimalInaccurate
+    );
+    if is_lp && certify_or_reject {
+        max_iter / 2
+    } else {
+        max_iter
+    }
 }
 
 /// Run an equilibrated solve: Ruiz-scale `prob`, solve the scaled problem with
@@ -4837,6 +4898,80 @@ mod objective_constant_metric_tests {
         assert!(slack_is_resolvable(1e-3, 1.0));
         // An exact zero never counts, at any magnitude.
         assert!(!slack_is_resolvable(0.0, 0.0));
+    }
+}
+
+#[cfg(test)]
+/// gh #293 retry budget. The halving is gated on two conditions and both
+/// are load-bearing, so both are pinned here rather than left to the corpus.
+mod equilibrated_retry_budget_tests {
+    use super::equilibrated_retry_budget;
+    use crate::qp::{QpProblem, QpStatus, Triplet};
+
+    fn lp() -> QpProblem {
+        QpProblem {
+            n: 1,
+            p_lower: vec![],
+            c: vec![1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![0.0],
+            ub: vec![1.0],
+        }
+    }
+
+    fn qp() -> QpProblem {
+        QpProblem {
+            p_lower: vec![Triplet::new(0, 0, 2.0)],
+            ..lp()
+        }
+    }
+
+    /// An LP retry that has not converged is only ever accepted as a
+    /// certified `Optimal`, so half a budget is all it can usefully spend.
+    #[test]
+    fn a_stalled_lp_retry_gets_half_the_budget() {
+        for first in [QpStatus::IterationLimit, QpStatus::OptimalInaccurate] {
+            assert_eq!(equilibrated_retry_budget(&lp(), first, 200), 100);
+        }
+    }
+
+    /// The retry exists for Hessian curvature that NT scaling cannot see,
+    /// which a QP can legitimately spend most of a budget recovering from —
+    /// `QSCFXM1/2/3` and `Q25FV47` are accepted at 131–168 iterations, and a
+    /// blanket cap would demote all four to `OptimalInaccurate`.
+    #[test]
+    fn a_qp_retry_keeps_the_full_budget() {
+        for first in [QpStatus::IterationLimit, QpStatus::OptimalInaccurate] {
+            assert_eq!(equilibrated_retry_budget(&qp(), first, 200), 200);
+        }
+    }
+
+    /// A `NumericalFailure` first solve accepts *any* non-failing retry
+    /// status as an improvement on a breakdown. Capping the budget there
+    /// would let the cap manufacture an `IterationLimit` and have it
+    /// accepted — returning the capped iterate and reporting "Maximum
+    /// iterations exceeded" where the honest answer is "Numerical failure".
+    /// `issue_535_lp_falls_back_to_nlp` catches the end-to-end symptom on
+    /// `lp_afiro` at `qp_tau=0.99`; this pins the cause.
+    #[test]
+    fn a_broken_down_lp_retry_keeps_the_full_budget() {
+        assert_eq!(
+            equilibrated_retry_budget(&lp(), QpStatus::NumericalFailure, 200),
+            200
+        );
+    }
+
+    /// The budget is a fraction of the caller's, not a constant, so a
+    /// user-set `max_iter` carries through instead of being overridden.
+    #[test]
+    fn the_budget_scales_with_a_user_set_max_iter() {
+        assert_eq!(
+            equilibrated_retry_budget(&lp(), QpStatus::IterationLimit, 40),
+            20
+        );
     }
 }
 


### PR DESCRIPTION
Two changes to the `pounce-convex` HSDE driver. They were developed
separately but land together because the second one's measured benefit is
almost entirely absorbed by the first, and shipping them apart would leave a
number in the history that is no longer true.

## 1. Escalate the primal `(x,x)` regularization on wrong inertia

`KktStructure::build` writes `P + opts.reg*I` into the `(x,x)` block of the
augmented KKT once, and nothing ever rewrites it — `update_blocks` touches
only the cone blocks, `update_eq_reg` only the `y` diagonal. For an LP `P = 0`,
so that block **is** the regularization, frozen at the 1e-10 static default
for the life of the solve.

Against a Jacobian with entries O(1) that leaves the x-pivots on the roundoff
floor, and LDL^T loses their signs. The driver reads that back as a
wrong-inertia deficit and escalates `delta_c` and the `(z,z)` regularization —
neither of which can repair a defect that lives in `(x,x)`. So it refactors,
sees the same deficit, escalates again, and burns its whole try budget every
iteration without ever touching the cause.

Instrumented on NETLIB `gen`:

| | mean tries/iter | mean first-try deficit | iterations starting wrong |
|---|---|---|---|
| static 1e-10 (default) | **4.19** | **134.8** | 376/400 |
| `(x,x)` at 1e-6 | **0.00** | **0.0** | 0/400 |

Attributing the fix to a block, by pinning each in isolation:

| config | wall | mean tries/iter |
|---|---|---|
| baseline | 176.04 s | 4.19 |
| **`(x,x)` only = 1e-6** | **1.69 s** | **0.06** |
| `delta_c` / `(z,z)` only | 113.02 s | 2.32 |
| both | 31.84 s | 0.00 |

This is Ipopt's Algorithm IC knob (Wachter & Biegler): `delta_w` answers wrong
inertia, `delta_c` answers a rank-deficient equality Jacobian. POUNCE was
escalating the wrong two ladders.

The fix adds `KktStructure::update_primal_reg`, which rewrites the `(x,x)`
diagonal as `P + delta_w` each iteration (`P` is captured at build time so the
rewrite cannot lose it), and stages the HSDE escalation ladder: `delta_w`
first, `delta_c`/`(z,z)` only once `delta_w` has saturated at `DELTA_W_MAX`. A
per-solve latch stops re-probing the whole `delta_w` ladder on a solve where
it has already saturated without curing the defect.

**Two things this deliberately does not do**, both because the corpus said so:

* **It does not raise the static default.** A static 1e-6 fixes `gen`
  (199 -> 16 iterations) and looks spectacular in isolation, but across the
  corpus it costs 48 verdicts and shifts `pilot.we`'s objective by 12% *while
  still certifying `Optimal`*. The regularized problem is a different problem.
  Only iterates that actually show a deficit should pay.

* **It does not bump `delta_w` alongside `delta_c`/`reg_eff`.** That was the
  first draft, and it cost `cq5` and `maros` their `Optimal` verdict — the
  gh #218 ratchet, live: escalating `delta_c` on a cone-conditioning symptom
  biases the equality residual by `delta_c*||dy||` and floors `pres`
  permanently. Staging is what clears it.

## 2. Cap the gh #293 equilibrated retry for non-converging LPs

The gh #293 retry re-solves with Ruiz equilibration and re-runs the full
`max_iter`. For a pure LP whose first solve merely failed to converge that is
almost always wasted: every accepted LP retry in the corpus converged by
iteration 78, while every LP retry that ran to the 199-iteration cap was
discarded.

Two gates, both load-bearing and both unit-pinned:

* **`P = 0`.** Equilibration exists to surface curvature the NT scaling cannot
  see, so a QP retry genuinely needs the room — `QSCFXM1/2/3` and `Q25FV47`
  are accepted at 131-168 iterations and a flat cap would demote four clean
  `Optimal` results.
* **`IterationLimit | OptimalInaccurate`, not `NumericalFailure`.** A
  `NumericalFailure` first solve accepts a retry on status alone, so a cap
  there could *manufacture* an `IterationLimit` and have it accepted —
  reporting "Maximum iterations exceeded", with the capped retry's iterate,
  where the honest answer is "Numerical failure".
  `issue_535_lp_falls_back_to_nlp` pins this.

## Combined measurement

LP+QP corpus, 371 LP + 138 QP, `solver_selection` forced to `lp-ipm`/`qp-ipm`
so there is no NLP fallback to mask a correctness change:

**1261.3 s -> 605.7 s (-52.0%), 4 verdicts gained, 0 lost, 0 objective moves
above 1e-6 relative.**

| problem | before | after |
|---|---|---|
| `gen` | 174.15 s / 199 it, *acceptable* | **2.77 s / 18 it, Optimal** |
| `gen1` | 173.95 s / 199 it, *acceptable* | **2.77 s / 18 it, Optimal** |
| `df2177` | 78.31 s / 199 it, *max-iter* | **0.66 s / 9 it, Optimal** |
| `dsbmip` | *max-iter* | **Optimal** |
| `aa01`/`air04` | 49.4 s | 6.0 s |
| `aa03`/`air06` | 23.8 s | 4.0 s |
| `complex` | 36.83 s | 27.64 s |

**No slowdown survives repeat measurement.** The corpus sweep's two largest
"slower" lines were both QPs at identical iteration counts; re-running each
three times per binary shows them as run-to-run noise, with the *baseline*
sweep having caught a fast outlier:

| | baseline x3 | this branch x3 |
|---|---|---|
| `BOYD2` | 184.4 / 186.0 / 183.0 s | 184.9 / 184.5 / 183.3 s |
| `BOYD1` | 80.4 / 77.1 / 80.7 s | 78.3 / 78.1 / 78.3 s |

Objectives bit-identical, iteration counts identical (78 and 42).

### The honest accounting on change 2

Measured on its own against the previous behaviour, the retry cap was worth
124.6 s, concentrated in `gen` -47.9, `gen1` -47.5, `df2177` -19.8,
`complex` -9.6.

**Stacked on change 1, it is worth -0.4 s (-0.1 %) — the noise floor.**
`gen`, `gen1` and `df2177` now converge on the first solve and never reach the
retry at all. What survives is `complex` -9.2 s and `pilot.ja` -1.1 s, the two
LPs that still hit the cap on the first solve and still pay for a rejected
retry.

It is kept for those two, and for the correctness of its two gates, **not**
for its original headline number. Anyone reading `eff0b280`'s commit message
in isolation later would otherwise take 124.6 s as this branch's contribution
from that change, and it is not.

## Trajectory sweep

Per CLAUDE.md this is a trajectory change, so `scripts/sweep-fixtures.sh` ran
against a clean `main` baseline binary. **Exactly one line moves, identically
on both legs:**

```
lp_degen2  SolveSucceeded  it=20 -> it=18  obj=-1435.178018 -> -1435.178017
```

`lp_degen2` is the corpus's one degenerate LP and routes to `pounce-convex`.
The ~20 other LP/QP/QCQP fixtures on the same arm are byte-identical — the
`delta_w` ladder only engages when the factorization actually reports a
defect, so a healthy iterate takes the path it took before. Fewer iterations,
both exits `Optimal`, objective agreeing to 10 significant figures (relative
move 2.1e-10). The new run stops at overall NLP error 6.3e-8 against the
baseline's 9.6e-9 — it crosses the termination threshold two iterations
earlier rather than settling to a worse point. Both are legal exits, but it is
a real trajectory move and is recorded as one.

The `lbfgs` leg matching is **not** independent confirmation:
`hessian_approximation` is an NLP-path option and this fixture never reaches
the NLP path, so the two legs are the same solve.

## Tests

`cargo test --workspace --no-fail-fast` on the combined branch: **3510
passed, 0 failed** (3506 on change 1 alone; the retry cap adds 4 unit tests
pinning its two gates).

Problems without the defect pay nothing — `pilot.we`, `forplan`, `greenbea`
and `pilot87` return bit-identical objectives to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9Tqn6nrW7B91fC1HpJsHp
