### PR TITLE
ci: pin CasADi to 3.7.* until the 3.8.0 breakage is fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,10 +517,24 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      # PINNED, deliberately against this job's own design (gh #782).
+      # Everything below derives the version it builds against from the
+      # installed wheel, so that a CasADi release bumps this job
+      # automatically. 3.8.0 (2026-08-25) exercised that and turned the job
+      # red on both runners in two independent ways: the Linux wheel appears
+      # to be built with the new libstdc++ ABI, against `casadi/Makefile`'s
+      # hardcoded `CXX11_ABI ?= 0`, so every `std::string`-taking symbol goes
+      # undefined at link; and macOS -- no dual-ABI there at all -- fails the
+      # code-generation check instead. Every PR opened that day failed this
+      # job regardless of its contents.
+      #
+      # `3.7.*` still tracks patch releases within the last known-good minor.
+      # Remove the pin when gh #782 is fixed; the auto-tracking is the point
+      # of the job and this pin is the thing standing in its way.
       - name: Install CasADi
         run: |
           python -m pip install --upgrade pip
-          python -m pip install casadi numpy
+          python -m pip install "casadi==3.7.*" numpy
 
       # The tag has to match the installed wheel exactly; `make fetch-src`
       # derives it from `casadi.__version__` rather than pinning a literal,
@@ -574,7 +588,10 @@ jobs:
         run: |
           cd casadi/wheel && ./build.sh
           python -m venv /tmp/casadi-wheel-env
-          /tmp/casadi-wheel-env/bin/pip install -q casadi dist/pounce_casadi-*.whl
+          # Same pin as the install step above (gh #782): the wheel under
+          # test was built against 3.7, so resolving a newer CasADi here
+          # would test a pairing the build never produced.
+          /tmp/casadi-wheel-env/bin/pip install -q "casadi==3.7.*" dist/pounce_casadi-*.whl
           /tmp/casadi-wheel-env/bin/python - <<'PY'
           import casadi as ca
           import pounce_casadi  # registers the plugin in-process


### PR DESCRIPTION
CasADi 3.8.0 hit PyPI on 2026-08-25 at 12:47 UTC and broke the `CasADi plugin
parity` job on both runners within hours. **Every PR opened from that day
onward fails this job regardless of its contents** — main's last green run
(`dcebdc5f`) built against `CASADI_MINOR_VERSION=7`.

The job derives the version it builds against from the installed wheel and
`make -C casadi fetch-src` clones the matching tag. That is deliberate: a
CasADi release is supposed to bump this job automatically. It did, and found
two independent breakages.

**Linux** — `casadi/Makefile:93` hardcodes `CXX11_ABI ?= 0` because pip
CasADi wheels have historically used the pre-C++11 libstdc++ ABI. The 3.8.0
wheel appears to use the new one, so every `std::string`-taking symbol goes
undefined:

```
undefined reference to `casadi::MX::_sym(std::string const&, casadi::Sparsity const&)'
undefined reference to `casadi::nlpsol(std::string const&, std::string const&, ...)'
collect2: error: ld returned 1 exit status
```

**macOS** — libc++, so no dual-ABI problem exists there at all. This is a
genuinely separate failure: the suite passes every other check and fails only
on `generated C compiles — 1 error generated`. The Linux job never got far
enough to reach that check.

This PR only pins `casadi==3.7.*` (still tracking patches within the last
known-good minor) at both install sites. It does **not** fix either
breakage — gh #782 carries those, and removing this pin is on its checklist.
Flagging plainly that the pin points against the job's own design; the
auto-tracking is the point, and this is standing in its way until #782 lands.

Refs #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9Tqn6nrW7B91fC1HpJsHp
