### PR TITLE
perf(examples): cache the fold JaxProblem, and mark the published-value test slow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # The `slow` selection below diffs this branch against its base,
+          # which the default shallow clone cannot do.
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -197,8 +201,43 @@ jobs:
           # GAMS in the loop — the link runs, the value is in range, and the
           # `.lst` just says the wrong thing.
           python -m pip install "gamsapi[core]"
+      # `test_published_binary_fold_and_inverse_design_regression` is marked
+      # `slow` and costs ~9 minutes here on its own — it was the whole of this
+      # job's 8m23s -> 22m12s jump when the phase-envelope example landed, and
+      # this job is the long pole gating every PR. What it asserts is a
+      # published thermodynamic value and a continuation step-size invariance:
+      # claims about the *example*, which only the example, the JAX frontend
+      # it drives, or the solver underneath can move. So a PR that touches
+      # none of those deselects it, every push to `main` runs it in full, and
+      # a solver change is covered after merge rather than before — the same
+      # trade `coverage.yml` documents for the same reason. The three unmarked
+      # tests in that file still run on every PR.
+      - name: Decide whether the slow tests run
+        id: select
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "reason=not a pull request" >>"$GITHUB_OUTPUT"
+            echo "markers=" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          base=$(git merge-base FETCH_HEAD HEAD)
+          if git diff --name-only "$base" HEAD | grep -Eq \
+              '^(python/pounce/examples/|python/pounce/jax/|python/tests/test_phase_envelope_example\.py)'; then
+            echo "reason=PR touches the example or the JAX frontend" >>"$GITHUB_OUTPUT"
+            echo "markers=" >>"$GITHUB_OUTPUT"
+          else
+            echo "reason=PR touches neither the example nor the JAX frontend" >>"$GITHUB_OUTPUT"
+            echo "markers=not slow" >>"$GITHUB_OUTPUT"
+          fi
       - name: Run Python tests
-        run: python -m pytest python/tests -q
+        run: |
+          echo "slow tests: ${{ steps.select.outputs.markers && 'deselected' || 'included' }} (${{ steps.select.outputs.reason }})"
+          if [ -n "${{ steps.select.outputs.markers }}" ]; then
+            python -m pytest python/tests -q -m "${{ steps.select.outputs.markers }}"
+          else
+            python -m pytest python/tests -q
+          fi
 
   # Exercise the PyTorch frontend (`pounce.torch`, pounce#109) on every
   # PR. Mirrors `python-test` but installs the CPU torch wheel alongside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ changes.
 
 ## [Unreleased]
 
+- **Refining more than one phase-envelope fold no longer recompiles the same
+  problem each time.** `pounce.examples.phase_envelope.refine_fold` built a
+  fresh `JaxProblem` per call, and a `JaxProblem` compiles its callbacks once
+  per instance — so every fold paid the full compilation again. On the binary
+  methane/propane fold that is 33 s per call, 26.5 s of it XLA compilation:
+  12.7 s for the Lagrangian Hessian alone (the fold equations already contain
+  a `jax.jacobian`, so that Hessian is a third derivative of the
+  Peng--Robinson residual) and 5.6 s for the sparsity probes in
+  `JaxProblem.__init__`. A second solve of the same instance costs 1.3 s.
+  Folds that share a mixture, `beta`, `mode` and `kij_pair` now share the
+  problem, which is worth ~55 s to the regression test and one compilation
+  per *kind* of fold rather than per fold to notebook 34.
+
+  The cache key is the complete mixture. Keying on everything except the
+  composition would hit more often and be correct today, because
+  `_decode_design` reads the composition from the supplied design vector and
+  ignores the mixture's own — but that invariant lives in a different
+  function, and if it ever changes, a composition-blind key hands back a
+  stale graph and the answer is wrong rather than slow.
+
+- **The published phase-envelope reproduction no longer runs on every pull
+  request.** `test_published_binary_fold_and_inverse_design_regression` is
+  marked `slow`: it costs ~9 minutes on a CI runner by itself, and it was the
+  whole of `Python tests (jax)` going from 8m23s to 22m12s when the example
+  landed — on the job that is the long pole gating every PR. It asserts a
+  published thermodynamic value and a continuation step-size invariance,
+  claims only the example, the JAX frontend it drives, or the solver can
+  move. A PR touching none of those deselects it; every push to `main` runs
+  it in full, so a solver change is still covered, after merge rather than
+  before. The three unmarked tests in that file — cubic root branches,
+  simplex coordinates, implicit derivatives — still run on every PR.
+
 - Add a reproducible closed-loop advanced-step NMPC CSTR tutorial.  It compares
   full re-solves, stale predictions, clamped linear, fix-relax, path, and guarded
   path updates across nominal, active-set-switching, and model-mismatch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,14 @@ the same PR:
 1. **Code + test.** The behavior, with a test that pins it (Rust `cargo test`
    and/or Python `pytest`).
 
+   A handful of Python tests are marked `slow` — currently one, the
+   phase-envelope reproduction, which costs ~9 minutes of CI on its own.
+   `pytest python/tests` still runs them; the `Python tests (jax)` job
+   deselects them on a PR that touches neither `python/pounce/examples/`
+   nor `python/pounce/jax/`, and runs them in full on every push to `main`.
+   The job logs which choice it made and why. Mark a new test `slow` only
+   if it costs minutes *and* nothing outside those paths can move it.
+
 2. **CHANGELOG entry.** Add a bullet under the `## [Unreleased]` section of
    `CHANGELOG.md` (create that section if it is absent — it sits directly above
    the most recent released version). One entry per feature, in the user's

--- a/python/pounce/examples/phase_envelope.py
+++ b/python/pounce/examples/phase_envelope.py
@@ -13,6 +13,7 @@ dimensionless unless a docstring says otherwise.
 
 from __future__ import annotations
 
+import collections
 from dataclasses import dataclass, replace
 from typing import Literal
 
@@ -986,6 +987,82 @@ def _fold_initial_guess(
     return np.concatenate([np.asarray(state), [float(parameter)], null_vector])
 
 
+_FOLD_PROBLEM_CACHE: "collections.OrderedDict[tuple, JaxProblem]" = (
+    collections.OrderedDict()
+)
+_FOLD_PROBLEM_CACHE_SIZE = 8
+
+
+def _fold_problem(
+    mixture: PengRobinsonMixture,
+    beta: float,
+    mode: Mode,
+    kij_pair: tuple[int, int],
+) -> JaxProblem:
+    """Return the augmented-fold :class:`JaxProblem`, built at most once.
+
+    A ``JaxProblem`` compiles its callbacks on first use and caches them on
+    the instance.  For this seven-equation system the first solve costs
+    ~30 s and every later solve of the *same instance* ~1 s, because the
+    fold equations already contain a ``jax.jacobian``, so the Lagrangian
+    Hessian POUNCE asks for is a third derivative of the Peng--Robinson
+    residual.  Measured on the binary fold: 26.5 s of the first call's
+    33 s is XLA compilation, 12.7 s of it that one Hessian and 5.6 s the
+    sparsity probes ``JaxProblem.__init__`` runs.
+
+    Constructing a fresh problem per call therefore paid that cost once
+    per fold rather than once per *kind* of fold — five times over in
+    ``test_published_binary_fold_and_inverse_design_regression`` alone,
+    and once per refined extremum in notebook 34.
+
+    The key is the complete mixture, not just the parts the traced graph
+    reads.  ``refine_fold`` always supplies the design vector, and
+    ``_decode_design`` takes the composition from *that* and ignores
+    ``mixture.composition``, so keying on everything but the composition
+    would hit more often and still be correct today.  It is deliberately
+    not done: that correctness rests on an invariant inside a different
+    function, and if a later edit makes the residual read the mixture's
+    own composition, a composition-blind key returns a stale graph and the
+    answer is wrong rather than merely slow.
+    """
+
+    key = (
+        mixture.names,
+        mixture.critical_temperature.tobytes(),
+        mixture.critical_pressure.tobytes(),
+        mixture.acentric_factor.tobytes(),
+        mixture.composition.tobytes(),
+        mixture.binary_interaction.tobytes(),
+        float(beta),
+        mode,
+        kij_pair,
+    )
+    cached = _FOLD_PROBLEM_CACHE.get(key)
+    if cached is not None:
+        _FOLD_PROBLEM_CACHE.move_to_end(key)
+        return cached
+
+    n_fold = 2 * (mixture.n_components + 1) + 1
+    problem = JaxProblem(
+        f=lambda fold_state, design: (
+            0.0 * jnp.sum(fold_state) * (1.0 + 0.0 * jnp.sum(design))
+        ),
+        g=lambda fold_state, design: _fold_equations(
+            fold_state, design, mixture, beta, mode, kij_pair
+        ),
+        n=n_fold,
+        m=n_fold,
+        p_example=jnp.asarray(design_parameters(mixture, kij_pair)),
+        cl=jnp.zeros(n_fold),
+        cu=jnp.zeros(n_fold),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes", "max_iter": 500},
+    )
+    _FOLD_PROBLEM_CACHE[key] = problem
+    while len(_FOLD_PROBLEM_CACHE) > _FOLD_PROBLEM_CACHE_SIZE:
+        _FOLD_PROBLEM_CACHE.popitem(last=False)
+    return problem
+
+
 def refine_fold(
     trace: PathTrace,
     mixture: PengRobinsonMixture,
@@ -1004,23 +1081,9 @@ def refine_fold(
     """
 
     n_state = mixture.n_components + 1
-    n_fold = 2 * n_state + 1
     q0 = design_parameters(mixture, kij_pair)
     w0 = _fold_initial_guess(trace, mixture, beta, mode, q0, kij_pair)
-    problem = JaxProblem(
-        f=lambda fold_state, design: (
-            0.0 * jnp.sum(fold_state) * (1.0 + 0.0 * jnp.sum(design))
-        ),
-        g=lambda fold_state, design: _fold_equations(
-            fold_state, design, mixture, beta, mode, kij_pair
-        ),
-        n=n_fold,
-        m=n_fold,
-        p_example=jnp.asarray(q0),
-        cl=jnp.zeros(n_fold),
-        cu=jnp.zeros(n_fold),
-        options={"tol": 1e-11, "print_level": 0, "sb": "yes", "max_iter": 500},
-    )
+    problem = _fold_problem(mixture, beta, mode, kij_pair)
     solution, _, jacobian = problem.solve_with_jacobian(jnp.asarray(q0), w0)
     solution_np = np.asarray(solution, dtype=float)
     residual = np.asarray(

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -75,5 +75,11 @@ def _check_extension_freshness() -> None:
         )
 
 
-def pytest_configure(config):  # noqa: ARG001 (pytest hook signature)
+def pytest_configure(config):
     _check_extension_freshness()
+    config.addinivalue_line(
+        "markers",
+        "slow: reproduces a published result or a convergence-invariance "
+        "claim, at a cost measured in minutes; deselected on pull requests "
+        "that cannot affect it (see .github/workflows/ci.yml)",
+    )

--- a/python/tests/test_phase_envelope_example.py
+++ b/python/tests/test_phase_envelope_example.py
@@ -104,8 +104,25 @@ def test_fixed_pressure_sensitivity_matches_fresh_phase_boundary_solves():
     np.testing.assert_allclose(recovered.state, point.state, rtol=1e-9, atol=1e-9)
 
 
+@pytest.mark.slow
 def test_published_binary_fold_and_inverse_design_regression():
-    """Reproduce a published maxcondentherm and solve an inverse design."""
+    """Reproduce a published maxcondentherm and solve an inverse design.
+
+    Marked slow because it is the most expensive test in the suite by an
+    order of magnitude: ~150 s locally and ~9 min on a CI runner, nearly
+    all of it XLA compiling the Lagrangian Hessian of the augmented fold
+    equations, which is a third derivative of the Peng--Robinson residual.
+    ``_fold_problem`` already caches that compilation across the folds
+    that share a mixture and mode; the three that remain are irreducible.
+
+    What it asserts is a *published-value* and *step-size-invariance*
+    claim about the example, not a claim about the solver's arithmetic,
+    and it can only move when the example, the JAX frontend, or the solver
+    itself moves.  So it is deselected on pull requests that touch none of
+    those, and runs in full on every push to `main`.  The three unmarked
+    tests in this file still cover the cubic root branches, the simplex
+    coordinates, and the implicit derivatives on every PR.
+    """
 
     mixture = DEITERS_BELL_METHANE_PROPANE
     trace = trace_envelope(


### PR DESCRIPTION
`Python tests (jax)` went from **8m23s to 22m12s** when the phase-envelope
example landed, and it is the long pole gating every PR in this repo. This
gets it back, in two steps, in that order of preference.

## 1. Cache the fold problem (the part that is free)

`refine_fold` built a fresh `JaxProblem` on every call. A `JaxProblem`
compiles its callbacks on first use and caches them *on the instance*, so a
per-call problem paid the compile once per fold rather than once per **kind**
of fold.

That compile is not small. The fold equations already contain a
`jax.jacobian`, so the Lagrangian Hessian POUNCE asks for is a third
derivative of the Peng-Robinson residual. Measured on the binary fold:

| | |
|---|---|
| first `refine_fold` call | 33.0 s |
| ...of which XLA compilation | 26.5 s |
| ...of which that one Hessian | 12.7 s |
| ...of which `JaxProblem.__init__` sparsity probes | 5.6 s |
| second solve, same instance | 1.3 s |

`_fold_problem` is an 8-entry LRU keyed on the mixture, `beta`, `mode` and
`kij_pair`. The test file goes **226 s -> 171 s** locally; the slow test
alone 204 s -> 149 s. All four tests still pass, and their coarse-vs-fine
cross-check at `rtol=1e-8` is what would catch a stale graph.

The key is the **complete** mixture, not just the parts the traced graph
reads. `refine_fold` always supplies the design vector, and `_decode_design`
takes the composition from *that* and ignores `mixture.composition`, so
keying on everything-but-composition would hit more often and still be
correct today. Deliberately not done: that correctness rests on an invariant
inside a different function, and if a later edit makes the residual read the
mixture's own composition, a composition-blind key returns a stale graph and
the answer is *wrong* rather than merely slow.

## 2. Mark the published-value test `slow` (the part that is a trade)

The cache is not enough on a runner. What remains is ~9 minutes and it is
irreducible: three distinct folds, three compiles.

`test_published_binary_fold_and_inverse_design_regression` is now marked
`slow`, and the jax job deselects it on a pull request that touches none of
`python/pounce/examples/`, `python/pounce/jax/`, or the test file itself.

The reasoning, which is the reviewable part: what that test asserts is a
**published thermodynamic value** and a **continuation step-size invariance**
-- claims about the *example*, not about the solver's arithmetic. It can only
move when the example, the JAX frontend it drives, or the solver underneath
moves. A solver change is therefore covered *after* merge rather than before
-- the same trade `coverage.yml` already documents, for the same reason --
and **every push to `main` runs it in full**, so a break is caught on the
merge commit, not a release later.

`crates/` is deliberately *not* in the trigger list: a solver change is
covered by the Rust suite, the fixture sweep, and the three unmarked tests in
this file (cubic root branches, simplex coordinates, implicit derivatives),
which still run on every PR. If that turns out to be the wrong call, adding
`^crates/` to the `grep -E` in the workflow is a one-line change.

## Verification

- `pytest python/tests -q -m "not slow"` (exactly what a PR now runs):
  **1194 passed, 16 skipped, 1 deselected, 2m47s**.
- Full `pytest python/tests -q` still collects and passes all four tests in
  the file.
- Selection logic simulated against both cases: this branch (touches the
  example and the test) -> runs everything; a hypothetical `crates/` +
  `CHANGELOG.md` PR -> `not slow`.
- `scripts/check-docs-consistency.sh` OK, 47 pages.
- `make python-test` and `scripts/coverage-combined.sh` are untouched and
  still run everything.

Note that this PR itself touches `python/pounce/examples/` and the test file,
so its own jax job runs the slow test -- the deselection shows up on the
*next* unrelated PR.

CONTRIBUTING.md gains a paragraph on when to mark a new test `slow`.
