### PR TITLE
Catalyst pellet: make the nested thermal limit an optimizer constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,57 @@ changes.
 
 ## [Unreleased]
 
+- **Catalyst-pellet tutorial: the nested route's thermal limit is a
+  constraint, not a state bound** (#787). `solve_nested_design` defines a
+  `thermal_margin` inequality, but the inner `solve_forward` root solve used
+  `temperature_limit_k` as the temperature *state* bound. A converged inner
+  solution could therefore never report a negative margin: a thermally
+  difficult candidate stalled against the bound with an unclosed energy
+  balance, and the outer SLSQP was handed a failed state solve instead of the
+  constraint violation it exists to respond to. It could not tell "this design
+  is too hot" from "the physics did not converge", and aborted on the first
+  such candidate.
+
+  `PelletConfig` now separates the two: `temperature_limit_k` stays the design
+  constraint, while `state_temperature_floor_k` and
+  `state_temperature_ceiling_k` (400 K to 900 K) are the root solve's own
+  numerical bracket, deliberately straddling the design ceiling. The bracket
+  is loose enough that the design constraint binds first and tight enough to
+  keep the solve off the ignited branch — for the nominal parameters the
+  low-temperature branch turns back just above a 613 K peak as the external
+  heat-transfer coefficient is lowered (converging at 612.7 K for
+  `h = 171.5 W m^-2 K^-1`, not at all by `h = 170`), and past that fold the
+  only remaining steady state is a mass-transfer-limited runaway of order
+  `10^3 K` hot and far outside the Koschany fit. `solve_design` is unchanged:
+  the simultaneous route still carries the design ceiling directly as a state
+  bound, which is the point of that transcription.
+
+  `PelletSolution` gained `thermal_margin_k` and `thermally_feasible`, so a
+  hot-but-converged solution is distinguishable from a failed one at the API
+  level; `success` remains a statement about the state solve alone. The
+  bracket is not a kinetic-validity claim — a converged state above
+  `temperature_limit_k` is reported infeasible and never returned as a design.
+
+  Regression: with the ceiling moved to 570 K, under the 572.5 K peak of the
+  equal-inventory uniform eight-cell pellet, the uniform candidate converges
+  to residual 1.4e-13 with a -2.51 K margin, while collapsing the bracket back
+  onto the ceiling reproduces the old failure (pinned at 570.000 K, residual
+  1.8e-03); both design routes then drive the constraint active and agree on
+  the same profile to 1e-5. Nominal eight-cell results are unchanged to
+  1e-13 — the designs reported in #779 remain near 579 K with the ceiling
+  slack.
+
+  One clarification on the report's own configuration: the eight-cell mesh at
+  `heat_transfer_coefficient_w_m2_k=80` still fails, and correctly so. That
+  film coefficient is past the fold — the low-temperature branch no longer
+  exists there, so there is no steady state for the root solve to find and
+  `success=False` is the honest answer, not a bound artifact (the peak
+  temperature stalls at 555 K, nowhere near the 613 K ceiling). Both routes now
+  say so with a message that names the failed state solve rather than
+  re-raising a bare solver string. The constraint-handling gap the report
+  identified is real and is fixed; it is reproduced above at a film coefficient
+  where a solution does exist.
+
 - **A truncated `.nl` file is rejected instead of solved** (#785). A `.nl`
   cut short before its trailing segments — an interrupted write, a full disk,
   a partial copy, a killed AMPL/Pyomo writer — parsed without complaint:

--- a/docs/src/catalyst-pellet.md
+++ b/docs/src/catalyst-pellet.md
@@ -111,10 +111,56 @@ The tutorial does not optimize until these checks pass:
    algorithms. Agreement supplies an independent route check; the simultaneous
    form is retained because all balance equations, state bounds, the inventory,
    and the thermal ceiling remain explicit to POUNCE.
+5. The two routes are re-compared with the thermal ceiling **active**, not
+   merely slack, because they enforce it by different mechanisms (see below).
 
 The optimized profile is always re-solved after interpolating its state to a
 finer finite-volume mesh. That forward refinement is outside the optimization
 NLP and catches basis/mesh artifacts.
+
+### Two routes, one thermal ceiling, two mechanisms
+
+`temperature_limit_k` is a *design* constraint, and both routes enforce it,
+but not in the same place:
+
+* `solve_design` (simultaneous) carries it as an **upper bound on the
+  temperature state variables**. POUNCE sees the constraint directly and the
+  states never leave the feasible box.
+* `solve_nested_design` carries it as an **explicit SLSQP inequality**
+  evaluated on the converged inner solution,
+  `temperature_limit_k - max(T) >= 0`.
+
+That difference forces a third number into `PelletConfig`. The nested inner
+solve is a *bounded* least-squares root solve, so if its temperature box were
+also `temperature_limit_k`, a candidate hot enough to violate the ceiling
+could not converge: it would stall against the bound with a nonzero energy
+residual, and the outer optimizer would be handed a failed state solve instead
+of a negative margin. It could then never distinguish "this design is too hot"
+from "the physics did not converge", and would abort on the first thermally
+difficult candidate rather than steering away from it (gh#787).
+
+The inner solve therefore gets its own **numerical bracket**,
+`state_temperature_floor_k` to `state_temperature_ceiling_k` (400 K to 900 K by
+default), which deliberately straddles the 613 K design ceiling. The bracket is
+chosen loose enough that the design constraint always binds first, and tight
+enough to keep the root solve off the ignited branch. That branch is close: for
+the nominal parameters, lowering the external heat-transfer coefficient turns
+the low-temperature branch back just above a 613 K peak — it still converges at
+`h = 171.5 W m^-2 K^-1` (612.7 K) and no longer converges at
+`h = 170 W m^-2 K^-1`. Past that fold the only remaining steady state is the
+mass-transfer-limited runaway, whose external Prater temperature rise
+`(-Delta H) k_m c_bulk / h` is of order `10^3 K` here — far outside the 453 to
+613 K Koschany range, and not a state the tutorial should ever return.
+
+The bracket is not a kinetic-validity claim. A converged state above
+`temperature_limit_k` is extrapolating the fit; it is reported as thermally
+infeasible (`PelletSolution.thermal_margin_k < 0`,
+`thermally_feasible is False`) and is never returned as a design.
+`PelletSolution.success` stays a statement about the state solve alone, so the
+two failure modes remain separable at the API level. Below the turning point
+the distinction is real and the routes agree: with the ceiling moved to 570 K,
+under the 572.5 K peak of the equal-inventory uniform pellet, both routes drive
+the constraint active and return the same design.
 
 ## Nominal design problem
 
@@ -131,6 +177,9 @@ subject to 0 <= a[j] <= 1
            sum_j volume_fraction[j] a[j] = 0.16
            species balances, energy balance, c_i >= 0, T <= 613 K.
 ```
+
+The `T <= 613 K` row is the design ceiling in both routes; only the mechanism
+that enforces it differs, as described above.
 
 `lambda=0.5` is fixed before the solve. The notebook compares equal-inventory
 uniform, ideal step egg-shell, and regularized optimized profiles. The
@@ -186,6 +235,13 @@ jupyter nbconvert --to notebook --execute --inplace \
 - Every design is a local NLP solution. Two documented initializations agree
   in the short case, but neither that check nor POUNCE certifies a global
   optimum for this nonlinear model.
+- The low-temperature steady state is not the only one, and it does not always
+  exist. At the nominal operating point it folds once the external
+  heat-transfer coefficient drops below roughly `171 W m^-2 K^-1`; past that
+  the forward solve reports `success=False` rather than jumping to the ignited
+  branch. That is a statement about the model's steady states, not about the
+  thermal design constraint, and `thermal_margin_k` is what distinguishes the
+  two.
 - Effective diffusivities, porosity, films, and reaction enthalpy are tutorial
   assumptions. Model-form uncertainty is not in the two-parameter covariance.
 - Independent Fick diffusion omits Stefan-Maxwell coupling and pressure-driven

--- a/python/notebooks/37_catalyst_pellet_inverse_design.ipynb
+++ b/python/notebooks/37_catalyst_pellet_inverse_design.ipynb
@@ -398,6 +398,91 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3a7f21c8",
+   "metadata": {},
+   "source": [
+    "Agreement above is with the thermal ceiling **slack** — both designs peak near 579 K, well under 613 K — so it only exercises the balances and the inventory. The two routes do not enforce the ceiling the same way, and that difference is only visible when it binds. `solve_design` carries `temperature_limit_k` as an upper **bound on the temperature states**; `solve_nested_design` carries it as an explicit **SLSQP inequality** on the converged inner solve.\n",
+    "\n",
+    "The nested form only works because the inner root solve has its own, looser numerical bracket, `state_temperature_floor_k` to `state_temperature_ceiling_k` (400 K to 900 K). If the inner solve's temperature box were the design ceiling itself, a candidate hot enough to violate the ceiling could not converge — it would stall against the bound with an unclosed energy balance — and the outer optimizer would receive a failed state solve instead of a negative margin, unable to tell \"too hot\" from \"did not converge\" (gh#787)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5d0e94b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "uniform pellet against a 570 K ceiling\n",
+      "  loose root-solve bracket:   success=True   max residual=1.40e-13  Tmax= 572.509 K  margin= -2.509 K\n",
+      "  bracket = design ceiling:   success=False  max residual=1.83e-03  Tmax= 570.000 K  (pinned at the bound)\n",
+      "route          success  Tmax [K]   margin [K]  production [mol/s]\n",
+      "simultaneous   True      570.000   +1.49e-10  4.2221310219e-07\n",
+      "nested         True      570.000   +6.71e-12  4.2221310188e-07\n",
+      "max activity difference: 2.3570832508035267e-08\n",
+      "active thermal ceiling, both routes  PASS\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The two routes enforce the same thermal ceiling by different mechanisms, so\n",
+    "# check them again with that ceiling *active* rather than slack (gh#787).\n",
+    "# 570 K sits under the 572.5 K peak of the equal-inventory uniform pellet.\n",
+    "constrained = replace(config, temperature_limit_k=570.0)\n",
+    "hot = solve_forward(uniform_activity, constrained)\n",
+    "coupled = solve_forward(\n",
+    "    uniform_activity,\n",
+    "    replace(constrained, state_temperature_ceiling_k=constrained.temperature_limit_k),\n",
+    ")\n",
+    "print('uniform pellet against a 570 K ceiling')\n",
+    "print(f'  loose root-solve bracket:   success={hot.success!s:5s}  '\n",
+    "      f'max residual={hot.max_scaled_residual:.2e}  '\n",
+    "      f'Tmax={hot.max_temperature_k:8.3f} K  margin={hot.thermal_margin_k:+7.3f} K')\n",
+    "print(f'  bracket = design ceiling:   success={coupled.success!s:5s}  '\n",
+    "      f'max residual={coupled.max_scaled_residual:.2e}  '\n",
+    "      f'Tmax={coupled.max_temperature_k:8.3f} K  (pinned at the bound)')\n",
+    "\n",
+    "constrained_nested = solve_nested_design(constrained)\n",
+    "constrained_simultaneous = solve_design(constrained)\n",
+    "print('route          success  Tmax [K]   margin [K]  production [mol/s]')\n",
+    "for label, result in (('simultaneous', constrained_simultaneous),\n",
+    "                      ('nested', constrained_nested)):\n",
+    "    print(f'{label:13s}  {result.success!s:7s}  '\n",
+    "          f'{result.nominal.max_temperature_k:8.3f}  '\n",
+    "          f'{result.nominal.thermal_margin_k:+10.2e}  '\n",
+    "          f'{result.nominal.production_mol_s:.10e}')\n",
+    "print('max activity difference:',\n",
+    "      np.max(np.abs(constrained_simultaneous.activity - constrained_nested.activity)))\n",
+    "\n",
+    "active_ceiling_agreement = (\n",
+    "    hot.success and hot.thermal_margin_k < 0.0 and not coupled.success\n",
+    "    and constrained_nested.success and constrained_simultaneous.success\n",
+    "    and abs(constrained_nested.nominal.thermal_margin_k) < 1e-6\n",
+    "    and abs(constrained_simultaneous.nominal.thermal_margin_k) < 1e-6\n",
+    "    and np.allclose(constrained_simultaneous.activity,\n",
+    "                    constrained_nested.activity, rtol=1e-5, atol=1e-7)\n",
+    "    and constrained_nested.nominal.production_mol_s < hot.production_mol_s\n",
+    ")\n",
+    "print('active thermal ceiling, both routes  '\n",
+    "      f'{\"PASS\" if active_ceiling_agreement else \"FAIL\"}')\n",
+    "assert active_ceiling_agreement"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b2c6ef0",
+   "metadata": {},
+   "source": [
+    "Both facts are visible above. The uniform pellet is a *converged* solution — residual at solver tolerance — that reports a negative `thermal_margin_k`; collapsing the bracket onto the ceiling turns the same candidate into a failed solve pinned at 570.000 K with a 1.8e-03 residual. With the two separated, SLSQP drives the constraint active and reproduces the simultaneous design.\n",
+    "\n",
+    "The bracket is a numerical guard, not a kinetic-validity claim. A converged state above `temperature_limit_k` extrapolates the Koschany fit; it is reported as thermally infeasible and never returned as a design. `success` remains a statement about the state solve alone."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dde01bbc",
    "metadata": {},
    "source": [
@@ -408,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "2ef51deb",
    "metadata": {
     "execution": {
@@ -506,7 +591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "10a18548",
    "metadata": {
     "execution": {
@@ -566,7 +651,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "1457932c",
    "metadata": {
     "execution": {
@@ -652,7 +737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "catalyst-verification",
    "metadata": {
     "execution": {

--- a/python/pounce/examples/catalyst_pellet.py
+++ b/python/pounce/examples/catalyst_pellet.py
@@ -85,6 +85,17 @@ class PelletConfig:
     they must be replaced when a particular support is being modeled.
     ``nodes`` must be divisible by ``zones`` so each activity coefficient owns
     the same physical volume on every solve and refinement mesh.
+
+    ``temperature_limit_k`` is the *design* constraint.
+    ``state_temperature_floor_k`` and ``state_temperature_ceiling_k`` are a
+    separate *numerical* bracket that keeps the fixed-activity root solve on a
+    physical branch, and they deliberately straddle the design ceiling: the
+    forward solve must be able to converge on a candidate that is hot enough to
+    violate the design constraint, so that the constraint is what rejects it
+    rather than a failed state solve (gh#787).  The bracket is not a kinetic
+    validity claim -- a converged state above ``temperature_limit_k`` is
+    extrapolating the Koschany fit and is reported as thermally infeasible,
+    never as a design.
     """
 
     radius_m: float = 1.25e-3  # [m], 2.5 mm diameter
@@ -109,12 +120,26 @@ class PelletConfig:
     pellet_porosity: float = 0.35  # [-], explicit tutorial assumption
     reaction_enthalpy_j_mol: float = -164_000.0  # [J mol_CO2^-1]
     temperature_limit_k: float = 613.0  # [K], kinetic validity ceiling
+    state_temperature_floor_k: float = 400.0  # [K], root-solve safety bracket
+    state_temperature_ceiling_k: float = 900.0  # [K], root-solve safety bracket
     activity_inventory: float = 0.16  # volume-average activity [-]
     activity_upper: float = 1.0  # Koschany catalyst basis [-]
     regularization_weight: float = 0.5  # objective weight [-]
     nodes: int = 8
     zones: int = 4
     kinetics: KoschanyKinetics = KoschanyKinetics()
+
+    def __post_init__(self) -> None:
+        if not self.state_temperature_floor_k < self.temperature_limit_k:
+            raise ValueError(
+                "state_temperature_floor_k must be below temperature_limit_k"
+            )
+        if not self.temperature_limit_k <= self.state_temperature_ceiling_k:
+            raise ValueError(
+                "state_temperature_ceiling_k must not be below "
+                "temperature_limit_k; the root-solve bracket has to contain "
+                "the design-feasible temperature range"
+            )
 
     @property
     def bulk_total_concentration_mol_m3(self) -> float:
@@ -165,12 +190,31 @@ class PelletSolution:
     message: str
     state_scaled: np.ndarray
     scenario: Scenario
+    temperature_limit_k: float
 
     @property
     def max_temperature_k(self) -> float:
         """Maximum cell-center temperature [K]."""
 
         return float(np.max(self.temperature_k))
+
+    @property
+    def thermal_margin_k(self) -> float:
+        """Design thermal margin ``T_limit - max(T)`` [K].
+
+        Negative on a converged solution means the candidate is thermally
+        infeasible, which is a different fact from ``success=False`` (the state
+        solve itself did not converge).  Keeping the two distinguishable is why
+        the root solve carries its own temperature bracket (gh#787).
+        """
+
+        return self.temperature_limit_k - self.max_temperature_k
+
+    @property
+    def thermally_feasible(self) -> bool:
+        """True when this solution respects the design temperature ceiling."""
+
+        return self.thermal_margin_k >= 0.0
 
     @property
     def effectiveness(self) -> float:
@@ -366,14 +410,27 @@ def _effective_diffusivities_backend(config, log_diffusivity_scale, xp):
     return xp.asarray(config.effective_diffusivities_m2_s) * scale
 
 
-def _state_bounds(config: PelletConfig, nodes: int):
+def _state_bounds(config: PelletConfig, nodes: int, *, temperature_ceiling_k: float):
+    """Scaled box bounds for the state vector.
+
+    ``temperature_ceiling_k`` is required rather than defaulted because the two
+    design routes deliberately carry different ceilings.  The simultaneous NLP
+    passes ``config.temperature_limit_k``: there the thermal constraint *is* a
+    variable bound, and POUNCE sees it directly.  The fixed-activity root solve
+    passes ``config.state_temperature_ceiling_k``, the loose numerical bracket,
+    so that a thermally infeasible candidate converges and reports a negative
+    margin instead of failing the bounded least-squares solve (gh#787).
+    """
+
     lower = np.empty((5, nodes), dtype=float)
     upper = np.empty((5, nodes), dtype=float)
     lower[:4] = 1.0e-12
     upper[:4] = 2.0
-    lower[4] = (400.0 - config.bulk_temperature_k) / TEMPERATURE_SCALE_K
+    lower[4] = (
+        config.state_temperature_floor_k - config.bulk_temperature_k
+    ) / TEMPERATURE_SCALE_K
     upper[4] = (
-        config.temperature_limit_k - config.bulk_temperature_k
+        float(temperature_ceiling_k) - config.bulk_temperature_k
     ) / TEMPERATURE_SCALE_K
     return lower.ravel(), upper.ravel()
 
@@ -645,6 +702,7 @@ def _solution_from_state(
         message=str(message),
         state_scaled=np.asarray(state_scaled, dtype=float),
         scenario=scenario,
+        temperature_limit_k=config.temperature_limit_k,
     )
     solution._intrinsic_production_mol_s = intrinsic
     return solution
@@ -664,6 +722,12 @@ def solve_forward(
     resolve gradients, mesh refinement, and uncertainty sampling.  The primary
     design route is :func:`solve_design`, which puts these same state balances
     and the activity variables into one simultaneous POUNCE NLP.
+
+    The temperature box here is ``state_temperature_floor_k`` to
+    ``state_temperature_ceiling_k``, not ``temperature_limit_k``.  A hot
+    candidate therefore converges and reports a negative
+    :attr:`PelletSolution.thermal_margin_k`; ``success`` stays a statement
+    about the state solve alone.
     """
 
     activity = np.asarray(activity, dtype=float)
@@ -682,7 +746,12 @@ def solve_forward(
         if initial_state is None
         else np.asarray(initial_state, dtype=float)
     )
-    lower, upper = _state_bounds(config, nodes)
+    # The root solve carries the loose numerical bracket, never the design
+    # ceiling: a candidate that violates temperature_limit_k must converge here
+    # so the outer route can see its negative thermal margin (gh#787).
+    lower, upper = _state_bounds(
+        config, nodes, temperature_ceiling_k=config.state_temperature_ceiling_k
+    )
 
     def fun(state):
         return np.asarray(residual_jit(state, activity, parameters), dtype=float)
@@ -1002,7 +1071,11 @@ def solve_design(
             np.asarray([0.99 * min(seed_productions) / production_reference])
         )
     x0 = np.concatenate(x0_parts)
-    state_lower, state_upper = _state_bounds(config, nodes)
+    # The simultaneous route keeps the design ceiling as an explicit variable
+    # bound; POUNCE enforces it directly on every scenario state.
+    state_lower, state_upper = _state_bounds(
+        config, nodes, temperature_ceiling_k=config.temperature_limit_k
+    )
     lb_parts = [*([state_lower] * len(scenarios)), np.zeros(zones)]
     ub_parts = [
         *([state_upper] * len(scenarios)),
@@ -1013,6 +1086,11 @@ def solve_design(
         ub_parts.append(np.asarray([10.0]))
     lb = np.concatenate(lb_parts)
     ub = np.concatenate(ub_parts)
+    # The seed comes from the root solve, whose temperature bracket is looser
+    # than this NLP's design ceiling, so a hot seed can sit above ``ub``.  Clip
+    # it back into the box; this is exactly a no-op for a seed that already
+    # respects the ceiling, which is every nominal configuration.
+    x0 = np.clip(x0, lb, ub)
     n_variables = x0.size
     equality_constraints = len(scenarios) * state_size + 1
     n_constraints = equality_constraints + (len(scenarios) if robust else 0)
@@ -1102,6 +1180,14 @@ def solve_nested_design(
     exact implicit derivative from :func:`implicit_observable_jacobian`.  It is
     retained as a cross-check; the simultaneous POUNCE transcription remains
     the primary route because it exposes every balance and bound directly.
+
+    The two routes enforce the same thermal ceiling by different mechanisms.
+    :func:`solve_design` carries ``temperature_limit_k`` as a state variable
+    bound.  Here it is an explicit SLSQP inequality on the converged inner
+    solution, which only means anything because the inner solve uses the looser
+    ``state_temperature_ceiling_k`` bracket: a thermally infeasible candidate
+    has to be able to converge before the outer optimizer can be told to move
+    away from it (gh#787).
     """
 
     from scipy.optimize import minimize
@@ -1123,7 +1209,13 @@ def solve_nested_design(
         np.full(zones, config.activity_inventory), config, nodes=nodes
     )
     if not reference.success:
-        raise RuntimeError(reference.message)
+        # No production normalization is available without this solve. A
+        # failure here is the state solve, not the thermal ceiling: the inner
+        # bracket is looser than temperature_limit_k, so a merely hot uniform
+        # pellet converges and is normalized against normally.
+        raise RuntimeError(
+            f"uniform-inventory reference state solve failed: {reference.message}"
+        )
     production_reference = max(reference.production_mol_s, 1.0e-12)
     cached_activity = None
     cached_solution = None
@@ -1136,7 +1228,11 @@ def solve_nested_design(
             seed = None if cached_solution is None else cached_solution.state_scaled
             solution = solve_forward(candidate, config, nodes=nodes, initial_state=seed)
             if not solution.success:
-                raise RuntimeError(solution.message)
+                # A genuine state-solve failure, not a thermal violation: the
+                # inner bracket is deliberately looser than the design ceiling,
+                # so a hot-but-converged candidate reaches ``thermal_margin``
+                # below instead of aborting the outer solve here.
+                raise RuntimeError(f"inner state solve failed: {solution.message}")
             cached_activity = candidate.copy()
             cached_solution = solution
             cached_jacobian = implicit_observable_jacobian(solution, config)
@@ -1158,8 +1254,9 @@ def solve_nested_design(
         return gradient
 
     def thermal_margin(activity):
+        # The design constraint, enforced on the converged inner state.
         solution, _ = evaluate(activity)
-        return config.temperature_limit_k - solution.max_temperature_k
+        return solution.thermal_margin_k
 
     def thermal_jacobian(activity):
         _, jacobian = evaluate(activity)
@@ -1362,7 +1459,7 @@ def validate_uncertainty(
         activity, config, nodes=nodes, scenario=nominal_scenario
     )
     if not nominal_solution.success:
-        raise RuntimeError(nominal_solution.message)
+        raise RuntimeError(f"nominal state solve failed: {nominal_solution.message}")
     jacobian = implicit_observable_jacobian(
         nominal_solution, config, with_respect_to="scenario"
     )

--- a/python/tests/test_catalyst_pellet_example.py
+++ b/python/tests/test_catalyst_pellet_example.py
@@ -264,6 +264,108 @@ def test_simultaneous_and_nested_design_agree_and_refine():
     assert refined.max_temperature_k < config.temperature_limit_k
 
 
+def test_thermal_ceiling_is_a_constraint_not_a_failed_state_solve():
+    """gh#787: the design ceiling and the root-solve bracket are separate.
+
+    The nested route can only respond to ``temperature_limit_k`` if a candidate
+    that violates it still converges, so that the outer optimizer is handed a
+    negative margin rather than an exception.  The configuration below puts the
+    ceiling at 570 K, below the 572.5 K peak of the uniform pellet, which makes
+    the constraint bind at the nominal eight-cell operating point.
+    """
+
+    config = replace(PelletConfig(nodes=8, zones=4), temperature_limit_k=570.0)
+    uniform = np.full(config.zones, config.activity_inventory)
+
+    # Converged *and* thermally infeasible. The root solve reaches a genuine
+    # root -- residual and energy closure at solver tolerance -- whose peak
+    # temperature nonetheless violates the design ceiling.
+    hot = solve_forward(uniform, config)
+    assert hot.success, hot.message
+    assert hot.max_scaled_residual < 1e-10
+    assert hot.energy_balance_relative < 1e-10
+    assert hot.max_temperature_k > config.temperature_limit_k
+    assert hot.thermal_margin_k < 0.0
+    assert not hot.thermally_feasible
+
+    # The pre-fix formulation, recovered by collapsing the numerical bracket
+    # onto the design ceiling: the identical candidate now fails the bounded
+    # least-squares solve, its peak temperature pinned at the bound instead of
+    # sitting at a root. That is the state this issue is about -- a failed
+    # state solve where the honest answer is "converged, but too hot".
+    coupled = replace(config, state_temperature_ceiling_k=config.temperature_limit_k)
+    pinned = solve_forward(uniform, coupled)
+    assert not pinned.success
+    assert pinned.max_scaled_residual > 1e-4
+    assert pinned.energy_balance_relative > 1e-3
+    assert pinned.max_temperature_k == pytest.approx(
+        config.temperature_limit_k, abs=1e-9
+    )
+
+    # With the two separated, SLSQP sees the constraint and moves off it. Both
+    # routes drive the ceiling active and land on the same design, even though
+    # the nested route enforces it as an explicit inequality on the converged
+    # inner solve and the simultaneous route as a state variable bound.
+    nested = solve_nested_design(config)
+    simultaneous = solve_design(config)
+
+    assert nested.success, nested.status
+    assert simultaneous.success, simultaneous.status
+    assert nested.max_constraint_violation < 1e-7
+    assert simultaneous.max_constraint_violation < 1e-8
+    assert nested.nominal.thermal_margin_k == pytest.approx(0.0, abs=1e-6)
+    assert simultaneous.nominal.thermal_margin_k == pytest.approx(0.0, abs=1e-6)
+    np.testing.assert_allclose(
+        nested.activity, simultaneous.activity, rtol=1e-5, atol=1e-7
+    )
+    np.testing.assert_allclose(
+        nested.nominal.production_mol_s,
+        simultaneous.nominal.production_mol_s,
+        rtol=1e-6,
+    )
+    # The ceiling is load-bearing here: honouring it costs production against
+    # the equal-inventory uniform pellet that violates it.
+    assert nested.nominal.production_mol_s < hot.production_mol_s
+
+
+def test_root_solve_bracket_must_contain_the_design_ceiling():
+    with pytest.raises(ValueError, match="state_temperature_ceiling_k"):
+        PelletConfig(temperature_limit_k=613.0, state_temperature_ceiling_k=600.0)
+    with pytest.raises(ValueError, match="state_temperature_floor_k"):
+        PelletConfig(temperature_limit_k=613.0, state_temperature_floor_k=620.0)
+
+
+def test_eight_cell_routes_agree_when_the_thermal_ceiling_is_slack():
+    """The nominal validated mesh is unaffected by the gh#787 separation."""
+
+    config = PelletConfig(nodes=8, zones=4)
+    nested = solve_nested_design(config)
+    simultaneous = solve_design(config)
+
+    assert nested.success, nested.status
+    assert simultaneous.success, simultaneous.status
+    # Both reported designs sit near 579 K, well under the 613 K ceiling, so
+    # the thermal constraint is inactive and the two routes are comparing only
+    # the balances and the inventory.
+    assert nested.nominal.thermal_margin_k > 30.0
+    assert simultaneous.nominal.thermal_margin_k > 30.0
+    assert nested.nominal.thermally_feasible
+    assert simultaneous.nominal.thermally_feasible
+    np.testing.assert_allclose(
+        nested.activity, simultaneous.activity, rtol=8e-4, atol=3e-6
+    )
+    np.testing.assert_allclose(
+        nested.nominal.production_mol_s,
+        simultaneous.nominal.production_mol_s,
+        rtol=2e-6,
+    )
+    np.testing.assert_allclose(
+        nested.nominal.max_temperature_k,
+        simultaneous.nominal.max_temperature_k,
+        rtol=2e-8,
+    )
+
+
 def test_covariance_drives_robust_design_and_sampled_resolves():
     config = PelletConfig(nodes=6, zones=3)
     fit = fit_effective_parameters(config=config)


### PR DESCRIPTION
## Problem

`solve_nested_design` declares a `thermal_margin` inequality, but its inner `solve_forward` root solve used `temperature_limit_k` as the temperature **state** bound. A converged inner solution could therefore never report a negative margin — so the constraint could never be violated, and so SLSQP could never respond to it.

Eight-cell mesh, uniform equal-inventory activity, design ceiling moved to 570 K (under the 572.5 K peak of that pellet so the constraint binds):

| root-solve temperature box | `success` | max scaled residual | peak T | `thermal_margin_k` |
|---|---|---|---|---|
| before (= `temperature_limit_k`) | `False` | 1.83e-03 | 570.000 K (pinned at the bound) | — |
| after (400–900 K bracket) | `True` | 1.40e-13 | 572.509 K | −2.509 K |

Before, the outer optimizer received a failed state solve and aborted. It could not tell *"this design is too hot"* from *"the physics did not converge"*.

## Cause

One number was doing two jobs. `_state_bounds` built the temperature box from `temperature_limit_k` for **both** routes, but the two routes need different things from it:

* `solve_design` (simultaneous) genuinely wants the design ceiling as a variable bound — POUNCE sees the constraint directly. That is the point of the transcription.
* `solve_forward` is a *bounded least-squares root solve*. Putting the design ceiling on it makes the design-infeasible region unreachable rather than reachable-and-rejected: the solve stalls against the bound with an unclosed energy balance instead of converging to a root the constraint can then reject.

## Fix

Separate the design constraint from the root solve's numerical bracket.

| field | role |
|---|---|
| `temperature_limit_k` = 613 K | design constraint (unchanged) |
| `state_temperature_floor_k` / `state_temperature_ceiling_k` = 400 / 900 K | root-solve bracket, deliberately straddling the ceiling |

`_state_bounds` now **requires** the ceiling as a keyword argument rather than defaulting, so neither route can pick one up by accident — the call site has to state which ceiling it means and why. `__post_init__` rejects a bracket that does not contain the design-feasible range, since a ceiling below `temperature_limit_k` makes the constraint unreachable again.

`PelletSolution` gains `thermal_margin_k` and `thermally_feasible`, so hot-but-converged is distinguishable from failed at the API level; `success` stays a statement about the state solve alone. The three state-solve failure paths now name themselves in the raised message instead of re-raising a bare solver string.

**Why 900 K, and why not something tighter.** Both sides of that choice are measured, not picked:

* It must be loose enough that the *constraint* binds first, never the bracket.
* It must be tight enough to keep the root solve off the ignited branch — and that branch is closer than it looks. Lowering the external film coefficient at the nominal operating point turns the low-temperature branch back just above a 613 K peak: it still converges at `h = 171.5 W m^-2 K^-1` (612.7 K) and no longer converges at `h = 170`. Past that fold the only remaining steady state is the mass-transfer-limited runaway, external Prater rise `(-ΔH) k_m c_bulk / h` of order 10³ K — far outside the 453–613 K Koschany range.

The bracket is explicitly **not** a kinetic-validity claim. A converged state above `temperature_limit_k` is extrapolating the fit; it is reported thermally infeasible and never returned as a design.

**Rejected alternative:** teaching the nested route to catch the failed inner solve and hand SLSQP a synthetic large penalty. That reads as a fix but keeps the two facts fused — a genuine non-convergence (no steady state at all, as at `h = 80` below) would be reported as a thermal violation, which is a *wrong* answer rather than a missing one. Separating the bounds keeps `success` and `thermal_margin_k` orthogonal, which is what the acceptance criterion actually asked for.

## Blast radius

Bit-identical in intent, and identical to ~1e-13 in fact, except the targeted case.

`solve_design` is unchanged: it still carries the design ceiling directly as a state bound. Its seed is now clipped into the box, which is exactly a no-op whenever the seed already respects the ceiling — every nominal configuration.

Nominal results diffed against the parent commit, `n=6/z=3` and `n=8/z=4`, forward + simultaneous + nested:

* same designs, same objectives, **same iteration counts** (simultaneous 10, nested 5 at `n=8`)
* agreement to ~1e-13 relative; the only movement is last-digit noise from the changed trust-region scaling inside `least_squares`
* the designs reported in #779 remain near 579 K with the ceiling slack, as that PR stated

No Rust changed — the diff is `python/pounce/examples/`, its test, notebook 37, the book page, and the CHANGELOG. No solver trajectory is involved, so `scripts/sweep-fixtures.sh` does not apply here.

## Tests

`python/tests/test_catalyst_pellet_example.py`, three new tests:

1. **`test_thermal_ceiling_is_a_constraint_not_a_failed_state_solve`** — the regression the issue asks for. Asserts the converged-but-infeasible candidate (residual < 1e-10, energy closure < 1e-10, negative margin), then reproduces the old failure in the same test by collapsing the bracket back onto the ceiling, then checks both routes drive the constraint active and agree:

   ```
   nested        True   Tmax 570.000  production 4.2221310188e-07
   simultaneous  True   Tmax 570.000  production 4.2221310219e-07
   ```

   **It bites.** Reintroducing the defect (pointing `solve_forward` back at `temperature_limit_k`) turns this test red — on `assert hot.success`, with `max scaled residual=1.832e-03`, which is exactly the stated reason — and **only** this test red. The other nine stay green, which is the point: the existing corpus runs entirely with the ceiling slack, so it could not see this.

2. **`test_eight_cell_routes_agree_when_the_thermal_ceiling_is_slack`** — the acceptance criterion that nominal eight-cell results are unaffected. Pins nested/simultaneous agreement on the validated mesh and that the margin is > 30 K, i.e. that this test is genuinely exercising the *slack* branch and is not a duplicate of (1).

3. **`test_root_solve_bracket_must_contain_the_design_ceiling`** — both `__post_init__` rejections.

Full Python suite: **1195 passed, 26 skipped** (16m31s). Pellet file: 10 passed.

**Deliberately not pinned:** the `h = 80` configuration from the issue. It still fails, correctly — see below — so pinning it would pin a state-solve failure, not this fix.

## One correction to the report

The issue's repro (`nodes=8`, `heat_transfer_coefficient_w_m2_k=80`) still raises, and that is the right answer rather than a remaining gap. That film coefficient is well past the fold: there is no low-temperature steady state to find, the peak stalls at 555.36 K — nowhere near the 613 K ceiling — and the temperature bound is never active in that solve. Seeding at 600/700/800/1000 K all land on the same non-root; the residual floor is a genuine local minimum of ‖R‖².

The constraint-handling gap the report identified is real and is fixed. It just isn't what that particular configuration demonstrates, so the regression reproduces it at a ceiling where a solution does exist. Both routes now say *"state solve failed"* in the message rather than re-raising a bare solver string.

## Docs

* `docs/src/catalyst-pellet.md` — validation ladder gains a rung (routes re-compared with the ceiling **active**), a new *"Two routes, one thermal ceiling, two mechanisms"* section covering the distinction and the bracket's rationale, and a limitations bullet on the fold.
* Notebook 37 — two markdown cells and one code cell demonstrating the distinction, with genuine recorded output. The cell self-verifies with its own assert rather than editing the existing verification cell's recorded run.

Fixes #787

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`catalyst-pellet.md`, already in `SUMMARY.md`)
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — **not run: no Rust in this diff.** Python-only change under `python/pounce/examples/`.
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_013w9NoX47rfcxW4WTqctkee)_