### PR TITLE
perf(examples): halve the phase-envelope regression test (#788)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,16 +202,22 @@ jobs:
           # `.lst` just says the wrong thing.
           python -m pip install "gamsapi[core]"
       # `test_published_binary_fold_and_inverse_design_regression` is marked
-      # `slow` and costs ~9 minutes here on its own — it was the whole of this
-      # job's 8m23s -> 22m12s jump when the phase-envelope example landed, and
-      # this job is the long pole gating every PR. What it asserts is a
-      # published thermodynamic value and a continuation step-size invariance:
-      # claims about the *example*, which only the example, the JAX frontend
-      # it drives, or the solver underneath can move. So a PR that touches
-      # none of those deselects it, every push to `main` runs it in full, and
-      # a solver change is covered after merge rather than before — the same
-      # trade `coverage.yml` documents for the same reason. The three unmarked
-      # tests in that file still run on every PR.
+      # `slow` — it was the whole of this job's 8m23s -> 22m12s jump when the
+      # phase-envelope example landed, on the job that is the long pole gating
+      # every PR. gh#788 halved it (759s -> 372s locally) by dropping the
+      # step-size-convergence pair and sharing the fold's compiled graph
+      # across compositions, but what is left is still minutes: two XLA
+      # compilations of a third derivative of the Peng--Robinson residual,
+      # both load bearing.
+      #
+      # What it asserts is a published thermodynamic value and an inverse
+      # design: claims about the *example*, which only the example, the JAX
+      # frontend it drives, or the solver underneath can move. So a PR that
+      # touches none of those deselects it, every push to `main` runs it in
+      # full, and a solver change is covered after merge rather than before —
+      # the same trade `coverage.yml` documents for the same reason. The
+      # unmarked tests in that file still run on every PR, including the one
+      # pinning the invariant the fold cache's key depends on.
       - name: Decide whether the slow tests run
         id: select
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ changes.
 
 ## [Unreleased]
 
+- **The phase-envelope regression test costs half what it did, and the half
+  that went was not where the issue expected** (#788).
+  `test_published_binary_fold_and_inverse_design_regression` measured 759s
+  end to end; it now measures 372s. Profiling it phase by phase put 84% of
+  the runtime in four XLA compilations of the augmented fold system's
+  Lagrangian Hessian — a third derivative of the Peng--Robinson residual, at
+  ~195s, ~196s, ~143s and ~106s — and only 13% in the three continuation
+  traces the issue proposed trimming. Shortening the traces alone would have
+  returned about 6%.
+
+  Two of the four compilations are gone. `_fold_problem`'s cache key drops
+  the composition, so the inverse design's verification fold reuses the
+  temperature graph instead of recompiling it (~143s): `refine_fold` always
+  supplies a design vector and `_decode_design` takes the composition from
+  *that*, ignoring the mixture's own. #789 identified that key but declined
+  it, because the invariant lives in a different function and a later edit
+  could silently hand back a stale graph — "wrong rather than merely slow".
+  The new unmarked `test_fold_equations_ignore_the_mixture_composition`
+  removes that objection by checking the invariant directly, on every PR;
+  it is mutation-checked, and goes red alone when `_decode_design` is made
+  to read `mixture.composition`.
+
+  The other (~196s) is the coarse pressure-mode fold, which existed only as
+  one side of the ds=0.10/ds=0.08 step-size-convergence comparison. Dropping
+  that pair, as the issue proposed, therefore removed a full compilation
+  rather than just the ds=0.08 trace. Notebook 34 cell 38 still publishes
+  the coarse/fine agreement (8.41e-12). The properties the #777 review
+  established all survive: the fold is still reached by a real continuation
+  from a real low-pressure anchor, the published Deiters--Bell 282.53 K
+  maxcondentherm is still checked, and the inverse design is still verified
+  by a fresh retrace rather than by re-reading the NLP's own answer.
+
+  What remains is two compilations, both load bearing — the temperature fold
+  (the published benchmark) and the inverse-design NLP (the design solve) —
+  so the test stays marked `slow`. `reparameterize_trace` lost its only
+  caller when the pressure fold went, and rather than lose its coverage it
+  gains a direct test against a synthetic trace, which costs no continuation
+  run and checks the reversal re-detection the incidental coverage never did.
+
 - **A truncated `.nl` file is rejected instead of solved** (#785). A `.nl`
   cut short before its trailing segments — an interrupted write, a full disk,
   a partial copy, a killed AMPL/Pyomo writer — parsed without complaint:
@@ -84,24 +123,24 @@ changes.
   problem, which is worth ~55 s to the regression test and one compilation
   per *kind* of fold rather than per fold to notebook 34.
 
-  The cache key is the complete mixture. Keying on everything except the
-  composition would hit more often and be correct today, because
-  `_decode_design` reads the composition from the supplied design vector and
-  ignores the mixture's own — but that invariant lives in a different
-  function, and if it ever changes, a composition-blind key hands back a
-  stale graph and the answer is wrong rather than slow.
+  The cache key omits the composition (#788, below): `_decode_design` reads
+  the composition from the supplied design vector and ignores the mixture's
+  own, so mixtures differing only in composition share one graph. That
+  invariant lives in a different function, so it is pinned by a test rather
+  than asserted in a comment.
 
 - **The published phase-envelope reproduction no longer runs on every pull
   request.** `test_published_binary_fold_and_inverse_design_regression` is
   marked `slow`: it costs ~9 minutes on a CI runner by itself, and it was the
   whole of `Python tests (jax)` going from 8m23s to 22m12s when the example
   landed — on the job that is the long pole gating every PR. It asserts a
-  published thermodynamic value and a continuation step-size invariance,
-  claims only the example, the JAX frontend it drives, or the solver can
-  move. A PR touching none of those deselects it; every push to `main` runs
-  it in full, so a solver change is still covered, after merge rather than
-  before. The three unmarked tests in that file — cubic root branches,
-  simplex coordinates, implicit derivatives — still run on every PR.
+  published thermodynamic value and an inverse design, claims only the
+  example, the JAX frontend it drives, or the solver can move. A PR touching
+  none of those deselects it; every push to `main` runs it in full, so a
+  solver change is still covered, after merge rather than before. The
+  unmarked tests in that file — cubic root branches, simplex coordinates,
+  implicit derivatives, trace reparameterization, and the fold cache's
+  composition invariant — still run on every PR.
 
 - **A new flagship Python tutorial performs uncertainty-aware inverse design
   of a nonisothermal CO2-methanation catalyst pellet** (#775). The reusable

--- a/python/pounce/examples/phase_envelope.py
+++ b/python/pounce/examples/phase_envelope.py
@@ -1012,18 +1012,34 @@ def _fold_problem(
 
     Constructing a fresh problem per call therefore paid that cost once
     per fold rather than once per *kind* of fold — five times over in
-    ``test_published_binary_fold_and_inverse_design_regression`` alone,
-    and once per refined extremum in notebook 34.
+    ``test_published_binary_fold_and_inverse_design_regression`` as it
+    stood when this cache landed, and once per refined extremum in
+    notebook 34.  That test now refines two folds, and with the key below
+    they share one compilation.
 
-    The key is the complete mixture, not just the parts the traced graph
-    reads.  ``refine_fold`` always supplies the design vector, and
-    ``_decode_design`` takes the composition from *that* and ignores
-    ``mixture.composition``, so keying on everything but the composition
-    would hit more often and still be correct today.  It is deliberately
-    not done: that correctness rests on an invariant inside a different
-    function, and if a later edit makes the residual read the mixture's
-    own composition, a composition-blind key returns a stale graph and the
-    answer is wrong rather than merely slow.
+    The key deliberately omits ``mixture.composition``.  ``refine_fold``
+    always supplies the design vector, and ``_decode_design`` takes the
+    composition from *that* and ignores ``mixture.composition``, so two
+    mixtures differing only in composition trace the same graph.  Keying
+    on the composition anyway cost a full recompile for the inverse
+    design's verification fold, which is the same mixture at a designed
+    composition -- 143 s of the 759 s
+    ``test_published_binary_fold_and_inverse_design_regression`` used to
+    take (gh#788).
+
+    That the composition is unread is an invariant of a *different*
+    function, so it is pinned by a test rather than by this comment:
+    ``test_fold_equations_ignore_the_mixture_composition`` evaluates
+    ``_fold_equations`` against two mixtures that differ only in
+    composition and requires the outputs to be identical.  It is one of
+    the unmarked tests, so it runs on every pull request.  If a later
+    edit makes the residual read ``mixture.composition``, that test goes
+    red rather than this cache quietly returning a stale graph -- which
+    is the failure mode a composition-blind key would otherwise have.
+
+    ``p_example`` is likewise composition-dependent and likewise safe to
+    share: ``JaxProblem`` reads only its shape and dtype, and probes the
+    sparsity pattern at random ``(x, p)`` draws of its own.
     """
 
     key = (
@@ -1031,7 +1047,6 @@ def _fold_problem(
         mixture.critical_temperature.tobytes(),
         mixture.critical_pressure.tobytes(),
         mixture.acentric_factor.tobytes(),
-        mixture.composition.tobytes(),
         mixture.binary_interaction.tobytes(),
         float(beta),
         mode,

--- a/python/tests/test_phase_envelope_example.py
+++ b/python/tests/test_phase_envelope_example.py
@@ -6,6 +6,7 @@ import pytest
 from pounce.examples.phase_envelope import (
     DEITERS_BELL_METHANE_PROPANE,
     NATURAL_GAS,
+    _fold_equations,
     composition_from_coordinates,
     design_composition_for_extremum,
     design_parameters,
@@ -19,6 +20,7 @@ from pounce.examples.phase_envelope import (
     trace_envelope,
     vapor_pressure,
 )
+from pounce.jax import PathTrace
 
 
 def test_simplex_log_ratio_coordinates_round_trip():
@@ -104,24 +106,122 @@ def test_fixed_pressure_sensitivity_matches_fresh_phase_boundary_solves():
     np.testing.assert_allclose(recovered.state, point.state, rtol=1e-9, atol=1e-9)
 
 
+def test_fold_equations_ignore_the_mixture_composition():
+    """Pin the invariant ``_fold_problem``'s cache key rests on (gh#788).
+
+    ``refine_fold`` always supplies a design vector, and ``_decode_design``
+    reads the composition from *that*, ignoring ``mixture.composition``.
+    ``_fold_problem`` therefore leaves the composition out of its cache key,
+    so the inverse design's verification fold reuses the compiled graph
+    instead of paying a second ~2-minute XLA compile of the augmented
+    system's third derivative.
+
+    That invariant lives in a different function, so it is checked here
+    rather than trusted.  This test is unmarked and cheap: it evaluates the
+    fold equations, never their Lagrangian Hessian, so it runs on every
+    pull request and goes red the moment the residual starts reading the
+    mixture's own composition.
+    """
+
+    mixture = DEITERS_BELL_METHANE_PROPANE
+    kij_pair = (0, 1)
+    design = design_parameters(mixture, kij_pair)
+    n_fold = 2 * (mixture.n_components + 1) + 1
+    fold_state = np.linspace(0.1, 0.9, n_fold)
+
+    other = mixture.with_composition(np.array([0.35, 0.65]))
+    assert not np.allclose(other.composition, mixture.composition)
+
+    baseline = np.asarray(
+        _fold_equations(fold_state, design, mixture, 0.0, "temperature", kij_pair)
+    )
+    shifted = np.asarray(
+        _fold_equations(fold_state, design, other, 0.0, "temperature", kij_pair)
+    )
+    np.testing.assert_array_equal(baseline, shifted)
+
+
+def test_reparameterize_trace_swaps_the_parameter_and_its_state_slot():
+    """Reparameterization rearranges converged coordinates, and only those.
+
+    This ran only inside the slow published-value test until gh#788 dropped
+    the pressure-mode fold it fed.  The function is pure array
+    rearrangement, so a synthetic trace covers it exactly and costs no
+    continuation run.
+    """
+
+    n = DEITERS_BELL_METHANE_PROPANE.n_components
+    theta = np.array([0.0, 1.0, 2.0, 1.5, 0.5])  # [ln K], with one reversal
+    state = np.column_stack(
+        [np.arange(5.0), np.arange(5.0) + 10.0, np.array([7.0, 8.0, 9.0, 8.5, 7.5])]
+    )  # [ln K_1, ln K_2, ln P]
+    trace = PathTrace(
+        s=np.arange(5.0),
+        theta=theta,
+        x=state,
+        lam=np.zeros((5, n + 1)),
+        n_steps=5,
+        n_correctors=5,
+        n_accepts=5,
+        turning_points=[2.0],
+    )
+
+    swapped = reparameterize_trace(
+        trace, DEITERS_BELL_METHANE_PROPANE, from_mode="temperature", to_mode="pressure"
+    )
+
+    # The old state slot n becomes the parameter; the old parameter takes it.
+    np.testing.assert_array_equal(swapped.theta, state[:, n])
+    np.testing.assert_array_equal(swapped.x[:, :n], state[:, :n])
+    np.testing.assert_array_equal(swapped.x[:, n], theta)
+    # Turning points are re-detected in the new parameter, not carried over.
+    assert swapped.turning_points == [9.0]
+    assert swapped.active_set_changes == []
+
+    # Same mode is a copy, not a rearrangement.
+    same = reparameterize_trace(
+        trace, DEITERS_BELL_METHANE_PROPANE, from_mode="pressure", to_mode="pressure"
+    )
+    np.testing.assert_array_equal(same.theta, theta)
+    np.testing.assert_array_equal(same.x, state)
+
+    with pytest.raises(ValueError, match="from_mode"):
+        reparameterize_trace(
+            trace, DEITERS_BELL_METHANE_PROPANE, from_mode="bogus", to_mode="pressure"
+        )
+
+
 @pytest.mark.slow
 def test_published_binary_fold_and_inverse_design_regression():
     """Reproduce a published maxcondentherm and solve an inverse design.
 
     Marked slow because it is the most expensive test in the suite by an
-    order of magnitude: ~150 s locally and ~9 min on a CI runner, nearly
-    all of it XLA compiling the Lagrangian Hessian of the augmented fold
-    equations, which is a third derivative of the Peng--Robinson residual.
-    ``_fold_problem`` already caches that compilation across the folds
-    that share a mixture and mode; the three that remain are irreducible.
+    order of magnitude, nearly all of it XLA compiling the Lagrangian
+    Hessian of the augmented fold equations, which is a third derivative
+    of the Peng--Robinson residual.  Two such compiles remain -- the
+    temperature fold and the inverse-design NLP -- and both are load
+    bearing: they are the published benchmark and the design solve.
 
-    What it asserts is a *published-value* and *step-size-invariance*
-    claim about the example, not a claim about the solver's arithmetic,
-    and it can only move when the example, the JAX frontend, or the solver
-    itself moves.  So it is deselected on pull requests that touch none of
-    those, and runs in full on every push to `main`.  The three unmarked
-    tests in this file still cover the cubic root branches, the simplex
-    coordinates, and the implicit derivatives on every PR.
+    gh#788 cut the other two.  ``_fold_problem``'s cache is keyed
+    blind to composition, so the verification retrace's fold reuses the
+    temperature graph instead of recompiling it.  And the ds=0.10/ds=0.08
+    step-size-convergence pair is gone, taking the pressure-mode fold with
+    it -- that fold existed only as one side of that comparison.  Notebook
+    34 cell 38 still publishes the coarse/fine agreement (8.41e-12), and
+    the properties the #777 review established all survive here: the fold
+    is still reached by a real continuation from a real low-pressure
+    anchor, the published Deiters--Bell value is still checked, and the
+    inverse design is still verified by a fresh trace rather than by
+    re-reading the NLP's own answer.
+
+    What it asserts is a *published-value* and *inverse-design* claim about
+    the example, not a claim about the solver's arithmetic, and it can only
+    move when the example, the JAX frontend, or the solver itself moves.
+    So it is deselected on pull requests that touch none of those, and runs
+    in full on every push to `main`.  The unmarked tests in this file still
+    cover the cubic root branches, the simplex coordinates, the implicit
+    derivatives, trace reparameterization, and the composition invariant
+    the fold cache depends on, on every PR.
     """
 
     mixture = DEITERS_BELL_METHANE_PROPANE
@@ -137,18 +237,6 @@ def test_published_binary_fold_and_inverse_design_regression():
         mixture,
         beta=0.0,
         mode="temperature",
-        kij_pair=(0, 1),
-    )
-    pressure_fold = refine_fold(
-        reparameterize_trace(
-            trace,
-            mixture,
-            from_mode="temperature",
-            to_mode="pressure",
-        ),
-        mixture,
-        beta=0.0,
-        mode="pressure",
         kij_pair=(0, 1),
     )
     diagnostics = diagnose_phase_point(
@@ -168,51 +256,6 @@ def test_published_binary_fold_and_inverse_design_regression():
     assert diagnostics.roots_are_admissible
     assert np.isclose(diagnostics.liquid_sum, 1.0, atol=1e-10)
     assert np.isclose(diagnostics.vapor_sum, 1.0, atol=1e-10)
-
-    # The augmented folds should be insensitive to the continuation sampling
-    # once each run brackets the same two extrema.
-    fine_trace = trace_envelope(
-        mixture,
-        beta=0.0,
-        mode="temperature",
-        ds=0.08,
-        n_steps=180,
-    )
-    fine_temperature_fold = refine_fold(
-        fine_trace,
-        mixture,
-        beta=0.0,
-        mode="temperature",
-        kij_pair=(0, 1),
-    )
-    fine_pressure_fold = refine_fold(
-        reparameterize_trace(
-            fine_trace,
-            mixture,
-            from_mode="temperature",
-            to_mode="pressure",
-        ),
-        mixture,
-        beta=0.0,
-        mode="pressure",
-        kij_pair=(0, 1),
-    )
-    np.testing.assert_allclose(
-        [
-            pressure_fold.pressure_pa,
-            pressure_fold.temperature_k,
-            fold.temperature_k,
-            fold.pressure_pa,
-        ],
-        [
-            fine_pressure_fold.pressure_pa,
-            fine_pressure_fold.temperature_k,
-            fine_temperature_fold.temperature_k,
-            fine_temperature_fold.pressure_pa,
-        ],
-        rtol=1e-8,
-        atol=1e-6,
-    )
 
     design = design_composition_for_extremum(
         fold,


### PR DESCRIPTION
`test_published_binary_fold_and_inverse_design_regression` measured 759s
end to end. It now measures 372s.

Profiling it phase by phase put 84% of the runtime in four XLA
compilations of the augmented fold system's Lagrangian Hessian -- a third
derivative of the Peng-Robinson residual, at ~195s, ~196s, ~143s and
~106s -- and only 13% in the three continuation traces #788 proposed
trimming. Shortening the traces alone would have returned about 6%.

Two of the four compilations are gone.

`_fold_problem`'s cache key drops the composition, so the inverse
design's verification fold reuses the temperature graph instead of
recompiling it (~143s): `refine_fold` always supplies a design vector and
`_decode_design` takes the composition from *that*, ignoring the
mixture's own. #789 identified that key and declined it, because the
invariant lives in a different function and a later edit could silently
hand back a stale graph -- "wrong rather than merely slow". The new
unmarked `test_fold_equations_ignore_the_mixture_composition` removes
that objection by checking the invariant directly, on every PR. It is
mutation-checked: making `_decode_design` read `mixture.composition`
turns that test, and only that test, red.

The other (~196s) is the coarse pressure-mode fold, which existed only as
one side of the ds=0.10/ds=0.08 step-size-convergence comparison.
Dropping that pair therefore removed a full compilation rather than just
the ds=0.08 trace. Notebook 34 cell 38 still publishes the coarse/fine
agreement (8.41e-12).

The properties the #777 review established all survive: the fold is still
reached by a real continuation from a real low-pressure anchor, the
published Deiters-Bell 282.53 K maxcondentherm is still checked, and the
inverse design is still verified by a fresh retrace rather than by
re-reading the NLP's own answer.

What remains is two compilations, both load bearing -- the temperature
fold (the published benchmark) and the inverse-design NLP (the design
solve) -- so the test stays marked `slow` and the CI deselection #789
added stays in place.

`reparameterize_trace` lost its only caller when the pressure fold went.
Rather than lose its coverage it gains a direct test against a synthetic
trace, which costs no continuation run and checks the reversal
re-detection the incidental coverage never did.

Fixes #788

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B1tEcJXPcuyyR9dtvKGPLS
