### PR TITLE
jax QP layer: read lb/ub concretely so jnp bounds survive jax.jit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ changes.
 
 ## [Unreleased]
 
+- **`pounce.jax.solve_qp`: jnp `lb`/`ub` no longer break under `jax.jit`**
+  (#795). `_expand_bounds` decided which bound rows to fold into `G`/`h` with
+  `np.isfinite(float(ub[i]))`. Indexing is a `jnp` op, and inside a `jit`
+  trace every `jnp` op is staged into the jaxpr — so `ub[i]` came back a
+  tracer and `float()` raised `ConcretizationTypeError`. A numpy array, a
+  Python list, or the same bounds routed through `G`/`h` were all indexed
+  eagerly and survived, as did the jnp form when called eagerly or under
+  `vmap`; only `jit` + jnp-`lb`/`ub` failed, which is the idiomatic call for
+  a layer whose whole purpose is to sit inside a jitted model. The bounds are
+  now read once as concrete host values (`np.asarray`) before the finiteness
+  test, which is where that decision belongs: how many rows get folded is
+  structural, and the folded rows are constants that carry no gradient.
+  Covers `solve_qp`, `solve_qp_batch` and `QpLayer`.
+
+  A bound *built inside* the trace still cannot be read — its value does not
+  exist at trace time — but that case now raises a `ValueError` naming the
+  fix (hoist the construction out, or pass differentiable bound levels
+  through `G`/`h`) instead of jax's bare conversion error. This is distinct
+  from #740, whose defect was in the NLP path (`_diff.py`,
+  `UnexpectedTracerError`) and whose hoisting workaround did *not* help here.
+
 - **Catalyst-pellet tutorial: the nested route's thermal limit is a
   constraint, not a state bound** (#787). `solve_nested_design` defines a
   `thermal_margin` inequality, but the inner `solve_forward` root solve used

--- a/python/pounce/jax/_qp.py
+++ b/python/pounce/jax/_qp.py
@@ -29,7 +29,10 @@ Bounds ``lb ≤ x ≤ ub`` are supported in the *forward* solve by folding
 them into ``G``/``h`` before differentiation, so the IFT sees a single
 inequality block. The folded bound rows are constants, so they carry no
 gradient back to ``lb``/``ub`` (differentiate bound *levels* by passing
-them through ``G``/``h`` explicitly instead).
+them through ``G``/``h`` explicitly instead). ``lb``/``ub`` may be numpy,
+a list, or a jnp array, but they are read on the host at trace time —
+which entries are finite fixes how many rows get folded — so they cannot
+be *built inside* a jitted function (hoist the construction out).
 
 Batching. :func:`solve_qp` is usable under ``jax.vmap`` (each instance is
 an independent, sequential host solve). For a *parallel* batch over many
@@ -90,28 +93,55 @@ from .._ad_common import (
 )  # single source of truth (DiffHandoff contract)
 
 
+def _concrete_bounds(bnd, name):
+    """Read a bound vector as concrete host values (issue #795).
+
+    Which bound rows exist is a *structural* decision — it fixes the shape
+    of the folded ``G``/``h`` — so it has to be made at trace time, off a
+    concrete array. Reading ``bnd[i]`` element-by-element instead stages
+    each read into the jaxpr under ``jax.jit`` (every ``jnp`` op inside a
+    jit trace is staged, even on a closed-over constant), and ``float()``
+    on the resulting tracer raises ``ConcretizationTypeError`` — which is
+    why a jnp ``lb``/``ub`` failed under ``jit`` while the identical numpy
+    array, which is indexed eagerly, worked. One ``np.asarray`` of the
+    whole vector happens before any tracing and covers both.
+
+    A genuinely traced bound (built inside the trace, or differentiated)
+    cannot be read this way at all; raise the documented alternative
+    rather than jax's bare conversion error."""
+    try:
+        return np.asarray(bnd, dtype=float)
+    except (jax.errors.TracerArrayConversionError, jax.errors.ConcretizationTypeError):
+        raise ValueError(
+            f"pounce.jax QP layer: `{name}` must be a concrete array (numpy, a "
+            "list, or a jnp array built outside the trace) — its finite entries "
+            "decide which constant rows are folded into G/h, so they are read at "
+            "trace time and carry no gradient. Pass traced or differentiable "
+            "bound levels through `G`/`h` instead."
+        ) from None
+
+
 def _expand_bounds(G, h, lb, ub, n):
     """Fold finite variable bounds into G/h as extra rows.
 
     Returns ``(G_full, h_full)`` as dense jnp arrays. ``x_i ≤ ub_i`` and
-    ``−x_i ≤ −lb_i``."""
+    ``−x_i ≤ −lb_i``. The folded rows are constants — see
+    :func:`_concrete_bounds` for why the levels are read on the host."""
     rows = []
     rhs = []
     if G is not None and G.shape[0] > 0:
         rows.append(G)
         rhs.append(h)
-    if ub is not None:
+    # ub first, then lb, so the folded block order is stable.
+    for bnd, name, sign in ((ub, "ub", 1.0), (lb, "lb", -1.0)):
+        if bnd is None:
+            continue
+        vals = _concrete_bounds(bnd, name)
         for i in range(n):
-            if np.isfinite(float(ub[i])):
-                e = jnp.zeros(n).at[i].set(1.0)
+            if np.isfinite(vals[i]):
+                e = jnp.zeros(n).at[i].set(sign)
                 rows.append(e[None, :])
-                rhs.append(jnp.asarray(ub[i]).reshape(1))
-    if lb is not None:
-        for i in range(n):
-            if np.isfinite(float(lb[i])):
-                e = jnp.zeros(n).at[i].set(-1.0)
-                rows.append(e[None, :])
-                rhs.append((-jnp.asarray(lb[i])).reshape(1))
+                rhs.append(jnp.asarray(sign * vals[i]).reshape(1))
     if not rows:
         return jnp.zeros((0, n)), jnp.zeros((0,))
     return jnp.concatenate(rows, axis=0), jnp.concatenate(rhs, axis=0)
@@ -467,7 +497,11 @@ def solve_qp(
 
     All array args are dense jnp/np arrays. Bounds are folded into the
     inequality block as constant rows (no gradient flows to ``lb``/``ub``;
-    pass differentiable bound levels through ``G``/``h`` instead).
+    pass differentiable bound levels through ``G``/``h`` instead). Because
+    the finite entries decide *how many* rows are folded, ``lb``/``ub`` are
+    read concretely at trace time: a numpy array, a list, or a jnp array
+    built outside the trace all work; a bound built inside a jitted
+    function does not.
 
     ``warm_start`` (optional) supplies a previous primal ``x`` (an array, or
     anything with an ``x`` attribute/key — e.g. a prior result) to seed the

--- a/python/tests/test_qp_jax.py
+++ b/python/tests/test_qp_jax.py
@@ -387,3 +387,134 @@ def test_check_psd_true_on_psd_p_solves_normally():
     x_default = solve_qp(P=P, c=c, G=G, h=h)
     x_forced = solve_qp(P=P, c=c, G=G, h=h, check_psd=True)
     np.testing.assert_allclose(np.asarray(x_forced), np.asarray(x_default), atol=1e-12)
+
+
+# --------------------------------------------------------------------------
+# jnp lb/ub under jax.jit (issue #795)
+#
+# `_expand_bounds` used to test each bound with ``float(ub[i])``. Under jit
+# every jnp op is staged, so indexing a jnp bound produced a tracer and
+# ``float()`` raised ConcretizationTypeError -- while the identical numpy
+# array, indexed eagerly, worked. The bounds decide *which* constant rows
+# are folded into G/h, so they are read on the host with one np.asarray.
+#
+# The inactive-bounds case alone cannot see the folded rows at all (drop
+# every bound row and it still passes), so each case below either puts a
+# bound on the solution or asserts the row count.
+# --------------------------------------------------------------------------
+
+_B_P = np.eye(2) * 2.0
+_B_C = jnp.array([-1.0, 2.0])
+_B_UNCONSTRAINED = np.array([0.5, -1.0])  # x* = -P^-1 c, bounds inactive
+
+
+def _solve_bounded(lb, ub, c=_B_C):
+    return solve_qp(P=_B_P, c=c, lb=lb, ub=ub)
+
+
+# Built outside any trace, as the issue's repro does -- a jnp array
+# constructed *inside* a jit is a tracer with no recoverable value (jax
+# stages even a tracer-free op), which is the separate, still-unsupported
+# case pinned by test_traced_bounds_raise_actionable_error below.
+_B_LB_WIDE, _B_UB_WIDE = jnp.full(2, -10.0), jnp.full(2, 10.0)
+_B_LB, _B_UB = jnp.array([-0.5, -0.5]), jnp.array([0.25, 0.25])
+_B_BOUNDED = np.array([0.25, -0.5])  # both bounds bind
+
+
+def test_jit_jnp_bounds_inactive_matches_closed_form():
+    x = jax.jit(lambda cc: _solve_bounded(_B_LB_WIDE, _B_UB_WIDE, cc))(_B_C)
+    np.testing.assert_allclose(np.asarray(x), _B_UNCONSTRAINED, atol=1e-8)
+
+
+def test_jit_jnp_bounds_active_matches_numpy_bounds():
+    # Both bounds bind, so a fix that quietly dropped the folded rows fails
+    # here even though it would pass the inactive case above.
+    x_jnp = jax.jit(lambda cc: _solve_bounded(_B_LB, _B_UB, cc))(_B_C)
+    x_np = jax.jit(
+        lambda cc: _solve_bounded(np.asarray(_B_LB), np.asarray(_B_UB), cc)
+    )(_B_C)
+    np.testing.assert_allclose(np.asarray(x_jnp), np.asarray(x_np), atol=1e-8)
+    np.testing.assert_allclose(np.asarray(x_jnp), _B_BOUNDED, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "lb, ub",
+    [
+        (jnp.array([-0.5, -0.5]), np.array([0.25, 0.25])),  # only lb is jnp
+        (np.array([-0.5, -0.5]), jnp.array([0.25, 0.25])),  # only ub is jnp
+        ([-0.5, -0.5], [0.25, 0.25]),  # python lists
+    ],
+)
+def test_jit_mixed_bound_containers(lb, ub):
+    # Either side alone triggered the defect.
+    x = jax.jit(lambda cc: _solve_bounded(lb, ub, cc))(_B_C)
+    np.testing.assert_allclose(np.asarray(x), [0.25, -0.5], atol=1e-6)
+
+
+_B_LB_INF = jnp.array([-jnp.inf, -0.5])
+_B_UB_INF = jnp.array([0.25, jnp.inf])
+
+
+def test_jit_jnp_bounds_infinite_entries_fold_only_finite_rows():
+    # Structural selection has to survive the host read: only x0's upper
+    # bound and x1's lower bound are finite, and both bind.
+    x = jax.jit(lambda cc: _solve_bounded(_B_LB_INF, _B_UB_INF, cc))(_B_C)
+    np.testing.assert_allclose(np.asarray(x), [0.25, -0.5], atol=1e-6)
+
+    from pounce.jax._qp import _expand_bounds
+
+    G_full, h_full = _expand_bounds(
+        jnp.zeros((0, 2)), jnp.zeros((0,)), _B_LB_INF, _B_UB_INF, 2
+    )
+    assert G_full.shape == (2, 2) and h_full.shape == (2,)
+    np.testing.assert_allclose(np.asarray(G_full), [[1.0, 0.0], [0.0, -1.0]])
+    np.testing.assert_allclose(np.asarray(h_full), [0.25, 0.5])
+
+
+def test_jnp_bounds_eager_and_vmap_still_work():
+    np.testing.assert_allclose(
+        np.asarray(_solve_bounded(_B_LB, _B_UB)), _B_BOUNDED, atol=1e-6
+    )
+    cs = jnp.stack([_B_C, _B_C * 0.5])
+    xs = jax.vmap(lambda cc: _solve_bounded(_B_LB, _B_UB, cc))(cs)
+    assert xs.shape == (2, 2)
+    np.testing.assert_allclose(np.asarray(xs[0]), _B_BOUNDED, atol=1e-6)
+
+
+def test_jit_jnp_bounds_still_differentiates_c():
+    g = jax.jit(jax.grad(lambda cc: _solve_bounded(_B_LB_WIDE, _B_UB_WIDE, cc).sum()))(
+        _B_C
+    )
+    # x = -P^-1 c with the bounds inactive, so dx_sum/dc = -diag(1/2).
+    np.testing.assert_allclose(np.asarray(g), [-0.5, -0.5], atol=1e-6)
+
+
+def test_jit_jnp_bounds_batch_and_layer():
+    cs = jnp.stack([_B_C, _B_C])
+    xs = jax.jit(lambda cc: solve_qp_batch(P=_B_P, c=cc, lb=_B_LB, ub=_B_UB))(cs)
+    np.testing.assert_allclose(np.asarray(xs[0]), _B_BOUNDED, atol=1e-6)
+    np.testing.assert_allclose(np.asarray(xs[1]), _B_BOUNDED, atol=1e-6)
+
+    layer = QpLayer(P=_B_P, lb=_B_LB, ub=_B_UB)
+    x = jax.jit(layer)(_B_C)
+    np.testing.assert_allclose(np.asarray(x), _B_BOUNDED, atol=1e-6)
+
+
+def test_traced_bounds_raise_actionable_error():
+    # A bound built *in* the trace cannot be read on the host at all -- the
+    # row structure depends on it, and jax stages the construction whether
+    # or not it depends on an argument. Point at hoisting and at the
+    # documented G/h route rather than letting jax's bare conversion error
+    # out. (This is #740's workaround territory, not #795's defect.)
+    def f(scale):
+        return solve_qp(P=_B_P, c=_B_C, lb=-scale * jnp.ones(2), ub=scale * jnp.ones(2))
+
+    with pytest.raises(ValueError, match=r"`(lb|ub)` must be a concrete array"):
+        jax.jit(f)(jnp.float64(0.25))
+
+    def g(cc):
+        # No dependence on the argument at all -- still staged, still caught.
+        return solve_qp(P=_B_P, c=cc, ub=jnp.full(2, 0.25))
+
+    with pytest.raises(ValueError, match=r"built outside the trace"):
+        jax.jit(g)(_B_C)


### PR DESCRIPTION
Fixes #795

## Problem

`pounce.jax.solve_qp` raised `ConcretizationTypeError` under `jax.jit` whenever
`lb` or `ub` was a **jnp** array. The identical bounds as numpy, as a Python
list, or routed through `G`/`h` all worked, and the jnp form worked fine
eagerly and under `vmap` — only the `jit` + jnp-`lb`/`ub` combination broke.
That is the idiomatic call for a layer whose entire purpose is to sit inside a
jitted model, and the docstring's *"All array args are dense jnp/np arrays"*
invites it.

Measured on the report's fixture (`n=2`, `P=2I`, `c=(-1, 2)`, bounds inactive
at the solution, so the QP reduces to the unconstrained `min ½xᵀPx + cᵀx`):

| how `lb`/`ub` are passed | `jax.jit` before | `jax.jit` after | oracle |
|---|---|---|---|
| numpy array | `[0.5, -1.0]` | `[0.5, -1.0]` | `[0.5, -1.0]` |
| Python list | `[0.5, -1.0]` | `[0.5, -1.0]` | `[0.5, -1.0]` |
| folded into `G`/`h` as jnp | `[0.5, -1.0]` | `[0.5, -1.0]` | `[0.5, -1.0]` |
| **jnp array** | **`ConcretizationTypeError`** | **`[0.5, -1.0]`** | `[0.5, -1.0]` |

Oracle is the closed form `x* = -P⁻¹c = -(2I)⁻¹(-1, 2) = (0.5, -1.0)`. Eager and
`vmap` were correct before and after. Either side alone triggered it (`lb` jnp +
`ub` numpy failed, and vice versa).

## Cause

`_expand_bounds` (`python/pounce/jax/_qp.py:105`, and `:111` for `lb`) tested
each bound with `np.isfinite(float(ub[i]))`. Indexing is a `jnp` op, and inside
a `jit` trace **every** `jnp` op is staged into the jaxpr — so `ub[i]` came back
a `DynamicJaxprTracer` and `float()` on it threw. numpy arrays and lists are
indexed by numpy, never touch the trace, and survived; that asymmetry is the
whole bug.

The tracing rule is finer than "hoist it out", which is worth stating because
#740's workaround is exactly that. Measured on jax 0.10.2:

| how the jnp bound is produced | inside a `jit` trace |
|---|---|
| built outside, closed over | stays a concrete `ArrayImpl` |
| `jnp.full(2, -10.0)` written inline | `DynamicJaxprTracer`, value unrecoverable |
| derived from a traced argument | `DynamicJaxprTracer` |

So jax stages a construction inside the trace **even when it depends on no
tracer**. Row 1 is #795 and is fixable; rows 2 and 3 are not — the value does
not exist at trace time.

## Fix

Read each bound vector once with `np.asarray` *before* the finiteness test, in
a new `_concrete_bounds` helper. That is where the decision belongs: how many
rows get folded into `G`/`h` is **structural** — it fixes the shape of the
inequality block — so it has to be settled at trace time, and the folded rows
are constants that carry no gradient, which is already the layer's documented
contract. `solve_qp`, `solve_qp_batch` and `QpLayer` all share the helper, so
one change covers all three entry points.

Rows 2–3 of the table above now raise a `ValueError` naming the fix (hoist the
construction out, or pass differentiable bound levels through `G`/`h`) instead
of jax's bare conversion error. Previously they raised `ConcretizationTypeError`
from inside a private helper, so this is strictly better diagnostics, not a
narrowing.

Rejected: threading the bounds through as traced values and folding a *fixed*
`2n`-row block with `±inf` rhs entries for the absent bounds. That makes the
row count independent of the values and would support rows 2–3 — but it hands
the interior-point solver `2n` inequality rows on every QP with any bound, most
of them vacuous, and an infinite rhs is not something the convex core accepts.
The cost lands on every user to serve a case the docstring already routes to
`G`/`h`.

Also rejected: recovering the constant behind a `DynamicJaxprTracer`. There is
no public API for it (`_value` is `None`; the tracer holds only a jaxpr `Var`),
and constant-folding a jaxpr to satisfy an argument-reading helper is the wrong
layer to solve this at.

## Blast radius

Confined to the jax QP layer's bound folding. The folded `G`/`h` rows are
numerically identical for every input that worked before — same rows, same
order (`ub` block then `lb` block, unchanged), same values — so no solver
trajectory moves and `scripts/sweep-fixtures.sh` does not apply: this is
frontend row assembly, not a change to which correction the solver reaches for
or how it scales its steps.

Two deliberate, contained behaviour changes:

- Bound levels now enter `h_full` as host floats rather than `jnp.asarray(ub[i])`.
  This makes the "no gradient flows to `lb`/`ub`" contract structural instead of
  incidental. No behaviour is lost: under a `grad` trace the old `float(ub[i])`
  raised too, so there was never a path where a gradient reached `lb`/`ub`.
- An integer-dtype bounds array now becomes float at fold time rather than
  being promoted by `jnp.concatenate`. Same values.

The NLP path (`_diff.py`, #740) is untouched — different module, different
defect, different error.

## Tests

Ten new tests in `python/tests/test_qp_jax.py`. **Eight fail on the parent
commit (`4c9abf7`)**: seven with `ConcretizationTypeError` at `_qp.py:105`, the
exact reported failure, and `test_traced_bounds_raise_actionable_error` because
the parent raises that same `ConcretizationTypeError` where the new contract
promises a `ValueError`.

The two that pass pre-fix do so by design and are labelled as such: the
Python-list parametrization (lists always worked — it is there so a future
change cannot break them silently) and the eager/`vmap` no-regression guard.

Worth calling out, because it shaped the test set: **the reported repro has
bounds inactive at the solution, so it cannot see the folded rows at all.** A
"fix" that discarded every bound row would pass it and return the right answer.
So the tests also cover:

- binding bounds, `jit` + jnp vs. the same bounds as numpy, both against the
  closed form `[0.25, -0.5]`;
- mixed sides (`lb` jnp + `ub` numpy, and the reverse), each of which triggered
  it alone;
- infinite entries — `lb = (-inf, -0.5)`, `ub = (0.25, +inf)` — with a direct
  assertion on the folded block (`G_full == [[1, 0], [0, -1]]`, `h_full ==
  [0.25, 0.5]`), so structural selection is pinned and not merely implied by an
  objective value;
- `solve_qp_batch` and `QpLayer` under `jit`, the other two callers of the
  helper;
- `jax.grad` w.r.t. `c` still flowing under `jit` with jnp bounds
  (`dx_sum/dc = -diag(½)`), so the fix is not a silent detachment.

The jnp fixtures are hoisted to module scope, matching the report and matching
what row 1 of the cause table says is actually supported; the in-trace
construction is pinned separately by the `ValueError` test, including a variant
that depends on no traced argument at all.

Ran: `test_qp_jax.py` 31 passed, `test_jax.py` 106 passed, `test_socp_jax.py` +
`test_qp.py` 16 passed, against a `maturin develop --release` build of this
branch.

Not pinned: nothing deliberately left uncovered.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — **n/a**: no page documents the jax
      QP layer's bound-argument tracing rules (`docs/src/differentiable-solves.md`
      covers the handoff contract; `solve_qp` in `docs/src/python.md` is the
      host API). The rule is now in the `_qp.py` module docstring and in
      `solve_qp`'s docstring, which is the user-facing surface for it.
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean —
      **n/a**: no Rust changed. Not run, so not claimed.
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GwDS69FgmM7xmQBtiQDP8

---
_Generated by [Claude Code](https://claude.ai/code/session_019GwDS69FgmM7xmQBtiQDP8)_