### PR TITLE
perf(kkt): merge the limited-memory SMW factorize+batch into one backend call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1143,6 +1143,48 @@ changes.
   because a fitted vertex value is blind to a uniform rescaling of the
   abscissa — which is why the arclength is asserted beside it rather than
   the temperature being trusted alone.
+- **Limited-memory: the SMW update now costs one pass over the KKT factor,
+  not two (gh #730 follow-up).** Under `hessian_approximation=limited-memory`,
+  `LowRankAugSystemSolver` builds its Sherman-Morrison-Woodbury correction by
+  solving the augmented system for the `2q` low-rank columns. Upstream issues
+  a single `MultiSolve` over all of them
+  (`IpLowRankAugSystemSolver.cpp:487`), so the factorization and every
+  column's back-substitution share one traversal of the factor. POUNCE split
+  that in two: a single-RHS `solve` to pay the factorization, then a batched
+  `try_resolve_many_flat` for the rest. A sparse triangular solve streams the
+  whole factor once per call and then applies it to each column, so its cost
+  is `F + nrhs·W` — and on a large KKT `F` is several times `W`. The split
+  therefore threw away one full `F` on every SMW update.
+
+  There is now a factorizing multi-RHS path (`try_solve_many_flat`) and the
+  cold SMW block takes it, so all columns ride along with the factorization.
+
+  Be careful reading the timing rows, because most of the movement between
+  them is bookkeeping: the merged call bills its substitutions to
+  `LinearSystemFactorization`, so `LinearSystemBackSolve` falls by far more
+  than any work is removed. Measured on `benchmarks/large_scale/laptime`
+  (58 014 variables, 62 014 constraints, FERAL, 100 iterations, two
+  interleaved A/B pairs): back-solve 34.2 s → 23.7 s (−31%) against
+  factorization 55.6 s → 64.7 s (+16%), for a **net −1.45 s of 89 s of
+  linear algebra, −1.6%**, and −0.7% overall. The baseline's own run-to-run
+  spread is 4.2%, so the net is **inside noise on wall time** and should not
+  be quoted as a wall-clock win. It is, however, the size the mechanism
+  predicts — roughly 20 ms per removed factor traversal over ~75–90 SMW
+  updates — so it is real work removed, just not much of it on this model
+  and this backend.
+
+  The trajectory is **bit-identical** over all 100 iterations in both pairs
+  and the fixture sweep is empty on both legs, so nothing was re-associated.
+  Whether the effect is larger under MA57, where the fixed-versus-per-RHS
+  cost ratio differs, is unmeasured here — no coinhsl in the dev container.
+
+  The gh#729 bit-identity gate still governs: the merged call is taken only
+  when the backend affirms `multi_solve_matches_single_solve` at the full
+  column count, and the old split remains as the fallback. Reported by
+  @srikanth-gm, whose measurements on a 59 939-variable CasADi collocation
+  model put POUNCE/MA57 within 1.6% of Ipopt/MA57 on wall time while spending
+  41% more per iteration on back-solve; this addresses part of that row.
+
 - **The NLP arm no longer certifies a constrained maximum as
   `Solve_Succeeded` (gh #797).** On the CLI fixture `nonconvex_qp.nl` —
   `min x₀·x₁ s.t. x₀ + x₁ = 2, 0 ≤ x ≤ 4`, whose restriction to the feasible

--- a/crates/pounce-algorithm/src/kkt/aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/aug_system_solver.rs
@@ -231,6 +231,36 @@ pub trait AugSystemSolver {
         None
     }
 
+    /// Factorize **and** solve `nrhs` right-hand sides in a single
+    /// backend call, with `packed_rhs` in the same column-major layout
+    /// [`Self::try_resolve_many_flat`] uses. Solutions overwrite
+    /// `packed_rhs` in place.
+    ///
+    /// This is the factorizing counterpart of `try_resolve_many_flat`,
+    /// and it exists to reproduce upstream's single
+    /// `AugSystemSolver::MultiSolve` (`IpLowRankAugSystemSolver.cpp:487`)
+    /// in one step rather than two. Splitting that call into a
+    /// single-RHS `solve` followed by a batched `try_resolve_many_flat`
+    /// costs one **extra full traversal of the factor**: a sparse
+    /// triangular solve streams the whole factor once per call and then
+    /// applies it to every column, so its cost is `F + nrhs·W` with `F`
+    /// several times `W` on a large KKT. Merging the two calls removes
+    /// one `F` per Sherman-Morrison-Woodbury update.
+    ///
+    /// Returns `None` when the backend does not support the path, in
+    /// which case the caller keeps the split. Inertia bookkeeping
+    /// (`check_neg_evals` / `num_neg_evals`) matches [`Self::solve`].
+    fn try_solve_many_flat(
+        &mut self,
+        _coeffs: &AugSysCoeffs<'_>,
+        _packed_rhs: &mut [Number],
+        _nrhs: usize,
+        _check_neg_evals: bool,
+        _num_neg_evals: Index,
+    ) -> Option<ESymSolverStatus> {
+        None
+    }
+
     /// Whether [`Self::try_resolve_many_flat`] with `nrhs` columns returns
     /// **bit-identical** results to `nrhs` separate [`Self::resolve`] calls.
     ///

--- a/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
@@ -595,10 +595,19 @@ impl LowRankAugSystemSolver {
         // `W` on a KKT this size, so the split throws away one `F` per
         // SMW update. The same bit-identity gate as the warm batch
         // below applies, at the wider `n_cols_us`.
+        //
+        // Note there is deliberately no `dim == inner.system_dim()`
+        // precondition here, unlike the warm batch below. Cold, the
+        // inner solver has not assembled yet, so its `system_dim()` is
+        // still 0 and that check would reject every first factorization
+        // — silently, leaving the merged path unexercised by any mock
+        // whose `system_dim()` is 0 when cold. `try_solve_many_flat`
+        // assembles first and then declines if the packed length
+        // disagrees, which is the same guard applied where the answer
+        // is actually known.
         if !self.inner_has_factor
             && n_cols_us > 1
             && dim > 0
-            && dim == self.inner.system_dim() as usize
             && self.inner.multi_solve_matches_single_solve(n_cols_us)
         {
             let mut packed = vec![0.0; dim * n_cols_us];
@@ -1296,6 +1305,11 @@ mod tests {
         backsolves: Cell<usize>,
         batched_calls: Cell<usize>,
         batched_cols: Cell<usize>,
+        /// Calls to the *factorizing* multi-RHS path, and the columns
+        /// they carried. Separate from `batched_calls` so a test can
+        /// tell "one merged call" from "a factorization plus a batch".
+        factor_batched_calls: Cell<usize>,
+        factor_batched_cols: Cell<usize>,
         factored_diag: RefCell<Vec<Number>>,
         factored_delta_x: Cell<Number>,
     }
@@ -1417,6 +1431,53 @@ mod tests {
         /// shows up as a wrong answer rather than a wrong count.
         fn multi_solve_matches_single_solve(&self, _nrhs: usize) -> bool {
             self.packed
+        }
+
+        /// The factorizing counterpart: captures the factor like
+        /// `solve` does, then applies it to every packed column. One
+        /// call, one factorization, all columns — which is the whole
+        /// point of the path.
+        fn try_solve_many_flat(
+            &mut self,
+            coeffs: &AugSysCoeffs<'_>,
+            packed_rhs: &mut [Number],
+            nrhs: usize,
+            _check_neg_evals: bool,
+            _num_neg_evals: Index,
+        ) -> Option<ESymSolverStatus> {
+            if !self.packed {
+                return None;
+            }
+            let wdiag = coeffs
+                .w
+                .expect("CountingInner requires W")
+                .as_any()
+                .downcast_ref::<DiagMatrix>()
+                .expect("CountingInner requires W to be a DiagMatrix");
+            let diag_rc = wdiag.get_diag().expect("Wdiag has no diag set").clone();
+            let diag = downcast_dense(diag_rc.as_ref()).expanded_values();
+            let dim = diag.len();
+            if packed_rhs.len() != dim * nrhs {
+                return None;
+            }
+            *self.stats.factored_diag.borrow_mut() = diag.clone();
+            self.stats.factored_delta_x.set(coeffs.delta_x);
+            self.stats
+                .factorizations
+                .set(self.stats.factorizations.get() + 1);
+            self.stats
+                .factor_batched_calls
+                .set(self.stats.factor_batched_calls.get() + 1);
+            self.stats
+                .factor_batched_cols
+                .set(self.stats.factor_batched_cols.get() + nrhs);
+            let delta_x = coeffs.delta_x;
+            for col in packed_rhs.chunks_mut(dim) {
+                for (i, x) in col.iter_mut().enumerate() {
+                    *x /= diag[i] + delta_x;
+                }
+            }
+            Some(ESymSolverStatus::Success)
         }
 
         fn try_resolve_many_flat(
@@ -1969,13 +2030,10 @@ mod tests {
             "a mock without the packed path must take the per-column arm"
         );
         assert!(
-            stats_batch.batched_calls.get() >= 1,
-            "the packed mock must actually reach the batched arm"
-        );
-        assert_eq!(
-            stats_batch.batched_cols.get(),
-            2,
-            "3 V columns: column 0 pays the factorization, 2 are batched"
+            stats_batch.factor_batched_calls.get() >= 1,
+            "the packed mock must actually reach the merged arm — a mock \
+             whose `system_dim()` is 0 when cold silently would not, and \
+             then this test would be green about code it never ran"
         );
         assert_eq!(
             stats_batch.factorizations.get(),
@@ -1985,6 +2043,38 @@ mod tests {
         assert_eq!(
             sol_loop, sol_batch,
             "batched and per-column arms must agree bit-for-bit"
+        );
+
+        // All three V columns ride along with the factorization in a
+        // single backend call. Before the merge this read
+        // `factor_batched_calls == 0`, `batched_cols == 2` — column 0
+        // through the single-RHS `solve`, then a second call carrying
+        // the other two. That second call streams the whole factor
+        // again, which is the cost this removes.
+        assert_eq!(
+            stats_batch.factor_batched_calls.get(),
+            1,
+            "the cold SMW block must be ONE factorizing multi-RHS call"
+        );
+        assert_eq!(
+            stats_batch.factor_batched_cols.get(),
+            3,
+            "all 3 V columns must ride along with the factorization"
+        );
+        assert_eq!(
+            stats_batch.batched_calls.get(),
+            0,
+            "no separate back-solve pass may remain over the same factor"
+        );
+        // One `resolve` remains, and must: it is the actual RHS being
+        // solved against the same factor after the V columns have built
+        // the SMW correction. Upstream pays it too. What the merge
+        // removes is the second pass over the factor that used to carry
+        // the V columns.
+        assert_eq!(
+            stats_batch.backsolves.get(),
+            1,
+            "only the main RHS solve may remain over the cached factor"
         );
     }
 

--- a/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
@@ -557,23 +557,100 @@ impl LowRankAugSystemSolver {
 
         // Every column here shares one matrix, so only the first one
         // needs a factorization; the rest are back-substitutions
-        // against it. Upstream gets that from a single `MultiSolve`
-        // over all `nrhs` columns (`IpLowRankAugSystemSolver.cpp:487`),
-        // which reaches `StdAugSystemSolver::MultiSolve` and factorizes
-        // once. We reproduce it in two steps: pay the factorization on
-        // column 0 through the single-RHS path when the inner solver is
-        // cold, then hand every remaining column to the inner solver's
-        // packed multi-RHS back-substitution in one call. That is the
-        // only way `nrhs > 1` reaches the backend — both FERAL
-        // (`solve_many_into`) and MA57 (`ma57cd_` with `nrhs`) block the
-        // triangular solves, and neither can do so one column at a time
-        // (gh#729).
+        // against it. Batching is the only way `nrhs > 1` reaches the
+        // backend at all — both FERAL (`solve_many_into`) and MA57
+        // (`ma57cd_` with `nrhs`) block the triangular solves, and
+        // neither can do so one column at a time (gh#729).
         //
-        // Whether the batch is *taken* is a separate question, asked
-        // below. FERAL answers it from a measured width ceiling; MA57
-        // blocks at every width, so it declines unless
-        // `ma57_batched_backsolve` says otherwise, and by default the
-        // loop further down solves these columns one at a time.
+        // Three paths, in preference order:
+        //
+        //  1. cold inner solver, backend affirms bit-identity at
+        //     `n_cols`: one `try_solve_many_flat` — factorize and
+        //     substitute every column together, which is upstream's
+        //     single `MultiSolve` (`IpLowRankAugSystemSolver.cpp:487`);
+        //  2. otherwise: factorize on column 0 through the single-RHS
+        //     path, then batch the remaining columns. Correct, but it
+        //     streams the factor twice;
+        //  3. backend declines the packed path entirely: one
+        //     single-RHS solve per column.
+        //
+        // Who answers the bit-identity gate matters as much as where it
+        // is asked. FERAL answers from a measured width ceiling. MA57
+        // blocks at every width and so declines by default; it takes
+        // paths 1 and 2 only when `ma57_batched_backsolve` is on, which
+        // is a permission the user grants and not a measurement anyone
+        // has made — see `dev-notes/ma57-batched-backsolve.md`.
+        let n_x = space_x.dim() as usize;
+        let n_s = space_s.dim() as usize;
+        let n_c = space_c.dim() as usize;
+        let n_d = space_d.dim() as usize;
+        let dim = n_x + n_s + n_c + n_d;
+
+        // Cold inner solver: factorize and back-substitute every column
+        // in ONE backend call, which is what upstream's single
+        // `MultiSolve` does (`IpLowRankAugSystemSolver.cpp:487`).
+        // Paying the factorization through the single-RHS path and then
+        // batching the rest streams the factor twice — a sparse
+        // triangular solve costs `F + nrhs*W` with `F` several times
+        // `W` on a KKT this size, so the split throws away one `F` per
+        // SMW update. The same bit-identity gate as the warm batch
+        // below applies, at the wider `n_cols_us`.
+        if !self.inner_has_factor
+            && n_cols_us > 1
+            && dim > 0
+            && dim == self.inner.system_dim() as usize
+            && self.inner.multi_solve_matches_single_solve(n_cols_us)
+        {
+            let mut packed = vec![0.0; dim * n_cols_us];
+            let mut packed_ok = true;
+            for k in 0..n_cols_us {
+                let col = &mut packed[k * dim..k * dim + n_x];
+                if !copy_dense_into(v_x.get_vector(k as Index).as_ref(), col) {
+                    packed_ok = false;
+                    break;
+                }
+                // s/c/d blocks are zero by construction; `packed`
+                // starts zeroed.
+            }
+            if packed_ok {
+                let ic = inner_coeffs(&self.factor, coeffs);
+                if let Some(status) = self.inner.try_solve_many_flat(
+                    &ic,
+                    &mut packed,
+                    n_cols_us,
+                    check_neg_evals,
+                    num_neg_evals,
+                ) {
+                    if self.inner.provides_inertia() {
+                        self.num_neg_evals = self.inner.number_of_neg_evals();
+                    }
+                    if status != ESymSolverStatus::Success {
+                        self.inner_has_factor = false;
+                        self.inner_factor_neg_evals = None;
+                        return (Err(status), out_s, out_c, out_d);
+                    }
+                    self.inner_has_factor = true;
+                    self.inner_factor_neg_evals = check_neg_evals.then_some(num_neg_evals);
+                    for k in 0..n_cols_us {
+                        let col = &packed[k * dim..(k + 1) * dim];
+                        let mut sol_x = space_x.make_new_dense();
+                        let mut sol_s = space_s.make_new_dense();
+                        let mut sol_c = space_c.make_new_dense();
+                        let mut sol_d = space_d.make_new_dense();
+                        sol_x.set_values(&col[..n_x]);
+                        sol_s.set_values(&col[n_x..n_x + n_s]);
+                        sol_c.set_values(&col[n_x + n_s..n_x + n_s + n_c]);
+                        sol_d.set_values(&col[n_x + n_s + n_c..]);
+                        out_x.set_vector(k as Index, Rc::new(sol_x) as Rc<dyn Vector>);
+                        out_s.set_vector(k as Index, Rc::new(sol_s) as Rc<dyn Vector>);
+                        out_c.set_vector(k as Index, Rc::new(sol_c) as Rc<dyn Vector>);
+                        out_d.set_vector(k as Index, Rc::new(sol_d) as Rc<dyn Vector>);
+                    }
+                    return (Ok(out_x), out_s, out_c, out_d);
+                }
+            }
+        }
+
         let mut k0 = 0usize;
         if !self.inner_has_factor && n_cols_us > 0 {
             let rhs_x_dyn: &dyn Vector = v_x.get_vector(0).as_ref();
@@ -607,11 +684,6 @@ impl LowRankAugSystemSolver {
         // dimension, or hands us a column we cannot read as a dense
         // slice.
         if k0 < n_cols_us {
-            let n_x = space_x.dim() as usize;
-            let n_s = space_s.dim() as usize;
-            let n_c = space_c.dim() as usize;
-            let n_d = space_d.dim() as usize;
-            let dim = n_x + n_s + n_c + n_d;
             let nrhs = n_cols_us - k0;
             // The batch is a pure time optimization: these columns feed
             // the SMW correction of an iterate whose trajectory must not

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -694,8 +694,13 @@ impl AugSystemSolver for StdAugSystemSolver {
             self.last_status = Some(s);
             return Some(s);
         }
+        // Decline rather than fail: the caller cannot know `dim` before
+        // this call assembles, so a disagreement here means "this
+        // backend's layout is not what you packed", and the split path
+        // is a correct answer to that. Assembling and then declining is
+        // safe — `assemble` is idempotent and no factorization ran.
         if packed_rhs.len() != (self.dim as usize) * nrhs {
-            return Some(ESymSolverStatus::FatalError);
+            return None;
         }
 
         // `new_matrix = true`: this is the factorizing call, so it is

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -97,6 +97,15 @@ pub struct StdAugSystemSolver {
     /// to `<dump_dir>/iter_NNN/kkt_solve_MMM.jsonl`, gated by the
     /// configured iter-spec for [`DiagCategory::Kkt`].
     diagnostics: Option<Rc<DiagnosticsState>>,
+
+    /// The deprecated `POUNCE_DUMP_KKT` path, resolved once. It used to
+    /// be read with `std::env::var` on *every* `solve`, which puts a
+    /// global-environment lock and a linear scan of `environ` on the
+    /// hottest path in the solver for a debug surface that is off in
+    /// every production run. Resolving it once is also what lets
+    /// `try_solve_many_flat` decline the batch when a dump is active
+    /// without re-reading the environment per call.
+    legacy_dump_path: std::cell::OnceCell<Option<String>>,
 }
 
 impl std::fmt::Debug for StdAugSystemSolver {
@@ -118,6 +127,7 @@ impl StdAugSystemSolver {
             linsol,
             initialized: false,
             struct_sig: None,
+            legacy_dump_path: std::cell::OnceCell::new(),
             n_x: 0,
             n_s: 0,
             n_c: 0,
@@ -395,6 +405,24 @@ impl StdAugSystemSolver {
         (&self.irn, &self.jcn, &self.vals)
     }
 
+    /// The deprecated `POUNCE_DUMP_KKT` target, read from the
+    /// environment at most once per solver.
+    fn legacy_dump_path(&self) -> Option<&String> {
+        self.legacy_dump_path
+            .get_or_init(|| std::env::var("POUNCE_DUMP_KKT").ok())
+            .as_ref()
+    }
+
+    /// Whether either KKT-dump surface is armed. The batched
+    /// factorizing path declines when one is, so a dump run keeps
+    /// emitting one record per single-RHS solve exactly as before.
+    fn kkt_dump_active(&self) -> bool {
+        self.diagnostics
+            .as_deref()
+            .is_some_and(|d| d.want(DiagCategory::Kkt))
+            || self.legacy_dump_path().is_some()
+    }
+
     pub(crate) fn pack_rhs(&self, rhs: &AugSysRhs<'_>, packed: &mut [Number]) {
         let n_x = self.n_x as usize;
         let n_s = self.n_s as usize;
@@ -569,7 +597,7 @@ impl AugSystemSolver for StdAugSystemSolver {
                 }
             }
         }
-        if let Ok(path) = std::env::var("POUNCE_DUMP_KKT") {
+        if let Some(path) = self.legacy_dump_path().cloned() {
             use std::sync::atomic::{AtomicBool, Ordering};
             static WARNED: AtomicBool = AtomicBool::new(false);
             if !WARNED.swap(true, Ordering::SeqCst) {
@@ -645,6 +673,67 @@ impl AugSystemSolver for StdAugSystemSolver {
 
     fn multi_solve_matches_single_solve(&self, nrhs: usize) -> bool {
         self.linsol.multi_solve_matches_single_solve(nrhs)
+    }
+
+    fn try_solve_many_flat(
+        &mut self,
+        coeffs: &AugSysCoeffs<'_>,
+        packed_rhs: &mut [Number],
+        nrhs: usize,
+        check_neg_evals: bool,
+        num_neg_evals: Index,
+    ) -> Option<ESymSolverStatus> {
+        // A KKT dump wants one JSONL record per solve, and
+        // `write_kkt_record` describes a single RHS/solution pair.
+        // Decline so a dump run keeps the split path it has always had.
+        if self.kkt_dump_active() {
+            return None;
+        }
+        let s = self.assemble(coeffs);
+        if s != ESymSolverStatus::Success {
+            self.last_status = Some(s);
+            return Some(s);
+        }
+        if packed_rhs.len() != (self.dim as usize) * nrhs {
+            return Some(ESymSolverStatus::FatalError);
+        }
+
+        // `new_matrix = true`: this is the factorizing call, so it is
+        // attributed to `linear_system_factorization` exactly as the
+        // single-RHS `solve` above is (upstream
+        // `IpStdAugSystemSolver.cpp:155`). The back-substitution for all
+        // `nrhs` columns rides along inside it, which is the point —
+        // upstream pays one factor traversal here, not two.
+        let _factor_guard = self
+            .timing
+            .as_deref()
+            .map(|t| t.linear_system_factorization.guard());
+        let status = self.linsol.multi_solve(
+            &self.vals,
+            true,
+            nrhs as Index,
+            packed_rhs,
+            check_neg_evals,
+            num_neg_evals,
+        );
+        drop(_factor_guard);
+        self.last_status = Some(status);
+        // Same refresh rule as `solve`: any outcome where the backend
+        // computed an inertia updates the cached count (pounce#99).
+        if self.linsol.provides_inertia()
+            && matches!(
+                status,
+                ESymSolverStatus::Success
+                    | ESymSolverStatus::WrongInertia
+                    | ESymSolverStatus::Singular
+            )
+        {
+            self.last_neg_evals = self.linsol.number_of_neg_evals();
+        }
+        if status == ESymSolverStatus::Success {
+            self.have_factor = true;
+        }
+        Some(status)
     }
 
     fn try_resolve_many_flat(


### PR DESCRIPTION
**Draft.** The change is structurally right and bit-identical, but the measured gain on FERAL is inside run-to-run noise. The number that would justify merging is an MA57 one, and I cannot produce it here — see **Why this is a draft** at the bottom.

Follow-up to [#730](https://github.com/jkitchin/pounce/issues/730), prompted by @srikanth-gm's re-measurement in [this comment](https://github.com/jkitchin/pounce/issues/730#issuecomment-5441740884). No closing keyword: #730 is already closed by #735, and this addresses part of the residual that comment identified.

## Problem

@srikanth-gm re-ran a 59,939-variable CasADi direct-collocation model under `hessian_approximation=limited-memory` against the current build and reported POUNCE/MA57 now within 1.6% of Ipopt/MA57 on wall time — but still spending **+39% solver-internal time per iteration**, of which the largest named component was **+41% on back-solve**, with numeric factorization at parity (+2.9%).

Their per-iteration figures:

| per iteration (s) | Ipopt/MA57 | POUNCE/MA57 | Δ |
|---|---:|---:|---:|
| numeric factorization | 0.1595 | 0.1642 | +2.9% |
| back-solve | 0.1301 | 0.1836 | **+41%** |
| solver internal | 0.3423 | 0.4763 | +39% |

Two observations on that decomposition, which are worth recording because they bound what this PR can be expected to fix:

- **"Single largest identifiable component" is doing real work in that sentence.** Subtracting both linear-algebra rows from solver-internal leaves 0.0758 s/iter — **57% of the gap sits in neither row**, versus back-solve's 40%. In relative terms it is the bigger discrepancy (POUNCE 0.1285 vs Ipopt 0.0527, +144%). This PR does not touch it, and it remains unmapped.
- **The two back-solve rows are not measured over the same region.** Ipopt's `LinearSystemBackSolve` wraps `ma57c` and nothing else (`IpMa57TSolverInterface.cpp:756-807`). POUNCE's guard wraps `TSymLinearSolver::multi_solve`, which also applies the RHS scale and solution unscale — two passes over 118,276 doubles per call, with `linear_system_scaling=slack-based` on — where Ipopt bills those to a separate `LinearSystemScaling` row. The magnitude is small (~0.07% of the row) but the rows are not strictly comparable.

## Cause

Under limited-memory, `LowRankAugSystemSolver` builds its Sherman-Morrison-Woodbury correction by solving the augmented system for the low-rank columns. Upstream issues **one** `MultiSolve` over all of them (`IpLowRankAugSystemSolver.cpp:487`), so the factorization and every column's back-substitution share a single traversal of the factor.

POUNCE split that in two: a single-RHS `solve` to pay the factorization, then a batched `try_resolve_many_flat` for the remaining columns. A sparse triangular solve streams the whole factor once per call and then applies it to each column, so its cost is `F + nrhs·W`. Instrumenting the backend entry point on `benchmarks/large_scale/laptime` and fitting the two best-sampled widths gave **F ≈ 19 ms, W ≈ 7 ms** — the fixed traversal is roughly 3× the marginal per-RHS cost. The split therefore discarded one full `F` on every SMW update.

Measured call distribution over 40 iterations (179 backend calls), before the change:

```
nrhs  refactor  calls  median
   1     true      42   271 ms   <- factorize, serving ONE rhs
   1     false     63    26 ms
   5     false     34    59 ms
   6     false     33    62 ms
```

## Fix

A factorizing multi-RHS path, `AugSystemSolver::try_solve_many_flat`, implemented on `StdAugSystemSolver` as a single `TSymLinearSolver::multi_solve(new_matrix = true, nrhs)`. The cold SMW block takes it, so all columns ride along with the factorization.

The gh#729 bit-identity gate still governs and is only widened: the merged call is taken solely when the backend affirms `multi_solve_matches_single_solve` at the full column count. The old split remains the fallback, and both KKT-dump surfaces force it so a dump run keeps its one-record-per-solve shape.

**What was tried and rejected.** The first cut gated the merged path on `dim == inner.system_dim()`, mirroring the warm batch below it. That is unanswerable before `assemble()` — cold, `system_dim()` is still 0 — so it rejected the first factorization of every run. It was not inert: later updates took the merged call once `dim` was set, so the timing looked right. It also meant the existing test never executed the new code, because the mock's `system_dim()` is 0 whenever it holds no factor. That is the gh#756 failure mode from CLAUDE.md verbatim. The precondition is gone; `try_solve_many_flat` now assembles and then declines with `None` on a packed-length mismatch, which asks the same question where the answer exists. Assembling and declining is safe — `assemble` is idempotent and no factorization ran.

Also caches the deprecated `POUNCE_DUMP_KKT` probe. It was an environment lock plus a linear scan of `environ` on every solve, for a surface that is off in every production run.

## Blast radius

Baseline `74c96ec^` (= current `main`).

**Fixture sweep: empty diff**, 152 fixture-legs, both `exact` and `lbfgs`, all three engines (36 `cvx-qp`, 35 `nlp`, 5 `cvx-qcqp` per leg). No status, objective, iteration count or engine moved.

**Trajectory bit-identical** over 100 iterations on `laptime` (58,014 vars / 62,014 cons, limited-memory), in both A/B pairs — every printed digit of objective, dual infeasibility, constraint violation and complementarity. The baseline is deterministic run-to-run, so the comparison is single-variable.

Timing, two interleaved pairs, only the binary changing:

| row | base 1 | base 2 | merged 1 | merged 2 | mean Δ | rel |
|---|---:|---:|---:|---:|---:|---:|
| LinearSystemBackSolve | 34.891 | 33.567 | 24.093 | 23.282 | −10.541 s | −30.8% |
| LinearSystemFactorization | 57.014 | 54.140 | 65.438 | 63.898 | +9.091 s | +16.4% |
| **linear algebra total** | 91.927 | 87.727 | 89.548 | 87.197 | **−1.454 s** | **−1.6%** |
| OverallAlgorithm | 114.794 | 110.167 | 112.964 | 110.321 | −0.838 s | −0.7% |
| callbacks | 9.780 | 9.577 | 9.888 | 9.710 | +0.120 s | +1.2% |

**Read the back-solve row with care: most of its drop is bookkeeping.** The merged call bills its substitutions to `LinearSystemFactorization` by construction, so −31% on one row against +16% on the other nets to −1.45 s. Baseline run-to-run spread is 4.2%, so **the net is inside noise on wall time and should not be quoted as a wall-clock win.**

It is, however, the size the mechanism predicts — ~20 ms per removed traversal over ~75–90 SMW updates ≈ 1.5–1.8 s — so it is real work removed, just not much of it on this model and this backend. Callback time is flat, which is the control: identical trajectory means identical callback work, so the delta is POUNCE's own.

Earlier in this branch I reported −7.8% overall. That does not reproduce and should be disregarded: the host changed mid-investigation, and the identical baseline binary now takes 110–115 s where it took 72–76 s. The figures above are the corrected ones.

## Tests

`batched_smw_columns_match_the_per_column_path` is extended to pin the merged call: **one** factorizing multi-RHS call carrying all 3 V columns, **zero** separate back-solve passes over the same factor, and still bit-identical to the per-column arm. The single remaining `resolve` is the actual RHS being solved against that factor, which upstream pays too.

**It bites.** With the merged path disabled (`&& false` on the gate) it fails at `factor_batched_calls >= 1` — "the packed mock must actually reach the merged arm" — which is the assertion that would have caught the first cut's dead gate. On the parent commit it fails for the same reason.

Deliberately not pinned: the timing itself. It is inside noise here and machine-dependent, so a performance assertion would be flaky. The sweep and the bit-identity assertion are what guard correctness.

- 960 tests pass, 0 failed, across 62 binaries (`pounce-algorithm`, `pounce-nlp`, `pounce-linsol`)
- `cargo fmt --all --check` clean
- CI's `clippy -D correctness -D suspicious` clean; warning count on the three touched files is 29 before and 29 after

## Why this is a draft

The reported +41% back-solve is an **MA57** number on @srikanth-gm's model. Everything above is **FERAL** on `laptime`, because there is no coinhsl in this container. The `F + nrhs·W` cost shape holds for any supernodal triangular solve, so the direction transfers — but `F/W` is exactly the ratio that decides whether this is worth 1.5 s or considerably more, and it is backend-specific. On FERAL the answer is "real but inside noise", which is not on its own a reason to merge.

What would settle it: this branch measured under MA57, ideally on the reporting model. @srikanth-gm, if you have the appetite for another A/B, that is the run that would tell us whether this moves your back-solve row — the trajectory is bit-identical, so it is a clean swap of `pounce_cinterface` with nothing else changing.

Independent of the timing, the change makes POUNCE's SMW call structure match upstream's and removes a demonstrably redundant pass over the factor, which may be worth taking on its own terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DSYzDXdPyz4fEukH1bBZS)_