### PR TITLE
A square-problem feasible point is a solved-band answer, not a solver error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,92 @@ changes.
 
 ## [Unreleased]
 
+- **A square problem solved to feasibility is now reported as a success
+  (gh #815).** `Feasible_Point_Found` wrote AMPL `solve_result_num = 100`.
+  Pyomo's contrib v2 `.sol` reader maps `100..=199` to
+  `TerminationCondition.error`, so a correct answer reached the caller as a
+  *solver error*; the legacy reader maps it to `optimal` with
+  `status=warning`, the same complaint that moved `Solved_To_Acceptable_Level`
+  out of that band in gh #591. It is now `2`, Ipopt's own code, in the
+  `0..=99` solved band. `pounce`'s process exit code follows (0, not 1), and
+  the two `pyomo_pounce` status tables (`v2._V2_STATUS`,
+  `sens._STATUS_RESULT`) report the status as a success rather than as
+  `unknown` / `warning`.
+
+  **The reason the band was `100` had stopped being true of the code.** The
+  doc comment defending it said the two statuses do not mean the same thing:
+  that Ipopt returns `FEASIBLE_POINT_FOUND` only for a square problem, where a
+  feasible point *is* the solution, while POUNCE used it more loosely for any
+  usable feasible point that missed the convergence criteria. POUNCE does not.
+  The status has one producer — `min_c_1nrm.rs` returning
+  `RestorationOutcome::FeasiblePointFound` — behind one gate, now
+  `square_feasible_point_found` in `resto_inner_solver.rs`, whose first
+  conjunct is `is_square_problem`: `c.x.dim() == c.y_c.dim()`, a port of
+  `IpoptCalculatedQuantities::IsSquareProblem`. Same condition as Ipopt, hence
+  the same meaning, and on a square problem there is no further criterion to
+  miss because the objective is constant. Two other surfaces had already
+  written the correct reading down —
+  `python/pounce/gams/link.py` maps the status to
+  `(MODELSTAT_FEASIBLE, SOLVESTAT_NORMAL)`, and
+  `issue_390_nonlinear_equality_scale.rs` calls it "a success-band answer —
+  AMPL `objno` code 2, which every band table reads as SOLVED" — so the repo
+  had been contradicting itself in comments for as long as the divergence
+  existed.
+
+  **What it cost, measured.** gh #815 is a 536x536 IDAES naphtha-hydrotreater
+  flowsheet, zero degrees of freedom. Written the way IDAES writes it for
+  Ipopt (`writer_config={"scale_model": True}`), POUNCE reaches a constraint
+  violation of **2.208e-06 in the model's original units in 1.0 s**, 18
+  iterations; adding `linear_presolve=True` gives a 468x468 model, 2.899e-06
+  in 0.8 s, 7 iterations. The two configurations agree on the flowsheet's
+  thiophene conversion to six digits (0.3918770, 0.3918766). Before this
+  change that solve loaded as `termination_condition=optimal, status=warning`
+  through the legacy reader and as `TerminationCondition.error` through the
+  v2 reader; it now loads `optimal` / `ok`, and the `.sol` line moved from
+  `objno 0 100` to `objno 0 2`.
+
+  **This does not make the model as filed solvable, and the issue's premise
+  did not survive measurement.** On the raw unscaled `.nl`, POUNCE stalls at a
+  constraint violation of ~4.97e+03; so does Ipopt 3.13.2/ma27, which exits
+  `Restoration Failed` at 2418 iterations from a stall at `inf_pr = 1.56e+01`
+  against POUNCE's 1.60e+01, the two trajectories being bit-identical over
+  iterations 0-3. An 18-configuration option sweep — linear solver, `mu`
+  strategy, scaling method, `nlp_scaling_max_gradient`, `mu_init`,
+  `start_with_resto`, `expect_infeasible_problem`, bound handling, `mc64`
+  equilibration, iteration cap — moved none of it: every configuration ended
+  `Restoration_Failed` or `Infeasible_Problem_Detected` at that same
+  violation. What makes the model tractable is IDAES's own per-variable
+  scaling factors applied by the NL writer, which is a frontend
+  configuration and not reachable from any solver option; no
+  `nlp_scaling_method` substitutes for it. Ipopt did not solve this model in
+  any configuration tried here, including through the reporter's own script.
+
+  **What the new tests are and are not evidence about.**
+  `the_exit_code_and_the_sol_band_never_disagree` states the guard as an `iff`
+  over all twenty statuses, so a status added to the exit-code success set but
+  not the solved band, or the reverse, fails it — gh #815 is that predicate
+  failing on `FeasiblePointFound` and gh #591 was the same shape one status
+  over. `only_a_square_problem_yields_a_feasible_point_verdict` holds the
+  conjunct the whole band argument rests on, with every other input at a value
+  that would pass, so squareness alone decides it. None of this is end-to-end:
+  **no fixture in the CLI corpus reaches this exit**, and 72 generated square
+  models — three nonlinearity families, three start points, three row-scale
+  spreads — under five option sets failed to reach it too. It needs a model
+  larger than the corpus carries, and the end-to-end evidence is gh #815's own
+  536x536 model, cited above. `scripts/sweep-fixtures.sh` moved 0 of 154
+  fixture-legs, which is a control rather than evidence: the sweep does not
+  read `solve_result_num`, and the only non-reporting edit here is the
+  extraction of an unchanged five-term conjunction into a named function.
+
+  Three Python success sets still count the status as a failure —
+  `_minimize._NLP_SUCCESS_STATUS` (shared by `_curve_fit`),
+  `jax._path._OK_STATUS` and `torch._path._OK_STATUS`. They are left split on
+  purpose: unlike the CLI, they are a scipy-style `success` flag on a library
+  call that writes no `.sol`, so they were not put in contradiction with a
+  file the same process had just written, and widening a public return value
+  deserves its own decision. Tracked as gh #820 so the split has an owner
+  rather than reading as an oversight.
+
 - **Both Lagrangian gradients are now cached, and the cache key carries `mu`
   (gh #812).** `curr_grad_lag_x` and `curr_grad_lag_s` had no entry among the
   caches in `ipopt_cq.rs`, so every read reassembled

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2126,12 +2126,32 @@ fn nlp_exit_code(status: ApplicationReturnStatus, ampl: bool) -> ExitCode {
 }
 
 /// Whether an NLP solve outcome counts as a "success" for the (non-AMPL) exit
-/// code: `SolveSucceeded` or the reduced-accuracy `SolvedToAcceptableLevel`,
-/// matching Ipopt and the `minimize()` success set (#119).
+/// code: `SolveSucceeded`, the reduced-accuracy `SolvedToAcceptableLevel`
+/// (#119), or `FeasiblePointFound`.
+///
+/// The third member is not a widening of what counts as solved — it is the
+/// same solve this process just wrote a solved-band `.sol` for.
+/// `FeasiblePointFound` is emitted only for square problems
+/// (`pounce_restoration`'s `square_feasible_point_found`, gated on
+/// `is_square_problem`), where the objective is constant and a feasible
+/// point is the solution, and `status_to_solve_result_num` writes Ipopt's
+/// own AMPL code `2` for it. Leaving this set at two members would have
+/// this binary exit 1 while the `.sol` beside it reads solved — a
+/// disagreement between two channels of the same process, which is the
+/// shape of the defect gh #815 was.
+///
+/// Three Python surfaces still exclude the status from their success sets:
+/// `_minimize._NLP_SUCCESS_STATUS` (shared by `_curve_fit`),
+/// `jax._path._OK_STATUS` and `torch._path._OK_STATUS`. They are a separate
+/// contract — a scipy-style `success` flag on a library call that never
+/// produces a `.sol` — and are tracked on their own rather than changed
+/// here.
 fn nlp_solve_succeeded(status: ApplicationReturnStatus) -> bool {
     matches!(
         status,
-        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ApplicationReturnStatus::SolveSucceeded
+            | ApplicationReturnStatus::SolvedToAcceptableLevel
+            | ApplicationReturnStatus::FeasiblePointFound
     )
 }
 
@@ -3750,6 +3770,7 @@ mod nlp_exit_code_tests {
     //! The doc was corrected; these tests lock the actual behavior so the doc
     //! and code can't drift again.
     use super::nlp_solve_succeeded;
+    use super::status_to_solve_result_num;
     use pounce_nlp::return_codes::ApplicationReturnStatus as A;
 
     #[test]
@@ -3758,6 +3779,66 @@ mod nlp_exit_code_tests {
         assert!(nlp_solve_succeeded(A::SolvedToAcceptableLevel));
         assert!(nlp_solve_succeeded(A::SolveSucceeded));
     }
+
+    /// gh #815. A square problem solved to feasibility is a success on this
+    /// channel too, and the failure mode this pins is a *disagreement*: the
+    /// same process writes a `.sol` whose `solve_result_num` is Ipopt's `2`,
+    /// in the solved band, so exiting 1 would have the two channels of one
+    /// run contradict each other.
+    #[test]
+    fn a_square_problem_feasible_point_counts_as_success() {
+        assert!(nlp_solve_succeeded(A::FeasiblePointFound));
+    }
+
+    /// The invariant behind the test above, over the whole enum: this
+    /// binary's exit code and the `.sol` it writes must never disagree
+    /// about whether the solve was a success. Stated as an `iff` so it
+    /// catches a future status added to one channel and not the other, in
+    /// either direction — gh #815 was this predicate failing on
+    /// `FeasiblePointFound`, and gh #591 was the same shape one status
+    /// over.
+    #[test]
+    fn the_exit_code_and_the_sol_band_never_disagree() {
+        for s in ALL_STATUSES {
+            let code = status_to_solve_result_num(s);
+            let solved_band = (0..=99).contains(&code);
+            assert_eq!(
+                nlp_solve_succeeded(s),
+                solved_band,
+                "{s:?}: exit-code success is {} but solve_result_num {code} \
+                 puts the `.sol` {} the solved band",
+                nlp_solve_succeeded(s),
+                if solved_band { "inside" } else { "outside" },
+            );
+        }
+    }
+
+    /// Spelled out rather than imported: `pounce_nlp`'s copy lives in its
+    /// own `#[cfg(test)]` module. `return_codes.rs` is the source of truth
+    /// for membership, and the `_ =>` arm in `status_to_solve_result_num`
+    /// does not exist, so a new variant fails that match first.
+    const ALL_STATUSES: [A; 20] = [
+        A::SolveSucceeded,
+        A::SolvedToAcceptableLevel,
+        A::InfeasibleProblemDetected,
+        A::SearchDirectionBecomesTooSmall,
+        A::DivergingIterates,
+        A::UserRequestedStop,
+        A::FeasiblePointFound,
+        A::MaximumIterationsExceeded,
+        A::RestorationFailed,
+        A::ErrorInStepComputation,
+        A::MaximumCpuTimeExceeded,
+        A::MaximumWallTimeExceeded,
+        A::NotEnoughDegreesOfFreedom,
+        A::InvalidProblemDefinition,
+        A::InvalidOption,
+        A::InvalidNumberDetected,
+        A::UnrecoverableException,
+        A::NonIpoptExceptionThrown,
+        A::InsufficientMemory,
+        A::InternalError,
+    ];
 
     #[test]
     fn non_convergent_statuses_are_not_success() {

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -915,11 +915,13 @@ pub fn run_inner_resto(
     } else {
         eval_orig_rel_c_inf_pr_at_inner_curr(&*final_iv.x, outer_nlp)
     };
-    let feasible_point_found = is_square_problem
-        && matches!(status, SolverReturn::StopAtAcceptablePoint)
-        && orig_inf_pr_at_final.is_finite()
-        && orig_inf_pr_at_final < outer_constr_viol_tol
-        && orig_rel_inf_pr_at_final <= SQUARE_FEASIBLE_REL_VIOL_THRESHOLD;
+    let feasible_point_found = square_feasible_point_found(
+        is_square_problem,
+        status,
+        orig_inf_pr_at_final,
+        outer_constr_viol_tol,
+        orig_rel_inf_pr_at_final,
+    );
 
     let inner_kkt_err = alg.cq.borrow().curr_nlp_error();
     let inner_stationarity_converged = inner_kkt_err <= 10.0 * outer_tol;
@@ -1290,6 +1292,39 @@ fn eval_orig_inf_pr_at_inner_curr(
 /// the outer side: one band, so a model cannot be judged feasible by one of
 /// the three and infeasible by another.
 const SQUARE_FEASIBLE_REL_VIOL_THRESHOLD: f64 = 1e-2;
+
+/// The square-problem arm's gate: may this recovered point be reported as
+/// `FeasiblePointFound`?
+///
+/// Extracted from the caller so the first conjunct can be held by a test.
+/// `is_square_problem` is not one condition among five — it is what the
+/// status *means*, and two things downstream are built on it:
+///
+/// * `pounce_solve_report::status_to_solve_result_num` writes AMPL code
+///   `2` for `FeasiblePointFound`, in the `0..=99` solved band, because on
+///   a square problem the objective is constant and a feasible point is
+///   the solution. That reasoning is void for a non-square problem, where
+///   a feasible point says nothing about optimality.
+/// * `pyomo_pounce.v2._V2_STATUS` and `pyomo_pounce.sens._STATUS_RESULT`
+///   report the status as a success for the same reason.
+///
+/// This is the crate's only producer of the status, so widening this gate
+/// past square problems would silently turn those three surfaces into
+/// wrong answers rather than merely optimistic ones (gh #815 is what the
+/// opposite error cost: the band said failure and the answer was right).
+fn square_feasible_point_found(
+    is_square_problem: bool,
+    status: SolverReturn,
+    orig_inf_pr_at_final: f64,
+    outer_constr_viol_tol: f64,
+    orig_rel_inf_pr_at_final: f64,
+) -> bool {
+    is_square_problem
+        && matches!(status, SolverReturn::StopAtAcceptablePoint)
+        && orig_inf_pr_at_final.is_finite()
+        && orig_inf_pr_at_final < outer_constr_viol_tol
+        && orig_rel_inf_pr_at_final <= SQUARE_FEASIBLE_REL_VIOL_THRESHOLD
+}
 
 /// The orig NLP's equality-block violation at the inner IPM's converged
 /// iterate, as a fraction of each row's **declared** right-hand side:
@@ -1732,6 +1767,85 @@ mod tests {
             ConvergenceStatus::MaxIterExceeded,
             "`max_resto_iter=2` must stop the restoration sub-solve at 2",
         );
+    }
+
+    /// The conjunct the reported status *means*, held here because three
+    /// surfaces outside this crate are built on it — see
+    /// `square_feasible_point_found`'s doc comment. Every other input is
+    /// held at a value that would pass, so this asserts squareness alone
+    /// decides, not that some other guard happens to also refuse.
+    #[test]
+    fn only_a_square_problem_yields_a_feasible_point_verdict() {
+        let pass = |sq| {
+            square_feasible_point_found(
+                sq,
+                SolverReturn::StopAtAcceptablePoint,
+                1.0e-6, // orig violation, under the tol below
+                1.0e-4, // outer constr_viol_tol
+                1.0e-4, // relative violation, under the 1e-2 band
+            )
+        };
+        assert!(
+            pass(true),
+            "a square problem at these residuals is the verdict"
+        );
+        assert!(
+            !pass(false),
+            "a non-square problem must never reach FeasiblePointFound: the \
+             solved-band `.sol` code and both pyomo_pounce success rows are \
+             justified only by squareness",
+        );
+    }
+
+    /// The remaining conjuncts, each refused on its own from the same
+    /// passing baseline — so a future rewrite cannot drop one silently and
+    /// still be caught only by the squareness test above.
+    #[test]
+    fn each_residual_guard_refuses_on_its_own() {
+        let g =
+            |status, inf_pr, tol, rel| square_feasible_point_found(true, status, inf_pr, tol, rel);
+        assert!(g(
+            SolverReturn::StopAtAcceptablePoint,
+            1.0e-6,
+            1.0e-4,
+            1.0e-4
+        ));
+        // Not an acceptable-point stop.
+        assert!(!g(SolverReturn::Success, 1.0e-6, 1.0e-4, 1.0e-4));
+        assert!(!g(SolverReturn::MaxiterExceeded, 1.0e-6, 1.0e-4, 1.0e-4));
+        // Violation not finite, or not under the outer tolerance.
+        assert!(!g(
+            SolverReturn::StopAtAcceptablePoint,
+            f64::NAN,
+            1.0e-4,
+            1.0e-4
+        ));
+        assert!(!g(
+            SolverReturn::StopAtAcceptablePoint,
+            f64::INFINITY,
+            1.0e-4,
+            1.0e-4
+        ));
+        assert!(!g(
+            SolverReturn::StopAtAcceptablePoint,
+            1.0e-3,
+            1.0e-4,
+            1.0e-4
+        ));
+        // Absolutely tiny but large against the row's own magnitude — the
+        // scale-free companion guard, at 101% of the 1e-2 band.
+        assert!(!g(
+            SolverReturn::StopAtAcceptablePoint,
+            1.0e-6,
+            1.0e-4,
+            1.01e-2
+        ));
+        assert!(g(
+            SolverReturn::StopAtAcceptablePoint,
+            1.0e-6,
+            1.0e-4,
+            1.0e-2
+        ));
     }
 
     #[test]

--- a/crates/pounce-solve-report/src/lib.rs
+++ b/crates/pounce-solve-report/src/lib.rs
@@ -597,19 +597,56 @@ fn empty_stats() -> StatisticsInfo {
 /// stays visible in the status name and the `.sol` message line; it just
 /// no longer reads as a warning.
 ///
-/// `FeasiblePointFound` deliberately stays in the 100 "solved, with a
-/// warning" band even though Ipopt emits `2` for it. The two statuses do
-/// not mean the same thing: Ipopt returns `FEASIBLE_POINT_FOUND` only for
-/// a square problem, where a feasible point *is* the solution, while
-/// POUNCE uses it for a usable feasible point that did not meet the
-/// convergence criteria — a run its own interfaces do not call a success
-/// (`pyomo_pounce.v2._V2_STATUS`, `pyomo_pounce.sens._STATUS_RESULT`).
+/// `FeasiblePointFound` is `2`, Ipopt's own code, and therefore in the
+/// `0..=99` solved band. It used to be `100`, justified by the claim that
+/// the two statuses do not mean the same thing — that Ipopt returns
+/// `FEASIBLE_POINT_FOUND` only for a square problem, where a feasible
+/// point *is* the solution, while POUNCE used it more loosely for any
+/// usable feasible point that missed the convergence criteria.
+///
+/// That claim was false about POUNCE's own code. The status has exactly
+/// one production site: `min_c_1nrm.rs` returns
+/// `RestorationOutcome::FeasiblePointFound`, reached only through the
+/// gate at `resto_inner_solver.rs`, which is `is_square_problem && ...`.
+/// `is_square_problem()` (`ipopt_alg.rs`) is `c.x.dim() == c.y_c.dim()`,
+/// a port of `IpoptCalculatedQuantities::IsSquareProblem` — the same
+/// condition Ipopt uses. So POUNCE emits this status *only* for square
+/// problems, carrying Ipopt's meaning precisely, and on a square problem
+/// there is no further convergence criterion to miss: the objective is
+/// constant, so a feasible point is the solution.
+///
+/// The band is what consumers key on, and `100` was not a softer way of
+/// saying the same thing — it inverted the answer. Pyomo's v2 reader
+/// (`pyomo/contrib/solver/solvers/asl_sol_reader.py`) maps `100..=199` to
+/// `TerminationCondition.error`, so a correct square-problem solve
+/// reached the caller as a *solver error*; the legacy reader
+/// (`pyomo/opt/plugins/sol.py`) maps it to `optimal` + `status=warning`,
+/// the same gh #591 warning `SolvedToAcceptableLevel` was moved out of the
+/// band to escape. Ipopt on the identical solve loads clean in both. This
+/// is what gh #815 surfaced: an IDAES square flowsheet that POUNCE solves
+/// to a constraint violation of 2.2e-06 was reported as a failure.
+///
+/// This crate is not the only place that had to agree. `python/pounce/gams/link.py`
+/// already mapped the status to `(MODELSTAT_FEASIBLE, SOLVESTAT_NORMAL)`
+/// and listed it as a success, and
+/// `crates/pounce-algorithm/tests/issue_390_nonlinear_equality_scale.rs`
+/// already called it "a success-band answer — AMPL `objno` code 2, which
+/// every band table reads as SOLVED". The two Pyomo tables
+/// (`pyomo_pounce.v2._V2_STATUS`, `pyomo_pounce.sens._STATUS_RESULT`) were
+/// the dissenters and moved with this change.
+///
+/// Being in the solved band is *not* a claim that any feasible point is
+/// acceptable. `issue_390_nonlinear_equality_scale.rs` is the guard that a
+/// model with no solution is never reported feasible at any row scale; the
+/// relative-violation threshold at `resto_inner_solver.rs` is what keeps
+/// that true. This mapping decides how a verdict is reported, not when it
+/// is reached.
 pub fn status_to_solve_result_num(status: ApplicationReturnStatus) -> i32 {
     use ApplicationReturnStatus::*;
     match status {
         SolveSucceeded => 0,
         SolvedToAcceptableLevel => 1,
-        FeasiblePointFound => 100,
+        FeasiblePointFound => 2,
         InfeasibleProblemDetected => 200,
         DivergingIterates => 300,
         SearchDirectionBecomesTooSmall => 400,
@@ -920,9 +957,40 @@ mod tests {
         // the `.sol` message line.
         assert_ne!(code, status_to_solve_result_num(SolveSucceeded));
 
-        // A feasible-but-unconverged point is a different claim and keeps
-        // the warning band — see the mapping's doc comment.
-        assert_eq!(status_to_solve_result_num(FeasiblePointFound), 100);
+        // `FeasiblePointFound` is also in the solved band, for its own
+        // reason — see `a_square_problem_feasible_point_is_in_the_solved_band`.
+        assert_ne!(code, status_to_solve_result_num(FeasiblePointFound));
+    }
+
+    /// POUNCE emits `FeasiblePointFound` only for square problems — the
+    /// status has one production site (`min_c_1nrm.rs`) behind one gate
+    /// (`resto_inner_solver.rs`), and that gate is `is_square_problem &&
+    /// ...`. That is exactly Ipopt's meaning, and on a square problem a
+    /// feasible point *is* the solution, so the code is Ipopt's own `2`.
+    ///
+    /// The band, not the number, is what breaks: at `100` Pyomo's v2 ASL
+    /// reader returns `TerminationCondition.error` for a correct solve
+    /// (gh #815 — an IDAES flowsheet solved to a 2.2e-06 constraint
+    /// violation and reported as a solver error), and the legacy reader
+    /// returns `status=warning`, the same gh #591 complaint that moved
+    /// `SolvedToAcceptableLevel` out of the band.
+    #[test]
+    fn a_square_problem_feasible_point_is_in_the_solved_band() {
+        use ApplicationReturnStatus::*;
+        let code = status_to_solve_result_num(FeasiblePointFound);
+        assert_eq!(
+            code, 2,
+            "Ipopt's ASL driver emits 2 for FEASIBLE_POINT_FOUND"
+        );
+        assert!(
+            (0..=99).contains(&code),
+            "must be in the solved band both Pyomo readers accept, got {code}",
+        );
+        // Still its own verdict: distinguishable from both other members of
+        // the band, with the distinction carried verbatim in the status name
+        // and the `.sol` message line.
+        assert_ne!(code, status_to_solve_result_num(SolveSucceeded));
+        assert_ne!(code, status_to_solve_result_num(SolvedToAcceptableLevel));
     }
 
     #[test]

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -123,7 +123,12 @@ expect them to differ by a sign — that is by design, not a bug.
 
 ## Exit codes
 
-- `0` — `Solve_Succeeded` (or `Solved_To_Acceptable_Level`).
+- `0` — `Solve_Succeeded`, `Solved_To_Acceptable_Level`, or
+  `Feasible_Point_Found`. These are exactly the statuses whose
+  [`solve_result_num`](solution-output.md#reading-solve_result_num) falls in
+  the `0`–`99` solved band, and the two channels are held to that by a test:
+  the exit code and the `.sol` a run writes can never disagree about whether
+  the solve succeeded.
 - non-zero — any other `ApplicationReturnStatus`.
 
 In AMPL solver mode (`-AMPL`) the exit code instead follows the AMPL

--- a/docs/src/solution-output.md
+++ b/docs/src/solution-output.md
@@ -36,7 +36,7 @@ Solver to AMPL* §5). Consumers key on the **band**, not the exact number:
 Pyomo maps each band to a `TerminationCondition`, so anything in `200`–`299`
 arrives as `TerminationCondition.infeasible`.
 
-### Solved: strict vs. acceptable
+### Solved: strict, acceptable, and square
 
 POUNCE writes the same codes IPOPT's AMPL driver writes, so a model can be
 moved between the two solvers without a reader change:
@@ -45,8 +45,9 @@ moved between the two solvers without a reader change:
 |---|---|---|
 | `0` | `Solve_Succeeded` | The convergence criteria (`tol` and friends) were met. |
 | `1` | `Solved_To_Acceptable_Level` | The [acceptable-level fallback](options.md#solved_to_acceptable_level-and-acceptable_progress_kappa): the strict tolerances were not met, but `acceptable_tol` was, for `acceptable_iter` consecutive iterations. |
+| `2` | `Feasible_Point_Found` | A **square** problem — as many equality rows as variables — recovered to feasibility. |
 
-Both are accepted solves and both sit in the `0`–`99` band. That matters
+All three are accepted solves and all three sit in the `0`–`99` band. That matters
 beyond tidiness: Pyomo's legacy `.sol` reader loads the `0`–`99` band as
 `SolverStatus.ok` and the `100`–`199` band as `SolverStatus.warning`, with
 `TerminationCondition.optimal` either way. POUNCE reported acceptable-level
@@ -63,6 +64,23 @@ on a solve IPOPT loads clean
 between strict and acceptable convergence is still there — in the code itself
 (`1`, not `0`), in the `.sol` message line, and in the JSON report's `status`
 field — it simply no longer reads as a warning.
+
+`Feasible_Point_Found` was `100` up to and including 0.10.0 for the same
+reason and was fixed the same way
+([#815](https://github.com/jkitchin/pounce/issues/815)). It is worth being
+precise about why a feasible point counts as *solved* here, because in general
+it would not: POUNCE emits this status only when the problem is square, which
+is the condition IPOPT uses for its own `2`. On a square problem there is
+nothing to optimise — the objective is constant over a feasible set the
+equalities have already pinned — so a point that satisfies the constraints is
+the solution, and there is no further criterion it could be said to have
+missed. For a non-square problem the status is never produced.
+
+The stakes were higher than a logged warning. Pyomo's newer `.sol` reader
+(`pyomo.contrib.solver`) maps the `100`–`199` band to
+`TerminationCondition.error`, not to `optimal`-with-a-warning, so on that route
+a square flowsheet that POUNCE had solved to a constraint violation of
+2.2e-06 was delivered to the caller as a solver error.
 
 ### Infeasible: proved vs. local
 

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -451,8 +451,25 @@ _STATUS_RESULT = {
         (TerminationCondition.optimal, SolverStatus.ok),
     "Solved_To_Acceptable_Level":
         (TerminationCondition.optimal, SolverStatus.ok),
+    # `ok`, not `warning`, for the reason `Solved_To_Acceptable_Level`
+    # above is `ok`: POUNCE emits this status only for a square problem
+    # (`resto_inner_solver.rs` gates it on `is_square_problem`), where the
+    # objective is constant and a feasible point is the solution, and the
+    # AMPL code it emits for it (2, Ipopt's own) puts the `.sol` route in
+    # the 0..99 band both Pyomo readers load as a success. `warning` here
+    # would make this route disagree with the `.sol` route and with
+    # `v2._V2_STATUS` on the same solve (gh #815).
+    #
+    # The session asymmetry below is unchanged and deliberate: the engine's
+    # `on_converged` callback still fires only for Solve_Succeeded /
+    # Solved_To_Acceptable_Level, so this solve arrives with `converged =
+    # False` and no retained factorization. That is not a reporting gap to
+    # close by widening the callback gate -- a square feasible point is
+    # reached through the restoration phase, whose factorization is not the
+    # original problem's KKT matrix, so a session built from it would answer
+    # sensitivity queries from the wrong system.
     "Feasible_Point_Found":
-        (TerminationCondition.feasible, SolverStatus.warning),
+        (TerminationCondition.optimal, SolverStatus.ok),
     "Infeasible_Problem_Detected":
         (TerminationCondition.infeasible, SolverStatus.warning),
     "Diverging_Iterates":
@@ -872,10 +889,12 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
         # the stale solve. With the session cleared they raise their
         # usual "no sensitivity session" error. Note the Feasible_Point_Found
         # asymmetry: the engine's on_converged callback fires only for
-        # Solve_Succeeded / Solved_To_Acceptable_Level, so a feasible-point
-        # solve reports termination_condition=feasible yet has converged=False
-        # and lands here -- no KKT factorization is retained, so its session
-        # is dropped even though the status is not a hard failure.
+        # Solve_Succeeded / Solved_To_Acceptable_Level, so a square-problem
+        # feasible point reports termination_condition=optimal, status=ok yet
+        # has converged=False and lands here -- no KKT factorization is
+        # retained, so its session is dropped even though the solve succeeded.
+        # See `_STATUS_RESULT` for why widening the callback gate is the wrong
+        # way to close that gap.
         reg.session = None
         for name, val in zip(var_names, np.asarray(x)):
             ov = model.find_component(name)

--- a/pyomo-pounce/pyomo_pounce/v2.py
+++ b/pyomo-pounce/pyomo_pounce/v2.py
@@ -206,13 +206,25 @@ _V2_STATUS = {
         TerminationCondition.convergenceCriteriaSatisfied,
         SolutionStatus.optimal,
     ),
-    # A feasible point that did not meet the convergence criteria: the
-    # point is usable, the run is not a success. `unknown` is the honest
-    # termination condition here -- none of the v2 members says "stopped
-    # with a feasible point".
+    # A square problem solved to feasibility. This is a success, and the
+    # row must say so: POUNCE emits this status only when
+    # `is_square_problem` holds (`resto_inner_solver.rs`, the status's one
+    # gate), which is Ipopt's own condition, and on a square problem the
+    # objective is constant -- a feasible point is the solution. The row
+    # used to read `(unknown, feasible)` on the theory that POUNCE used the
+    # status more loosely than Ipopt does; it does not.
+    #
+    # These values are exactly what the `.sol` route now produces for the
+    # same solve: POUNCE writes AMPL code 2 (Ipopt's own), and Pyomo's v2
+    # reader maps the 0..99 band to
+    # `(convergenceCriteriaSatisfied, optimal)`. Keeping the two routes in
+    # agreement is the same rule that governs `Solved_To_Acceptable_Level`
+    # above (gh #591); disagreeing here is what gh #815 was -- an IDAES
+    # square flowsheet solved to a 2.2e-06 constraint violation and
+    # reported to the caller as a failure.
     "Feasible_Point_Found": (
-        TerminationCondition.unknown,
-        SolutionStatus.feasible,
+        TerminationCondition.convergenceCriteriaSatisfied,
+        SolutionStatus.optimal,
     ),
     "Infeasible_Problem_Detected": (
         TerminationCondition.locallyInfeasible,


### PR DESCRIPTION
Fixes #815.

`Feasible_Point_Found` wrote AMPL `solve_result_num = 100`. Pyomo's contrib v2
`.sol` reader maps `100..=199` to `TerminationCondition.error`, so a correct
answer reached the caller as a **solver error**; the legacy reader maps the
band to `optimal` with `status=warning` — the same complaint that moved
`Solved_To_Acceptable_Level` out of it in #591. It is now `2`, Ipopt's own
code, in the `0..=99` solved band.

## The justification for `100` had stopped being true of the code

The doc comment defending the divergence said the two statuses do not mean the
same thing: that Ipopt returns `FEASIBLE_POINT_FOUND` only for a square
problem, where a feasible point *is* the solution, while POUNCE used it more
loosely for a usable feasible point that missed the convergence criteria.

POUNCE does not. The status has exactly one producer — `min_c_1nrm.rs`
returning `RestorationOutcome::FeasiblePointFound` — behind exactly one gate in
`resto_inner_solver.rs`, whose first conjunct is `is_square_problem`
(`c.x.dim() == c.y_c.dim()`, a port of
`IpoptCalculatedQuantities::IsSquareProblem`). Same condition as Ipopt, so the
same meaning; and on a square problem the objective is constant, so there is no
remaining criterion the point could be said to have missed.

Two surfaces in this repo had already written the correct reading down and were
being contradicted by that comment: `python/pounce/gams/link.py` maps the status
to `(MODELSTAT_FEASIBLE, SOLVESTAT_NORMAL)` and lists it as a success, and
`issue_390_nonlinear_equality_scale.rs` calls it "a success-band answer — AMPL
`objno` code 2, which every band table reads as SOLVED".

## Changes

| | before | after |
|---|---|---|
| `status_to_solve_result_num` | `100` | `2` |
| `pounce` exit code (non-`-AMPL`) | `1` | `0` |
| `v2._V2_STATUS` | `(unknown, feasible)` | `(convergenceCriteriaSatisfied, optimal)` |
| `sens._STATUS_RESULT` | `(feasible, warning)` | `(optimal, ok)` |

The two `pyomo_pounce` rows are set to exactly what the `.sol` route now
produces for the same solve — the rule both tables' docstrings already state,
and the rule #591 established.

The exit code moves because leaving it would have created a *fresh*
inconsistency: the same process would exit 1 while the `.sol` beside it read
solved.

The five-term gate is extracted verbatim into `square_feasible_point_found` so
the `is_square_problem` conjunct — which is what the whole band argument rests
on — can be held by a test instead of a comment. No logic changed.

## Measured

gh #815 is a 536x536 IDAES naphtha-hydrotreater flowsheet, zero degrees of
freedom. Written the way IDAES writes it for Ipopt
(`writer_config={"scale_model": True}`), through Pyomo end-to-end, residuals in
the model's original units:

| | result | wall | max abs residual | thiophene conversion |
|---|---|---|---|---|
| POUNCE, `scale_model` | `optimal` / `ok` | 1.0 s | 2.208e-06 | 0.39187704 |
| POUNCE, `linear_presolve` + `scale_model` | `optimal` / `ok` | 0.8 s | 2.899e-06 | 0.39187658 |

Before this change those same two solves loaded as `optimal` / **`warning`**
through the legacy reader and as `TerminationCondition.error` through the v2
reader. The `.sol` line moved from `objno 0 100` to `objno 0 2`.

## What this does not fix, and a correction to the issue's premise

The model **as filed** — the raw unscaled `.nl` — is not solvable by either
solver here:

- POUNCE stalls at a constraint violation of ~4.97e+03. An 18-configuration
  option sweep (linear solver, `mu` strategy, scaling method,
  `nlp_scaling_max_gradient`, `mu_init`, `start_with_resto`,
  `expect_infeasible_problem`, bound handling, `mc64`, iteration cap) ended
  `Restoration_Failed` or `Infeasible_Problem_Detected` in every case, at that
  same violation.
- Ipopt 3.13.2/ma27 exits `Restoration Failed` at 2418 iterations from a stall
  at `inf_pr = 1.56e+01`, against POUNCE's 1.60e+01 — the two trajectories are
  bit-identical over iterations 0–3.

What makes the model tractable is IDAES's own per-variable scaling factors
applied by the NL writer. That is a frontend configuration; no
`nlp_scaling_method` substitutes for it. Ipopt did not solve this model in any
configuration tried here, including through the reporter's own script — so the
issue's framing ("Ipopt solves it, POUNCE does not") does not hold, while
POUNCE's actual defect on it was real and is what this PR fixes.

## Tests

- `the_exit_code_and_the_sol_band_never_disagree` — the guard as an `iff` over
  all twenty statuses, so a status added to one channel and not the other fails
  it in either direction. #815 is this predicate failing on
  `FeasiblePointFound`; #591 was the same shape one status over.
- `only_a_square_problem_yields_a_feasible_point_verdict` — squareness alone
  decides, every other input held at a passing value.
- `each_residual_guard_refuses_on_its_own` — the other four conjuncts, each
  refused individually from that passing baseline.
- `a_square_problem_feasible_point_is_in_the_solved_band` — the code and the
  band, with the reason.

**What these are not evidence about.** None of it is end-to-end. No fixture in
the CLI corpus reaches this exit; 72 generated square models (three
nonlinearity families x three start points x three row-scale spreads) under
five option sets failed to reach it as well. The exit needs a model larger than
the corpus carries, and the end-to-end evidence is #815's own 536x536 model
above.

`scripts/sweep-fixtures.sh` moved **0 of 154** fixture-legs. That is a control,
not evidence: the sweep does not read `solve_result_num`, and the only
non-reporting edit here is a verbatim extraction.

## Left split on purpose

Three Python success sets still count the status as a failure —
`_minimize._NLP_SUCCESS_STATUS` (shared by `_curve_fit`), `jax._path._OK_STATUS`
and `torch._path._OK_STATUS`. Unlike the CLI they are a scipy-style `success`
flag on a library call that writes no `.sol`, so they were not put in
contradiction with a file the same process had just written, and widening a
public return value deserves its own decision. Filed as #820 so it has an owner
rather than reading as an oversight.

#817, opened earlier against this issue, is **not** a fix for it and is not
part of this PR.
