### PR TITLE
fix(ma57): thread the ma57_* options into the backend, and emit the CoinHSL rpath from the binary's package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,21 @@ changes.
   Linux with `libcoinhsl.so` on the loader path never showed this, which is why
   it went unnoticed.
 
+  **`ma57_pivtolmax` below `ma57_pivtol` is now refused, not silently lifted.**
+  A pre-existing deviation from upstream that only became reachable once the
+  above landed. Upstream has two branches
+  (`IpMa57TSolverInterface.cpp:311-320`): an *explicitly set* `ma57_pivtolmax`
+  under `ma57_pivtol` raises `OPTION_INVALID`, while an *unset* one has its
+  registered default lifted to `ma57_pivtol`. pounce applied the lift
+  unconditionally, so a self-contradictory pair — an escalation ceiling below
+  the tolerance it starts from — was quietly rewritten and nothing said so.
+  `IpoptApplication::optimize_tnlp` now refuses it with `Invalid_Option`, at
+  both the main and `resto.` prefixes; the reader reports what the user wrote
+  and leaves the verdict to the layer that has an error channel. The lifting
+  branch is deliberately preserved: `ma57_pivtolmax` defaults to `1e-4`, so a
+  rule that merely compared the two numbers would reject `ma57_pivtol 0.5` on
+  its own — the most ordinary MA57 tuning there is.
+
   **Guards.** `pounce-algorithm/tests/ma57_options_reach_the_backend.rs` asserts
   that each option arrives at a live backend built by the real factory, at both
   prefixes, via a new `SparseSymLinearSolverInterface::as_any` downcast seam —
@@ -83,8 +98,11 @@ changes.
   `pounce-cli/tests/ma57_binary_starts.rs` covers gh #811 and the end-to-end
   gh #825 property. Both need CoinHSL, so neither runs in CI; the always-running
   half is `pounce-algorithm/tests/no_production_site_builds_ma57_with_defaults.rs`,
-  which fails on any `Ma57SolverInterface::new()` in production source. All are
-  mutation-checked: reintroduce either defect and the matching tests, and only
+  which fails on any `Ma57SolverInterface::new()` in production source, and
+  `pounce-algorithm/tests/ma57_pivtol_bracket.rs`, which covers both branches of
+  the `ma57_pivtolmax` rule and needs no HSL at all. All are mutation-checked:
+  reintroduce any of the defects — the discarded options, the missing rpath, the
+  unconditional lift, or a lift-blind refusal — and the matching tests, and only
   those, go red.
 
 - **A restoration failure now opens the second-opinion ladder.** (Found while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,84 @@ changes.
 
 ## [Unreleased]
 
+- **Every `ma57_*` option now reaches the MA57 backend, and an `--features
+  ma57` build now starts.** Fixes gh #825 and gh #811.
+
+  All nine `ma57_*` options — `ma57_print_level`, `ma57_pivtol`,
+  `ma57_pivtolmax`, `ma57_pre_alloc`, `ma57_pivot_order`,
+  `ma57_automatic_scaling`, `ma57_block_size`, `ma57_node_amalgamation`,
+  `ma57_small_pivot_flag` — were registered, documented, accepted, and then
+  discarded. A correct reader (`Ma57Options::from_options_list`) existed and
+  was unit-tested, so it looked live; nothing called it. Every production
+  construction site went through `Ma57SolverInterface::new()`, which
+  hard-codes `Options::defaults()`.
+
+  The root cause was an asymmetry with FERAL. `default_backend_factory` took a
+  `FeralConfig` read off the application's `OptionsList` and had no equivalent
+  parameter for MA57, so the factory had nothing to give it. Both factories now
+  take a `Ma57Config` alongside the `FeralConfig`, built by the new
+  `ma57_config_from_options(options, prefix)`. **This is a breaking change to
+  `default_backend_factory` / `default_backend_factory_with_sink`**, and
+  deliberately so: the argument is what makes the omission a compile error
+  rather than a silent default.
+
+  The failure mode was that there was no failure mode. Two solves whose option
+  blocks differed by eight orders of magnitude in `ma57_pivtol` and swapped the
+  elimination ordering printed identical iteration logs and an objective
+  identical to all seventeen digits — no warning, no diagnostic, no journal
+  message. Measured on `deb7` after the fix, `ma57_pivtol=0.5` moves the solve
+  from 124 iterations plus a fallback retry to 165 and `Solve_Succeeded`.
+
+  **`resto.`-prefixed options work now too.** `from_options_list` always took a
+  prefix, mirroring upstream's
+  `Ma57TSolverInterface::InitializeImpl(options, prefix)`, and with no callers
+  the facility did not exist. The restoration sub-IPM builds its own backend
+  through its own `InnerBackendFactoryFactory`, so the two are genuinely
+  independent: on `deb7`, `resto.ma57_pivtol=0.5` gives 130 iterations —
+  neither the baseline's 124 nor the un-prefixed arm's 165.
+
+  **No trajectory change on any existing run.** Every registered default is
+  identical to the reader's fallback and to `Options::defaults()`
+  (`default_options_are_the_registrys` pins this, which is the gh #677 shape —
+  registered with one default, read with another). A default MA57 run is
+  bit-identical to before; FERAL is untouched, and the fixture sweep is clean.
+
+  Two consequences worth naming. Any Ipopt-vs-POUNCE MA57 comparison run with a
+  shared options file that sets `ma57_*` was not like-for-like: gh #825 reports
+  one setting `ma57_pre_alloc: 2.0`, which Ipopt honoured and POUNCE did not,
+  so POUNCE paid for a reallocation Ipopt avoided. The handicap was not in
+  POUNCE's favour, and such numbers — including the `LinearSystemFactorization`
+  comparison on gh #730 and the figures on gh #809 — should be re-measured.
+  Separately, the mechanism gh #809 needs to make
+  `multi_solve_matches_single_solve` an MA57 opt-in now exists; the gate itself
+  is not implemented here.
+
+  **gh #811, found while building MA57 binaries to review gh #809.** An
+  `--features ma57` build died at process start: `Library not loaded:
+  @rpath/libcoinhsl.dylib ... no LC_RPATH's found`. `pounce-hsl/build.rs`
+  emitted `cargo:rustc-link-arg=-Wl,-rpath,...`, which applies only to targets
+  in the emitting package — and pounce-hsl is a library with no binary, so the
+  flag reached nothing. It could not even be patched after the fact: a release
+  link leaves no header padding, so `install_name_tool -add_rpath` refuses. The
+  directory now travels as `links` metadata (`cargo:rpath=` →
+  `DEP_COINHSL_RPATH`), which `pounce-cli/build.rs` and the new
+  `pounce-algorithm/build.rs` re-emit against their own targets, together with
+  `-headerpad_max_install_names` on macOS so a packaging step can relocate it.
+  Linux with `libcoinhsl.so` on the loader path never showed this, which is why
+  it went unnoticed.
+
+  **Guards.** `pounce-algorithm/tests/ma57_options_reach_the_backend.rs` asserts
+  that each option arrives at a live backend built by the real factory, at both
+  prefixes, via a new `SparseSymLinearSolverInterface::as_any` downcast seam —
+  configuration reaching a backend is not otherwise observable through that
+  trait, which is why the defect had no symptom.
+  `pounce-cli/tests/ma57_binary_starts.rs` covers gh #811 and the end-to-end
+  gh #825 property. Both need CoinHSL, so neither runs in CI; the always-running
+  half is `pounce-algorithm/tests/no_production_site_builds_ma57_with_defaults.rs`,
+  which fails on any `Ma57SolverInterface::new()` in production source. All are
+  mutation-checked: reintroduce either defect and the matching tests, and only
+  those, go red.
+
 - **A restoration failure now opens the second-opinion ladder.** (Found while
   investigating gh #815; it is *not* a fix for that issue — see the note at the
   end of this entry.)

--- a/crates/pounce-algorithm/Cargo.toml
+++ b/crates/pounce-algorithm/Cargo.toml
@@ -10,6 +10,10 @@ description = "Algorithm-side core for POUNCE (port of Ipopt's src/Algorithm/): 
 keywords = ["ipopt", "interior-point", "nlp", "optimization", "solver"]
 categories = ["mathematics", "algorithms", "science"]
 
+# Re-emits the CoinHSL `-rpath` onto this package's test binaries under
+# `--features ma57`; see build.rs and gh#811. No-op without the feature.
+build = "build.rs"
+
 [dependencies]
 pounce-common.workspace = true
 pounce-linalg.workspace = true

--- a/crates/pounce-algorithm/build.rs
+++ b/crates/pounce-algorithm/build.rs
@@ -1,0 +1,39 @@
+//! Re-emits the CoinHSL `-rpath` against this package's test binaries.
+//!
+//! `crates/pounce-hsl/build.rs` knows the CoinHSL lib directory, but
+//! `cargo:rustc-link-arg` applies only to targets in the package that
+//! emitted it, and pounce-hsl is a library with no binary of its own —
+//! so the flag reached nothing and an MA57-linked executable died at
+//! process start with "Library not loaded: @rpath/libcoinhsl.dylib ...
+//! no LC_RPATH's found" (gh#811). There is no propagating spelling of a
+//! linker argument, so the directory travels as build-script metadata:
+//! pounce-hsl declares `links = "coinhsl"` and emits `cargo:rpath=<dir>`,
+//! which cargo hands to the build script of each direct dependent as
+//! `DEP_COINHSL_RPATH`.
+//!
+//! This crate ships no binary; what needs the rpath is
+//! `tests/ma57_through_t_sym_solver.rs` and
+//! `tests/ma57_options_reach_the_backend.rs`, which link the dylib and
+//! run under `cargo test -p pounce-algorithm --features ma57`. The env
+//! var exists only when pounce-hsl is in the graph, i.e. under that
+//! feature; a default build emits nothing here.
+//!
+//! Kept in sync with `crates/pounce-cli/build.rs`, which does the same
+//! for the `pounce` binaries.
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=DEP_COINHSL_RPATH");
+    let Ok(rpath) = std::env::var("DEP_COINHSL_RPATH") else {
+        return;
+    };
+    if rpath.is_empty() {
+        return;
+    }
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{rpath}");
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        // Header padding so a packaging step can rewrite the rpath with
+        // `install_name_tool` afterwards; a release link otherwise leaves
+        // no room and the tool refuses.
+        println!("cargo:rustc-link-arg=-Wl,-headerpad_max_install_names");
+    }
+}

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -3107,8 +3107,17 @@ impl IpoptApplication {
         if let Some(perm) = &self.external_ordering {
             feral_cfg.ordering = pounce_feral::OrderingMethod::External(perm.clone());
         }
+        // MA57's knobs come off the same `OptionsList`, at the main-IPM
+        // prefix. The restoration sub-IPM reads them again under
+        // `"resto."` when its caller mints the inner backend factory —
+        // see `ma57_config_from_options`.
+        let ma57_cfg = ma57_config_from_options(&self.options, "");
         let factory = self.linear_backend_factory.take().unwrap_or_else(|| {
-            default_backend_factory_with_sink(feral_cfg, Arc::clone(&self.linsol_summary_sink))
+            default_backend_factory_with_sink(
+                feral_cfg,
+                ma57_cfg,
+                Arc::clone(&self.linsol_summary_sink),
+            )
         });
         let bundle = builder.build_with_backend(factory);
 
@@ -4654,34 +4663,124 @@ fn journal_level_from_int(v: i32) -> JournalLevel {
     }
 }
 
+/// MA57 backend knobs snapshotted off an `OptionsList`, ready to be
+/// handed to a backend factory.
+///
+/// The type exists — rather than passing `pounce_hsl::Ma57Options`
+/// directly — so that the factory signature is the same shape whether or
+/// not the `ma57` cargo feature is on. `pounce-py`, `pounce-cinterface`
+/// and `pounce-restoration` all call [`default_backend_factory`] and none
+/// of them can name a `pounce-hsl` type; without the feature this struct
+/// carries nothing and costs nothing.
+///
+/// Build it with [`ma57_config_from_options`]. It is the MA57 half of
+/// what [`feral_config_from_options`] does for FERAL, and the asymmetry
+/// between the two was the root cause of gh#825: FERAL's knobs were
+/// threaded into the factory and MA57's were not, so the factory had
+/// nothing to give MA57 and called `Ma57SolverInterface::new()` — which
+/// hard-codes the defaults. Every `ma57_*` option was registered,
+/// documented, accepted, and then silently discarded.
+#[derive(Debug, Clone, Default)]
+pub struct Ma57Config {
+    #[cfg(feature = "ma57")]
+    opts: pounce_hsl::Ma57Options,
+}
+
+impl Ma57Config {
+    /// The wrapped MA57 settings.
+    #[cfg(feature = "ma57")]
+    pub fn options(&self) -> &pounce_hsl::Ma57Options {
+        &self.opts
+    }
+}
+
+/// Read the `ma57_*` options off `options` under `prefix`, for handing
+/// to [`default_backend_factory`] / [`default_backend_factory_with_sink`].
+///
+/// `prefix` is `""` for the main IPM and `"resto."` for the restoration
+/// sub-IPM, mirroring upstream's
+/// `Ma57TSolverInterface::InitializeImpl(options, prefix)`. The
+/// restoration sub-IPM builds its own backend through its own
+/// `InnerBackendFactoryFactory` (see
+/// `pounce_restoration::resto_inner_solver`), so the two really are
+/// separately configurable — before gh#825 neither was.
+///
+/// Without the `ma57` cargo feature this returns an empty config and
+/// does not touch `options`; nothing downstream can consume MA57
+/// settings in that build.
+pub fn ma57_config_from_options(
+    options: &pounce_common::options_list::OptionsList,
+    prefix: &str,
+) -> Ma57Config {
+    #[cfg(feature = "ma57")]
+    {
+        Ma57Config {
+            opts: pounce_hsl::Ma57Options::from_options_list(options, prefix),
+        }
+    }
+    #[cfg(not(feature = "ma57"))]
+    {
+        let _ = (options, prefix);
+        Ma57Config::default()
+    }
+}
+
+/// Construct the MA57 backend for a factory, or fall back to FERAL when
+/// the `ma57` cargo feature is off.
+///
+/// Factored out of the two factories below so there is exactly one place
+/// that decides how an MA57 backend is built from a [`Ma57Config`]. Both
+/// factories used to inline `Ma57SolverInterface::new()`, and the
+/// duplication is half of why gh#825 was easy to miss.
+fn make_ma57_backend(
+    ma57_cfg: &Ma57Config,
+    feral_fallback: impl FnOnce() -> Box<dyn SparseSymLinearSolverInterface>,
+) -> Box<dyn SparseSymLinearSolverInterface> {
+    #[cfg(feature = "ma57")]
+    {
+        let _ = feral_fallback;
+        Box::new(pounce_hsl::Ma57SolverInterface::with_options(
+            *ma57_cfg.options(),
+        ))
+    }
+    #[cfg(not(feature = "ma57"))]
+    {
+        // ma57 feature not compiled in — fall back to FERAL.
+        let _ = ma57_cfg;
+        feral_fallback()
+    }
+}
+
 /// Default symmetric linear-solver factory, parameterized by the
-/// pounce-extension FERAL knobs read off the application's
-/// `OptionsList`.
+/// pounce-extension FERAL knobs and the `ma57_*` knobs read off the
+/// application's `OptionsList`.
 ///
 /// FERAL (pure-Rust) is the shipping default. The HSL MA57 backend is
 /// available when the `ma57` cargo feature is enabled; without it,
 /// requesting `linear_solver = ma57` falls back to FERAL with a
 /// warning printed by the journalist (see [`AlgorithmBuilder`]).
-pub fn default_backend_factory(feral_cfg: pounce_feral::FeralConfig) -> LinearBackendFactory {
+///
+/// Both configs are snapshots, not live views: take them with
+/// [`feral_config_from_options`] and [`ma57_config_from_options`] at the
+/// point the application's options are fully populated. The factory is
+/// called more than once per solve (the main KKT solver and, under
+/// limited memory, the Hessian-free bypass solver), so each call gets a
+/// fresh backend built from the same snapshot.
+pub fn default_backend_factory(
+    feral_cfg: pounce_feral::FeralConfig,
+    ma57_cfg: Ma57Config,
+) -> LinearBackendFactory {
     Box::new(
         move |choice: LinearSolverChoice| -> Box<dyn SparseSymLinearSolverInterface> {
             match choice {
                 LinearSolverChoice::Feral => Box::new(
                     pounce_feral::FeralSolverInterface::with_config(feral_cfg.clone()),
                 ),
-                LinearSolverChoice::Ma57 => {
-                    #[cfg(feature = "ma57")]
-                    {
-                        Box::new(pounce_hsl::Ma57SolverInterface::new())
-                    }
-                    #[cfg(not(feature = "ma57"))]
-                    {
-                        // ma57 feature not compiled in — fall back to FERAL.
-                        Box::new(pounce_feral::FeralSolverInterface::with_config(
-                            feral_cfg.clone(),
-                        ))
-                    }
-                }
+                LinearSolverChoice::Ma57 => make_ma57_backend(&ma57_cfg, || {
+                    Box::new(pounce_feral::FeralSolverInterface::with_config(
+                        feral_cfg.clone(),
+                    ))
+                }),
             }
         },
     )
@@ -4695,6 +4794,7 @@ pub fn default_backend_factory(feral_cfg: pounce_feral::FeralConfig) -> LinearBa
 /// sink — the HSL backend doesn't carry the same instrumentation yet.
 pub fn default_backend_factory_with_sink(
     feral_cfg: pounce_feral::FeralConfig,
+    ma57_cfg: Ma57Config,
     sink: Arc<Mutex<LinearSolverSummary>>,
 ) -> LinearBackendFactory {
     Box::new(
@@ -4704,19 +4804,12 @@ pub fn default_backend_factory_with_sink(
                     pounce_feral::FeralSolverInterface::with_config(feral_cfg.clone())
                         .with_summary_sink(Arc::clone(&sink)),
                 ),
-                LinearSolverChoice::Ma57 => {
-                    #[cfg(feature = "ma57")]
-                    {
-                        Box::new(pounce_hsl::Ma57SolverInterface::new())
-                    }
-                    #[cfg(not(feature = "ma57"))]
-                    {
-                        Box::new(
-                            pounce_feral::FeralSolverInterface::with_config(feral_cfg.clone())
-                                .with_summary_sink(Arc::clone(&sink)),
-                        )
-                    }
-                }
+                LinearSolverChoice::Ma57 => make_ma57_backend(&ma57_cfg, || {
+                    Box::new(
+                        pounce_feral::FeralSolverInterface::with_config(feral_cfg.clone())
+                            .with_summary_sink(Arc::clone(&sink)),
+                    )
+                }),
             }
         },
     )

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -957,6 +957,26 @@ impl IpoptApplication {
             );
             return ApplicationReturnStatus::InvalidOption;
         }
+        // A `ma57_pivtolmax` the user set *below* `ma57_pivtol` is a
+        // contradiction — the escalation ceiling under its floor — and
+        // upstream refuses it outright
+        // (`IpMa57TSolverInterface.cpp:313`, `OPTION_INVALID`). pounce
+        // used to silently rewrite it to `ma57_pivtol`. That was
+        // unreachable while gh#825 was live, since no `ma57_*` value
+        // reached the backend at all, and became reachable the moment
+        // that was fixed — so it is refused here rather than shipped as
+        // a new way to be quietly ignored.
+        if let Some(msg) = self.ma57_pivtol_bracket_refusal() {
+            use pounce_common::journalist::JournalCategory;
+            eprintln!("{msg}");
+            self.journalist.print(
+                JournalLevel::J_ERROR,
+                JournalCategory::J_MAIN,
+                &format!("{msg}\n"),
+            );
+            return ApplicationReturnStatus::InvalidOption;
+        }
+
         let backend_warnings = self.take_unimplemented_backend_warnings();
         for warning in self
             .unexploited_hint_warnings()
@@ -2367,6 +2387,57 @@ impl IpoptApplication {
         apply_sqp_options(&self.options, &mut builder.sqp);
         apply_qp_subproblem_options(&self.options, &mut builder.sqp_qp);
         builder
+    }
+
+    /// Refuse an explicitly set `ma57_pivtolmax` that sits below
+    /// `ma57_pivtol`, at either option prefix.
+    ///
+    /// Upstream's `Ma57TSolverInterface::InitializeImpl` asserts
+    /// `pivtolmax >= pivtol` and raises `OPTION_INVALID`, but only when
+    /// the user set `ma57_pivtolmax` explicitly; left unset, the
+    /// registered default is lifted to `ma57_pivtol` instead. Both
+    /// halves are mirrored — the lifting in
+    /// `pounce_hsl::ma57::Options::from_options_list`, the refusal here.
+    ///
+    /// Checked at **both** prefixes because the restoration sub-IPM
+    /// configures its own MA57 backend from `"resto."`-scoped options
+    /// (gh#825), so `resto.ma57_pivtolmax` can contradict
+    /// `resto.ma57_pivtol` without the un-prefixed pair being wrong.
+    ///
+    /// Deliberately **not** gated on the `ma57` cargo feature or on
+    /// `linear_solver` resolving to MA57. It is a consistency check on
+    /// two numbers the user wrote, needs no HSL to perform, and a
+    /// verdict that changed with a build flag would be worse than a
+    /// consistent one — it would also be untestable in CI, which cannot
+    /// link CoinHSL. Only an *explicitly set* `ma57_pivtolmax` can
+    /// trigger it, so an options file that never mentions the option is
+    /// unaffected.
+    fn ma57_pivtol_bracket_refusal(&self) -> Option<String> {
+        for prefix in ["", "resto."] {
+            // `(_, true)` is the explicitly-set arm; an unset option
+            // reports the registry default with `false` and is the
+            // branch upstream lifts rather than refuses.
+            let Ok((pivtolmax, true)) = self.options.get_numeric_value("ma57_pivtolmax", prefix)
+            else {
+                continue;
+            };
+            let pivtol = self
+                .options
+                .get_numeric_value("ma57_pivtol", prefix)
+                .map(|(v, _)| v)
+                .unwrap_or(1e-8);
+            if pivtolmax < pivtol {
+                return Some(format!(
+                    "pounce: {prefix}ma57_pivtolmax ({pivtolmax:e}) is below \
+                     {prefix}ma57_pivtol ({pivtol:e}). ma57_pivtolmax is the ceiling MA57 \
+                     may raise the pivot tolerance to when it escalates for accuracy, so it \
+                     cannot sit below the tolerance it starts from. Raise \
+                     {prefix}ma57_pivtolmax to at least {pivtol:e}, or lower \
+                     {prefix}ma57_pivtol."
+                ));
+            }
+        }
+        None
     }
 
     /// Construct a LinearBackendFactory honoring the

--- a/crates/pounce-algorithm/tests/ma57_options_reach_the_backend.rs
+++ b/crates/pounce-algorithm/tests/ma57_options_reach_the_backend.rs
@@ -1,0 +1,234 @@
+//! The `ma57_*` options must reach the MA57 backend the factory builds.
+//!
+//! `pounce_hsl::ma57::Options::from_options_list` has always been unit
+//! tested, so the reader was covered and looked live. Nothing tested that
+//! the reader was *reached*, and it was not: every production
+//! construction of `Ma57SolverInterface` called `::new()`, which
+//! hard-codes `Options::defaults()`. All nine options were registered,
+//! documented, accepted — and discarded (gh#825). The symptom was that
+//! there was no symptom: two solves whose `ma57_*` blocks spanned eight
+//! orders of magnitude in `ma57_pivtol` and swapped the elimination
+//! ordering printed identical iteration logs and an objective identical
+//! to all seventeen digits.
+//!
+//! So this test asserts the property the missing one would have: build
+//! the factory the way the application builds it, ask it for an MA57
+//! backend, and read the settings back off the live object.
+//!
+//! Two things it is deliberately *not*:
+//!
+//! * Not a re-test of the reader. Every expected value below is written
+//!   out by hand rather than obtained from `from_options_list`, because
+//!   a comparison of the reader against itself passes just as happily
+//!   when the factory ignores it.
+//! * Not a check that the values are *upstream's*. That is
+//!   `upstream_options.rs`'s job; the registry's defaults and the
+//!   reader's fallbacks are compared in `default_options_are_the_registrys`
+//!   below, which is the gh#677 shape (registered with one default, read
+//!   with another) applied to this option family.
+//!
+//! Runs only under `--features ma57`, which is the only build in which
+//! MA57 exists. CI cannot link CoinHSL, so this test does not run there;
+//! `no_production_site_builds_ma57_with_default_options` is the half that
+//! does, and it is why that one exists.
+#![cfg(feature = "ma57")]
+#![allow(clippy::unwrap_used)]
+
+use pounce_algorithm::IpoptApplication;
+use pounce_algorithm::alg_builder::LinearSolverChoice;
+use pounce_algorithm::application::{
+    Ma57Config, default_backend_factory, default_backend_factory_with_sink,
+    feral_config_from_options, ma57_config_from_options,
+};
+use pounce_common::OptionsList;
+use pounce_hsl::{Ma57Options, Ma57SolverInterface};
+use pounce_linsol::SparseSymLinearSolverInterface;
+use pounce_linsol::summary::LinearSolverSummary;
+use std::sync::{Arc, Mutex};
+
+/// An options list with the registry attached, as the application has.
+///
+/// The registry matters: without it `get_integer_value` on an unset
+/// option is an `Err` and the reader's own fallback answers, while with
+/// it the *registered* default answers. Production always has the
+/// registry, so a test without one would exercise a branch no user
+/// reaches — and would miss a registry/reader default mismatch entirely.
+fn app() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.initialize().expect("registry initializes");
+    app
+}
+
+fn set(app: &mut IpoptApplication, assignment: &str) {
+    app.options_mut()
+        .read_from_str(assignment, true)
+        .unwrap_or_else(|e| panic!("{assignment}: {e:?}"));
+}
+
+/// The settings of the MA57 backend behind a factory's trait object.
+/// `Ma57Options` is `Copy`, so they outlive the boxed backend.
+fn options_of(backend: Box<dyn SparseSymLinearSolverInterface>) -> Ma57Options {
+    *backend
+        .as_any()
+        .expect("the MA57 backend opts into the downcast seam")
+        .downcast_ref::<Ma57SolverInterface>()
+        .expect("linear_solver=ma57 builds an Ma57SolverInterface")
+        .options()
+}
+
+/// Build an MA57 backend the way the application does, and read its
+/// settings back.
+fn ma57_options_from(options: &OptionsList, prefix: &str) -> Ma57Options {
+    let mut factory = default_backend_factory(
+        feral_config_from_options(options),
+        ma57_config_from_options(options, prefix),
+    );
+    options_of(factory(LinearSolverChoice::Ma57))
+}
+
+/// The nine values used throughout, chosen so every one differs from
+/// both the registry default and its neighbours — a factory that crossed
+/// two fields, or that honoured some options and not others, fails on the
+/// specific field rather than passing by coincidence.
+struct Probe;
+impl Probe {
+    const ASSIGNMENTS: [&'static str; 9] = [
+        "ma57_print_level 3",
+        "ma57_pivtol 0.5",
+        "ma57_pivtolmax 0.75",
+        "ma57_pre_alloc 5.0",
+        "ma57_pivot_order 2",
+        "ma57_automatic_scaling yes",
+        "ma57_block_size 128",
+        "ma57_node_amalgamation 1",
+        "ma57_small_pivot_flag 1",
+    ];
+
+    fn assert_arrived(o: &Ma57Options) {
+        assert_eq!(o.print_level(), 3, "ma57_print_level");
+        assert_eq!(o.pivtol(), 0.5, "ma57_pivtol");
+        assert_eq!(o.pivtolmax(), 0.75, "ma57_pivtolmax");
+        assert_eq!(o.pre_alloc(), 5.0, "ma57_pre_alloc");
+        assert_eq!(o.pivot_order(), 2, "ma57_pivot_order");
+        assert!(o.automatic_scaling(), "ma57_automatic_scaling");
+        assert_eq!(o.block_size(), 128, "ma57_block_size");
+        assert_eq!(o.node_amalgamation(), 1, "ma57_node_amalgamation");
+        assert_eq!(o.small_pivot_flag(), 1, "ma57_small_pivot_flag");
+    }
+}
+
+/// The headline: all nine options, set at the main-IPM prefix, arrive.
+///
+/// Before gh#825 every assertion here read the registry default instead.
+#[test]
+fn every_ma57_option_reaches_the_backend() {
+    let mut app = app();
+    for a in Probe::ASSIGNMENTS {
+        set(&mut app, a);
+    }
+    Probe::assert_arrived(&ma57_options_from(app.options(), ""));
+}
+
+/// The same through `default_backend_factory_with_sink`, which is the
+/// factory the application actually installs (`application.rs`, the
+/// `linear_backend_factory` fallback) — the plain one is what the
+/// restoration sub-IPM's callers mint. Both had the defect; a fix to one
+/// is not a fix to the other.
+#[test]
+fn the_sink_factory_reaches_the_backend_too() {
+    let mut app = app();
+    for a in Probe::ASSIGNMENTS {
+        set(&mut app, a);
+    }
+    let sink = Arc::new(Mutex::new(LinearSolverSummary::default()));
+    let mut factory = default_backend_factory_with_sink(
+        feral_config_from_options(app.options()),
+        ma57_config_from_options(app.options(), ""),
+        sink,
+    );
+    Probe::assert_arrived(&options_of(factory(LinearSolverChoice::Ma57)));
+}
+
+/// The `"resto."` prefix is a real facility, not decoration.
+///
+/// `from_options_list` has always taken a prefix, mirroring upstream's
+/// `Ma57TSolverInterface::InitializeImpl(options, prefix)`, and with no
+/// callers it did nothing. The restoration sub-IPM builds its own backend
+/// through its own `InnerBackendFactoryFactory`, so the two prefixes must
+/// land on genuinely independent backends.
+///
+/// Note which branch each half takes: the un-prefixed read must see the
+/// *main* value even though a `resto.` value is also set, and vice versa.
+/// A prefix that were ignored would pass a test that set only one of them.
+#[test]
+fn the_resto_prefix_selects_its_own_values() {
+    let mut app = app();
+    set(&mut app, "ma57_pivtol 0.5");
+    set(&mut app, "ma57_pivot_order 2");
+    set(&mut app, "resto.ma57_pivtol 0.125");
+    set(&mut app, "resto.ma57_pivot_order 3");
+
+    let main = ma57_options_from(app.options(), "");
+    assert_eq!(main.pivtol(), 0.5, "main IPM keeps its own pivtol");
+    assert_eq!(main.pivot_order(), 2);
+
+    let resto = ma57_options_from(app.options(), "resto.");
+    assert_eq!(resto.pivtol(), 0.125, "resto. overrides");
+    assert_eq!(resto.pivot_order(), 3);
+}
+
+/// An option set only at the main prefix still reaches the restoration
+/// backend, because upstream's prefixed lookup falls back to the
+/// un-prefixed value. The previous test pins the override; this pins the
+/// inheritance, which is the other branch of the same rule.
+#[test]
+fn the_resto_backend_inherits_unprefixed_values() {
+    let mut app = app();
+    set(&mut app, "ma57_pivtol 0.5");
+    let resto = ma57_options_from(app.options(), "resto.");
+    assert_eq!(resto.pivtol(), 0.5);
+}
+
+/// With nothing set, the backend must carry exactly what it carried
+/// before gh#825 — otherwise the fix is a trajectory change on every
+/// existing MA57 run.
+///
+/// This is the gh#677 shape: `limited_memory_initialization` was
+/// registered with one default and read with another, and nothing
+/// compared the two. Here the reader's fallbacks are dead code in
+/// production (the registry always answers first), so a divergence would
+/// show up only as a silently moved default — which is what this asserts
+/// against.
+#[test]
+fn default_options_are_the_registrys() {
+    let app = app();
+    let o = ma57_options_from(app.options(), "");
+    assert_eq!(o.print_level(), 0);
+    assert_eq!(o.pivtol(), 1e-8);
+    assert_eq!(o.pivtolmax(), 1e-4);
+    assert_eq!(o.pre_alloc(), 1.05);
+    assert_eq!(o.pivot_order(), 5);
+    assert!(!o.automatic_scaling());
+    assert_eq!(o.block_size(), 16);
+    assert_eq!(o.node_amalgamation(), 16);
+    assert_eq!(o.small_pivot_flag(), 0);
+    // And identical to the no-OptionsList constructor, which is what
+    // `::new()` used to hand production.
+    assert_eq!(o, Ma57Options::defaults());
+}
+
+/// `Ma57Config::default()` is the empty config, and a factory given one
+/// must still produce a *working* backend rather than, say, zeros in
+/// ICNTL. The two test call sites in the tree pass it (they never select
+/// MA57), so it has to be the upstream defaults and not junk.
+#[test]
+fn the_empty_config_is_the_upstream_defaults() {
+    let mut factory = default_backend_factory(
+        feral_config_from_options(&OptionsList::default()),
+        Ma57Config::default(),
+    );
+    assert_eq!(
+        options_of(factory(LinearSolverChoice::Ma57)),
+        Ma57Options::defaults()
+    );
+}

--- a/crates/pounce-algorithm/tests/ma57_options_reach_the_backend.rs
+++ b/crates/pounce-algorithm/tests/ma57_options_reach_the_backend.rs
@@ -217,6 +217,88 @@ fn default_options_are_the_registrys() {
     assert_eq!(o, Ma57Options::defaults());
 }
 
+/// The `ma57_pivtolmax` reader has two branches, and the *value* half of
+/// each is checked here; the refusal half is
+/// `ma57_pivtol_bracket.rs`, which needs no HSL and so runs in CI.
+///
+/// Upstream (`IpMa57TSolverInterface.cpp:311-320`) lifts the registered
+/// default to `ma57_pivtol` when the option is unset, and takes an
+/// explicitly set value verbatim. pounce used to apply the lift
+/// unconditionally, which silently rewrote an explicit value that sat
+/// below `ma57_pivtol`.
+#[test]
+fn an_unset_pivtolmax_is_lifted_to_pivtol() {
+    let mut app = app();
+    set(&mut app, "ma57_pivtol 0.5");
+    let o = ma57_options_from(app.options(), "");
+    assert_eq!(o.pivtol(), 0.5);
+    assert_eq!(
+        o.pivtolmax(),
+        0.5,
+        "the 1e-4 default must be lifted to ma57_pivtol, not left under it"
+    );
+}
+
+/// The other branch: set explicitly, taken verbatim. `0.75` is above
+/// `ma57_pivtol` so the pair is legal and the lift would be a no-op —
+/// what this pins is that a *legal* explicit value is not touched.
+#[test]
+fn an_explicit_pivtolmax_is_taken_verbatim() {
+    let mut app = app();
+    set(&mut app, "ma57_pivtol 0.25");
+    set(&mut app, "ma57_pivtolmax 0.75");
+    let o = ma57_options_from(app.options(), "");
+    assert_eq!(o.pivtolmax(), 0.75);
+}
+
+/// A contradictory explicit pair reaches the reader **verbatim**, not
+/// clamped.
+///
+/// This is the test that separates the two candidate rules. Everywhere
+/// else they agree: `ma57_pivtol_bracket.rs` refuses this pair inside
+/// `optimize_tnlp`, so no solve can carry it, and every legal pair is
+/// untouched by a clamp. Without this assertion, restoring the old
+/// unconditional `max(pivtolmax, pivtol)` leaves the whole suite green.
+///
+/// Verbatim is the right answer for a layering reason. This reader has
+/// no error channel — it returns `Options`, not `Result` — so a clamp
+/// here is a silent rewrite of what the user wrote, which is the exact
+/// behaviour being removed. The refusal belongs to the layer that can
+/// deliver a verdict, and `IpoptApplication::optimize_tnlp` is reached
+/// by every solve entry point pounce has.
+///
+/// What a caller who bypasses the application and builds a backend
+/// straight from an `OptionsList` gets: a `pivtolmax` under `pivtol`,
+/// which makes `increase_quality` lower the tolerance once and then
+/// report exhausted. Useless, not dangerous — and it is the answer to
+/// the question they asked.
+#[test]
+fn a_contradictory_explicit_pivtolmax_is_not_silently_clamped() {
+    let mut app = app();
+    set(&mut app, "ma57_pivtol 0.5");
+    set(&mut app, "ma57_pivtolmax 1e-9");
+    let o = ma57_options_from(app.options(), "");
+    assert_eq!(
+        o.pivtolmax(),
+        1e-9,
+        "the reader must report what the user wrote; refusing the pair is \
+         `optimize_tnlp`'s job, and clamping it here is how the contradiction \
+         used to disappear without a diagnostic"
+    );
+    assert_eq!(o.pivtol(), 0.5);
+}
+
+/// With neither set, the lift is what produces the registry default —
+/// `max(1e-4, 1e-8)`. Pins that the two branches agree on the default
+/// path, which is what keeps an existing MA57 run bit-identical.
+#[test]
+fn the_default_pair_is_unmoved_by_the_lift() {
+    let app = app();
+    let o = ma57_options_from(app.options(), "");
+    assert_eq!(o.pivtol(), 1e-8);
+    assert_eq!(o.pivtolmax(), 1e-4);
+}
+
 /// `Ma57Config::default()` is the empty config, and a factory given one
 /// must still produce a *working* backend rather than, say, zeros in
 /// ICNTL. The two test call sites in the tree pass it (they never select

--- a/crates/pounce-algorithm/tests/ma57_pivtol_bracket.rs
+++ b/crates/pounce-algorithm/tests/ma57_pivtol_bracket.rs
@@ -1,0 +1,195 @@
+//! `ma57_pivtolmax` below `ma57_pivtol` is refused, not silently lifted.
+//!
+//! `ma57_pivtolmax` is the ceiling MA57 may raise the pivot tolerance to
+//! when `increase_quality` escalates for accuracy; `ma57_pivtol` is where
+//! it starts. A ceiling below the floor is a contradiction, and upstream
+//! refuses it (`IpMa57TSolverInterface.cpp:311-320`, `OPTION_INVALID`):
+//!
+//! ```cpp
+//! if( options.GetNumericValue("ma57_pivtolmax", pivtolmax_, prefix) )
+//!    ASSERT_EXCEPTION(pivtolmax_ >= pivtol_, OPTION_INVALID, ...);
+//! else
+//!    pivtolmax_ = Max(pivtolmax_, pivtol_);
+//! ```
+//!
+//! pounce's reader applied that `Max` unconditionally, so an explicitly
+//! set `ma57_pivtolmax` under `ma57_pivtol` was quietly rewritten to
+//! `ma57_pivtol` — a self-contradictory pair accepted with no diagnostic.
+//! Harmless while gh#825 was live, because no `ma57_*` value reached the
+//! backend at all; reachable the moment that was fixed.
+//!
+//! **The rule branches, and both branches are tested here**, because
+//! either one alone passes while the other is broken:
+//!
+//! * *explicitly set* and below `ma57_pivtol` → refused;
+//! * *unset* and below `ma57_pivtol` → lifted, and the solve proceeds.
+//!
+//! The second is not a formality. `ma57_pivtolmax` is registered with a
+//! default of `1e-4`, so **any** `ma57_pivtol` above `1e-4` puts the
+//! default below the floor. A rule written as "refuse whenever
+//! `pivtolmax < pivtol`" would reject `ma57_pivtol 0.5` on its own —
+//! the single most ordinary thing a user tuning MA57 does.
+//!
+//! This file is **not** feature-gated, and that is the point: the check
+//! is a comparison of two numbers the user wrote, needs no HSL to
+//! perform, and CI cannot link CoinHSL. It is the one part of the
+//! gh#825 work that CI exercises end to end.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// `min (x - 1)^2`, unconstrained. As small as a TNLP gets: the refusal
+/// fires before any numerical work, so the model only has to exist.
+struct Quadratic;
+
+impl TNLP for Quadratic {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 1,
+            m: 0,
+            nnz_jac_g: 0,
+            nnz_h_lag: 1,
+            index_style: IndexStyle::C,
+        })
+    }
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-2.0e19]);
+        b.x_u.copy_from_slice(&[2.0e19]);
+        true
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.0]);
+        true
+    }
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 1.0) * (x[0] - 1.0))
+    }
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * (x[0] - 1.0);
+        true
+    }
+    fn eval_g(&mut self, _x: &[Number], _new_x: bool, _g: &mut [Number]) -> bool {
+        true
+    }
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        _mode: SparsityRequest<'_>,
+    ) -> bool {
+        true
+    }
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        of: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let z: [Index; 1] = [0];
+                irow.copy_from_slice(&z);
+                jcol.copy_from_slice(&z);
+            }
+            SparsityRequest::Values { values, .. } => values[0] = of * 2.0,
+        }
+        true
+    }
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn solve_with(options: &str) -> ApplicationReturnStatus {
+    let mut app = IpoptApplication::new();
+    app.initialize().expect("registry initializes");
+    app.initialize_with_options_str(&format!("print_level 0\n{options}"))
+        .unwrap_or_else(|e| panic!("options rejected at set time: {e:?}\n{options}"));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Quadratic));
+    app.optimize_tnlp(tnlp)
+}
+
+fn solved(s: ApplicationReturnStatus) -> bool {
+    matches!(
+        s,
+        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+    )
+}
+
+/// The refusing branch. Both values are individually legal — the
+/// registry bounds each to `(0, 1]` — so nothing rejects them at set
+/// time, and before this check nothing rejected the pair either.
+#[test]
+fn an_explicit_pivtolmax_below_pivtol_is_refused() {
+    let status = solve_with("ma57_pivtol 0.5\nma57_pivtolmax 1e-9\n");
+    assert_eq!(
+        status,
+        ApplicationReturnStatus::InvalidOption,
+        "an explicit ma57_pivtolmax under ma57_pivtol must be refused, not lifted"
+    );
+}
+
+/// The same pair under `"resto."`. The restoration sub-IPM configures
+/// its own MA57 backend from `resto.`-scoped options (gh#825), so this
+/// pair can contradict itself while the un-prefixed one is fine — and a
+/// check that looked at only one prefix would pass here.
+#[test]
+fn the_resto_prefixed_pair_is_refused_too() {
+    let status = solve_with("resto.ma57_pivtol 0.5\nresto.ma57_pivtolmax 1e-9\n");
+    assert_eq!(
+        status,
+        ApplicationReturnStatus::InvalidOption,
+        "the `resto.` prefix has its own MA57 backend and its own pair to keep consistent"
+    );
+}
+
+/// The lifting branch, and the reason the refusal is conditioned on the
+/// option being *explicitly set*.
+///
+/// `ma57_pivtolmax` defaults to `1e-4`, which is below this `ma57_pivtol`
+/// — so a rule that just compared the two numbers would reject the most
+/// ordinary MA57 tuning there is. Upstream lifts the default instead,
+/// and so must pounce.
+#[test]
+fn an_unset_pivtolmax_is_lifted_not_refused() {
+    let status = solve_with("ma57_pivtol 0.5\n");
+    assert!(
+        solved(status),
+        "raising ma57_pivtol above the ma57_pivtolmax *default* must lift the default, \
+         not refuse the solve — got {status:?}"
+    );
+}
+
+/// The boundary. Upstream asserts `pivtolmax >= pivtol`, so equality is
+/// legal; an off-by-one written as `>` would fail here and nowhere else.
+#[test]
+fn an_explicit_pivtolmax_equal_to_pivtol_is_accepted() {
+    let status = solve_with("ma57_pivtol 0.5\nma57_pivtolmax 0.5\n");
+    assert!(
+        solved(status),
+        "pivtolmax == pivtol is legal — got {status:?}"
+    );
+}
+
+/// An ordinary explicit pair, above the floor.
+#[test]
+fn an_explicit_pivtolmax_above_pivtol_is_accepted() {
+    let status = solve_with("ma57_pivtol 1e-6\nma57_pivtolmax 0.5\n");
+    assert!(solved(status), "status = {status:?}");
+}
+
+/// And the check does not fire on a solve that never mentions MA57 —
+/// the guard against a refusal that quietly rejects everything.
+#[test]
+fn a_solve_with_no_ma57_options_is_unaffected() {
+    let status = solve_with("");
+    assert!(solved(status), "status = {status:?}");
+}

--- a/crates/pounce-algorithm/tests/no_production_site_builds_ma57_with_defaults.rs
+++ b/crates/pounce-algorithm/tests/no_production_site_builds_ma57_with_defaults.rs
@@ -1,0 +1,145 @@
+//! No production code may construct an MA57 backend with hard-coded
+//! defaults.
+//!
+//! This is the CI-runnable half of the gh#825 guard, and it exists
+//! because the other half cannot run here. Asserting that the `ma57_*`
+//! options reach the backend requires an MA57 backend, which requires
+//! linking CoinHSL, which is licensed and not available to CI — so
+//! `ma57_options_reach_the_backend.rs` is `#![cfg(feature = "ma57")]`
+//! and never executes on a pull request. Without something that does,
+//! the fix is protected in CI only by the fact that
+//! `default_backend_factory` now *demands* a `Ma57Config`; a caller can
+//! still satisfy the compiler with `Ma57Config::default()` and put the
+//! defect straight back, silently, exactly as before.
+//!
+//! `Ma57SolverInterface::new()` is the defect's signature. It
+//! hard-codes `Options::defaults()`, its own doc comment says it is for
+//! tests — and it was the only path production code had. Every one of
+//! the three production construction sites called it, so all nine
+//! `ma57_*` options were registered, documented, accepted and dropped.
+//!
+//! What this test can and cannot see:
+//!
+//! * It reads source text. It cannot tell whether the options a call
+//!   site passes are the *right* ones (the resto sites read the
+//!   `"resto."` prefix; nothing here checks that) — only that the site
+//!   is not asking for defaults outright.
+//! * It scans `src/`, never `tests/`, and truncates each file at its
+//!   first `#[cfg(test)]`. `pounce-hsl`'s own unit tests legitimately
+//!   call `::new()` and live inside `src/ma57.rs`.
+//! * It skips line comments, several of which name the constructor in
+//!   order to warn against it — including the one on the constructor.
+//! * It is deliberately not feature-gated: the source is on disk in
+//!   every build, which is the whole point.
+
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // crates/
+    p.pop(); // workspace root
+    p
+}
+
+/// Every `.rs` file under `crates/*/src/`.
+fn production_sources(root: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    let crates = root.join("crates");
+    let entries =
+        std::fs::read_dir(&crates).unwrap_or_else(|e| panic!("read {}: {e}", crates.display()));
+    for entry in entries.flatten() {
+        let src = entry.path().join("src");
+        if src.is_dir() {
+            walk(&src, &mut out);
+        }
+    }
+    assert!(
+        out.len() > 100,
+        "expected to find the workspace's sources under {}; found {}",
+        crates.display(),
+        out.len()
+    );
+    out
+}
+
+/// The file's text with everything from its first `#[cfg(test)]` onward
+/// removed, so an in-file unit-test module does not count as production.
+fn production_text(text: &str) -> &str {
+    match text.find("#[cfg(test)]") {
+        Some(i) => &text[..i],
+        None => text,
+    }
+}
+
+#[test]
+fn no_production_site_builds_ma57_with_default_options() {
+    let root = workspace_root();
+    let mut offenders = Vec::new();
+    for path in production_sources(&root) {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for (lineno, line) in production_text(&text).lines().enumerate() {
+            // Comments name the constructor freely — several of them
+            // explain why not to call it, including the one on the
+            // constructor itself.
+            if line.trim_start().starts_with("//") {
+                continue;
+            }
+            if line.contains("Ma57SolverInterface::new()") {
+                offenders.push(format!(
+                    "{}:{}: {}",
+                    path.strip_prefix(&root).unwrap_or(&path).display(),
+                    lineno + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "`Ma57SolverInterface::new()` hard-codes `Options::defaults()`, so an MA57 backend \
+         built this way silently discards every `ma57_*` option the user set — that is gh#825. \
+         Production code has an `OptionsList`; build the backend from it, via \
+         `ma57_config_from_options(options, prefix)` threaded into `default_backend_factory` \
+         (prefix \"\" for the main IPM, \"resto.\" for the restoration sub-IPM), or via \
+         `Ma57SolverInterface::from_options_list` directly.\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// The guard is only worth anything if the string it looks for is the
+/// string the code would actually contain. If `Ma57SolverInterface` is
+/// renamed, or the constructor is, the test above starts passing
+/// vacuously — so pin that the needle still occurs somewhere in the
+/// tree (in `pounce-hsl`'s own tests, which are allowed to use it).
+#[test]
+fn the_needle_still_exists() {
+    let root = workspace_root();
+    let ma57 = root.join("crates/pounce-hsl/src/ma57.rs");
+    let text =
+        std::fs::read_to_string(&ma57).unwrap_or_else(|e| panic!("read {}: {e}", ma57.display()));
+    let called = text
+        .lines()
+        .any(|l| !l.trim_start().starts_with("//") && l.contains("Ma57SolverInterface::new()"));
+    assert!(
+        called,
+        "no `Ma57SolverInterface::new()` anywhere in {} — if the constructor was renamed or \
+         removed, update the needle in this file's sibling test, which is otherwise now \
+         passing vacuously.",
+        ma57.display()
+    );
+}

--- a/crates/pounce-cinterface/src/lib.rs
+++ b/crates/pounce-cinterface/src/lib.rs
@@ -35,7 +35,7 @@ pub mod fortran;
 pub mod solver;
 
 use pounce_algorithm::application::{
-    IpoptApplication, default_backend_factory, feral_config_from_options,
+    IpoptApplication, default_backend_factory, feral_config_from_options, ma57_config_from_options,
 };
 use pounce_algorithm::intermediate as ip_intermediate;
 use pounce_common::reg_options::OptionType;
@@ -736,9 +736,13 @@ pub unsafe extern "C" fn IpoptSolve(
             // provider so the ℓ₁ wrapper / auto-fallback don't panic on the
             // second inner solve (pounce#10 Phase 3 / pounce#24).
             let feral_cfg = feral_config_from_options(info.app.options());
+            // The `ma57_*` options under the `"resto."` prefix — dead until
+            // gh#825, because nothing threaded any MA57 config into a factory.
+            let ma57_cfg = ma57_config_from_options(info.app.options(), "resto.");
             let bff_mint = move || -> InnerBackendFactoryFactory {
                 let feral_cfg = feral_cfg.clone();
-                Box::new(move || default_backend_factory(feral_cfg.clone()))
+                let ma57_cfg = ma57_cfg.clone();
+                Box::new(move || default_backend_factory(feral_cfg.clone(), ma57_cfg.clone()))
             };
             let resto_provider = make_default_restoration_factory_provider(
                 RestoAlgorithmBuilder::new(),

--- a/crates/pounce-cinterface/src/solver.rs
+++ b/crates/pounce-cinterface/src/solver.rs
@@ -21,7 +21,7 @@
 //! now-null handle is safe (it null-checks).
 
 use pounce_algorithm::application::{
-    IpoptApplication, default_backend_factory, feral_config_from_options,
+    IpoptApplication, default_backend_factory, feral_config_from_options, ma57_config_from_options,
 };
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 use pounce_nlp::tnlp::TNLP;
@@ -212,9 +212,13 @@ pub unsafe extern "C" fn IpoptSolverSolve(
             // IpoptSolve). Multi-pass provider so the ℓ₁ wrapper / auto-fallback
             // don't panic on the second inner solve (pounce#10 / pounce#24).
             let feral_cfg = feral_config_from_options(info.problem.app.options());
+            // The `ma57_*` options under the `"resto."` prefix — dead until
+            // gh#825, because nothing threaded any MA57 config into a factory.
+            let ma57_cfg = ma57_config_from_options(info.problem.app.options(), "resto.");
             let bff_mint = move || -> InnerBackendFactoryFactory {
                 let feral_cfg = feral_cfg.clone();
-                Box::new(move || default_backend_factory(feral_cfg.clone()))
+                let ma57_cfg = ma57_cfg.clone();
+                Box::new(move || default_backend_factory(feral_cfg.clone(), ma57_cfg.clone()))
             };
             let resto_provider = make_default_restoration_factory_provider(
                 RestoAlgorithmBuilder::new(),

--- a/crates/pounce-cli/build.rs
+++ b/crates/pounce-cli/build.rs
@@ -1,12 +1,16 @@
 //! Stamps build-time metadata into the `pounce` binary so `--about`
-//! can print version/build/git/rustc info without runtime introspection.
+//! can print version/build/git/rustc info without runtime introspection,
+//! and — under `--features ma57` — emits the CoinHSL `-rpath` that the
+//! `pounce` binary needs to start.
 //!
-//! Everything here is best-effort: missing git or `date` just becomes
-//! "unknown" in the output. Nothing here changes link behavior.
+//! The metadata half is best-effort: missing git or `date` just becomes
+//! "unknown" in the output. The rpath half is not optional; see
+//! [`emit_coinhsl_rpath`].
 
 use std::process::Command;
 
 fn main() {
+    emit_coinhsl_rpath();
     // Re-stamp when HEAD moves; otherwise the SHA in the binary is stale.
     // The .git/HEAD path is relative to this crate's manifest dir.
     println!("cargo:rerun-if-changed=../../.git/HEAD");
@@ -71,4 +75,43 @@ fn run(cmd: &str, args: &[&str]) -> Option<String> {
     }
     let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
     Some(s)
+}
+
+/// Re-emit the CoinHSL `-rpath` against *this* package's targets.
+///
+/// `crates/pounce-hsl/build.rs` knows the CoinHSL lib directory, but
+/// `cargo:rustc-link-arg` applies only to targets in the package that
+/// emitted it, and pounce-hsl is a library with no binary of its own —
+/// so the flag reached nothing, and an `ma57` build of `pounce` died at
+/// process start with "Library not loaded: @rpath/libcoinhsl.dylib ...
+/// no LC_RPATH's found" (gh#811). There is no propagating spelling of a
+/// linker argument, so the directory travels as build-script metadata
+/// instead: pounce-hsl declares `links = "coinhsl"` and emits
+/// `cargo:rpath=<dir>`, which cargo hands to the build script of each
+/// direct dependent as `DEP_COINHSL_RPATH`.
+///
+/// The var is present only when pounce-hsl is in the graph, i.e. under
+/// `--features ma57`; a default build sees nothing here and emits
+/// nothing.
+///
+/// `rustc-link-arg` (not `-bins`) on purpose: the integration tests in
+/// `tests/` link the same dylib and have to start too, and
+/// `ma57_binary_starts.rs` is one of them.
+fn emit_coinhsl_rpath() {
+    println!("cargo:rerun-if-env-changed=DEP_COINHSL_RPATH");
+    let Ok(rpath) = std::env::var("DEP_COINHSL_RPATH") else {
+        return;
+    };
+    if rpath.is_empty() {
+        return;
+    }
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{rpath}");
+    // Leave header padding so a packaging step can rewrite the rpath
+    // afterwards with `install_name_tool`. Without it a release link
+    // leaves no room and `install_name_tool -add_rpath` refuses with
+    // "larger updated load commands do not fit (the program must be
+    // relinked)" — which is why gh#811 could not be patched in place.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg=-Wl,-headerpad_max_install_names");
+    }
 }

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -14,7 +14,7 @@
 //! carried by the file's `solve_result_num`.
 
 use pounce_algorithm::alg_builder::{LinearBackendFactory, LinearSolverChoice};
-use pounce_algorithm::application::IpoptApplication;
+use pounce_algorithm::application::{IpoptApplication, Ma57Config};
 use pounce_cli::builtin;
 use pounce_cli::cli::{Args, ProblemSource};
 use pounce_cli::counting_tnlp::CountingTnlp;
@@ -314,13 +314,19 @@ pub fn main() -> ExitCode {
     // IPM. Snapshot, not borrow: the BFF outlives the option-mutation
     // window we cleanly own here.
     let feral_cfg = pounce_algorithm::application::feral_config_from_options(app.options());
+    // Same snapshot discipline for MA57, except that the restoration sub-IPM reads the `ma57_*` options again
+    // under the `"resto."` prefix, which is upstream's
+    // `Ma57TSolverInterface::InitializeImpl(options, prefix)` facility and was
+    // dead code until gh#825 — nothing called it.
+    let ma57_cfg = pounce_algorithm::application::ma57_config_from_options(app.options(), "resto.");
     // Use the multi-pass provider so the ℓ₁ wrapper (`l1_exact_penalty_barrier`)
     // and the auto-fallback (`l1_fallback_on_restoration_failure`) don't
     // panic with "restoration factory invoked more than once" on their
     // second inner solve — see pounce#10 Phase 3 / pounce#24.
     let bff_mint = move || -> InnerBackendFactoryFactory {
         let feral_cfg = feral_cfg.clone();
-        Box::new(move || default_backend_factory(feral_cfg.clone()))
+        let ma57_cfg = ma57_cfg.clone();
+        Box::new(move || default_backend_factory(feral_cfg.clone(), ma57_cfg.clone()))
     };
     // Hand the inner IPM a builder mirroring the outer options so its
     // `mu_strategy` (adaptive vs. monotone) inherits the user's choice —
@@ -3474,8 +3480,17 @@ fn print_about() {
 /// feature. The `feral_cfg` argument carries the `feral_*` extension
 /// options (cascade-break / FMA / iterative-refinement) captured from
 /// the application's options list, so per-problem `.opt` overrides
-/// flow into the resto sub-IPM as well.
-fn default_backend_factory(feral_cfg: pounce_feral::FeralConfig) -> LinearBackendFactory {
+/// flow into the resto sub-IPM as well; `ma57_cfg` does the same for the
+/// `ma57_*` options, read under the `"resto."` prefix by the caller.
+///
+/// Both arguments are snapshots. `ma57_cfg` used to be absent, which is
+/// gh#825: this arm called `Ma57SolverInterface::new()` and every
+/// `ma57_*` option a user set was accepted and then discarded, with no
+/// warning and no observable effect on the solve.
+fn default_backend_factory(
+    feral_cfg: pounce_feral::FeralConfig,
+    ma57_cfg: Ma57Config,
+) -> LinearBackendFactory {
     Box::new(
         move |choice: LinearSolverChoice| -> Box<dyn SparseSymLinearSolverInterface> {
             match choice {
@@ -3485,10 +3500,13 @@ fn default_backend_factory(feral_cfg: pounce_feral::FeralConfig) -> LinearBacken
                 LinearSolverChoice::Ma57 => {
                     #[cfg(feature = "ma57")]
                     {
-                        Box::new(pounce_hsl::Ma57SolverInterface::new())
+                        Box::new(pounce_hsl::Ma57SolverInterface::with_options(
+                            *ma57_cfg.options(),
+                        ))
                     }
                     #[cfg(not(feature = "ma57"))]
                     {
+                        let _ = &ma57_cfg;
                         Box::new(pounce_feral::FeralSolverInterface::with_config(
                             feral_cfg.clone(),
                         ))

--- a/crates/pounce-cli/tests/ma57_binary_starts.rs
+++ b/crates/pounce-cli/tests/ma57_binary_starts.rs
@@ -1,0 +1,212 @@
+//! An `--features ma57` build of `pounce` must actually run, and its
+//! `ma57_*` options must actually do something.
+//!
+//! Two defects, one test file, because they were found together and
+//! neither is visible from the other's vantage point.
+//!
+//! **gh#811 — the binary would not start.** `crates/pounce-hsl/build.rs`
+//! emitted `cargo:rustc-link-arg=-Wl,-rpath,<coinhsl>/lib`, and that
+//! directive applies only to targets in the package that emits it.
+//! pounce-hsl is a library with no binary, so the flag reached nothing:
+//! `cargo build -p pounce-cli --features ma57` linked fine and the
+//! resulting `pounce` died at process start with
+//!
+//! ```text
+//! dyld: Library not loaded: @rpath/libcoinhsl.dylib
+//!   Reason: no LC_RPATH's found
+//! ```
+//!
+//! It could not even be patched afterwards — a release link leaves no
+//! header padding, so `install_name_tool -add_rpath` refuses. The fix
+//! passes the directory to dependents as `links` metadata
+//! (`DEP_COINHSL_RPATH`), which `crates/pounce-cli/build.rs` re-emits.
+//! Linux with `libcoinhsl.so` on the loader path never showed it, which
+//! is why it went unnoticed.
+//!
+//! **gh#825 — the options did nothing.** All nine `ma57_*` options were
+//! registered, documented, accepted, and discarded, because every
+//! production construction of the backend called
+//! `Ma57SolverInterface::new()`. No warning, no diagnostic, no journal
+//! message: two solves whose option blocks differed by eight orders of
+//! magnitude in `ma57_pivtol` printed identical logs.
+//!
+//! Only runs under `--features ma57`; CI cannot link CoinHSL. The
+//! always-runnable companions are
+//! `pounce-algorithm/tests/no_production_site_builds_ma57_with_defaults.rs`
+//! (gh#825's signature, checked in source) and the fact that
+//! `default_backend_factory` now requires a `Ma57Config` argument.
+#![cfg(feature = "ma57")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// gh#811. The dynamic loader has to resolve `@rpath/libcoinhsl.dylib`
+/// before `main` runs, so this fails at *process start* — no output, a
+/// signal or a nonzero status, and a dyld message on stderr — rather
+/// than anywhere the rest of the suite would notice.
+#[test]
+fn the_ma57_binary_starts() {
+    let out = Command::new(pounce_bin())
+        .arg("--version")
+        .output()
+        .expect("spawn pounce");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("Library not loaded") && !stderr.contains("LC_RPATH"),
+        "the ma57 build of `pounce` cannot start — the CoinHSL rpath did not reach the \
+         binary (gh#811). Check that crates/pounce-hsl/build.rs still emits \
+         `cargo:rpath=` and that crates/pounce-cli/build.rs still re-emits it from \
+         DEP_COINHSL_RPATH.\nstderr: {stderr}"
+    );
+    assert!(out.status.success(), "`pounce --version` failed: {stderr}");
+}
+
+/// The binary agrees it has MA57 compiled in. Guards against the test
+/// silently degrading into a check of a FERAL-only build, which would
+/// pass every assertion in this file for the wrong reason.
+#[test]
+fn the_binary_reports_ma57_enabled() {
+    let out = Command::new(pounce_bin())
+        .arg("--about")
+        .output()
+        .expect("spawn pounce");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("ma57:           enabled"),
+        "built with --features ma57 but `--about` does not report it:\n{stdout}"
+    );
+}
+
+/// A run's outcome: the iteration count of each solve it performed, in
+/// order, plus the status it finally reported.
+///
+/// A *vector*, because a POUNCE run is not always one solve — deb7 ends
+/// `Solved_To_Acceptable_Level`, which opens the auto-fallback retry, so
+/// a default run reports two blocks. Reading only the first or only the
+/// last would compare one arm's original solve against another arm's
+/// retry. The whole sequence is the trajectory signature.
+fn run(args: &[&str]) -> (Vec<u32>, String) {
+    let out = Command::new(pounce_bin())
+        .arg(fixture("deb7.nl"))
+        .arg("linear_solver=ma57")
+        .args(args)
+        .output()
+        .expect("spawn pounce");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let status = stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("Status:"))
+        .unwrap_or_else(|| {
+            panic!("{args:?} produced no status line\nstdout: {stdout}\nstderr: {stderr}")
+        })
+        .trim()
+        .to_string();
+    let iters = stdout
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("Number of Iterations....:"))
+        .filter_map(|v| v.trim().parse::<u32>().ok())
+        .collect::<Vec<_>>();
+    assert!(
+        !iters.is_empty(),
+        "{args:?} produced no iteration counts:\n{stdout}"
+    );
+    (iters, status)
+}
+
+fn solved(status: &str) -> bool {
+    matches!(status, "Solve_Succeeded" | "Solved_To_Acceptable_Level")
+}
+
+/// The dylib loads and MA57 actually solves — a stronger statement than
+/// "the process started", since `libcoinhsl`'s own `@rpath` dependencies
+/// (openblas, metis, libgfortran, libgomp) are resolved lazily and a
+/// missing one would surface only here.
+#[test]
+fn ma57_solves_a_model() {
+    let (_, status) = run(&[]);
+    assert!(
+        solved(&status),
+        "linear_solver=ma57 did not solve deb7: {status}"
+    );
+}
+
+/// gh#825, end to end and in the user's own terms: setting an `ma57_*`
+/// option changes the solve.
+///
+/// `ma57_pivtol` goes from the default `1e-8` — pivot for sparsity — to
+/// `0.5`, LAPACK's maximum-stability threshold. That is eight orders of
+/// magnitude on `CNTL(1)`; it changes which entries MA57 accepts as
+/// pivots and therefore the rounding of every factorization, so it
+/// cannot leave the trajectory untouched. Before the fix these two runs
+/// were identical to all seventeen digits of the objective, which is
+/// exactly what the issue reported.
+///
+/// Asserted as "the signatures differ", never as specific numbers: the
+/// property under test is that the option is *connected*, and pinning a
+/// count here would make an unrelated trajectory change fail this test
+/// for a reason its name does not describe.
+#[test]
+fn an_ma57_option_changes_the_solve() {
+    let (baseline, base_status) = run(&[]);
+    let (stabilized, stab_status) = run(&["ma57_pivtol=0.5"]);
+    assert!(solved(&base_status) && solved(&stab_status));
+    assert_ne!(
+        baseline, stabilized,
+        "ma57_pivtol=0.5 left the solve identical to the 1e-8 default. Either the option is \
+         being discarded again (gh#825), or it is reaching MA57 and genuinely changing \
+         nothing — the first is a bug and the second is worth understanding before this \
+         assertion is relaxed."
+    );
+}
+
+/// The `"resto."` prefix reaches the restoration sub-IPM's backend, and
+/// only that one.
+///
+/// Upstream's `Ma57TSolverInterface::InitializeImpl` takes a prefix and
+/// pounce's reader always mirrored it — but nothing called the reader,
+/// so the facility did not exist in practice (gh#825, impact 4). The
+/// restoration sub-IPM builds its *own* backend, through its own
+/// `InnerBackendFactoryFactory`, which is what makes the two separately
+/// configurable at all.
+///
+/// Both halves are asserted, because either alone passes while the other
+/// is broken:
+///
+/// * against the baseline — a prefixed value that reached nothing would
+///   leave the run untouched;
+/// * against the *un*-prefixed arm — a prefix that were simply ignored
+///   would make `resto.ma57_pivtol` a synonym for `ma57_pivtol` and
+///   reproduce that arm instead.
+#[test]
+fn the_resto_prefix_reaches_only_the_restoration_subsolve() {
+    let (baseline, base_status) = run(&[]);
+    let (unprefixed, _) = run(&["ma57_pivtol=0.5"]);
+    let (prefixed, prefixed_status) = run(&["resto.ma57_pivtol=0.5"]);
+    assert!(solved(&base_status) && solved(&prefixed_status));
+
+    assert_ne!(
+        baseline, prefixed,
+        "`resto.ma57_pivtol=0.5` did not move the run. This fixture is only evidence while \
+         its solve actually enters restoration — if deb7's trajectory has changed so that it \
+         no longer does, this test needs a model that does, not a relaxed assertion."
+    );
+    assert_ne!(
+        unprefixed, prefixed,
+        "`resto.ma57_pivtol=0.5` reproduced the un-prefixed arm exactly, which is what an \
+         ignored prefix looks like: the value reached the main IPM instead of the \
+         restoration sub-IPM."
+    );
+}

--- a/crates/pounce-cli/tests/nlp_batch.rs
+++ b/crates/pounce-cli/tests/nlp_batch.rs
@@ -16,7 +16,9 @@
 //! - a bound-tightened instance honors its own bounds while its
 //!   siblings are unaffected.
 
-use pounce_algorithm::application::{default_backend_factory, feral_config_from_options};
+use pounce_algorithm::application::{
+    Ma57Config, default_backend_factory, feral_config_from_options,
+};
 use pounce_algorithm::{IpoptApplication, install_serial_feral_backend, solve_nlp_batch_parallel};
 use pounce_nl::nl_reader::{NlTnlp, NlVariation, read_nl_file};
 use pounce_nlp::return_codes::ApplicationReturnStatus;
@@ -50,7 +52,7 @@ fn configure(_i: usize, app: &mut IpoptApplication) {
     feral_cfg.parallel = Some(false);
     let bff_mint = move || -> InnerBackendFactoryFactory {
         let feral_cfg = feral_cfg.clone();
-        Box::new(move || default_backend_factory(feral_cfg.clone()))
+        Box::new(move || default_backend_factory(feral_cfg.clone(), Ma57Config::default()))
     };
     let resto_provider = make_default_restoration_factory_provider(
         RestoAlgorithmBuilder::new(),

--- a/crates/pounce-hsl/README.md
+++ b/crates/pounce-hsl/README.md
@@ -24,11 +24,25 @@ this backend instead of falling back to FERAL.
 `build.rs` reads `COINHSL_DIR`, adds its `lib/` to the link search
 path, and embeds an `-rpath` so `libcoinhsl` and its transitive
 dependencies (`libopenblas`, `libmetis`, `libgfortran`, `libgomp`)
-resolve at runtime. That `-rpath` covers `pounce-hsl`'s own test and
-bench binaries only; to run a downstream binary such as the `pounce`
-CLI, also put `libcoinhsl`'s `lib/` on `DYLD_LIBRARY_PATH` (macOS) or
-`LD_LIBRARY_PATH` (Linux). The `links = "coinhsl"` declaration in
-`Cargo.toml` prevents accidental double-link.
+resolve at runtime — no `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` needed.
+
+The `-rpath` reaches downstream binaries by travelling as build-script
+metadata. `cargo:rustc-link-arg` applies only to targets in the package
+that emits it, and this crate builds no binary, so on its own it covered
+nothing outside `pounce-hsl`'s own tests — an `--features ma57` build of
+the `pounce` CLI linked cleanly and then died at process start with
+`Library not loaded: @rpath/libcoinhsl.dylib ... no LC_RPATH's found`
+([issue #811](https://github.com/jkitchin/pounce/issues/811)). The
+`links = "coinhsl"` declaration in `Cargo.toml` — which also prevents an
+accidental double-link — lets `build.rs` emit `cargo:rpath=<dir>`, which
+cargo hands to the build script of every *direct* dependent as
+`DEP_COINHSL_RPATH`. `crates/pounce-cli/build.rs` and
+`crates/pounce-algorithm/build.rs` read it and re-emit the flag against
+their own targets.
+
+**A package that grows an `ma57` feature and produces a binary or a
+linked test must do the same**, or it inherits the same silent failure.
+Guard: `crates/pounce-cli/tests/ma57_binary_starts.rs`.
 
 ## Why MA57?
 

--- a/crates/pounce-hsl/build.rs
+++ b/crates/pounce-hsl/build.rs
@@ -52,5 +52,25 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=openblas");
     // libcoinhsl.dylib's @rpath dependencies live in the same lib
     // directory, so this single rpath resolves all of them.
+    //
+    // Two emissions, because they reach different things.
+    //
+    // `rustc-link-arg` applies only to targets in *this* package — so
+    // it covers pounce-hsl's own integration tests and nothing else.
+    // It does not reach the `pounce` binary, and that was gh#811: an
+    // `ma57` build linked, then died at process start with
+    // "Library not loaded: @rpath/libcoinhsl.dylib ... no LC_RPATH's
+    // found". There is no propagating spelling of a linker argument,
+    // so a downstream package that produces a binary has to emit its
+    // own.
     println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir_str}");
+    // The propagating half. This crate declares `links = "coinhsl"`,
+    // so cargo hands `cargo:rpath=<dir>` to the build script of every
+    // package that depends on pounce-hsl *directly*, as the env var
+    // `DEP_COINHSL_RPATH`. `crates/pounce-cli/build.rs` reads it and
+    // re-emits the `-rpath` against its own targets. A new package
+    // that grows an `ma57` feature and produces a binary or a test
+    // must do the same; `crates/pounce-cli/tests/ma57_binary_starts.rs`
+    // is the guard that the CLI's copy still works.
+    println!("cargo:rpath={lib_dir_str}");
 }

--- a/crates/pounce-hsl/src/ma57.rs
+++ b/crates/pounce-hsl/src/ma57.rs
@@ -34,7 +34,7 @@ fn configure_openblas_threads_once() {
 
 /// Settings drawn from `OptionsList` at `InitializeImpl` time
 /// (`IpMa57TSolverInterface.cpp:287-421`).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Options {
     print_level: Index,
     pivtol: Number,
@@ -126,6 +126,56 @@ impl Options {
             node_amalgamation: 16,
             small_pivot_flag: 0,
         }
+    }
+
+    // Read-only accessors. These exist so a caller can see which
+    // settings a live backend was actually built with — the thing
+    // gh#825 had no way to observe, and the thing
+    // `pounce-algorithm/tests/ma57_options_reach_the_backend.rs`
+    // asserts. Construction stays through `from_options_list` /
+    // `defaults` so the `pivtolmax >= pivtol` clamp cannot be bypassed.
+
+    /// `ma57_print_level` → `ICNTL(5)`.
+    pub fn print_level(&self) -> Index {
+        self.print_level
+    }
+    /// `ma57_pivtol` → `CNTL(1)`.
+    pub fn pivtol(&self) -> Number {
+        self.pivtol
+    }
+    /// `ma57_pivtolmax` — ceiling for the `increase_quality` escalation.
+    pub fn pivtolmax(&self) -> Number {
+        self.pivtolmax
+    }
+    /// `ma57_pre_alloc` — factor-workspace safety factor.
+    pub fn pre_alloc(&self) -> Number {
+        self.pre_alloc
+    }
+    /// `ma57_pivot_order` → `ICNTL(6)`.
+    pub fn pivot_order(&self) -> Index {
+        self.pivot_order
+    }
+    /// `ma57_automatic_scaling` → `ICNTL(15)`.
+    pub fn automatic_scaling(&self) -> bool {
+        self.automatic_scaling
+    }
+    /// `ma57_block_size` → `ICNTL(11)`.
+    pub fn block_size(&self) -> Index {
+        self.block_size
+    }
+    /// `ma57_node_amalgamation` → `ICNTL(12)`.
+    pub fn node_amalgamation(&self) -> Index {
+        self.node_amalgamation
+    }
+    /// `ma57_small_pivot_flag` → `ICNTL(16)`.
+    pub fn small_pivot_flag(&self) -> Index {
+        self.small_pivot_flag
+    }
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self::defaults()
     }
 }
 
@@ -224,8 +274,15 @@ impl Ma57SolverInterface {
         me
     }
 
-    /// Default-options factory — primarily for unit tests that
-    /// construct an MA57 backend without an `OptionsList`.
+    /// Default-options factory, for tests and for callers that have no
+    /// `OptionsList` at hand.
+    ///
+    /// **Not for production wiring.** It discards user configuration by
+    /// construction, and being the only path production code took is
+    /// exactly gh#825: every `ma57_*` option was registered, documented,
+    /// accepted, and then dropped on the floor with no warning. A code
+    /// path that has an `OptionsList` must use [`Self::from_options_list`]
+    /// (or [`Self::with_options`] with a snapshot taken from one).
     pub fn new() -> Self {
         Self::with_options(Options::defaults())
     }
@@ -236,9 +293,21 @@ impl Ma57SolverInterface {
         Self::with_options(Options::from_options_list(opts, prefix))
     }
 
-    /// Maximum pivot tolerance; useful in tests.
+    /// The *current* pivot tolerance (`CNTL(1)`), which
+    /// [`SparseSymLinearSolverInterface::increase_quality`] raises
+    /// towards `pivtolmax`. Useful in tests. (The doc formerly read
+    /// "maximum pivot tolerance"; that is `options().pivtolmax()`.)
     pub fn pivtol(&self) -> Number {
         self.options.pivtol
+    }
+
+    /// The settings this backend was constructed with. The only way to
+    /// see, from outside, that an `OptionsList` actually reached MA57 —
+    /// gh#825 was nine registered options silently discarded by a
+    /// factory that called [`Self::new`], with no observable difference
+    /// in any solve.
+    pub fn options(&self) -> &Options {
+        &self.options
     }
 
     /// Initialise `icntl` / `cntl` from MA57ID and overlay the Ipopt
@@ -525,6 +594,12 @@ impl Default for Ma57SolverInterface {
 }
 
 impl SparseSymLinearSolverInterface for Ma57SolverInterface {
+    /// Opted in so a test can assert that an `OptionsList` reached this
+    /// backend — see [`Self::options`] and gh#825.
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
     fn initialize_structure(
         &mut self,
         dim: Index,

--- a/crates/pounce-hsl/src/ma57.rs
+++ b/crates/pounce-hsl/src/ma57.rs
@@ -62,13 +62,47 @@ impl Options {
             .ok()
             .map(|(v, _)| v)
             .unwrap_or(1e-8);
-        let pivtolmax_default = pivtol.max(1e-4);
-        let pivtolmax = opts
+        // `ma57_pivtolmax` has two branches upstream
+        // (`IpMa57TSolverInterface.cpp:311-320`), and which one runs
+        // turns on whether the user set the option *explicitly*:
+        //
+        // ```cpp
+        // if( options.GetNumericValue("ma57_pivtolmax", pivtolmax_, prefix) )
+        //    ASSERT_EXCEPTION(pivtolmax_ >= pivtol_, OPTION_INVALID, ...);
+        // else
+        //    pivtolmax_ = Max(pivtolmax_, pivtol_);
+        // ```
+        //
+        // So the `max` is the *default's* accommodation of a raised
+        // `ma57_pivtol`, not a clamp on the user. An explicitly set
+        // value is taken verbatim, and a value below `ma57_pivtol` is
+        // an error rather than something quietly adjusted upward.
+        //
+        // pounce used to apply the `max` unconditionally, which silently
+        // rewrote an explicit `ma57_pivtolmax` that sat below
+        // `ma57_pivtol` into `ma57_pivtol` — accepting a
+        // self-contradictory pair and reporting nothing. That was
+        // unreachable while gh#825 was live (no `ma57_*` value reached
+        // this backend at all), and became reachable the moment it was
+        // fixed.
+        //
+        // The refusal lives in `IpoptApplication::optimize_tnlp`
+        // (`ma57_pivtol_bracket_refusal`), which is where pounce reports
+        // an invalid option pair and is reached by every solve entry
+        // point. This reader is one level below that and has no error
+        // channel, so it does what upstream's assignment does and leaves
+        // the verdict to the layer that can deliver one.
+        let (pivtolmax_raw, pivtolmax_was_set) = opts
             .get_numeric_value("ma57_pivtolmax", prefix)
             .ok()
-            .map(|(v, _)| v)
-            .unwrap_or(pivtolmax_default)
-            .max(pivtol);
+            // No registry attached and the option unset: the registered
+            // default is unavailable, so stand in with upstream's.
+            .unwrap_or((1e-4, false));
+        let pivtolmax = if pivtolmax_was_set {
+            pivtolmax_raw
+        } else {
+            pivtolmax_raw.max(pivtol)
+        };
         let pre_alloc = opts
             .get_numeric_value("ma57_pre_alloc", prefix)
             .ok()
@@ -132,8 +166,9 @@ impl Options {
     // settings a live backend was actually built with — the thing
     // gh#825 had no way to observe, and the thing
     // `pounce-algorithm/tests/ma57_options_reach_the_backend.rs`
-    // asserts. Construction stays through `from_options_list` /
-    // `defaults` so the `pivtolmax >= pivtol` clamp cannot be bypassed.
+    // asserts. Read-only, not `pub` fields, so the two-branch
+    // `pivtolmax` rule in `from_options_list` stays the only way these
+    // are populated from an `OptionsList`.
 
     /// `ma57_print_level` → `ICNTL(5)`.
     pub fn print_level(&self) -> Index {

--- a/crates/pounce-linsol/src/sparse_sym_iface.rs
+++ b/crates/pounce-linsol/src/sparse_sym_iface.rs
@@ -147,6 +147,25 @@ pub trait SparseSymLinearSolverInterface {
     /// Required matrix layout. Caller marshals data into this format.
     fn matrix_format(&self) -> EMatrixFormat;
 
+    /// Downcast seam: the concrete backend behind the trait object, for
+    /// callers that need to inspect how it was configured.
+    ///
+    /// Defaults to `None`, so a backend is invisible here until it opts
+    /// in; nothing in the solve path consults this.
+    ///
+    /// It exists because gh#825 had no observable symptom. A factory
+    /// built its MA57 backend with `Ma57SolverInterface::new()` —
+    /// hard-coded defaults — so all nine `ma57_*` options were accepted
+    /// and discarded, and every arm of every solve came out identical to
+    /// all seventeen digits. Configuration reaching a backend is not
+    /// checkable through the rest of this trait: two differently
+    /// configured factorizations are both just "a solution". This gives
+    /// a test somewhere to stand. See
+    /// `pounce-algorithm/tests/ma57_options_reach_the_backend.rs`.
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
+
     /// Whether [`Self::determine_dependent_rows`] is supported.
     fn provides_degeneracy_detection(&self) -> bool {
         false

--- a/crates/pounce-py/src/nlp_batch.rs
+++ b/crates/pounce-py/src/nlp_batch.rs
@@ -24,7 +24,9 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use pounce_algorithm::IpoptApplication;
-use pounce_algorithm::application::{default_backend_factory, feral_config_from_options};
+use pounce_algorithm::application::{
+    default_backend_factory, feral_config_from_options, ma57_config_from_options,
+};
 use pounce_algorithm::batch::{
     FeralBackendPool, NlpBatchResult, NlpWarmStart, install_pooled_serial_feral_backend,
     install_serial_feral_backend, solve_nlp_batch as solve_batch_seq,
@@ -129,6 +131,10 @@ fn configure_worker(
 ) {
     let _ = apply_options(app, opts);
     let mut feral_cfg = feral_config_from_options(app.options());
+    // MA57 knobs for the main IPM (prefix "") and, below, for the
+    // restoration sub-IPM (prefix "resto.") — see gh#825.
+    let ma57_cfg = ma57_config_from_options(app.options(), "");
+    let ma57_resto_cfg = ma57_config_from_options(app.options(), "resto.");
     if let Some(pool) = pool {
         install_pooled_serial_feral_backend(app, pool);
         feral_cfg.parallel = Some(false);
@@ -137,12 +143,13 @@ fn configure_worker(
         feral_cfg.parallel = Some(false);
     } else {
         let cfg = feral_cfg.clone();
-        app.set_linear_backend_factory(default_backend_factory(cfg));
+        app.set_linear_backend_factory(default_backend_factory(cfg, ma57_cfg.clone()));
     }
     // Restoration phase, including for the inner solves it runs.
     let bff_mint = move || -> InnerBackendFactoryFactory {
         let feral_cfg = feral_cfg.clone();
-        Box::new(move || default_backend_factory(feral_cfg.clone()))
+        let ma57_cfg = ma57_resto_cfg.clone();
+        Box::new(move || default_backend_factory(feral_cfg.clone(), ma57_cfg.clone()))
     };
     let resto_provider = make_default_restoration_factory_provider(
         RestoAlgorithmBuilder::new(),

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -1616,6 +1616,13 @@ fn decode_bounds(
 /// caller's `feral_*` overrides. The python wrapper always uses FERAL —
 /// the optional MA57 backend would require linking against
 /// `pounce-hsl`, which we deliberately keep out of the wheel.
+///
+/// Hence no `Ma57Config` parameter here, unlike the two factories it
+/// mirrors (gh#825): there is no MA57 arm for one to reach. If the wheel
+/// ever links pounce-hsl, this function gains the parameter and the
+/// `"resto."`-prefixed snapshot at its call site, or the `ma57_*`
+/// options go silently missing on the Python path the way they did
+/// everywhere else.
 fn default_backend_factory(feral_cfg: pounce_feral::FeralConfig) -> LinearBackendFactory {
     Box::new(
         move |_choice: LinearSolverChoice| -> Box<dyn SparseSymLinearSolverInterface> {

--- a/crates/pounce-restoration/src/second_opinion_driver.rs
+++ b/crates/pounce-restoration/src/second_opinion_driver.rs
@@ -35,7 +35,7 @@ use crate::resto_inner_solver::{
     InnerBackendFactoryFactory, make_default_restoration_factory_provider,
 };
 use pounce_algorithm::application::{
-    IpoptApplication, default_backend_factory, feral_config_from_options,
+    IpoptApplication, default_backend_factory, feral_config_from_options, ma57_config_from_options,
 };
 use pounce_algorithm::second_opinion::{
     SecondOpinionAvailability, SecondOpinionTrigger, resolve_scaling_retry_outcome,
@@ -157,9 +157,14 @@ pub fn run_second_opinion_ladder(
         // Rebuild the restoration provider at this rung's options — see the
         // module docs.
         let feral_cfg = feral_config_from_options(app.options());
+        // Re-read at this rung's options, same as the feral config above: a
+        // rung may set `linear_solver` or an `ma57_*` knob, and the provider is
+        // rebuilt precisely so the sub-IPM sees the rung and not the baseline.
+        let ma57_cfg = ma57_config_from_options(app.options(), "resto.");
         let bff_mint = move || -> InnerBackendFactoryFactory {
             let feral_cfg = feral_cfg.clone();
-            Box::new(move || default_backend_factory(feral_cfg.clone()))
+            let ma57_cfg = ma57_cfg.clone();
+            Box::new(move || default_backend_factory(feral_cfg.clone(), ma57_cfg.clone()))
         };
         app.set_restoration_factory_provider(make_default_restoration_factory_provider(
             RestoAlgorithmBuilder::new(),

--- a/crates/pounce-restoration/tests/resto_lbfgs_issue102.rs
+++ b/crates/pounce-restoration/tests/resto_lbfgs_issue102.rs
@@ -10,7 +10,7 @@
 //! lower-triangle `eval_h` sparsity with zero values + L-BFGS).
 
 use pounce_algorithm::application::{
-    IpoptApplication, default_backend_factory, feral_config_from_options,
+    IpoptApplication, Ma57Config, default_backend_factory, feral_config_from_options,
 };
 use pounce_common::types::Number;
 use pounce_nlp::ApplicationReturnStatus;
@@ -146,7 +146,7 @@ fn resto_lbfgs_does_not_panic_issue102() {
     let feral_cfg = feral_config_from_options(app.options());
     let bff_mint = move || -> InnerBackendFactoryFactory {
         let feral_cfg = feral_cfg.clone();
-        Box::new(move || default_backend_factory(feral_cfg.clone()))
+        Box::new(move || default_backend_factory(feral_cfg.clone(), Ma57Config::default()))
     };
     let resto_provider = make_default_restoration_factory_provider(
         RestoAlgorithmBuilder::new(),

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -138,6 +138,22 @@ primarily useful for benchmarking against upstream Ipopt; the FERAL
 backend is the supported default for everyday use, and a build without
 `--features ma57` never touches `COINHSL_DIR`.
 
+The build embeds `$COINHSL_DIR/lib` as an rpath, so the resulting
+binary finds `libcoinhsl` and its own dependencies (openblas, metis,
+libgfortran, libgomp) without `LD_LIBRARY_PATH` or
+`DYLD_LIBRARY_PATH`. If you relocate the CoinHSL install afterwards,
+rebuild — or, on macOS, rewrite the path with `install_name_tool
+-rpath <old> <new>`, which works because the link reserves header
+padding for it.
+
+The `ma57_*` options (`ma57_pivtol`, `ma57_pivot_order`,
+`ma57_pre_alloc`, and the rest — see
+[Options](options.md)) are honoured by this build, and can be scoped to
+the restoration sub-solve with a `resto.` prefix, e.g.
+`resto.ma57_pivtol=0.5`. Before
+[issue #825](https://github.com/jkitchin/pounce/issues/825) they were
+accepted and silently discarded.
+
 ## Using POUNCE as a Rust library
 
 The workspace is a set of library crates (see

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -633,9 +633,15 @@ and a μ-reset spiral
 ([issue #58](https://github.com/jkitchin/pounce/issues/58),
 [issue #64](https://github.com/jkitchin/pounce/issues/64)).
 
-Pair with `ma57_automatic_scaling=yes` (default in HSL builds) and
-leave `linear_system_scaling=none` — MA57's internal scaling and a
-pounce-level Ruiz pass should not be stacked.
+Consider pairing with `ma57_automatic_scaling=yes` and leaving
+`linear_system_scaling=none` — MA57's internal scaling and a
+pounce-level Ruiz pass should not be stacked. Note that
+`ma57_automatic_scaling` defaults to `no`, matching upstream Ipopt;
+turning it on is a deliberate step. (This page previously called it
+"default in HSL builds", which was never true — and until the fix for
+[issue #825](https://github.com/jkitchin/pounce/issues/825) setting it
+either way had no effect, because no `ma57_*` option reached the
+backend.)
 
 ### FERAL ordering: when the adaptive dispatcher guesses wrong
 


### PR DESCRIPTION
Fixes #825
Fixes #811

Two defects, found together while building MA57 binaries. #811 has to be
fixed first or an `--features ma57` build cannot be run at all, which is
what hid #825 from anyone without the `RUSTFLAGS` incantation.

## Problem

**#825.** All nine `ma57_*` options were registered, documented, accepted
— and discarded. The failure mode was that there was no failure mode: no
warning, no diagnostic, no journal message, and an objective identical to
all seventeen digits between arms whose option blocks differed by eight
orders of magnitude.

Measured on `crates/pounce-cli/tests/fixtures/deb7.nl`, release build,
`linear_solver=ma57`. The iteration column is a vector because a
`Solved_To_Acceptable_Level` run opens the auto-fallback retry, so a
default run reports two solves:

| | before | after |
|---|---|---|
| *(no `ma57_*`)* | `[124, 96]` Solved_To_Acceptable_Level | `[124, 96]` Solved_To_Acceptable_Level |
| `ma57_pivtol=0.5` | `[124, 96]` — **identical** | `[165]` Solve_Succeeded |
| `resto.ma57_pivtol=0.5` | `[124, 96]` — **identical** | `[130, 96]` Solved_To_Acceptable_Level |

The third row is the `resto.` prefix landing on the restoration sub-IPM's
own backend and nowhere else: it is neither the baseline nor the
un-prefixed arm.

**#811.** An `--features ma57` build linked cleanly and died at process
start:

```
dyld: Library not loaded: @rpath/libcoinhsl.dylib
  Reason: no LC_RPATH's found
```

Reproduced on the parent commit, and it could not be patched after the
fact — a release link leaves no header padding, so `install_name_tool
-add_rpath` refuses. Linux with `libcoinhsl.so` on the loader path never
showed it.

## Cause

**#825 — an asymmetry with FERAL.** `default_backend_factory` took a
`FeralConfig` read off the application's `OptionsList` and had **no
equivalent parameter for MA57**, so the factory had nothing to give it and
fell back to `Ma57SolverInterface::new()`, which hard-codes
`Options::defaults()`. `Ma57Options::from_options_list` was a correct,
unit-tested reader with zero callers — covered, so it looked live.

**#811 — the flag reached nothing.** `cargo:rustc-link-arg` applies only
to targets in the package that emits it, and `pounce-hsl` is a library
with no binary of its own. There is no propagating spelling of a linker
argument.

## Fix

**#825.** Both factories now take a `Ma57Config` alongside the
`FeralConfig`, built by a new `ma57_config_from_options(options, prefix)`
— the MA57 half of what `feral_config_from_options` already did.

This is a **breaking change** to `default_backend_factory` /
`default_backend_factory_with_sink`, and that is the point: the argument
is what makes the omission a compile error instead of a silent default. I
considered keeping the old arity and adding a `_with_ma57` variant; that
was rejected because it leaves the plain function — the one every caller
already uses — as a working way to reproduce the bug.

`Ma57Config` is feature-independent (empty without `--features ma57`) so
`pounce-py`, `pounce-cinterface` and `pounce-restoration` can name it
without linking `pounce-hsl`. `pounce-py`'s own local FERAL-only factory
is deliberately left without the parameter — it has no MA57 arm to reach —
and now says so.

The `resto.` prefix works as a result. The restoration sub-IPM builds its
own backend through its own `InnerBackendFactoryFactory`, so the two are
genuinely independent; every site that mints one reads under `"resto."`.

**`ma57_pivtolmax` below `ma57_pivtol` is now refused, not silently
lifted.** A pre-existing deviation, unreachable while #825 was live and
reachable the moment it was fixed. Upstream has two branches
(`IpMa57TSolverInterface.cpp:311-320`): an explicitly set value under
`ma57_pivtol` raises `OPTION_INVALID`, an unset one has its default
lifted. pounce applied the lift unconditionally.

The reader now mirrors upstream's value semantics; the refusal lives in
`IpoptApplication::optimize_tnlp`, beside the other `InvalidOption` checks
and reached by every solve entry point, at both prefixes. Putting the
refusal in the reader was rejected: it returns `Options`, not `Result`, so
a clamp there is exactly the silent rewrite being removed.

The lifting branch is preserved deliberately. `ma57_pivtolmax` is
registered at `1e-4`, so a rule that merely compared the two numbers would
reject `ma57_pivtol 0.5` on its own — the most ordinary MA57 tuning there
is.

**#811.** The directory travels as `links` metadata: `pounce-hsl` declares
`links = "coinhsl"` and emits `cargo:rpath=<dir>`, which cargo hands to
each *direct* dependent's build script as `DEP_COINHSL_RPATH`.
`pounce-cli/build.rs` and a new `pounce-algorithm/build.rs` (for its MA57
integration tests) re-emit it against their own targets, plus
`-headerpad_max_install_names` on macOS so a packaging step can relocate
it. Emitting from `pounce-cli` alone was not enough — `pounce-algorithm`'s
test binaries link the same dylib.

## Blast radius

**Bit-identical except the targeted case.** `scripts/sweep-fixtures.sh`,
both legs, against `a5e0a837`:

* default FERAL path — 156 fixture-legs, empty diff;
* `linear_solver=ma57` — 156 fixture-legs, empty diff.

The MA57 leg is the one that matters here and it is why the sweep was run
twice. Both were re-run after the `pivtolmax` commit, because the new
refusal executes on *every* solve and had to be shown to reject no
fixture.

No trajectory change on defaults is not an argument, it is a measurement —
but it is also structurally true: every registered default is identical to
the reader's fallback and to `Options::defaults()`, which
`default_options_are_the_registrys` pins. That is the #677 shape
(registered with one default, read with another) applied to this family.

Public API: `default_backend_factory` and `default_backend_factory_with_sink`
change arity, and `SparseSymLinearSolverInterface` gains an `as_any` method
with a default of `None` (no implementor changes; nothing in the solve path
consults it). `pounce-algorithm` gains a `build.rs` that is a no-op without
`DEP_COINHSL_RPATH`.

## Tests

Four files. **CI cannot link CoinHSL**, so two of them are
`#![cfg(feature = "ma57")]` and never run there — the split is deliberate
and each file says which side it is on.

| file | pins | runs in CI |
|---|---|---|
| `pounce-algorithm/tests/ma57_options_reach_the_backend.rs` | each option arrives at a live backend built by the real factory, both prefixes, both factories | no |
| `pounce-cli/tests/ma57_binary_starts.rs` | #811, and #825 end to end through the binary | no |
| `pounce-algorithm/tests/ma57_pivtol_bracket.rs` | both branches of the `pivtolmax` rule | **yes** |
| `pounce-algorithm/tests/no_production_site_builds_ma57_with_defaults.rs` | any `Ma57SolverInterface::new()` in production source | **yes** |

Configuration reaching a backend is not observable through
`SparseSymLinearSolverInterface` — two differently configured
factorizations are both just "a solution" — which is *why* the defect had
no symptom. Hence the `as_any` seam, added so the first test has somewhere
to stand.

**How I know they bite.** The new tests cannot simply be run against the
parent commit: the factory signature differs there, so they would fail to
compile rather than fail for the stated reason. Instead each defect was
reintroduced into the fixed tree:

| mutation | result |
|---|---|
| MA57 arm back to `Ma57SolverInterface::new()` | 7 of 10 in `ma57_options_reach_the_backend` red; the 3 default-path tests stay green, correctly — the defect is invisible on defaults |
| same, seen in source | `no_production_site_builds_ma57_with_default_options` red, naming the file and line |
| drop `cargo:rpath=` from `pounce-hsl/build.rs` | all 5 of `ma57_binary_starts` red |
| restore the unconditional `pivtolmax` lift | `a_contradictory_explicit_pivtolmax_is_not_silently_clamped` red |
| drop the `pivtolmax` refusal | `an_explicit_pivtolmax_below_pivtol_is_refused` red |
| write the refusal lift-blind (ignore explicitly-set) | `an_unset_pivtolmax_is_lifted_not_refused` red |

The fourth row is worth reading. My first pass at the tests **missed** it:
restoring the old clamp left all of them green, because the refusal means no
solve can carry the contradictory pair, so every test that goes through a
solve passes either way. The discriminating test had to be written against
the reader directly.

**Known gaps.** The two feature-gated files are the real evidence for
#825 and #811 and CI never runs them; that is not fixable without an HSL
licence in CI, and the source guard exists precisely because of it. The
source guard reads text: it cannot tell whether a call site passes the
*right* prefix, only that it is not asking for defaults outright.

## Verification

Run locally against CoinHSL v2023.11.17 (aarch64-apple-darwin):

* `cargo fmt --all -- --check`, and CI's exact clippy invocation — clean
* `cargo test --workspace --exclude pounce-hsl` — pass
* `cargo test -p pounce-rs --all-features`, `cargo check -p pounce-hsl
  --all-targets` with `COINHSL_DIR` unset, `cargo check -p pounce-wasm
  --target wasm32-wasip1` — pass
* Python suite via `make python-ext` + `pytest -m "not slow"` — 1311
  passed, 4 skipped
* `scripts/check-release-consistency.sh` — OK
* MA57-gated, with `COINHSL_DIR` set: `pounce-hsl` (17), and the four new
  files at 10 / 6 / 2 / 5 tests — pass

I did not run `pyomo-pounce-smoke`, `casadi-plugin` or
`convexify-name-shim` locally; they drive the CLI and the Python package,
both exercised heavily above.

---

- [x] Tests fail on the parent commit for the stated reason — see the
      mutation table above for what was done instead, and why
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated — `installation.md` (the rpath
      is now embedded; `ma57_*` and the `resto.` prefix are honoured) and
      `troubleshooting.md`, which claimed `ma57_automatic_scaling=yes` was
      "default in HSL builds". It is `no`, and it was doubly wrong because
      the option did nothing at all. Both pages already in `SUMMARY.md`.
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the
      code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXuHz55zzpfSMGN6wSzHCk
