### PR TITLE
sens: rebuild the corrector's diagonal at the predicted point in every case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ changes.
   `limited-memory` solve the quasi-Newton matrix is kept, since no
   exact Hessian exists to evaluate elsewhere.
 
+  The rebuild covers the two cases that store a base-point diagonal
+  for the held factor's back-solves: a solve the sigma ceiling
+  (gh #737) touched, and one that crossed over into the declared
+  frame (gh #654). The corrector consults neither stored copy: it
+  re-derives the ceiling and the frame rule at the predicted point,
+  for both diagonal blocks. Measured on a ceiling-engaged fixture,
+  the correction went from no progress at any budget to matching the
+  no-ceiling control's first iteration.
+
   Across a release the step's endpoint does not show, the corrector
   still does not reach the re-solve. Just past the breakpoint the
   iterations decline and the no-improvement warning fires as before.

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -523,7 +523,7 @@ impl PdSensBacksolver {
         let Some(sigma) = self.released_sigma_x(released) else {
             return false;
         };
-        self.solve_released_prebuilt(released, sigma, rhs, lhs, shift)
+        self.solve_released_prebuilt(released, sigma, None, rhs, lhs, shift)
     }
 
     /// [`Self::solve_released_inner`] with the released `Σ` supplied by
@@ -536,6 +536,7 @@ impl PdSensBacksolver {
         &self,
         released: &[usize],
         sigma: Rc<dyn pounce_linalg::Vector>,
+        sigma_s: Option<Rc<dyn pounce_linalg::Vector>>,
         rhs: &[Number],
         lhs: &mut [Number],
         shift: bool,
@@ -565,7 +566,7 @@ impl PdSensBacksolver {
         if shift && !self.shift_released_rhs(released, &mut scaled) {
             return false;
         }
-        if !self.solve_released_scaled(sigma, &scaled, lhs) {
+        if !self.solve_released_scaled(sigma, sigma_s, &scaled, lhs) {
             return false;
         }
         if let Some(c) = self.conj.as_ref() {
@@ -739,6 +740,7 @@ impl PdSensBacksolver {
     fn solve_released_scaled(
         &self,
         sigma: Rc<dyn pounce_linalg::Vector>,
+        sigma_s: Option<Rc<dyn pounce_linalg::Vector>>,
         rhs: &[Number],
         lhs: &mut [Number],
     ) -> bool {
@@ -777,8 +779,10 @@ impl PdSensBacksolver {
             SigmaOverride {
                 x: Some(sigma),
                 // The release is an x-block operation; the row block
-                // keeps whichever frame the held iterate belongs to.
-                s: self.sigma_override().s,
+                // keeps whichever frame the held iterate belongs to,
+                // unless the caller built its own (the corrector's
+                // predicted-point pair).
+                s: sigma_s.or_else(|| self.sigma_override().s),
             },
         ) {
             return false;
@@ -793,20 +797,89 @@ impl PdSensBacksolver {
             && read_res_block(&*res_iv.v_u, &mut lhs[off[7]..off[8]])
     }
 
-    /// A fresh copy of [`Self::barrier_sigma_x`], its own object with
-    /// its own tag, so the factorization cache cannot resolve it to a
-    /// factor built at another iterate. `None` when the diagonal is
-    /// not dense.
-    pub(crate) fn fresh_barrier_sigma_x(&self) -> Option<Rc<dyn pounce_linalg::Vector>> {
+    /// The corrector's barrier diagonals, both blocks, built at the
+    /// CURRENT iterate, which during a correction is the predicted
+    /// point. The stored [`Self::sigma`] pair is deliberately not
+    /// consulted: it is frozen at the base point for the back-solves
+    /// through the held factor, and a correction factors its own
+    /// operator, so the frame rule and the ceiling are re-derived
+    /// where that operator lives. Declared-frame slacks when the held
+    /// iterate came from crossover (gh#654; the declared bounds are
+    /// constants, so the frame follows the iterate), the calculated
+    /// quantities otherwise, and the gh#737 ceiling applied from the
+    /// Jacobians at the same point. Released rows need no handling:
+    /// the correction zeroes their multipliers in the packed iterate,
+    /// so their sides contribute nothing. Pinned rows are raised
+    /// under the same ceiling. Always fresh objects, because the
+    /// factorization cache keys on their tags and a cached vector
+    /// could resolve to a factor built at another iterate.
+    pub(crate) fn corrector_sigma(
+        &self,
+        pinned: &[(usize, Number)],
+    ) -> Option<(Rc<dyn pounce_linalg::Vector>, Rc<dyn pounce_linalg::Vector>)> {
         use pounce_linalg::dense_vector::DenseVectorSpace;
-        let vals = self
-            .barrier_sigma_x()
-            .as_any()
-            .downcast_ref::<DenseVector>()
-            .map(|d| d.expanded_values())?;
-        let mut out = DenseVector::new(DenseVectorSpace::new(vals.len() as Index));
-        out.values_mut().copy_from_slice(&vals);
-        Some(Rc::new(out) as Rc<dyn pounce_linalg::Vector>)
+        let dense = |v: Rc<dyn pounce_linalg::Vector>| -> Option<Vec<Number>> {
+            v.as_any()
+                .downcast_ref::<DenseVector>()
+                .map(|d| d.expanded_values())
+        };
+        let (live_x, live_s) = if self.declared.is_some() {
+            let nlp_ref = self.nlp.borrow();
+            let (x_l, x_u) = nlp_ref.declared_x_bounds()?;
+            let (d_l, d_u) = nlp_ref.declared_d_bounds()?;
+            let d = self.data.borrow();
+            let curr = d.curr.as_ref()?;
+            let (sx, _, _) = declared_frame_sigma(
+                &*nlp_ref.px_l(),
+                &*nlp_ref.px_u(),
+                &*curr.x,
+                &x_l,
+                &x_u,
+                &*curr.z_l,
+                &*curr.z_u,
+                self.dims[0],
+            );
+            let (ss, _, _) = declared_frame_sigma(
+                &*nlp_ref.pd_l(),
+                &*nlp_ref.pd_u(),
+                &*curr.s,
+                &d_l,
+                &d_u,
+                &*curr.v_l,
+                &*curr.v_u,
+                self.dims[1],
+            );
+            (sx, ss)
+        } else {
+            let c = self.cq.borrow();
+            (c.curr_sigma_x(), c.curr_sigma_s())
+        };
+        let caps = sigma_pin_caps(&self.cq, self.dims[0]);
+        let cap_s = sigma_pin_cap(1.0);
+        let mut x = dense(live_x)?;
+        for (i, v) in x.iter_mut().enumerate() {
+            let c = caps.get(i).copied().unwrap_or(Number::INFINITY);
+            if *v > c {
+                *v = c;
+            }
+        }
+        for &(var_row, add) in pinned {
+            let c = caps.get(var_row).copied().unwrap_or(Number::INFINITY);
+            let slot = x.get_mut(var_row)?;
+            *slot = pinned_entry(*slot, add, c);
+        }
+        let mut s = dense(live_s)?;
+        for v in s.iter_mut() {
+            if *v > cap_s {
+                *v = cap_s;
+            }
+        }
+        let pack = |vals: Vec<Number>| -> Rc<dyn pounce_linalg::Vector> {
+            let mut out = DenseVector::new(DenseVectorSpace::new(vals.len() as Index));
+            out.values_mut().copy_from_slice(&vals);
+            Rc::new(out) as Rc<dyn pounce_linalg::Vector>
+        };
+        Some((pack(x), pack(s)))
     }
 
     /// A natural-units compound vector, packed as a frozen

--- a/crates/pounce-sensitivity/src/corrector.rs
+++ b/crates/pounce-sensitivity/src/corrector.rs
@@ -480,18 +480,12 @@ pub(crate) fn run(
     }
     let _restore = restore;
 
-    // Built AFTER the swap, so the slacks and multipliers it reads
-    // are the predicted point's. Always a FRESH object: the
-    // factorization cache keys on this vector's tag, and handing it
-    // an already-cached vector could return a factor of a different
-    // operator. With both sets empty this is the predicted point's
-    // own barrier diagonal, copied.
-    let sigma = if released.is_empty() && pinned.is_empty() {
-        bs.fresh_barrier_sigma_x()
-    } else {
-        bs.active_set_sigma_x(&released, &pinned)
-    }
-    .ok_or_else(|| {
+    // Built AFTER the swap, so both diagonal blocks read the
+    // predicted point: the stored base-point pair, which the ceiling
+    // (gh#737) or crossover (gh#654) would otherwise freeze, is never
+    // consulted, and the frame rule and the ceiling are re-derived at
+    // the predicted point instead. See `corrector_sigma`.
+    let (sigma, sigma_s) = bs.corrector_sigma(&pinned).ok_or_else(|| {
         SolverError::SensComputationFailed("corrector: operator diagonal unavailable".into())
     })?;
 
@@ -499,7 +493,14 @@ pub(crate) fn run(
         // The same Rc every call: the factorization cache keys on its
         // tag, so the predicted point's operator is factored once and
         // every later solve is a back-solve.
-        bs.solve_released_prebuilt(&released, Rc::clone(&sigma), rhs, lhs, false)
+        bs.solve_released_prebuilt(
+            &released,
+            Rc::clone(&sigma),
+            Some(Rc::clone(&sigma_s)),
+            rhs,
+            lhs,
+            false,
+        )
     };
     // A released bound has no equation left, so its row does not count
     // toward the residual the stopping rule reads.

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -979,6 +979,11 @@ impl Solver {
     /// Jacobians, and the barrier diagonal all evaluated at the
     /// stepped iterate with the step's own multipliers, and the
     /// predictor's active set applied to the diagonal in that frame.
+    /// A base solve the sigma ceiling (gh#737) touched, or one that
+    /// crossed over into the declared frame (gh#654), is no
+    /// exception: both rules are re-derived at the predicted point
+    /// rather than read from the base-point diagonals stored for the
+    /// held factor's own back-solves.
     /// A chord iteration contracts at the rate the distance between
     /// its operator and the true Jacobian sets, and the predicted
     /// point is where the truth is. Under a `limited-memory` solve
@@ -1278,7 +1283,14 @@ impl Solver {
         // solve: a weak bound's multiplier is order sqrt(mu) and the
         // released convention holds it at exactly zero, so the step
         // shift's multiplier injection is deliberately omitted.
-        if !bs.solve_released_prebuilt(&released, Rc::clone(&sigma), &rhs_plain, &mut d0, false) {
+        if !bs.solve_released_prebuilt(
+            &released,
+            Rc::clone(&sigma),
+            None,
+            &rhs_plain,
+            &mut d0,
+            false,
+        ) {
             return Err(SolverError::BacksolveFailed);
         }
         work += 1;
@@ -1361,8 +1373,14 @@ impl Solver {
                 let mut unit = vec![0.0; dim];
                 unit[weak[k].var_row] = sign(k);
                 let mut xk = vec![0.0; dim];
-                if !bs.solve_released_prebuilt(&released, Rc::clone(&sigma), &unit, &mut xk, false)
-                {
+                if !bs.solve_released_prebuilt(
+                    &released,
+                    Rc::clone(&sigma),
+                    None,
+                    &unit,
+                    &mut xk,
+                    false,
+                ) {
                     return Err(SolverError::BacksolveFailed);
                 }
                 work += 1;
@@ -1485,6 +1503,7 @@ impl Solver {
                 if !bs.solve_released_prebuilt(
                     &released,
                     Rc::clone(&sigma),
+                    None,
                     &comb,
                     &mut corr,
                     false,

--- a/crates/pounce-sensitivity/tests/corrector_ceiling.rs
+++ b/crates/pounce-sensitivity/tests/corrector_ceiling.rs
@@ -1,15 +1,14 @@
-//! The corrector on a base solve that trips the gh#737 sigma ceiling.
+//! The corrector on a base solve the gh#737 sigma ceiling touched, or
+//! that crossed over into the gh#654 declared frame.
 //!
-//! When the ceiling caps at least one entry, the sensitivity layer
-//! stores the whole capped diagonal, and `barrier_sigma_x()` returns
-//! that stored copy instead of reading the current iterate. During a
-//! correction the current iterate is the predicted point, so on such
-//! a solve the corrector factors the base point's diagonal against
-//! predicted-point derivatives: the mixed operator the change that
-//! moved the corrector to the predicted point measured making no
-//! progress on the double column. This file pins what that mixture
-//! does to a correction here, against the same workload with the
-//! degenerate bound removed, which takes the live path.
+//! In both of those cases the sensitivity layer stores a base-point
+//! diagonal for the back-solves through the held factor, and
+//! `barrier_sigma_x()` returns the stored copy. The corrector must
+//! not use it: it factors its own operator at the predicted point,
+//! so `corrector_sigma` rebuilds both diagonal blocks there, with
+//! the frame rule and the ceiling re-derived at that point, and this
+//! file pins that a correction on such solves acts instead of
+//! stalling.
 //!
 //! The fixture is gh#737's cap trigger (a variable held between a
 //! binding equality and its own bound, the multiplier split not
@@ -17,26 +16,25 @@
 //! perturbation moves `y` through `exp(y)` curvature, which the plain
 //! step misses at second order and a correction closes.
 //!
-//! # Measured (2026-08-28, instrumented `barrier_sigma_x`)
+//! # Measured (2026-08-28), error against a tol 1e-10 re-solve
 //!
 //! ```text
-//!                       branch   plain err   c1        c2        c8
-//!  ceiling engaged      frozen   1.48e-1     1.48e-1   1.48e-1   1.48e-1   improved: false
-//!  bound removed        live     1.48e-1     1.04e-2   1.38e-3   5.0e-8    improved: true
+//!                                  plain err   c1        c8
+//!  ceiling engaged, frozen copy    1.48e-1     1.48e-1   1.48e-1   improved: false
+//!  ceiling engaged, rebuilt        1.48e-1     1.05e-2   1.05e-2   improved: true
+//!  bound removed (control)         1.48e-1     1.04e-2   5.0e-8    improved: true
 //! ```
 //!
-//! On the frozen branch the first iteration fails to reduce the
-//! residual and the no-improvement rule keeps the handed step, at
-//! every budget: the double column's signature. Forcing the live
-//! branch on the same capped fixture recovers the correction in
-//! proportion to what the raw diagonal permits: fully on a geometry
-//! whose uncapped entry is `7.1e15` (to `1.8e-7` at budget 8), and
-//! only the first iteration (to `1.0e-2`, then flat) on this one,
-//! whose uncapped entry is `6.9e27`, past what the factorization can
-//! carry, which is why the ceiling exists. A fix therefore needs the
-//! live rebuild plus the ceiling re-derived at the predicted point,
-//! not raw `z/s`, and the first test below is pinned deliberately:
-//! that fix flips it, and should update it on purpose.
+//! The frozen row is the pre-`corrector_sigma` behaviour, the double
+//! column's no-progress signature: the first iteration fails to
+//! reduce the residual against the mixed operator and the
+//! no-improvement rule keeps the handed step at every budget. The
+//! rebuilt row's first iteration matches the control's, and the
+//! plateau past it belongs to the degenerate rows themselves: the
+//! trial residual at the non-unique multiplier split stops falling,
+//! measured identically under a forced raw uncapped diagonal
+//! (`6.9e27` on this geometry), so no diagonal choice moves it. The
+//! control, with nothing degenerate, continues to the floor.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -228,6 +226,7 @@ fn solved(
     t: Number,
     q0: Number,
     bounded: bool,
+    crossover: bool,
     start: Option<Vec<Number>>,
     tol: Option<Number>,
 ) -> Solver {
@@ -238,6 +237,13 @@ fn solved(
         o.set_string_value("sb", "yes", true, false).unwrap();
         o.set_numeric_value("bound_relax_factor", 0.0, true, false)
             .unwrap();
+        o.set_string_value(
+            "crossover",
+            if crossover { "yes" } else { "no" },
+            true,
+            false,
+        )
+        .unwrap();
         if let Some(tol) = tol {
             o.set_numeric_value("tol", tol, true, false).unwrap();
         }
@@ -265,7 +271,14 @@ fn solved(
 /// The perturbed problem's solution at tol 1e-10, warm-started from
 /// the base point, the same truth the re-solve oracle uses.
 fn truth(t: Number, bounded: bool, base_x: &[Number]) -> Vec<Number> {
-    let s = solved(t, Q0 + DELTA, bounded, Some(base_x.to_vec()), Some(1e-10));
+    let s = solved(
+        t,
+        Q0 + DELTA,
+        bounded,
+        false,
+        Some(base_x.to_vec()),
+        Some(1e-10),
+    );
     s.converged().expect("truth converged").x.clone()
 }
 
@@ -279,20 +292,22 @@ fn add(base: &[Number], step: &[Number]) -> Vec<Number> {
     base.iter().zip(step).map(|(&b, &s)| b + s).collect()
 }
 
-/// A base solve the ceiling touched hands the corrector the frozen
-/// base-point diagonal, and the correction achieves nothing: the
-/// first iteration fails to reduce the residual against the mixed
-/// operator, the no-improvement rule keeps the handed step, and
-/// `improved()` says so at every budget.
+/// A base solve the ceiling touched corrects like any other: the
+/// diagonal is rebuilt at the predicted point with the ceiling
+/// re-derived there, never the stored base-point copy.
 ///
-/// Pinned deliberately: a corrector that closes this workload on a
-/// ceiling-engaged solve has gained a predicted-point diagonal with
-/// the ceiling re-derived there, and this test should then be
-/// updated on purpose. The module doc carries the forced-live
-/// measurement saying what to expect from such a fix.
+/// The first iteration takes the error down an order and the residual
+/// fifteenfold, matching the no-ceiling control's first iteration.
+/// The iterations then stop: the trial residual at the degenerate
+/// rows, where the multiplier split between the bound and the
+/// equality is not unique, does not fall further, and the measured
+/// plateau is identical under a forced raw uncapped diagonal, so it
+/// is the degeneracy's own property and no diagonal choice moves it.
+/// The budget-8 error equals the budget-1 error here, pinned as a
+/// measured fact rather than a target.
 #[test]
-fn a_ceiling_solve_stalls_the_correction() {
-    let solver = solved(2.0, Q0, true, None, None);
+fn a_ceiling_solve_corrects_at_the_predicted_point() {
+    let solver = solved(2.0, Q0, true, false, None, None);
     let report = solver.classify_activity().expect("activity report");
     assert!(
         report.var_sigma[0] > 1e10 && report.var_sigma[0] < 1e20,
@@ -315,29 +330,25 @@ fn a_ceiling_solve_stalls_the_correction() {
         let (out, rep) = solver
             .correct_step(&[3], &[DELTA], &step, budget)
             .expect("corrector");
-        assert!(
-            !rep.improved(),
-            "budget {budget}: the mixed operator finds no reduction and \
-             must say so: residual {:e} -> {:e}",
-            rep.initial_residual,
-            rep.residual,
-        );
         let corrected = dist(&add(&base, &out[..n]), &want);
         assert!(
-            (corrected - plain).abs() < 1e-8,
-            "budget {budget}: a correction that achieves nothing leaves \
-             the estimate where it was: {plain:e} -> {corrected:e}",
+            rep.improved() && corrected < plain / 10.0,
+            "budget {budget}: the predicted-point diagonal must let the \
+             correction act: {plain:e} -> {corrected:e} (residual {:e} \
+             -> {:e})",
+            rep.initial_residual,
+            rep.residual,
         );
     }
 }
 
-/// The identical workload with only the degenerate bound removed
-/// takes the live branch and converges, which pins the stall above on
-/// the frozen diagonal rather than on the workload or the equality
-/// block.
+/// The identical workload with only the degenerate bound removed has
+/// no ceiling and nothing degenerate, and converges to the floor: the
+/// control separating the workload from the degenerate rows' plateau
+/// above.
 #[test]
 fn the_same_workload_without_the_ceiling_corrects() {
-    let solver = solved(2.0, Q0, false, None, None);
+    let solver = solved(2.0, Q0, false, false, None, None);
     let base = solver.converged().expect("converged").x.clone();
     let want = truth(2.0, false, &base);
     let step = solver
@@ -353,6 +364,37 @@ fn the_same_workload_without_the_ceiling_corrects() {
         rep.improved() && corrected < 1e-6 && corrected < plain * 1e-5,
         "the live operator closes the curvature: {plain:e} -> {corrected:e} \
          (residual {:e} -> {:e})",
+        rep.initial_residual,
+        rep.residual,
+    );
+}
+
+/// The other way the stored diagonal freezes: a solve that crossed
+/// over into the declared frame. `corrector_sigma` re-derives that
+/// frame at the predicted point (the declared bounds are constants,
+/// so the frame follows the iterate), and the correction acts the
+/// same way it does on the interior ceiling solve above.
+#[test]
+fn a_crossover_solve_corrects_at_the_predicted_point() {
+    let solver = solved(2.0, Q0, true, true, None, None);
+    let base = solver.converged().expect("converged").x.clone();
+    let want = truth(2.0, true, &base);
+    let step = solver
+        .parametric_step_full(&[3], &[DELTA])
+        .expect("full step");
+    let n = base.len();
+    let plain = dist(&add(&base, &step[..n]), &want);
+    assert!(
+        plain > 1e-1,
+        "the workload must leave the plain step something to close: {plain:e}",
+    );
+    let (out, rep) = solver
+        .correct_step(&[3], &[DELTA], &step, 8)
+        .expect("corrector");
+    let corrected = dist(&add(&base, &out[..n]), &want);
+    assert!(
+        rep.improved() && corrected < plain / 10.0,
+        "the declared frame must follow the iterate: {plain:e} ->          {corrected:e} (residual {:e} -> {:e})",
         rep.initial_residual,
         rep.residual,
     );

--- a/crates/pounce-sensitivity/tests/corrector_ceiling.rs
+++ b/crates/pounce-sensitivity/tests/corrector_ceiling.rs
@@ -1,0 +1,359 @@
+//! The corrector on a base solve that trips the gh#737 sigma ceiling.
+//!
+//! When the ceiling caps at least one entry, the sensitivity layer
+//! stores the whole capped diagonal, and `barrier_sigma_x()` returns
+//! that stored copy instead of reading the current iterate. During a
+//! correction the current iterate is the predicted point, so on such
+//! a solve the corrector factors the base point's diagonal against
+//! predicted-point derivatives: the mixed operator the change that
+//! moved the corrector to the predicted point measured making no
+//! progress on the double column. This file pins what that mixture
+//! does to a correction here, against the same workload with the
+//! degenerate bound removed, which takes the live path.
+//!
+//! The fixture is gh#737's cap trigger (a variable held between a
+//! binding equality and its own bound, the multiplier split not
+//! unique) welded to a curvature workload on a second parameter: the
+//! perturbation moves `y` through `exp(y)` curvature, which the plain
+//! step misses at second order and a correction closes.
+//!
+//! # Measured (2026-08-28, instrumented `barrier_sigma_x`)
+//!
+//! ```text
+//!                       branch   plain err   c1        c2        c8
+//!  ceiling engaged      frozen   1.48e-1     1.48e-1   1.48e-1   1.48e-1   improved: false
+//!  bound removed        live     1.48e-1     1.04e-2   1.38e-3   5.0e-8    improved: true
+//! ```
+//!
+//! On the frozen branch the first iteration fails to reduce the
+//! residual and the no-improvement rule keeps the handed step, at
+//! every budget: the double column's signature. Forcing the live
+//! branch on the same capped fixture recovers the correction in
+//! proportion to what the raw diagonal permits: fully on a geometry
+//! whose uncapped entry is `7.1e15` (to `1.8e-7` at budget 8), and
+//! only the first iteration (to `1.0e-2`, then flat) on this one,
+//! whose uncapped entry is `6.9e27`, past what the factorization can
+//! carry, which is why the ceiling exists. A fix therefore needs the
+//! live rebuild plus the ceiling re-derived at the predicted point,
+//! not raw `z/s`, and the first test below is pinned deliberately:
+//! that fix flips it, and should update it on purpose.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use pounce_sensitivity::Solver;
+
+/// Where the parameter row holds `pv`, and equally `x`'s upper bound.
+const PIN: Number = 1.0;
+/// The second parameter row's base value.
+const Q0: Number = 1.0;
+/// The perturbation asked of the second parameter row.
+const DELTA: Number = -0.45;
+
+/// ```text
+/// min  ½(x − t)² + ½(w − 1)² + exp(y) − q·y + ½(b − ½ − (q − Q0))²
+/// s.t. g₀:  x − pv = 0
+///      g₁:      pv = PIN      ← holds x on its own upper bound
+///      g₂:  w − x  = 0
+///      g₃:      q  = q0       ← the perturbed parameter row
+///      0 ≤ x ≤ PIN,  0 ≤ b,  pv, w, q, y free
+/// ```
+///
+/// The `x`/`pv`/`w` block is gh#737's cap trigger verbatim and is not
+/// perturbed. The `q` block is the correction workload: at the base,
+/// `y* = ln(Q0) = 0` and `b* = ½`; at `q0 + DELTA` the re-solve has
+/// `y* = ln(0.55)` while the linear step reaches `ln'(1)·DELTA`, and
+/// `b* = 0.05`, one tenth of its base slack.
+struct CeilingWithWorkload {
+    /// Objective target for `x`, above `PIN`. `2.0` trips the
+    /// ceiling; `1e3` converges through a different multiplier split
+    /// and lands two hundred times short of it (measured on gh#737's
+    /// fixture, unchanged here).
+    t: Number,
+    /// The second parameter row's right-hand side.
+    q0: Number,
+    /// Whether `x` carries its upper bound. `false` removes only the
+    /// bound, so the equality still holds `x` at `PIN` but nothing is
+    /// degenerate and no ceiling can engage.
+    bounded: bool,
+    /// Starting point override, for warm-starting the truth solve.
+    start: Option<Vec<Number>>,
+}
+
+impl TNLP for CeilingWithWorkload {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 6,
+            m: 4,
+            nnz_jac_g: 6,
+            nnz_h_lag: 7,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        // x, pv, w, q, y, b
+        b.x_l[0] = 0.0;
+        b.x_u[0] = if self.bounded { PIN } else { 1.0e19 };
+        for i in 1..5 {
+            b.x_l[i] = -1.0e19;
+            b.x_u[i] = 1.0e19;
+        }
+        b.x_l[5] = 0.0;
+        b.x_u[5] = 1.0e19;
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        b.g_l[1] = PIN;
+        b.g_u[1] = PIN;
+        b.g_l[2] = 0.0;
+        b.g_u[2] = 0.0;
+        b.g_l[3] = self.q0;
+        b.g_u[3] = self.q0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        match &self.start {
+            Some(x0) => sp.x.copy_from_slice(x0),
+            None => {
+                sp.x[..3].fill(0.5);
+                sp.x[3] = Q0;
+                sp.x[4] = 0.0;
+                sp.x[5] = 0.5;
+            }
+        }
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types.fill(Linearity::Linear);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let d = x[5] - 0.5 - (x[3] - Q0);
+        Some(
+            0.5 * (x[0] - self.t).powi(2) + 0.5 * (x[2] - 1.0).powi(2) + x[4].exp() - x[3] * x[4]
+                + 0.5 * d * d,
+        )
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let d = x[5] - 0.5 - (x[3] - Q0);
+        g[0] = x[0] - self.t;
+        g[1] = 0.0;
+        g[2] = x[2] - 1.0;
+        g[3] = -x[4] - d;
+        g[4] = x[4].exp() - x[3];
+        g[5] = d;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] - x[1];
+        g[1] = x[1];
+        g[2] = x[2] - x[0];
+        g[3] = x[3];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for (k, &(r, c)) in [(0, 0), (0, 1), (1, 1), (2, 2), (2, 0), (3, 3)]
+                    .iter()
+                    .enumerate()
+                {
+                    irow[k] = r as Index;
+                    jcol[k] = c as Index;
+                }
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, -1.0, 1.0, 1.0, -1.0, 1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // lower triangle: (0,0) (2,2) (3,3) (4,4) (5,5) (4,3) (5,3)
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for (k, &(r, c)) in [(0, 0), (2, 2), (3, 3), (4, 4), (5, 5), (4, 3), (5, 3)]
+                    .iter()
+                    .enumerate()
+                {
+                    irow[k] = r as Index;
+                    jcol[k] = c as Index;
+                }
+            }
+            SparsityRequest::Values { values } => {
+                let y = x.map_or(0.0, |x| x[4]);
+                values[0] = obj_factor;
+                values[1] = obj_factor;
+                values[2] = obj_factor;
+                values[3] = obj_factor * y.exp();
+                values[4] = obj_factor;
+                values[5] = -obj_factor;
+                values[6] = -obj_factor;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _c: &IpoptCq) {}
+}
+
+fn solved(
+    t: Number,
+    q0: Number,
+    bounded: bool,
+    start: Option<Vec<Number>>,
+    tol: Option<Number>,
+) -> Solver {
+    let mut app = IpoptApplication::new();
+    {
+        let o = app.options_mut();
+        o.set_integer_value("print_level", 0, true, false).unwrap();
+        o.set_string_value("sb", "yes", true, false).unwrap();
+        o.set_numeric_value("bound_relax_factor", 0.0, true, false)
+            .unwrap();
+        if let Some(tol) = tol {
+            o.set_numeric_value("tol", tol, true, false).unwrap();
+        }
+    }
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(CeilingWithWorkload {
+        t,
+        q0,
+        bounded,
+        start,
+    }));
+    let mut solver = Solver::new(app, tnlp);
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "fixture must converge (t={t:e}, q0={q0}); got {status:?}",
+    );
+    solver
+}
+
+/// The perturbed problem's solution at tol 1e-10, warm-started from
+/// the base point, the same truth the re-solve oracle uses.
+fn truth(t: Number, bounded: bool, base_x: &[Number]) -> Vec<Number> {
+    let s = solved(t, Q0 + DELTA, bounded, Some(base_x.to_vec()), Some(1e-10));
+    s.converged().expect("truth converged").x.clone()
+}
+
+fn dist(a: &[Number], b: &[Number]) -> Number {
+    a.iter()
+        .zip(b)
+        .fold(0.0_f64, |m, (&x, &y)| m.max((x - y).abs()))
+}
+
+fn add(base: &[Number], step: &[Number]) -> Vec<Number> {
+    base.iter().zip(step).map(|(&b, &s)| b + s).collect()
+}
+
+/// A base solve the ceiling touched hands the corrector the frozen
+/// base-point diagonal, and the correction achieves nothing: the
+/// first iteration fails to reduce the residual against the mixed
+/// operator, the no-improvement rule keeps the handed step, and
+/// `improved()` says so at every budget.
+///
+/// Pinned deliberately: a corrector that closes this workload on a
+/// ceiling-engaged solve has gained a predicted-point diagonal with
+/// the ceiling re-derived there, and this test should then be
+/// updated on purpose. The module doc carries the forced-live
+/// measurement saying what to expect from such a fix.
+#[test]
+fn a_ceiling_solve_stalls_the_correction() {
+    let solver = solved(2.0, Q0, true, None, None);
+    let report = solver.classify_activity().expect("activity report");
+    assert!(
+        report.var_sigma[0] > 1e10 && report.var_sigma[0] < 1e20,
+        "the fixture only says anything with the ceiling engaged: \
+         sigma on x is {:e}",
+        report.var_sigma[0],
+    );
+    let base = solver.converged().expect("converged").x.clone();
+    let want = truth(2.0, true, &base);
+    let step = solver
+        .parametric_step_full(&[3], &[DELTA])
+        .expect("full step");
+    let n = base.len();
+    let plain = dist(&add(&base, &step[..n]), &want);
+    assert!(
+        plain > 1e-1,
+        "the workload must leave the plain step something to close: {plain:e}",
+    );
+    for budget in [1_usize, 8] {
+        let (out, rep) = solver
+            .correct_step(&[3], &[DELTA], &step, budget)
+            .expect("corrector");
+        assert!(
+            !rep.improved(),
+            "budget {budget}: the mixed operator finds no reduction and \
+             must say so: residual {:e} -> {:e}",
+            rep.initial_residual,
+            rep.residual,
+        );
+        let corrected = dist(&add(&base, &out[..n]), &want);
+        assert!(
+            (corrected - plain).abs() < 1e-8,
+            "budget {budget}: a correction that achieves nothing leaves \
+             the estimate where it was: {plain:e} -> {corrected:e}",
+        );
+    }
+}
+
+/// The identical workload with only the degenerate bound removed
+/// takes the live branch and converges, which pins the stall above on
+/// the frozen diagonal rather than on the workload or the equality
+/// block.
+#[test]
+fn the_same_workload_without_the_ceiling_corrects() {
+    let solver = solved(2.0, Q0, false, None, None);
+    let base = solver.converged().expect("converged").x.clone();
+    let want = truth(2.0, false, &base);
+    let step = solver
+        .parametric_step_full(&[3], &[DELTA])
+        .expect("full step");
+    let n = base.len();
+    let plain = dist(&add(&base, &step[..n]), &want);
+    let (out, rep) = solver
+        .correct_step(&[3], &[DELTA], &step, 8)
+        .expect("corrector");
+    let corrected = dist(&add(&base, &out[..n]), &want);
+    assert!(
+        rep.improved() && corrected < 1e-6 && corrected < plain * 1e-5,
+        "the live operator closes the curvature: {plain:e} -> {corrected:e} \
+         (residual {:e} -> {:e})",
+        rep.initial_residual,
+        rep.residual,
+    );
+}

--- a/crates/pounce-sensitivity/tests/corrector_predicted_operator.rs
+++ b/crates/pounce-sensitivity/tests/corrector_predicted_operator.rs
@@ -10,7 +10,7 @@
 //! about one half, and the predicted-operator rate is under a tenth,
 //! so only the predicted operator reaches the tolerance below.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use pounce_algorithm::application::IpoptApplication;
@@ -32,7 +32,12 @@ use pounce_sensitivity::Solver;
 /// predictor is the tangent `dx = delta`, and everything the corrector
 /// closes is genuine curvature: at `delta = 0.5` the predictor is off
 /// by `0.5 - ln 1.5 = 9.45e-2`.
-struct ExpCurvature;
+struct ExpCurvature {
+    /// Exact-Hessian evaluations served, for the limited-memory test
+    /// below: a `limited-memory` solve and its correction must never
+    /// ask for one.
+    h_evals: Rc<Cell<usize>>,
+}
 
 impl TNLP for ExpCurvature {
     fn get_nlp_info(&mut self) -> Option<NlpInfo> {
@@ -103,6 +108,7 @@ impl TNLP for ExpCurvature {
                 jcol.copy_from_slice(&[0, 0]);
             }
             SparsityRequest::Values { values } => {
+                self.h_evals.set(self.h_evals.get() + 1);
                 let xv = x.expect("hessian point")[0];
                 values[0] = obj_factor * xv.exp();
                 values[1] = -obj_factor;
@@ -114,7 +120,7 @@ impl TNLP for ExpCurvature {
     fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
 }
 
-fn solved() -> Solver {
+fn solved_with(limited_memory: bool) -> (Solver, Rc<Cell<usize>>) {
     let mut app = IpoptApplication::new();
     app.options_mut()
         .set_integer_value("print_level", 0, true, false)
@@ -128,14 +134,27 @@ fn solved() -> Solver {
     app.options_mut()
         .set_numeric_value("bound_relax_factor", 0.0, true, false)
         .unwrap();
+    if limited_memory {
+        app.options_mut()
+            .set_string_value("hessian_approximation", "limited-memory", true, false)
+            .unwrap();
+    }
     app.initialize().unwrap();
-    let mut solver = Solver::new(app, Rc::new(RefCell::new(ExpCurvature)));
+    let h_evals = Rc::new(Cell::new(0_usize));
+    let tnlp = ExpCurvature {
+        h_evals: Rc::clone(&h_evals),
+    };
+    let mut solver = Solver::new(app, Rc::new(RefCell::new(tnlp)));
     let status = solver.solve();
     assert!(
         matches!(status, ApplicationReturnStatus::SolveSucceeded),
-        "base solve failed: {status:?}",
+        "base solve failed (limited_memory={limited_memory}): {status:?}",
     );
-    solver
+    (solver, h_evals)
+}
+
+fn solved() -> Solver {
+    solved_with(false).0
 }
 
 /// Six iterations must close the curvature gap. The base-point
@@ -173,5 +192,47 @@ fn the_corrector_closes_curvature_the_base_operator_cannot() {
         "six iterations on the predicted point's operator close the \
          curvature gap: |corrected - ln(1+delta)| = {err:e}, predictor \
          error {predictor_err:e}",
+    );
+}
+
+/// A `limited-memory` solve keeps its quasi-Newton matrix through the
+/// correction: `ConvergedState` captures the option, the corrector
+/// skips the exact-Hessian re-evaluation, and the exact Hessian is
+/// never requested, which the fixture's own counter proves. The
+/// correction still acts, against the L-BFGS matrix held while the
+/// Jacobians and the barrier diagonal move to the predicted point: on
+/// this fixture the quasi-Newton matrix sits near `e^0 = 1` against a
+/// true `W* = 1.5`, so the contraction is near one half per iteration
+/// rather than the exact-Hessian operator's tenth, and eight
+/// iterations take the predictor's `9.45e-2` curvature error to
+/// `4.0e-4`.
+#[test]
+fn a_limited_memory_solve_corrects_without_an_exact_hessian() {
+    let (solver, h_evals) = solved_with(true);
+    assert_eq!(
+        h_evals.get(),
+        0,
+        "a limited-memory solve never asks for the exact Hessian",
+    );
+    let base_x = solver.converged().expect("converged").x[0];
+    let delta = 0.5;
+    let exact = (1.0_f64 + delta).ln();
+    let step = solver
+        .parametric_step_full(&[0], &[delta])
+        .expect("full step");
+    let predictor_err = (base_x + step[0] - exact).abs();
+    let (refined, report) = solver
+        .correct_step(&[0], &[delta], &step, 8)
+        .expect("corrector");
+    assert_eq!(
+        h_evals.get(),
+        0,
+        "the correction must not evaluate one either: the quasi-Newton          matrix is all there is",
+    );
+    assert!(report.improved(), "the corrector must report improvement");
+    let err = (base_x + refined[0] - exact).abs();
+    assert!(
+        err < predictor_err / 100.0,
+        "eight iterations against the held quasi-Newton matrix still          close two orders of the curvature gap: {err:e} from a          predictor error of {predictor_err:e}",
     );
 }


### PR DESCRIPTION
Carries three commits by @devin-griff that landed on #824 after #829 was cut, and which #829 therefore missed:

| commit | what it does |
|---|---|
| `268082a` | pin the corrector's stall on a ceiling-engaged base solve |
| `e7446da` | rebuild the corrector's diagonal blocks at the predicted point in every case |
| `02a6c10` | pin the limited-memory correction, no exact Hessian requested |

**This is a defect fix for what #829 shipped**, not a nice-to-have. `938a736` is currently on `main` with the frozen-diagonal bug live.

## Problem

`barrier_sigma_x()` returns the stored base-point diagonal whenever the gh#737 ceiling capped an entry or the solve crossed over into the gh#654 declared frame. #824 moved the diagonal's construction below the iterate swap, but that only reaches the predicted point when the stored override is absent — so on a capped or crossed-over solve the correction factored a mixed operator: base-point diagonal, predicted-point everything else.

I raised this in review, then withdrew it after my own fixture showed the frozen diagonal was benign. **My withdrawal was too broad.** My fixture's capped variable sits hard on its bound and stays there, so the frozen and predicted entries agree and the copy is harmless. @devin-griff identified the class where they do not agree — a variable held between a binding equality and its bound, base slack exactly zero, predicted slack the put-back margin — where the stored entry is `7.0e13` against a predicted-frame value near `2.5e10`, and measured it, everything upstream held fixed and only the diagonal's source toggled:

| diagonal handed to the correction | budget 1 | budget 8 | residual | `improved()` |
|---|---|---|---|---|
| frozen base-point copy (what `main` has now) | 1.48e-1 | 1.48e-1 | 8.76e-2 unchanged | false |
| live predicted-point | 1.05e-2 | 1.05e-2 | 8.76e-2 → 5.79e-3 | true |
| control, degenerate bound removed | 1.04e-2 | 5.0e-8 | → 5.1e-9 | true |

That class came from notebook 36's CSTR with an initial condition on a bound, so it is not synthetic.

## Fix

`corrector_sigma` builds both diagonal blocks at the current iterate — the predicted point during a correction: declared-frame slacks when the held iterate came from crossover, calculated quantities otherwise, the ceiling re-derived from the Jacobians at the same point, released rows excluded through their zeroed multipliers, pinned rows raised under the same ceiling. The stored base-point pair is never consulted. The rationale is that the stored pair exists to keep base-point back-solves consistent with the held factor, and the corrector stopped back-solving through that factor when #824 made it factor its own operator.

## Blast radius

I re-ran my own #828 sweep fixture against this branch. Errors are identical to `main` at every `A`, dead zone included — corroborating both the no-op claim and #828's orthogonality:

| `A` | `main` (938a736) | this branch |
|---|---|---|
| 1e-4 … 1e-2 | 1.7678e-2 (dead) | 1.7678e-2 (dead) |
| 1e-1 | 1.0000e-10, resid → **3.032e0** | 1.0000e-10, resid → **3.481e-11** |
| 1.0 | 1.0000e-10, resid → 2.220e-16 | 1.0000e-10, resid → 2.220e-16 |

Worth recording: the `A = 1e-1` row is the one I used to withdraw the finding, and the residual column shows the defect was live there all along — the error had already bottomed out on the closed-form floor at `1e-10` while the residual plateaued nine orders high at `3.032e0`. The signal was in data I had and did not weigh.

## Tests

New `corrector_ceiling.rs` (401 lines) pins the stall class and a crossover arm. `corrector_predicted_operator.rs` gains an `eval_h` counter and a limited-memory arm, pinning that a `limited-memory` solve and its correction request zero exact-Hessian evaluations while still taking the predictor's 9.45e-2 curvature error to 4.0e-4 at budget 8 — closing the coverage gap #829 shipped with open.

Verified on this merged branch before pushing: `cargo fmt --all -- --check` clean, `cargo check --workspace --all-targets` clean, **254** `pounce-sensitivity` tests pass with 0 failures (up from 250).

## Open question from the author

@devin-griff asked for review on two calls, which I have not independently assessed: re-deriving the cap from the predicted-point Jacobians rather than reusing the captured `cap_x`, and the declared-frame recompute at a moved iterate. Both are visible in `e7446da`.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry
- [x] `cargo fmt --all -- --check`, `cargo check`, `cargo test` clean on this branch
- [x] Every claim in this PR body is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgEEpCex63TMkwuqQcvLn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgEEpCex63TMkwuqQcvLn2)_