### PR TITLE
changelog: drop the stale duplicate corrector entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,33 +141,6 @@ changes.
   unconditional lift, or a lift-blind refusal — and the matching tests, and only
   those, go red.
 
-- **The corrector's operator is assembled at the predicted point.**
-  `corrector_iter`'s iterations used to run against the factorization
-  the solve left behind, evaluated at the base point. They now pay one
-  derivative evaluation and one factorization at the predicted point,
-  with the Hessian, the constraint Jacobians, and the barrier diagonal
-  all evaluated at the stepped iterate with the step's own
-  multipliers, and the predictor's active set applied to the diagonal
-  in that frame. A chord iteration contracts at the rate the distance
-  between its operator and the true Jacobian sets, so the correction
-  converges an order faster where the Hessian bends over the step,
-  reaches a bound the step carries a coordinate onto instead of
-  achieving nothing there, on the holding side of a kink lands on the
-  re-solve itself, and on a 62k-variable collocation model reaches
-  the base solve's own solution quality in one back-solve at
-  perturbations where the held-factor chord needed three. Under a
-  `limited-memory` solve the quasi-Newton matrix is kept, since no
-  exact Hessian exists to evaluate elsewhere.
-
-  Across a release the step's endpoint does not show, the corrector
-  still does not reach the re-solve. Just past the breakpoint the
-  iterations decline and the no-improvement warning fires as before.
-  Deeper past it, the weak diagonal entry the step's clamped
-  multiplier builds lets them move the variable partway off the bound
-  and reduce the residual they measure, without the released row
-  applied, so the answer stays short of the re-solve by a
-  delta-dependent margin. The release-deciding modes cross exactly at
-  every depth.
 - **A restoration failure now opens the second-opinion ladder.** (Found while
   investigating gh #815; it is *not* a fix for that issue — see the note at the
   end of this entry.)


### PR DESCRIPTION
Cleanup of a mess I made. Docs only, no code.

## Problem

`[Unreleased]` describes the corrector change **twice**. Landing #824's work through two PRs did it: #829 added the entry as written before the diagonal rebuild, #830 added the updated entry at a different position in the section, and since the two blocks did not overlap textually the merge kept both.

The two are not identical. The surviving copy at line 12 has the paragraph on rebuilding both diagonal blocks at the predicted point and consulting neither stored base-point copy. The duplicate at line 144 does not — it is the superseded description, the one that says the diagonal is carried in the predictor's active-set frame and stops there.

Per CLAUDE.md the `## [X.Y.Z]` section is what goes into the GitHub Release body by hand, so left alone this ships release notes that describe a design that did not ship, immediately after a paragraph describing the one that did.

## Fix

Delete the stale block (27 lines). The remaining entry is the complete one.

Guarded the edit rather than trusting line numbers: the script asserts the block being removed starts with the entry heading, ends on `every depth.`, and does **not** contain `The rebuild covers the two cases` — so it refuses to run if it is pointed at the current entry instead of the stale one.

## Blast radius

`CHANGELOG.md` only. Verified after the edit: exactly one copy of the entry heading remains, exactly one copy of the rebuild paragraph remains, the following `- **A restoration failure now opens the second-opinion ladder.**` entry is intact, and all 10 `## [` version headings are present.

Also swept the rest of `[Unreleased]` for other duplication from the double merge — `uniq -d` over the entry headings returns only this one — and diffed `938a736..177e45f` to confirm no source file was double-applied.

---
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms — this PR *is* the changelog fix
- [x] Every claim in this PR body is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgEEpCex63TMkwuqQcvLn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgEEpCex63TMkwuqQcvLn2)_