### PR TITLE
fix(sensitivity): read a capped bound's multiplier back through its cap (gh#828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ changes.
 
 ## [Unreleased]
 
+- **Sensitivity: bound-multiplier derivatives are readable again under the
+  gh #737 barrier ceiling, and `corrector_iter` works there** (gh #828).
+  A strongly active bound whose constraint row carries a small Jacobian
+  coefficient reaches that ceiling well before anything looks pathological.
+  When it did, the solve held the bound softly — which is what the ceiling
+  is for — but recovered the bound's own multiplier derivative stiffly, off
+  the uncapped quantities, so the two halves disagreed by exactly the cap's
+  ratio. The returned `dz` was wrong by that factor (`1.8e7` against a true
+  `0` on the issue's fixture, growing as the coefficient shrank), and
+  `estimate(..., corrector_iter=n)` / `estimate_report(..., corrector_iter=n)`
+  opened on a stationarity residual of the same size, failed to reduce it,
+  and handed back the *uncorrected* step at every budget. The report said so
+  (`improved()` was false), so no wrong answer was passed off as a corrected
+  one — but the refinement was unavailable in exactly the stiff, tightly
+  bounded regime it is asked for. Both the returned step's multiplier block
+  and the corrector's own operator now read those rows back through the same
+  cap. Affects the Rust `pounce-sensitivity` API and the Python / Pyomo
+  sensitivity entry points on top of it; where the ceiling does not bind —
+  every result that was already correct — nothing moves.
+
 - **A `maturin develop` checkout has a working `pounce` CLI again** (gh #816).
   `maturin develop` builds the extension module and nothing else. The wheel's
   `pounce` console script is a shim whose whole job is to exec the bundled

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -524,20 +524,30 @@ impl PdSensBacksolver {
     /// active and a pinned entry is raised by an addend — so no single
     /// per-variable ratio describes it, and those paths are left in the
     /// frame they already had.
+    ///
+    /// Returns `false` when a ratio is in force and the correction
+    /// could **not** be applied — an unexpected vector or matrix type
+    /// behind a block, a missing iterate — and every caller fails the
+    /// solve on it. Skipping quietly would put back exactly the defect
+    /// this exists to fix, with no signal: `Σ` capped, the multiplier
+    /// rows read back uncapped, and an answer that looks like every
+    /// other. `true` whenever every ratio is `1.0`, which is the whole
+    /// of an uncapped solve and costs one pass over two slices.
+    #[must_use]
     pub(crate) fn rescale_bound_multipliers(
         &self,
         lhs: &mut [Number],
         ratio_x: &[Number],
         ratio_s: &[Number],
-    ) {
+    ) -> bool {
         let unit = |r: &[Number]| r.iter().all(|&v| v == 1.0);
         if unit(ratio_x) && unit(ratio_s) {
-            return;
+            return true;
         }
         let off = self.offsets();
         let d = self.data.borrow();
         let Some(curr) = d.curr.as_ref() else {
-            return;
+            return false;
         };
         let cq_ref = self.cq.borrow();
         let nlp_ref = self.nlp.borrow();
@@ -565,16 +575,23 @@ impl PdSensBacksolver {
                        primal_lo: usize,
                        block_lo: usize,
                        block_hi: usize,
-                       sign: Number| {
-            if block_hi == block_lo {
-                return;
+                       sign: Number|
+         -> bool {
+            if block_hi == block_lo || ratio.iter().all(|&v| v == 1.0) {
+                return true;
             }
             let (Some(pos), Some(zv), Some(sv)) = (rows(p), dense(z), dense(slack)) else {
-                return;
+                return false;
             };
+            // The expansion's rows ARE the block, one per bound; a
+            // mismatch means the index arithmetic below is against the
+            // wrong layout, so say so rather than scatter into it.
+            if pos.len() != block_hi - block_lo {
+                return false;
+            }
             for (k, &i) in pos.iter().enumerate() {
                 let (Some(&r), Some(&zk), Some(&sk)) = (ratio.get(i), zv.get(k), sv.get(k)) else {
-                    continue;
+                    return false;
                 };
                 if r == 1.0 || sk == 0.0 || !sk.is_finite() {
                     continue;
@@ -582,7 +599,7 @@ impl PdSensBacksolver {
                 let dx = lhs[primal_lo + i];
                 lhs[block_lo + k] += sign * (1.0 - r) * (zk / sk) * dx;
             }
-            debug_assert!(pos.len() == block_hi - block_lo);
+            true
         };
         fix(
             &*nlp_ref.px_l(),
@@ -593,8 +610,7 @@ impl PdSensBacksolver {
             off[4],
             off[5],
             1.0,
-        );
-        fix(
+        ) && fix(
             &*nlp_ref.px_u(),
             &*curr.z_u,
             &*cq_ref.curr_slack_x_u(),
@@ -603,8 +619,7 @@ impl PdSensBacksolver {
             off[5],
             off[6],
             -1.0,
-        );
-        fix(
+        ) && fix(
             &*nlp_ref.pd_l(),
             &*curr.v_l,
             &*cq_ref.curr_slack_s_l(),
@@ -613,8 +628,7 @@ impl PdSensBacksolver {
             off[6],
             off[7],
             1.0,
-        );
-        fix(
+        ) && fix(
             &*nlp_ref.pd_u(),
             &*curr.v_u,
             &*cq_ref.curr_slack_s_u(),
@@ -623,7 +637,7 @@ impl PdSensBacksolver {
             off[7],
             off[8],
             -1.0,
-        );
+        )
     }
 
     /// Whether the held-factor back-solve may run
@@ -747,7 +761,9 @@ impl PdSensBacksolver {
         // factored, and `z / s` is read off the iterate in the frame
         // that operator lives in (gh#828).
         if let Some((rx, rs)) = ratios {
-            self.rescale_bound_multipliers(lhs, rx, rs);
+            if !self.rescale_bound_multipliers(lhs, rx, rs) {
+                return false;
+            }
         }
         if let Some(c) = self.conj.as_ref() {
             for (l, &f) in lhs.iter_mut().zip(c.f.iter()) {
@@ -992,7 +1008,11 @@ impl PdSensBacksolver {
     /// so their sides contribute nothing. Pinned rows are raised
     /// under the same ceiling. Always fresh objects, because the
     /// factorization cache keys on their tags and a cached vector
-    /// could resolve to a factor built at another iterate.
+    /// could resolve to a factor built at another iterate. How much of
+    /// each entry the ceiling left standing comes back with them, in
+    /// the same [`CorrectorOperator`], because the solve that folds a
+    /// bound row into one of these diagonals has to read that row back
+    /// through the same cap (gh#828).
     pub(crate) fn corrector_sigma(&self, pinned: &[(usize, Number)]) -> Option<CorrectorOperator> {
         use pounce_linalg::dense_vector::DenseVectorSpace;
         let dense = |v: Rc<dyn pounce_linalg::Vector>| -> Option<Vec<Number>> {
@@ -1817,7 +1837,9 @@ impl PdSensBacksolver {
                 return false;
             }
 
-            self.rescale_bound_multipliers(lhs_row, &self.sigma.ratio_x, &self.sigma.ratio_s);
+            if !self.rescale_bound_multipliers(lhs_row, &self.sigma.ratio_x, &self.sigma.ratio_s) {
+                return false;
+            }
         }
         true
     }
@@ -2294,8 +2316,7 @@ impl PdSensBacksolver {
         if self.unpack(&res_iv, lhs).is_err() {
             return false;
         }
-        self.rescale_bound_multipliers(lhs, &self.sigma.ratio_x, &self.sigma.ratio_s);
-        true
+        self.rescale_bound_multipliers(lhs, &self.sigma.ratio_x, &self.sigma.ratio_s)
     }
 }
 

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -178,6 +178,36 @@ struct EffectiveSigma {
     /// entry from the bounds that stay active, and a rebuilt entry has
     /// to land under the same ceiling the rest of the diagonal did.
     cap_x: Rc<Vec<Number>>,
+    /// `Σ_used / Σ_base` per var-x row — how much of each variable's
+    /// barrier stiffness survived the ceiling. `1.0` wherever the
+    /// ceiling did not bind, which is every entry of an uncapped
+    /// solve. Read by
+    /// [`PdSensBacksolver::rescale_bound_multipliers`] (gh#828); see
+    /// there for why the multiplier block has to know.
+    ratio_x: Rc<Vec<Number>>,
+    /// [`Self::ratio_x`] for the `s` block.
+    ratio_s: Rc<Vec<Number>>,
+}
+
+/// The operator a correction factors: both barrier diagonals built at
+/// the predicted point, plus how much of each entry survived the
+/// gh#737 ceiling.
+///
+/// The two ratios travel with the diagonals because they answer the
+/// same question about the same operator — a solve that eliminates a
+/// bound row into a *capped* diagonal has to read that row back
+/// through the same cap, and separating the two is exactly the gh#828
+/// defect. See [`PdSensBacksolver::rescale_bound_multipliers`].
+pub(crate) struct CorrectorOperator {
+    /// `x`-block diagonal at the predicted point.
+    pub(crate) sigma_x: Rc<dyn pounce_linalg::Vector>,
+    /// `s`-block diagonal at the predicted point.
+    pub(crate) sigma_s: Rc<dyn pounce_linalg::Vector>,
+    /// Per var-x row, the fraction of the uncapped diagonal the
+    /// ceiling left standing; `1.0` where it did not bind.
+    pub(crate) ratio_x: Vec<Number>,
+    /// [`Self::ratio_x`] for the `s` block.
+    pub(crate) ratio_s: Vec<Number>,
 }
 
 /// `Σ` and the active-bound slacks of a **crossed-over** iterate,
@@ -373,12 +403,18 @@ impl PdSensBacksolver {
         // each row's slack to its `d(x)` row, exactly `1` in the scaled
         // space this is measured in, so its ceiling is one scalar.
         let cap_s = sigma_pin_cap(1.0);
-        let x = cap_sigma(&base_x, &|i| {
-            cap_x.get(i).copied().unwrap_or(Number::INFINITY)
-        })
-        .or_else(|| declared.map(|d| Rc::clone(&d.sigma_x)));
+        let cap_of_x = |i: usize| cap_x.get(i).copied().unwrap_or(Number::INFINITY);
+        let ratio_x = Rc::new(cap_ratio(&base_x, &cap_of_x));
+        let ratio_s = Rc::new(cap_ratio(&base_s, &|_| cap_s));
+        let x = cap_sigma(&base_x, &cap_of_x).or_else(|| declared.map(|d| Rc::clone(&d.sigma_x)));
         let s = cap_sigma(&base_s, &|_| cap_s).or_else(|| declared.map(|d| Rc::clone(&d.sigma_s)));
-        EffectiveSigma { x, s, cap_x }
+        EffectiveSigma {
+            x,
+            s,
+            cap_x,
+            ratio_x,
+            ratio_s,
+        }
     }
 
     /// Re-measure `Σ` against the declared bounds when the held iterate
@@ -455,6 +491,141 @@ impl PdSensBacksolver {
         }
     }
 
+    /// Put the four bound-multiplier blocks of a scaled-space solution
+    /// into the same frame the operator was factored in (gh#828).
+    ///
+    /// `PdFullSpaceSolver` eliminates the bound rows into the `x` / `s`
+    /// diagonal and recovers them afterwards as
+    /// `dz = r_z/s − (z/s)·dx`. That recovery re-derives `z/s` straight
+    /// off the iterate, which is right exactly when the diagonal it
+    /// eliminated into *was* `Σ = Σ z/s` — and under the gh#737 ceiling
+    /// it is not. The solve then holds the capped bound softly and
+    /// reads its multiplier back stiffly, and the two disagree by the
+    /// cap ratio.
+    ///
+    /// The measured cost is not subtle. On gh#828's fixture a strongly
+    /// active bound with `Σ = 2.5e12` capped to `7.0e5` came back with
+    /// `dz = 1.78e7` against a true `0`, growing as `A⁻²` as the row
+    /// coefficient shrank — enough that `correct_step` opened on a
+    /// stationarity residual of `1.78e7`, failed to improve it in one
+    /// chord step, and handed the caller back its own uncorrected
+    /// input at every budget.
+    ///
+    /// Consistency asks for the capped bound's complementarity row to
+    /// read `s·dz + r·z·dx = r_z` — the same `r` the diagonal was
+    /// scaled by — so the fix adds `(1 − r)·(z/s)·dx` back onto each
+    /// affected row. `r == 1` wherever the ceiling did not bind, which
+    /// is every row of an uncapped solve, so this is exactly a no-op
+    /// off the capped path.
+    ///
+    /// Scoped to the solves that carry [`Self::sigma_override`]. A
+    /// *released* or *pinned* diagonal is not a rescaling of the base
+    /// one — a released entry is rebuilt from the bounds that stay
+    /// active and a pinned entry is raised by an addend — so no single
+    /// per-variable ratio describes it, and those paths are left in the
+    /// frame they already had.
+    pub(crate) fn rescale_bound_multipliers(
+        &self,
+        lhs: &mut [Number],
+        ratio_x: &[Number],
+        ratio_s: &[Number],
+    ) {
+        let unit = |r: &[Number]| r.iter().all(|&v| v == 1.0);
+        if unit(ratio_x) && unit(ratio_s) {
+            return;
+        }
+        let off = self.offsets();
+        let d = self.data.borrow();
+        let Some(curr) = d.curr.as_ref() else {
+            return;
+        };
+        let cq_ref = self.cq.borrow();
+        let nlp_ref = self.nlp.borrow();
+        let dense = |v: &dyn pounce_linalg::Vector| -> Option<Vec<Number>> {
+            v.as_any()
+                .downcast_ref::<DenseVector>()
+                .map(|d| d.expanded_values())
+        };
+        let rows = |m: &dyn pounce_linalg::Matrix| -> Option<Vec<usize>> {
+            m.as_any()
+                .downcast_ref::<pounce_linalg::expansion_matrix::ExpansionMatrix>()
+                .map(|e| {
+                    e.expanded_pos_indices()
+                        .iter()
+                        .map(|&i| i as usize)
+                        .collect()
+                })
+        };
+        // `sign` is the one the expansion carries: a lower bound folds
+        // in as `−z·dx` and an upper one as `+z·dx`.
+        let mut fix = |p: &dyn pounce_linalg::Matrix,
+                       z: &dyn pounce_linalg::Vector,
+                       slack: &dyn pounce_linalg::Vector,
+                       ratio: &[Number],
+                       primal_lo: usize,
+                       block_lo: usize,
+                       block_hi: usize,
+                       sign: Number| {
+            if block_hi == block_lo {
+                return;
+            }
+            let (Some(pos), Some(zv), Some(sv)) = (rows(p), dense(z), dense(slack)) else {
+                return;
+            };
+            for (k, &i) in pos.iter().enumerate() {
+                let (Some(&r), Some(&zk), Some(&sk)) = (ratio.get(i), zv.get(k), sv.get(k)) else {
+                    continue;
+                };
+                if r == 1.0 || sk == 0.0 || !sk.is_finite() {
+                    continue;
+                }
+                let dx = lhs[primal_lo + i];
+                lhs[block_lo + k] += sign * (1.0 - r) * (zk / sk) * dx;
+            }
+            debug_assert!(pos.len() == block_hi - block_lo);
+        };
+        fix(
+            &*nlp_ref.px_l(),
+            &*curr.z_l,
+            &*cq_ref.curr_slack_x_l(),
+            ratio_x,
+            off[0],
+            off[4],
+            off[5],
+            1.0,
+        );
+        fix(
+            &*nlp_ref.px_u(),
+            &*curr.z_u,
+            &*cq_ref.curr_slack_x_u(),
+            ratio_x,
+            off[0],
+            off[5],
+            off[6],
+            -1.0,
+        );
+        fix(
+            &*nlp_ref.pd_l(),
+            &*curr.v_l,
+            &*cq_ref.curr_slack_s_l(),
+            ratio_s,
+            off[1],
+            off[6],
+            off[7],
+            1.0,
+        );
+        fix(
+            &*nlp_ref.pd_u(),
+            &*curr.v_u,
+            &*cq_ref.curr_slack_s_u(),
+            ratio_s,
+            off[1],
+            off[7],
+            off[8],
+            -1.0,
+        );
+    }
+
     /// Whether the held-factor back-solve may run
     /// `PdFullSpaceSolver`'s iterative refinement.
     ///
@@ -523,7 +694,7 @@ impl PdSensBacksolver {
         let Some(sigma) = self.released_sigma_x(released) else {
             return false;
         };
-        self.solve_released_prebuilt(released, sigma, None, rhs, lhs, shift)
+        self.solve_released_prebuilt(released, sigma, None, None, rhs, lhs, shift)
     }
 
     /// [`Self::solve_released_inner`] with the released `Σ` supplied by
@@ -532,11 +703,13 @@ impl PdSensBacksolver {
     /// the sigma object's tag, so a sigma rebuilt per call forces a
     /// re-factorization per call, while a held one factorizes once and
     /// back-solves thereafter.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn solve_released_prebuilt(
         &self,
         released: &[usize],
         sigma: Rc<dyn pounce_linalg::Vector>,
         sigma_s: Option<Rc<dyn pounce_linalg::Vector>>,
+        ratios: Option<(&[Number], &[Number])>,
         rhs: &[Number],
         lhs: &mut [Number],
         shift: bool,
@@ -568,6 +741,13 @@ impl PdSensBacksolver {
         }
         if !self.solve_released_scaled(sigma, sigma_s, &scaled, lhs) {
             return false;
+        }
+        // In scaled space, before the natural-units conjugation: the
+        // ceiling ratio is a property of the operator that was
+        // factored, and `z / s` is read off the iterate in the frame
+        // that operator lives in (gh#828).
+        if let Some((rx, rs)) = ratios {
+            self.rescale_bound_multipliers(lhs, rx, rs);
         }
         if let Some(c) = self.conj.as_ref() {
             for (l, &f) in lhs.iter_mut().zip(c.f.iter()) {
@@ -813,10 +993,7 @@ impl PdSensBacksolver {
     /// under the same ceiling. Always fresh objects, because the
     /// factorization cache keys on their tags and a cached vector
     /// could resolve to a factor built at another iterate.
-    pub(crate) fn corrector_sigma(
-        &self,
-        pinned: &[(usize, Number)],
-    ) -> Option<(Rc<dyn pounce_linalg::Vector>, Rc<dyn pounce_linalg::Vector>)> {
+    pub(crate) fn corrector_sigma(&self, pinned: &[(usize, Number)]) -> Option<CorrectorOperator> {
         use pounce_linalg::dense_vector::DenseVectorSpace;
         let dense = |v: Rc<dyn pounce_linalg::Vector>| -> Option<Vec<Number>> {
             v.as_any()
@@ -857,6 +1034,10 @@ impl PdSensBacksolver {
         let caps = sigma_pin_caps(&self.cq, self.dims[0]);
         let cap_s = sigma_pin_cap(1.0);
         let mut x = dense(live_x)?;
+        // What the diagonal would have been with no ceiling, kept
+        // entry by entry so the multiplier rows can be read back in
+        // the frame the operator is actually built in (gh#828).
+        let mut base_x = x.clone();
         for (i, v) in x.iter_mut().enumerate() {
             let c = caps.get(i).copied().unwrap_or(Number::INFINITY);
             if *v > c {
@@ -867,8 +1048,10 @@ impl PdSensBacksolver {
             let c = caps.get(var_row).copied().unwrap_or(Number::INFINITY);
             let slot = x.get_mut(var_row)?;
             *slot = pinned_entry(*slot, add, c);
+            *base_x.get_mut(var_row)? += add;
         }
         let mut s = dense(live_s)?;
+        let base_s = s.clone();
         for v in s.iter_mut() {
             if *v > cap_s {
                 *v = cap_s;
@@ -879,7 +1062,12 @@ impl PdSensBacksolver {
             out.values_mut().copy_from_slice(&vals);
             Rc::new(out) as Rc<dyn pounce_linalg::Vector>
         };
-        Some((pack(x), pack(s)))
+        Some(CorrectorOperator {
+            ratio_x: surviving_fraction(&base_x, &x),
+            ratio_s: surviving_fraction(&base_s, &s),
+            sigma_x: pack(x),
+            sigma_s: pack(s),
+        })
     }
 
     /// A natural-units compound vector, packed as a frozen
@@ -1507,7 +1695,13 @@ impl PdSensBacksolver {
         // Refined, for the reason spelled out in `solve_scaled_space`:
         // one shot, no outer loop.
         let allow_inexact = !self.may_refine();
-        let corrected = self.declared.is_some();
+        // Any override at all, not just crossover's: gh#737's ceiling
+        // is a second one, it fires with `declared` empty, and these
+        // tiers fold the bound rows in from the *calculated* `z / s`
+        // against whatever factor was left behind — which on the first
+        // call after convergence is the algorithm's own uncapped one.
+        // Same predicate, same reason, as `may_refine` (gh#828).
+        let corrected = !self.may_refine();
 
         // Tier 1: fully-inline flat-slice path. `PdFullSpaceSolver::
         // solve_many_cached_flat` downcasts the slack / z / v vectors to
@@ -1622,6 +1816,8 @@ impl PdSensBacksolver {
             {
                 return false;
             }
+
+            self.rescale_bound_multipliers(lhs_row, &self.sigma.ratio_x, &self.sigma.ratio_s);
         }
         true
     }
@@ -1823,6 +2019,46 @@ fn sigma_pin_cap(a: Number) -> Number {
 /// margin staying where it is.
 fn pinned_entry(had: Number, add: Number, cap: Number) -> Number {
     (had + add).min(cap)
+}
+
+/// How much of each entry of `sigma` survives `cap` — `min(Σ, cap)/Σ`,
+/// and exactly `1.0` wherever the ceiling does not bind (gh#828).
+///
+/// [`cap_sigma`] builds the *operator's* diagonal; this builds the
+/// factor the bound-multiplier rows have to be read back through, so
+/// the two describe the same system. Non-positive and non-finite
+/// entries get `1.0`: there is no ratio to take, and the capping loop
+/// leaves them alone too.
+fn cap_ratio(sigma: &Rc<dyn pounce_linalg::Vector>, cap: &dyn Fn(usize) -> Number) -> Vec<Number> {
+    let Some(dv) = sigma.as_any().downcast_ref::<DenseVector>() else {
+        return Vec::new();
+    };
+    let base = dv.expanded_values();
+    let used: Vec<Number> = base
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| {
+            let c = cap(i);
+            if v > c { c } else { v }
+        })
+        .collect();
+    surviving_fraction(&base, &used)
+}
+
+/// `used / base` entrywise, and `1.0` wherever the two agree or the
+/// base carries no ratio to take (gh#828). The shared kernel behind
+/// [`cap_ratio`] and [`CorrectorOperator::ratio_x`].
+fn surviving_fraction(base: &[Number], used: &[Number]) -> Vec<Number> {
+    base.iter()
+        .zip(used)
+        .map(|(&b, &u)| {
+            if u < b && b > 0.0 && b.is_finite() {
+                u / b
+            } else {
+                1.0
+            }
+        })
+        .collect()
 }
 
 /// `min(Σ, cap)` entrywise, or the input unchanged (and `None`) when no
@@ -2055,7 +2291,11 @@ impl PdSensBacksolver {
         if !ok {
             return false;
         }
-        self.unpack(&res_iv, lhs).is_ok()
+        if self.unpack(&res_iv, lhs).is_err() {
+            return false;
+        }
+        self.rescale_bound_multipliers(lhs, &self.sigma.ratio_x, &self.sigma.ratio_s);
+        true
     }
 }
 

--- a/crates/pounce-sensitivity/src/corrector.rs
+++ b/crates/pounce-sensitivity/src/corrector.rs
@@ -485,7 +485,7 @@ pub(crate) fn run(
     // (gh#737) or crossover (gh#654) would otherwise freeze, is never
     // consulted, and the frame rule and the ceiling are re-derived at
     // the predicted point instead. See `corrector_sigma`.
-    let (sigma, sigma_s) = bs.corrector_sigma(&pinned).ok_or_else(|| {
+    let op = bs.corrector_sigma(&pinned).ok_or_else(|| {
         SolverError::SensComputationFailed("corrector: operator diagonal unavailable".into())
     })?;
 
@@ -493,10 +493,16 @@ pub(crate) fn run(
         // The same Rc every call: the factorization cache keys on its
         // tag, so the predicted point's operator is factored once and
         // every later solve is a back-solve.
+        // The ratios go with the diagonals: the chord operator
+        // eliminates each bound row into a diagonal the gh#737 ceiling
+        // may have softened, so the row is read back through the same
+        // cap (gh#828). A no-op wherever the ceiling did not bind,
+        // which is every corrector fixture that predates it.
         bs.solve_released_prebuilt(
             &released,
-            Rc::clone(&sigma),
-            Some(Rc::clone(&sigma_s)),
+            Rc::clone(&op.sigma_x),
+            Some(Rc::clone(&op.sigma_s)),
+            Some((&op.ratio_x, &op.ratio_s)),
             rhs,
             lhs,
             false,

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -1287,6 +1287,7 @@ impl Solver {
             &released,
             Rc::clone(&sigma),
             None,
+            None,
             &rhs_plain,
             &mut d0,
             false,
@@ -1376,6 +1377,7 @@ impl Solver {
                 if !bs.solve_released_prebuilt(
                     &released,
                     Rc::clone(&sigma),
+                    None,
                     None,
                     &unit,
                     &mut xk,
@@ -1503,6 +1505,7 @@ impl Solver {
                 if !bs.solve_released_prebuilt(
                     &released,
                     Rc::clone(&sigma),
+                    None,
                     None,
                     &comb,
                     &mut corr,

--- a/crates/pounce-sensitivity/tests/issue_828_capped_bound_multipliers.rs
+++ b/crates/pounce-sensitivity/tests/issue_828_capped_bound_multipliers.rs
@@ -1,0 +1,518 @@
+//! gh#828 — the parametric step's bound-multiplier block, and the
+//! corrector's own, read back in the frame the gh#737 ceiling actually
+//! built the operator in.
+//!
+//! `PdFullSpaceSolver` eliminates each bound row into the `x` / `s`
+//! barrier diagonal and recovers it afterwards as
+//! `dz = r_z/s − (z/s)·dx`, re-deriving `z/s` straight off the iterate.
+//! That is right exactly when the diagonal it eliminated into *was*
+//! `Σ = Σ z/s`. Under gh#737's ceiling it is not: the solve holds the
+//! capped bound softly and reads its multiplier back stiffly, and the
+//! two disagree by the cap ratio.
+//!
+//! # The fixture
+//!
+//! ```text
+//! min exp(x0) − p·x0 + ½(x1 − (2.5 − 2p))² + ½(x2 + 5)²
+//! s.t.  p = p0,   A·x2 + x3 = 0,   x1 ≥ 0,  x2 ≥ 0
+//! ```
+//!
+//! with the closed form `x0 = ln p`, `x1 = max(0, 2.5 − 2p)`,
+//! `x2 = x3 = 0`, so the truth is independent of the machinery under
+//! test. `x2` sits hard on its bound at `Σ = z/s ≈ 2.5e12`; `A` is its
+//! only Jacobian coefficient, so it sets that variable's ceiling
+//! through `sigma_pin_cap(a) = (a/eps)·(a/64)` and sweeping `A` walks
+//! the cap in and out. `x1` is a near-bound row whose slack shrinks
+//! 5× over the step and `x0` carries the curvature, so the correction
+//! has real work to do in the uncapped coordinates.
+//!
+//! # Mutation table
+//!
+//! Measured at `delta = 0.2`, `tol = 1e-10`, `bound_relax_factor = 0`,
+//! budget 8. `dz` is the returned step's entry for `x2`'s lower-bound
+//! multiplier, whose true value is `0` — `z2 = 5` at both parameter
+//! values, the `½(x2+5)²` term not depending on `p`.
+//!
+//! | `A` | `dz` before | `dz` after | corrected error before | after |
+//! |---|---|---|---|---|
+//! | 1e-4 | 1.776e7  | −7.10e-6  | 1.7678e-2 (no progress) | 1.553e-4 |
+//! | 1e-3 | 1.776e5  | −7.10e-8  | 1.7678e-2 (no progress) | 4.736e-8 |
+//! | 1e-2 | 1.771e3  | −7.10e-10 | 1.7678e-2 (no progress) | 4.817e-10 |
+//! | 1e-1 | 1.276e1  | −7.11e-12 | 1.0000e-10              | 1.000e-10 |
+//! | 1.0  | −2.0e-12 | −2.0e-12  | 1.0000e-10              | 1.000e-10 |
+//!
+//! The ceiling does not bind at `A = 1.0` (`Σ = 2.5e12` against a cap
+//! of `7.0e13`), which is the arm that pins the fix as a no-op off the
+//! capped path — every number in that row is bit-identical across the
+//! change. Reintroduce the defect by dropping either call to
+//! `rescale_bound_multipliers` and the four capped rows go back to the
+//! "before" column, and each mutation is caught by the test whose name
+//! describes it: dropping the predictor's restores the `A⁻²` blow-up
+//! in `dz` and the corrector then opens on it, while dropping only the
+//! corrector's leaves it opening on the right `2.14e-2` and still
+//! unable to reduce it — `improved() == false` at `A ≤ 1e-2`, from a
+//! chord that softens the bound and reads it back stiff.
+//!
+//! Two more mutations, each caught by exactly one leg and by no
+//! other: turning over the sign in the `px_u` arm — silent above,
+//! because every rung in the table is bounded *below* only, so the
+//! `z_u` block never executes — reddens
+//! [`the_upper_bound_branch_is_read_back_through_its_cap_too`]; and
+//! moving the rescale to *after* the natural-units conjugation, which
+//! is invisible at unit scaling, reddens
+//! [`the_capped_correction_survives_a_change_of_variables`].
+//!
+//! # Which branch this reaches
+//!
+//! Every case here corrects with `released == 0` and `pinned == 0` —
+//! asserted below, so a later reader does not mistake it for
+//! evidence about the active-set branches. Those diagonals are not a
+//! rescaling of the base one and deliberately carry no ratio;
+//! `corrector_ceiling.rs` is the file that drives the pinned branch
+//! under the same ceiling.
+//!
+//! Nor is it evidence about the `s` block. Every fixture here has
+//! `dims[1] == 0` — no inequality slacks — so `ratio_s` is empty and
+//! the `pd_l` / `pd_u` arms of the rescale are never entered. They
+//! carry the same two signs as the `x` arms one block over, and a
+//! model with a bounded `d(x)` row stiff enough to reach
+//! `sigma_pin_cap(1.0) = 7.0e13` is what would exercise them.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, ScalingRequest, Solution,
+    SparsityRequest, StartingPoint, TNLP,
+};
+use pounce_sensitivity::Solver;
+
+const P0: Number = 1.0;
+const DELTA: Number = 0.2;
+
+/// min exp(x0) - p*x0 + ½(x1 - (2.5-2p))² + ½(x2+5)²
+/// s.t. g0: p = p0,  g1: A*x2 + x3 = 0,  x1 >= 0, x2 >= 0
+/// vars: x0, x1, x2, x3, p
+struct Fixture {
+    a: Number,
+    p0: Number,
+    start: Option<Vec<Number>>,
+    /// Reflect `x2` through its bound: the objective term becomes
+    /// `½(x2 − 5)²` and the bound an **upper** one at `0`, which is the
+    /// same model under `x2 → −x2` and the same `Σ = 5 / s`. It reaches
+    /// the other sign of the fold — see
+    /// [`the_upper_bound_branch_is_read_back_through_its_cap_too`].
+    mirror: bool,
+    /// Per-variable `user-scaling` factors, or `None` for an unscaled
+    /// solve.
+    x_scaling: Option<Vec<Number>>,
+}
+
+impl TNLP for Fixture {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 5,
+            m: 2,
+            nnz_jac_g: 3,
+            nnz_h_lag: 6,
+            index_style: IndexStyle::C,
+        })
+    }
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        let Some(d) = self.x_scaling.as_ref() else {
+            return false;
+        };
+        *req.obj_scaling = 1.0;
+        *req.use_x_scaling = true;
+        req.x_scaling.copy_from_slice(d);
+        *req.use_g_scaling = false;
+        true
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = -1.0e19;
+        b.x_u[0] = 1.0e19;
+        b.x_l[1] = 0.0;
+        b.x_u[1] = 1.0e19;
+        if self.mirror {
+            b.x_l[2] = -1.0e19;
+            b.x_u[2] = 0.0;
+        } else {
+            b.x_l[2] = 0.0;
+            b.x_u[2] = 1.0e19;
+        }
+        b.x_l[3] = -1.0e19;
+        b.x_u[3] = 1.0e19;
+        b.x_l[4] = -1.0e19;
+        b.x_u[4] = 1.0e19;
+        b.g_l[0] = self.p0;
+        b.g_u[0] = self.p0;
+        b.g_l[1] = 0.0;
+        b.g_u[1] = 0.0;
+        true
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        match &self.start {
+            Some(x0) => sp.x.copy_from_slice(x0),
+            None => {
+                sp.x[0] = 0.0;
+                sp.x[1] = 0.5;
+                sp.x[2] = if self.mirror { -0.5 } else { 0.5 };
+                sp.x[3] = 0.0;
+                sp.x[4] = self.p0;
+            }
+        }
+        true
+    }
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types.fill(Linearity::Linear);
+        true
+    }
+    fn eval_f(&mut self, x: &[Number], _n: bool) -> Option<Number> {
+        let c = 2.5 - 2.0 * x[4];
+        let pull = if self.mirror { -5.0 } else { 5.0 };
+        Some(x[0].exp() - x[4] * x[0] + 0.5 * (x[1] - c).powi(2) + 0.5 * (x[2] + pull).powi(2))
+    }
+    fn eval_grad_f(&mut self, x: &[Number], _n: bool, g: &mut [Number]) -> bool {
+        let r = x[1] - (2.5 - 2.0 * x[4]);
+        g[0] = x[0].exp() - x[4];
+        g[1] = r;
+        g[2] = x[2] + if self.mirror { -5.0 } else { 5.0 };
+        g[3] = 0.0;
+        g[4] = -x[0] + 2.0 * r;
+        true
+    }
+    fn eval_g(&mut self, x: &[Number], _n: bool, g: &mut [Number]) -> bool {
+        g[0] = x[4];
+        g[1] = self.a * x[2] + x[3];
+        true
+    }
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _n: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for (k, &(r, c)) in [(0usize, 4usize), (1, 2), (1, 3)].iter().enumerate() {
+                    irow[k] = r as Index;
+                    jcol[k] = c as Index;
+                }
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, self.a, 1.0]);
+            }
+        }
+        true
+    }
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        _n: bool,
+        obj_factor: Number,
+        _l: Option<&[Number]>,
+        _nl: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // lower triangle: (0,0) (1,1) (2,2) (4,4) (4,0) (4,1)
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for (k, &(r, c)) in [(0usize, 0usize), (1, 1), (2, 2), (4, 4), (4, 0), (4, 1)]
+                    .iter()
+                    .enumerate()
+                {
+                    irow[k] = r as Index;
+                    jcol[k] = c as Index;
+                }
+            }
+            SparsityRequest::Values { values } => {
+                let x0 = x.map_or(0.0, |x| x[0]);
+                values[0] = obj_factor * x0.exp();
+                values[1] = obj_factor;
+                values[2] = obj_factor;
+                values[3] = obj_factor * 4.0;
+                values[4] = -obj_factor;
+                values[5] = obj_factor * 2.0;
+            }
+        }
+        true
+    }
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _c: &IpoptCq) {}
+}
+
+fn solved(a: Number, p0: Number, start: Option<Vec<Number>>) -> Solver {
+    solved_with(a, p0, start, false, None)
+}
+
+fn solved_with(
+    a: Number,
+    p0: Number,
+    start: Option<Vec<Number>>,
+    mirror: bool,
+    x_scaling: Option<Vec<Number>>,
+) -> Solver {
+    let mut app = IpoptApplication::new();
+    {
+        let o = app.options_mut();
+        o.set_integer_value("print_level", 0, true, false).unwrap();
+        o.set_string_value("sb", "yes", true, false).unwrap();
+        o.set_numeric_value("bound_relax_factor", 0.0, true, false)
+            .unwrap();
+        o.set_numeric_value("tol", 1e-10, true, false).unwrap();
+        if x_scaling.is_some() {
+            o.set_string_value("nlp_scaling_method", "user-scaling", true, false)
+                .unwrap();
+        }
+    }
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Fixture {
+        a,
+        p0,
+        start,
+        mirror,
+        x_scaling,
+    }));
+    let mut solver = Solver::new(app, tnlp);
+    let st = solver.solve();
+    assert!(
+        matches!(
+            st,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "a={a:e}: {st:?}"
+    );
+    solver
+}
+
+fn truth(p: Number) -> Vec<Number> {
+    vec![p.ln(), (2.5 - 2.0 * p).max(0.0), 0.0, 0.0, p]
+}
+
+fn dist(a: &[Number], b: &[Number]) -> Number {
+    a.iter()
+        .zip(b)
+        .fold(0.0_f64, |m, (&x, &y)| m.max((x - y).abs()))
+}
+
+/// Row coefficients that walk the gh#737 ceiling from biting hard to
+/// not biting at all.
+const COEFFS: [Number; 5] = [1e-4, 1e-3, 1e-2, 1e-1, 1.0];
+
+/// `x2`'s lower-bound multiplier row inside the compound KKT vector,
+/// checked against the block dimensions rather than assumed: the `z_l`
+/// block holds the bounded-below variables in order, and `x1` and `x2`
+/// are the only two.
+fn capped_dz_row(dims: &[usize; 8]) -> usize {
+    assert_eq!(
+        dims,
+        &[5, 0, 2, 0, 2, 0, 0, 0],
+        "fixture shape moved; the z_l row below is read off it"
+    );
+    dims[0] + dims[1] + dims[2] + dims[3] + 1
+}
+
+/// The predictor's multiplier block stays in the capped frame.
+///
+/// Before the fix this entry grew as `A⁻²` — 1.776e7 at `A = 1e-4` —
+/// against a true `0`, because the elimination used the capped `Σ`
+/// and the recovery divided by the uncapped `s`.
+#[test]
+fn the_parametric_step_reads_a_capped_bound_back_through_its_cap() {
+    for a in COEFFS {
+        let s = solved(a, P0, None);
+        let dims = s.block_dims().expect("block dims");
+        let row = capped_dz_row(&dims);
+        let step = s.parametric_step_full(&[0], &[DELTA]).expect("step");
+        let dz = step[row];
+        assert!(
+            dz.abs() < 1e-3,
+            "a={a:e}: dz={dz:e} on a bound whose multiplier does not move"
+        );
+    }
+}
+
+/// `correct_step` improves on its input at every rung of the sweep,
+/// and the improvement is not cosmetic: the error against the closed
+/// form drops by at least two orders from the predictor's.
+///
+/// Before the fix the four capped rungs stopped after one iteration
+/// with `improved() == false` and handed back the uncorrected step —
+/// `estimate(corrector_iter = ...)` silently unavailable in exactly
+/// the stiff, tightly-bounded regime a caller reaches for it in.
+#[test]
+fn the_corrector_makes_progress_under_the_ceiling() {
+    let want = truth(P0 + DELTA);
+    for a in COEFFS {
+        let s = solved(a, P0, None);
+        let base = s.converged().expect("converged").x.clone();
+        let n = base.len();
+        let step = s.parametric_step_full(&[0], &[DELTA]).expect("step");
+        let plain: Vec<Number> = base.iter().zip(&step[..n]).map(|(&b, &d)| b + d).collect();
+        let plain_err = dist(&plain, &want);
+
+        let (out, rep) = s.correct_step(&[0], &[DELTA], &step, 8).expect("correct");
+        let corrected: Vec<Number> = base.iter().zip(&out[..n]).map(|(&b, &d)| b + d).collect();
+        let err = dist(&corrected, &want);
+
+        assert!(
+            rep.improved(),
+            "a={a:e}: no progress, r0={:e}",
+            rep.initial_residual
+        );
+        assert!(
+            err < plain_err / 100.0,
+            "a={a:e}: corrected {err:e} against predicted {plain_err:e}"
+        );
+        // The residual the corrector opens on is the model's own
+        // second-order term, not the cap's: it is the same 2.14e-2 at
+        // every rung, where before the fix it ran 1.776e7 down to
+        // 2.14e-2 as the ceiling let go.
+        assert!(
+            (rep.initial_residual - 2.14e-2).abs() < 1e-3,
+            "a={a:e}: initial residual {:e}",
+            rep.initial_residual
+        );
+        // See the module header: this leg says nothing about the
+        // release or pin branches.
+        assert_eq!((rep.released, rep.pinned), (0, 0), "a={a:e}");
+    }
+}
+
+/// Off the capped path nothing moves. `A = 1.0` leaves `Σ = 2.5e12`
+/// under a ceiling of `7.0e13`, and the whole correction has to be
+/// bit-identical to what it was before the ratio existed — the
+/// `1.0` row of the module's mutation table.
+#[test]
+fn an_uncapped_bound_is_untouched_by_the_ratio() {
+    let want = truth(P0 + DELTA);
+    let s = solved(1.0, P0, None);
+    let base = s.converged().expect("converged").x.clone();
+    let n = base.len();
+    let dims = s.block_dims().expect("block dims");
+    let step = s.parametric_step_full(&[0], &[DELTA]).expect("step");
+    // `dz` here is the barrier standoff `−s2`, the whole of what the
+    // equation-11 correction takes off a bound at `mu`; it is what the
+    // capped rows should approach and never did.
+    assert!(
+        (step[capped_dz_row(&dims)] + 2.0e-12).abs() < 1e-14,
+        "dz={:e}",
+        step[capped_dz_row(&dims)]
+    );
+    let (out, rep) = s.correct_step(&[0], &[DELTA], &step, 8).expect("correct");
+    let corrected: Vec<Number> = base.iter().zip(&out[..n]).map(|(&b, &d)| b + d).collect();
+    assert_eq!(rep.iterations, 8);
+    // 1e-10 is the corrector's own box put-back margin,
+    // `1e-10 * (1 + |base_i|)`, on `x2` — the floor this fixture can
+    // reach, not a tolerance chosen to pass.
+    assert!(dist(&corrected, &want) < 1.1e-10);
+}
+
+/// The corrected error, as a fraction of the closed form, for one
+/// solved arm of the sweep. The two legs below both work by comparing
+/// this number across a transformation that must not move it.
+fn corrected_error(s: &Solver, row: usize) -> (Number, Number, bool) {
+    let base = s.converged().expect("converged").x.clone();
+    let n = base.len();
+    let want = truth(P0 + DELTA);
+    let step = s.parametric_step_full(&[0], &[DELTA]).expect("step");
+    let (out, rep) = s.correct_step(&[0], &[DELTA], &step, 8).expect("correct");
+    let corrected: Vec<Number> = base.iter().zip(&out[..n]).map(|(&b, &d)| b + d).collect();
+    assert_eq!((rep.released, rep.pinned), (0, 0));
+    (dist(&corrected, &want), step[row], rep.improved())
+}
+
+/// The **upper**-bound sign of the fold.
+///
+/// A lower bound folds into the diagonal as `−z·dx` and an upper one
+/// as `+z·dx`, so the correction that puts the row back in the capped
+/// frame carries the opposite sign on each. Every fixture above is
+/// bounded below only, and a sign error on the other block is silent
+/// there: the whole `z_u` path would never execute.
+///
+/// The mirror is the same model under `x2 → −x2`, so the answer is
+/// the *same number*, and that is what is asserted — not a loose
+/// bound. Flip the sign in `rescale_bound_multipliers`'s `px_u` arm
+/// and the row comes back at roughly `−2·(z/s)·dx`, i.e. the defect's
+/// own `1.8e7` with the sign turned over.
+#[test]
+fn the_upper_bound_branch_is_read_back_through_its_cap_too() {
+    for a in COEFFS {
+        let lower = solved(a, P0, None);
+        let l_dims = lower.block_dims().expect("block dims");
+        let (l_err, l_dz, l_imp) = corrected_error(&lower, capped_dz_row(&l_dims));
+
+        let upper = solved_with(a, P0, None, true, None);
+        let u_dims = upper.block_dims().expect("block dims");
+        assert_eq!(
+            u_dims,
+            [5, 0, 2, 0, 1, 1, 0, 0],
+            "mirror shape moved; the z_u row below is read off it"
+        );
+        // `x1`'s lower-bound row is the whole of `z_l`; `x2`'s
+        // upper-bound row is the whole of `z_u`, which starts after it.
+        let u_row = u_dims[0] + u_dims[1] + u_dims[2] + u_dims[3] + u_dims[4];
+        let (u_err, u_dz, u_imp) = corrected_error(&upper, u_row);
+
+        assert!(l_imp && u_imp, "a={a:e}: no progress");
+        assert!(
+            (u_dz - l_dz).abs() <= 1e-6 * l_dz.abs(),
+            "a={a:e}: dz {u_dz:e} on the upper bound against {l_dz:e} on the lower"
+        );
+        assert!(
+            (u_err - l_err).abs() <= 1e-6 * l_err,
+            "a={a:e}: corrected error {u_err:e} against the mirror's {l_err:e}"
+        );
+    }
+}
+
+/// Invariance leg 1 for the capped multiplier rows: the correction is
+/// read off `z / s` in the solver's **scaled** frame and applied to a
+/// scaled `dx`, before the natural-units conjugation, so a frame slip
+/// there is invisible at unit scaling — which is every arm above.
+///
+/// Under `x̃ = d ⊙ x` the barrier diagonal carries `d⁻²` and so does
+/// the ceiling, because `sigma_pin_cap` is quadratic in a Jacobian
+/// coefficient that carries `d⁻¹`: the cap therefore binds on exactly
+/// the same rungs in both arms, which is what makes this leg a fair
+/// comparison rather than a comparison of a capped run to an uncapped
+/// one. The corrected answer is in natural units and must not move.
+///
+/// `initial_residual` is deliberately **not** compared: it is measured
+/// in the scaled frame and legitimately halves here.
+#[test]
+fn the_capped_correction_survives_a_change_of_variables() {
+    let d = vec![2.0, 0.5, 4.0, 0.25, 1.0];
+    for a in COEFFS {
+        let plain = solved(a, P0, None);
+        let p_dims = plain.block_dims().expect("block dims");
+        let (p_err, p_dz, p_imp) = corrected_error(&plain, capped_dz_row(&p_dims));
+
+        let scaled = solved_with(a, P0, None, false, Some(d.clone()));
+        let s_dims = scaled.block_dims().expect("block dims");
+        let (s_err, s_dz, s_imp) = corrected_error(&scaled, capped_dz_row(&s_dims));
+
+        assert!(p_imp && s_imp, "a={a:e}: no progress");
+        // Measured spread across the sweep is 0 to 7.5e-4 relative —
+        // the two arms converge to slightly different points, and this
+        // row is the barrier standoff read at whichever one. The
+        // budget is 13x that rather than 1.3x on purpose: both
+        // mutations this leg exists for (a frame slip, a sign flip)
+        // move it by order one or more, so there is nothing to buy by
+        // tightening it into flakiness.
+        assert!(
+            (s_dz - p_dz).abs() <= 1e-2 * p_dz.abs(),
+            "a={a:e}: dz {s_dz:e} scaled against {p_dz:e} unscaled"
+        );
+        assert!(
+            (s_err - p_err).abs() <= 1e-6 * p_err,
+            "a={a:e}: corrected error {s_err:e} scaled against {p_err:e} unscaled"
+        );
+    }
+    // Not a vacuous leg: at the stiffest rung the ceiling really does
+    // bind in the scaled arm. Its `dz` is the capped standoff, six
+    // orders off the `−2.0e-12` an uncapped row returns.
+    let s = solved_with(1e-4, P0, None, false, Some(d));
+    let dims = s.block_dims().expect("block dims");
+    let dz = s.parametric_step_full(&[0], &[DELTA]).expect("step")[capped_dz_row(&dims)];
+    assert!(dz.abs() > 1e-7, "the ceiling did not bind: dz={dz:e}");
+}

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -703,6 +703,22 @@ a step brings a variable onto a bound included — a bound the corrector
 newly pins arrives as `mu / s²` off the step's own endpoint, which is
 the same quantity by another name.
 
+It holds on the way back out, too. Folding a bound row into the diagonal
+is only half of a solve: the row's own multiplier is recovered from that
+diagonal afterwards, and the recovery has to divide by the same
+stiffness the fold used. Before
+[#828](https://github.com/jkitchin/pounce/issues/828) it divided by the
+uncapped one, so a capped bound was held softly and read back stiffly,
+and the returned bound-multiplier derivative came out wrong by the cap's
+ratio — `1.8e7` against a true `0` on that issue's fixture, growing as
+the row's Jacobian coefficient shrank. `corrector_iter` then opened on a
+stationarity residual of the same size, could not reduce it in a single
+step, and returned the step it had been handed at every budget: the
+refinement unavailable in exactly the stiff, tightly bounded regime a
+caller reaches for it in. The multiplier rows now come back through the
+same cap, on the returned step and on the corrector's own operator
+alike, and where the ceiling does not bind nothing moves.
+
 Nothing about the solve changes; this is the sensitivity system only.
 
 ### Solver options and warm starts


### PR DESCRIPTION
Fixes #828

## Problem, with numbers

`PdFullSpaceSolver` eliminates each bound row into the `x` / `s` barrier
diagonal and recovers it afterwards as `dz = r_z/s − (z/s)·dx`, re-deriving
`z/s` straight off the iterate. That is right exactly when the diagonal it
eliminated into *was* `Σ = Σ z/s`. Under the gh#737 ceiling it is not: the
solve holds the capped bound softly — which is the whole point of the
ceiling — and reads its multiplier back stiffly, and the two disagree by
exactly the cap ratio.

On the issue's fixture, a strongly active bound with `Σ = 2.5e12` capped to
`7.0e5` came back with

    dz2 = (−mu − z2·dx2)/s2 = (−1e-11 − 5·(−7.1054e-6))/2e-12 = 1.7764e7

against a true `0`, growing as `A⁻²` as the constraint row's Jacobian
coefficient `A` shrank (`Σ_cap ∝ A²`). That `1.78e7` is also, one for one,
the stationarity residual `correct_step` opened on — which is why it could
not reduce it in a single chord step, stopped with `improved() == false`,
and handed the caller back its own uncorrected input at every budget.

| `A` | `dz` before | `dz` after | corrected error before | after |
|---|---|---|---|---|
| 1e-4 | 1.776e7  | −7.10e-6  | 1.7678e-2 (no progress) | 1.553e-4 |
| 1e-3 | 1.776e5  | −7.10e-8  | 1.7678e-2 (no progress) | 4.736e-8 |
| 1e-2 | 1.771e3  | −7.10e-10 | 1.7678e-2 (no progress) | 4.817e-10 |
| 1e-1 | 1.276e1  | −7.11e-12 | 1.0000e-10              | 1.000e-10 |
| 1.0  | −2.0e-12 | −2.0e-12  | 1.0000e-10              | 1.000e-10 |

`A = 1.0` leaves `Σ = 2.5e12` under a ceiling of `7.0e13`, so the ceiling
does not bind and every number in that row is unchanged across this PR.

## Fix

This is the design question the issue poses — *"whether the parametric
step's multiplier block should be built in the capped frame too"* — answered
yes. Consistency asks the capped bound's complementarity row to read
`s·dz + r·z·dx = r_z` with the same `r = Σ_used/Σ_base` the diagonal was
scaled by, so `PdSensBacksolver::rescale_bound_multipliers` adds
`sign·(1 − r)·(z/s)·dx` back onto each affected row. `r == 1` wherever the
ceiling did not bind, so it is an exact no-op off the capped path.

The ratio travels **with** the diagonal it describes, because separating the
two is the defect: `EffectiveSigma` gained `ratio_x` / `ratio_s`, and
`corrector_sigma` now returns a `CorrectorOperator` carrying both diagonals
and both ratios. The rescale runs in **scaled space, before** the
natural-units conjugation — the ratio is a property of the operator that was
factored, and `z / s` is read off the iterate in that operator's frame.

**Scope.** Applied to the plain `sigma_override()` path (the predictor) and
to the corrector's own operator. Deliberately *not* applied to
`active_set_sigma_x`'s released/pinned diagonal: a released entry is rebuilt
from the bounds that stay active and a pinned entry is raised by an addend,
so no single per-variable ratio describes it. The new fixtures assert
`released == 0 && pinned == 0` so a later reader does not mistake them for
evidence about those branches.

**Adjacent hole, same cause.** `solve_many_scaled_space` gated its two
batched fast tiers on `self.declared.is_some()` — crossover only. Those
tiers fold the bound rows in from the *calculated* `z / s` against whatever
factor the last solve left behind, which on the first call after convergence
is the algorithm's own uncapped one. gh#737's ceiling is a second override
and fires with `declared` empty, so the gate now reads `!self.may_refine()`
— the same predicate, for the same reason, as `may_refine` itself.

## Blast radius

Off the capped path, nothing. `rescale_bound_multipliers` returns
immediately when every ratio is `1.0`, which is every entry of an uncapped
solve, and `an_uncapped_bound_is_untouched_by_the_ratio` pins that arm.
Where the ceiling *does* bind, the bound-multiplier rows of the returned
step change — from wrong to right. `dz` is the only block affected;
`dx`, `ds` and the constraint multipliers are untouched.

**Honest limit.** At the most extreme cap (`A = 1e-4`) the corrector now
makes progress but stalls at residual `1.864e-4` / error `1.553e-4` rather
than reaching the `1e-10` floor the uncapped rungs do. That is an accuracy
limit of a heavily softened chord, not a failure to progress — the operator
really has had that bound's stiffness reduced by seven orders — and it is
what the `err < plain_err / 100` assertion is calibrated against rather than
an absolute floor.

## Tests

New `crates/pounce-sensitivity/tests/issue_828_capped_bound_multipliers.rs`,
the issue's reproduction contributed as the author offered. Five legs, and
the file carries its own mutation table plus the list of what it is *not*
evidence about:

- `the_parametric_step_reads_a_capped_bound_back_through_its_cap` — the
  predictor's `dz`, swept over five row coefficients that walk the ceiling
  in and out.
- `the_corrector_makes_progress_under_the_ceiling` — `improved()`, a
  hundredfold error drop, and the initial residual pinned at the model's own
  `2.14e-2` at *every* rung, where before it ran `1.78e7` down to `2.14e-2`
  as the ceiling let go.
- `an_uncapped_bound_is_untouched_by_the_ratio` — the no-op arm.
- `the_upper_bound_branch_is_read_back_through_its_cap_too` — the other sign
  of the fold. A lower bound folds in as `−z·dx` and an upper one as
  `+z·dx`; every other fixture is bounded below only, so the `z_u` block
  never executes and a sign error there is silent. The mirror fixture is the
  same model under `x2 → −x2`, so the leg asserts the *same number*, not a
  loose bound.
- `the_capped_correction_survives_a_change_of_variables` — invariance leg 1
  for the new path, which reads `z / s` in the scaled frame and applies it to
  a scaled `dx`. Under `x̃ = d ⊙ x` both `Σ` and the ceiling carry `d⁻²`
  (`sigma_pin_cap` is quadratic in a coefficient carrying `d⁻¹`), so the cap
  binds on the same rungs in both arms and the natural-units answer must not
  move. `initial_residual` is deliberately not compared — it lives in the
  scaled frame and legitimately halves. The leg also asserts it is not
  vacuous: at the stiffest rung the scaled arm's `dz` is six orders off what
  an uncapped row returns.

Each mutation is caught by exactly the leg whose name describes it, and by
no other:

| mutation | red |
|---|---|
| drop the predictor's `rescale_bound_multipliers` | the `A⁻²` blow-up returns; predictor + corrector legs |
| drop the corrector's | opens on the right `2.14e-2`, still `improved() == false` at `A ≤ 1e-2` |
| flip the `px_u` sign | upper-bound leg only |
| move the rescale after the natural-units conjugation | scaling leg only |

`cargo test -p pounce-sensitivity` green (33 binaries), including
`sens_invariance_legs.rs`, `sens_resolve_oracle.rs`, `corrector_ceiling.rs`,
`issue_737_pinned_to_bound_sigma.rs` and `crossover_sigma_downstream.rs`.
Full workspace suite green. Not a trajectory change: nothing in
`pounce-algorithm` moves, so `scripts/sweep-fixtures.sh` is not implicated.

## /sens-review

Run on this diff; see the comment below for the per-entry table.

## Definition of done

- Code + test — above.
- CHANGELOG — `## [Unreleased]` bullet naming the Python / Pyomo surfaces.
- Book — `docs/src/sensitivity.md`, the gh#737 ceiling passage, which now
  says the ceiling holds on the way back out too.
