### PR TITLE
feat(ma57): let MA57 into the batched back-substitution, behind an opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ changes.
 
 ## [Unreleased]
 
+- **`ma57_batched_backsolve`: MA57 can now be let into the batched
+  back-substitution, and the cost of doing so is written down.** Under the
+  limited-memory quasi-Newton Hessian the Sherman-Morrison-Woodbury
+  correction offers the linear solver several right-hand sides at once, but
+  only to a backend that affirms its multi-RHS answer is bit-identical to
+  solving the columns one at a time — these columns feed an iterate whose
+  trajectory must not move (gh#729). FERAL affirms up to `nrhs = 16`; MA57
+  had no way to answer at all, so it inherited the conservative default and
+  the batch was unreachable on that backend, as was the pre-existing warm
+  batch below it. On MA57 the SMW columns have always been solved one
+  traversal of the factor at a time, which is part of why its back-solve row
+  measures worse than Ipopt's. The new option is the answer, and it is
+  **off by default** and stays off: MA57 blocks its substitution across
+  columns, so its batched result really is different — by about one ulp, and
+  measured on a 118276-row KKT system that is enough to move the objective's
+  last digit at iteration 20 and change the iteration count the run finishes
+  at. Turning it on is a trajectory change you are electing to accept, not a
+  free speed-up. What it buys, per iteration on that model: back-solve
+  −32.0%, numeric factorization +18.5%, linear-algebra total −4.2% against a
+  3–5% replicate spread — close to FERAL's own ratios, so the batch is not
+  worth more on MA57 than it is there. Do not compare wall-clock across the
+  option; the two settings walk different trajectories and the difference is
+  dominated by iteration count. Unlike FERAL's, the option carries no width
+  ceiling, because CoinHSL cannot be linked in CI and a ceiling nothing here
+  could re-derive is the shape of defect the fixture-sweep post-mortem is
+  about. Takes a `resto.` prefix like the rest of the family. Rationale and
+  measurements: `dev-notes/ma57-batched-backsolve.md`; user documentation:
+  the Options book page.
+
 - **`hessian_approximation=finite-difference`: the exact Hessian for models
   that have none.** A collocation model built from an FMU or CasADi supplies
   analytic first derivatives and no second ones, and until now that left only

--- a/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
@@ -568,6 +568,12 @@ impl LowRankAugSystemSolver {
         // (`solve_many_into`) and MA57 (`ma57cd_` with `nrhs`) block the
         // triangular solves, and neither can do so one column at a time
         // (gh#729).
+        //
+        // Whether the batch is *taken* is a separate question, asked
+        // below. FERAL answers it from a measured width ceiling; MA57
+        // blocks at every width, so it declines unless
+        // `ma57_batched_backsolve` says otherwise, and by default the
+        // loop further down solves these columns one at a time.
         let mut k0 = 0usize;
         if !self.inner_has_factor && n_cols_us > 0 {
             let rhs_x_dyn: &dyn Vector = v_x.get_vector(0).as_ref();

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -1531,6 +1531,16 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
     )?;
     r.add_bounded_integer_option("ma57_small_pivot_flag", "Handling of small pivots", 0, 1, 0, "If set to 1, then when small entries defined by CNTL(2) are detected they are removed and the corresponding pivots placed at the end of the factorization. This can be particularly efficient if the matrix is highly rank deficient. This is ICNTL(16) in MA57.")?;
 
+    // ===== MA57 batched back-substitution (pounce extension; not in upstream Ipopt) =====
+    // Registered in the MA57 category, immediately after the ported
+    // options above, because it is an MA57 setting from a user's point
+    // of view even though upstream has no equivalent. Registered
+    // unconditionally, like every other `ma57_*` option: the registry is
+    // built without regard to the `ma57` cargo feature, and an option
+    // that appeared only in some builds would make `pounce
+    // --print-options` build-dependent.
+    r.add_bool_option("ma57_batched_backsolve", "Whether MA57 may answer several right-hand sides in one blocked back-substitution.", false, "pounce extension; not an upstream Ipopt option. Callers that batch right-hand sides purely to save time -- today the Sherman-Morrison-Woodbury correction block in the limited-memory quasi-Newton path -- ask the linear solver first whether its multi-RHS answer is bit-identical to solving the columns one at a time. MA57 blocks the substitution across columns, so it is not: the batched answer is tolerance-equal but differs in about the last bit. Setting this to \"yes\" says you accept that. It is a trajectory change, not just a speed-up: on gh#809's review model the same binary with and without the batch diverges in the last digit of the objective at iteration 20 and finishes at a different iteration count, and on a nonconvex problem a perturbation that size can select a different local optimum (gh#729 did exactly that on pooling_rt2stp, landing 25% worse while still reporting Optimal Solution Found). What you get for it, measured per iteration on that model: back-solve -32%, numeric factorization +18.5%, linear-algebra total -4.2% against a 3-5% replicate spread. Do not compare wall-clock across this option -- the runs walk different trajectories, so the difference is dominated by iteration count rather than by work removed. See dev-notes/ma57-batched-backsolve.md.")?;
+
     // ===== FeralSolverInterface::RegisterOptions (pounce extension; not in upstream Ipopt) =====
     // The FERAL pure-Rust backend has several optional knobs that are
     // not (yet) part of the upstream Ipopt linear-solver option set.

--- a/crates/pounce-algorithm/tests/ma57_batched_backsolve_is_opt_in.rs
+++ b/crates/pounce-algorithm/tests/ma57_batched_backsolve_is_opt_in.rs
@@ -1,0 +1,99 @@
+//! `ma57_batched_backsolve` must stay registered, and must stay `no`.
+//!
+//! The option lets MA57 affirm
+//! `SparseSymLinearSolverInterface::multi_solve_matches_single_solve`,
+//! which is what admits `LowRankAugSystemSolver`'s SMW columns to a
+//! single blocked back-substitution instead of one traversal of the
+//! factor per column. MA57's blocked path is **not** bit-identical to
+//! the per-column one — measured at about one ulp on gh#809's review
+//! model, and enough to move the trajectory and the final iteration
+//! count — so the option is a permission the user grants, not a
+//! capability that should arrive switched on.
+//!
+//! Two properties, and neither is checkable by the tests that live
+//! next to the backend:
+//!
+//! * The **registered default** is `no`. `pounce-hsl`'s own reader
+//!   falls back to `false` when the option is absent, but that fallback
+//!   is dead code in production — the registry always answers first —
+//!   so a registry that defaulted to `yes` would silently switch every
+//!   MA57 run onto a different trajectory while every fallback in the
+//!   reader still read `false`. That is the gh#677 shape exactly:
+//!   registered with one default, read with another, nothing comparing
+//!   the two.
+//! * The option is **registered at all**. Unregistered reads as unset,
+//!   unset reads as `false`, and the feature would go quietly
+//!   unreachable rather than fail — which is gh#825's failure mode with
+//!   the sign flipped.
+//!
+//! This runs in CI, which the rest of the MA57 coverage cannot: CoinHSL
+//! is licensed and cannot be linked here, so
+//! `ma57_options_reach_the_backend.rs` is `#![cfg(feature = "ma57")]`
+//! and `pounce-hsl`'s tests are excluded from every CI job. Registration
+//! is deliberately unconditional on the `ma57` cargo feature — the
+//! registry is built the same way in every build so that
+//! `--print-options` is not build-dependent — which is what makes this
+//! assertion possible here.
+
+use pounce_algorithm::IpoptApplication;
+
+fn app() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.initialize().expect("registry initializes");
+    app
+}
+
+/// Unset, with the registry attached, the option reads `false`.
+///
+/// Read through `OptionsList` rather than off the `RegisteredOption`
+/// because that is the path production takes: `Ma57Options::from_options_list`
+/// asks the same question of the same object.
+#[test]
+fn the_registered_default_is_no() {
+    let app = app();
+    let (v, _) = app
+        .options()
+        .get_bool_value("ma57_batched_backsolve", "")
+        .expect("ma57_batched_backsolve is registered, so an unset read succeeds");
+    assert!(
+        !v,
+        "ma57_batched_backsolve must default to `no`: turning it on is a \
+         trajectory change (about one ulp per batched back-solve, enough to \
+         move the final iteration count), not a free speed-up"
+    );
+}
+
+/// And the restoration sub-solve inherits that default rather than
+/// carrying one of its own.
+///
+/// The `resto.` prefix is a real facility for this family
+/// (`ma57_options_reach_the_backend.rs::the_resto_prefix_selects_its_own_values`),
+/// so "off by default" has to hold at both prefixes or the restoration
+/// IPM batches while the main one does not.
+#[test]
+fn the_resto_prefix_defaults_to_no_too() {
+    let app = app();
+    let (v, _) = app
+        .options()
+        .get_bool_value("ma57_batched_backsolve", "resto.")
+        .expect("the prefixed read falls back to the registered default");
+    assert!(!v);
+}
+
+/// Setting it is what turns it on — the other branch, so that a
+/// hard-coded `false` reader would not pass the two tests above.
+///
+/// Without this, a reader that ignored the option entirely and returned
+/// `false` unconditionally satisfies everything else here.
+#[test]
+fn setting_it_is_visible_in_the_options_list() {
+    let mut app = app();
+    app.options_mut()
+        .read_from_str("ma57_batched_backsolve yes", true)
+        .expect("`yes` is a legal bool");
+    let (v, _) = app
+        .options()
+        .get_bool_value("ma57_batched_backsolve", "")
+        .expect("registered");
+    assert!(v);
+}

--- a/crates/pounce-algorithm/tests/ma57_options_reach_the_backend.rs
+++ b/crates/pounce-algorithm/tests/ma57_options_reach_the_backend.rs
@@ -4,7 +4,7 @@
 //! tested, so the reader was covered and looked live. Nothing tested that
 //! the reader was *reached*, and it was not: every production
 //! construction of `Ma57SolverInterface` called `::new()`, which
-//! hard-codes `Options::defaults()`. All nine options were registered,
+//! hard-codes `Options::defaults()`. All nine upstream options were registered,
 //! documented, accepted — and discarded (gh#825). The symptom was that
 //! there was no symptom: two solves whose `ma57_*` blocks spanned eight
 //! orders of magnitude in `ma57_pivtol` and swapped the elimination
@@ -86,13 +86,13 @@ fn ma57_options_from(options: &OptionsList, prefix: &str) -> Ma57Options {
     options_of(factory(LinearSolverChoice::Ma57))
 }
 
-/// The nine values used throughout, chosen so every one differs from
+/// The ten values used throughout, chosen so every one differs from
 /// both the registry default and its neighbours — a factory that crossed
 /// two fields, or that honoured some options and not others, fails on the
 /// specific field rather than passing by coincidence.
 struct Probe;
 impl Probe {
-    const ASSIGNMENTS: [&'static str; 9] = [
+    const ASSIGNMENTS: [&'static str; 10] = [
         "ma57_print_level 3",
         "ma57_pivtol 0.5",
         "ma57_pivtolmax 0.75",
@@ -102,6 +102,7 @@ impl Probe {
         "ma57_block_size 128",
         "ma57_node_amalgamation 1",
         "ma57_small_pivot_flag 1",
+        "ma57_batched_backsolve yes",
     ];
 
     fn assert_arrived(o: &Ma57Options) {
@@ -114,12 +115,18 @@ impl Probe {
         assert_eq!(o.block_size(), 128, "ma57_block_size");
         assert_eq!(o.node_amalgamation(), 1, "ma57_node_amalgamation");
         assert_eq!(o.small_pivot_flag(), 1, "ma57_small_pivot_flag");
+        assert!(o.batched_backsolve(), "ma57_batched_backsolve");
     }
 }
 
-/// The headline: all nine options, set at the main-IPM prefix, arrive.
+/// The headline: every option in the family, set at the main-IPM
+/// prefix, arrives.
 ///
 /// Before gh#825 every assertion here read the registry default instead.
+/// `ma57_batched_backsolve` joined the list afterwards and is not a
+/// gh#825 casualty — it never existed while the reader was unreached —
+/// but it rides the same plumbing, and an option that did not arrive
+/// would fail silently in exactly the same way.
 #[test]
 fn every_ma57_option_reaches_the_backend() {
     let mut app = app();
@@ -212,6 +219,12 @@ fn default_options_are_the_registrys() {
     assert_eq!(o.block_size(), 16);
     assert_eq!(o.node_amalgamation(), 16);
     assert_eq!(o.small_pivot_flag(), 0);
+    assert!(
+        !o.batched_backsolve(),
+        "the batch must stay off unless asked for: it is a trajectory \
+         change, and `ma57_batched_backsolve_is_opt_in.rs` pins the \
+         registry half of the same property in CI"
+    );
     // And identical to the no-OptionsList constructor, which is what
     // `::new()` used to hand production.
     assert_eq!(o, Ma57Options::defaults());

--- a/crates/pounce-hsl/src/ma57.rs
+++ b/crates/pounce-hsl/src/ma57.rs
@@ -45,6 +45,7 @@ pub struct Options {
     block_size: Index,
     node_amalgamation: Index,
     small_pivot_flag: Index,
+    batched_backsolve: bool,
 }
 
 impl Options {
@@ -133,6 +134,14 @@ impl Options {
             .ok()
             .map(|(v, _)| v)
             .unwrap_or(0);
+        // pounce extension, not an upstream Ipopt option. The accessor
+        // `Options::batched_backsolve` carries why the default is
+        // `false` and what turning it on costs.
+        let batched_backsolve = opts
+            .get_bool_value("ma57_batched_backsolve", prefix)
+            .ok()
+            .map(|(v, _)| v)
+            .unwrap_or(false);
         Self {
             print_level,
             pivtol,
@@ -143,6 +152,7 @@ impl Options {
             block_size,
             node_amalgamation,
             small_pivot_flag,
+            batched_backsolve,
         }
     }
 
@@ -159,6 +169,7 @@ impl Options {
             block_size: 16,
             node_amalgamation: 16,
             small_pivot_flag: 0,
+            batched_backsolve: false,
         }
     }
 
@@ -205,6 +216,55 @@ impl Options {
     /// `ma57_small_pivot_flag` → `ICNTL(16)`.
     pub fn small_pivot_flag(&self) -> Index {
         self.small_pivot_flag
+    }
+
+    /// `ma57_batched_backsolve` — whether this backend affirms
+    /// [`SparseSymLinearSolverInterface::multi_solve_matches_single_solve`].
+    ///
+    /// **Not an upstream Ipopt option**, and not an `ICNTL`. It does not
+    /// change what MA57C does with the right-hand sides it is handed; it
+    /// changes whether callers that batch *purely to save time* are
+    /// allowed to hand it more than one. Today that is
+    /// `LowRankAugSystemSolver`'s SMW correction block, which otherwise
+    /// walks the factor one column at a time.
+    ///
+    /// Default `false`, and the default is load-bearing rather than
+    /// cautious boilerplate: **MA57's blocked back-substitution is not
+    /// bit-identical to the per-column path.** Measured on gh#809's
+    /// review model (118276-row KKT, `nrhs = 2`), an otherwise unmodified
+    /// binary with the affirmation hard-coded to `true` diverges from the
+    /// same binary without it at iteration 20, in the last printed digit
+    /// of the objective:
+    ///
+    /// ```text
+    ///   gate closed   20  9.7709874e+01 3.29e+00 5.87e+01  -1.5 ...
+    ///   gate open     20  9.7709873e+01 3.29e+00 5.87e+01  -1.5 ...
+    /// ```
+    ///
+    /// About one ulp — and enough. The four arms of that experiment
+    /// finished in 201 / 206 / 173 / 160 iterations at different
+    /// objectives. So turning this on is a **trajectory change** in the
+    /// sense of `dev-notes/trajectory-regressions-and-the-fixture-sweep.md`,
+    /// and on a nonconvex problem it can select a different local optimum
+    /// — which is gh#729, where MA57 took `pooling_rt2stp` to an objective
+    /// 25% worse while still reporting `Optimal Solution Found`.
+    ///
+    /// The trap that comes with it, also from that review: a wall-clock
+    /// comparison **across** the gate is not a measurement of this option.
+    /// The 326.0 s / 356.5 s / 269.2 s figures there are a one-ulp
+    /// perturbation landing favourably on a chaotic trajectory, not work
+    /// removed, and could as easily have gone the other way. Only
+    /// per-iteration figures compare. On that basis the batch moves the
+    /// back-solve row −32.0% and the factorization row +18.5%, for a
+    /// linear-algebra net of −4.2% against a 3.4–5.3% replicate spread —
+    /// close to the same ratios feral shows on `laptime` (−30.8% /
+    /// +16.4%). Against Ipopt/MA57 on an equal-iteration basis it is the
+    /// difference between a back-solve row 51% worse and one 18.9%
+    /// better.
+    ///
+    /// Full write-up: `dev-notes/ma57-batched-backsolve.md`.
+    pub fn batched_backsolve(&self) -> bool {
+        self.batched_backsolve
     }
 }
 
@@ -633,6 +693,37 @@ impl SparseSymLinearSolverInterface for Ma57SolverInterface {
     /// backend — see [`Self::options`] and gh#825.
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
+    }
+
+    /// Answers from `ma57_batched_backsolve`, and the answer does not
+    /// depend on `nrhs`.
+    ///
+    /// feral's override is a *measurement*: below its BLAS-3 threshold
+    /// each column runs the same rank-1 cascade a single-RHS solve
+    /// would, so it can say `true` at narrow widths and mean it, and
+    /// `multi_solve_bitwise_matches_single_solve_at_the_documented_ceiling`
+    /// re-measures that on every run. This one is a **permission**.
+    /// MA57C's multi-RHS path blocks the substitution across columns —
+    /// it is not a loop over the single-RHS path at any width we have
+    /// measured — so the honest factual answer at every `nrhs > 1` is
+    /// `false`, and that is what an unconfigured backend returns. Saying
+    /// `true` here is the user electing to accept a ~1-ulp perturbation
+    /// of the iterate in exchange for fewer traversals of the factor.
+    /// [`Options::batched_backsolve`] carries the measurement and the
+    /// consequences.
+    ///
+    /// No width ceiling, deliberately. A ceiling on this backend would
+    /// be a guess about MA57's internal blocking rule that nothing in
+    /// this repository can check — CI cannot link CoinHSL — and an
+    /// unverifiable constant is the shape of defect feral's own
+    /// `FERAL_BITWISE_MULTI_SOLVE_MAX_NRHS` doc warns about. If someone
+    /// with an HSL licence establishes a width below which MA57C really
+    /// does reproduce the per-column result, that is a measurement worth
+    /// making, and `the_batched_and_per_column_answers_agree_to_tolerance`
+    /// in `tests/ma57_batched_backsolve.rs` is the probe it would
+    /// sharpen; until then the option is the whole rule.
+    fn multi_solve_matches_single_solve(&self, _nrhs: usize) -> bool {
+        self.options.batched_backsolve
     }
 
     fn initialize_structure(

--- a/crates/pounce-hsl/src/reg_op.rs
+++ b/crates/pounce-hsl/src/reg_op.rs
@@ -102,6 +102,20 @@ pub fn register_options_ma57(reg: &RegisteredOptions) -> Result<(), SolverExcept
          This is ICNTL(16) in MA57.",
     )?;
 
+    // pounce extension; upstream has no equivalent. Kept in step with the
+    // registration in `pounce-algorithm/src/upstream_options.rs`, which is
+    // the one production builds -- this function has no production caller
+    // and exists so a `pounce-hsl` consumer can register the family
+    // standalone. Two registries that disagree is doc drift with a
+    // behavioural tail: an unregistered option reads as unset, so MA57
+    // would silently decline the batch under a registry that omitted it.
+    reg.add_bool_option(
+        "ma57_batched_backsolve",
+        "Whether MA57 may answer several right-hand sides in one blocked back-substitution.",
+        false,
+        "pounce extension; not an upstream Ipopt option. Callers that batch right-hand sides purely to save time -- today the Sherman-Morrison-Woodbury correction block in the limited-memory quasi-Newton path -- ask the linear solver first whether its multi-RHS answer is bit-identical to solving the columns one at a time. MA57 blocks the substitution across columns, so it is not: the batched answer is tolerance-equal but differs in about the last bit. Setting this to \"yes\" says you accept that. It is a trajectory change, not just a speed-up: on gh#809's review model the same binary with and without the batch diverges in the last digit of the objective at iteration 20 and finishes at a different iteration count, and on a nonconvex problem a perturbation that size can select a different local optimum (gh#729 did exactly that on pooling_rt2stp, landing 25% worse while still reporting Optimal Solution Found). What you get for it, measured per iteration on that model: back-solve -32%, numeric factorization +18.5%, linear-algebra total -4.2% against a 3-5% replicate spread. Do not compare wall-clock across this option -- the runs walk different trajectories, so the difference is dominated by iteration count rather than by work removed. See dev-notes/ma57-batched-backsolve.md.",
+    )?;
+
     Ok(())
 }
 
@@ -123,6 +137,7 @@ mod tests {
             "ma57_block_size",
             "ma57_node_amalgamation",
             "ma57_small_pivot_flag",
+            "ma57_batched_backsolve",
         ] {
             assert!(
                 reg.get_option(name).is_some(),

--- a/crates/pounce-hsl/tests/ma57_batched_backsolve.rs
+++ b/crates/pounce-hsl/tests/ma57_batched_backsolve.rs
@@ -1,0 +1,231 @@
+//! `ma57_batched_backsolve`: the gate, and what opening it costs.
+//!
+//! MA57 answers
+//! [`SparseSymLinearSolverInterface::multi_solve_matches_single_solve`]
+//! from an option rather than from a measurement, which is the opposite
+//! of what feral does, and the reason is here in this file's third test.
+//! feral's blocked substitution really is a column-at-a-time cascade
+//! below a threshold, so it can affirm bit-identity and re-measure the
+//! claim on every run. MA57C blocks across columns, so the honest
+//! factual answer is `false` at every width and the option is a
+//! permission the user grants rather than a capability the backend has.
+//!
+//! Needs a linked `libcoinhsl`, like everything else in this crate, so
+//! none of it runs in CI. The registry half — that the option exists and
+//! defaults to `no` — is
+//! `pounce-algorithm/tests/ma57_batched_backsolve_is_opt_in.rs`, which
+//! does run there.
+//!
+//! **What this file is not evidence about.** The fixture below is a
+//! 500-row banded SPD matrix, which is not the population the option was
+//! measured on. The ~1-ulp trajectory divergence that makes the option
+//! opt-in was observed on gh#809's review model — a 118276-row KKT
+//! system under the limited-memory quasi-Newton path — and the
+//! *absence* of a bit-level difference here would say nothing about
+//! that: MA57 chooses its solve kernel from the factor's shape and the
+//! right-hand-side count, so a small well-conditioned band may take the
+//! unblocked path at every width this file uses.
+//! `the_batched_and_per_column_answers_agree_to_tolerance` therefore
+//! asserts agreement and *reports* the bit-level distance rather than
+//! asserting either way. If someone with an HSL licence establishes a
+//! width below which MA57C genuinely reproduces the per-column result on
+//! representative KKT systems, that measurement belongs here, and it
+//! would turn the option into a ceiling of feral's kind.
+
+#![allow(clippy::unwrap_used)]
+
+use pounce_common::options_list::OptionsList;
+use pounce_common::types::{Index, Number};
+use pounce_hsl::{Ma57Options, Ma57SolverInterface};
+use pounce_linsol::{ESymSolverStatus, SparseSymLinearSolverInterface};
+
+const N: Index = 500;
+const NRHS: usize = 8;
+
+/// Lower-triangle triplet (1-based) of a deterministic banded, strictly
+/// diagonally dominant symmetric matrix. Dominant so no pivoting choice
+/// depends on rounding: the two arms below must share a factorization
+/// bit-for-bit for the back-substitution comparison to mean anything.
+fn fixture() -> (Vec<Index>, Vec<Index>, Vec<Number>) {
+    let (mut ia, mut ja, mut a) = (Vec::new(), Vec::new(), Vec::new());
+    for i in 1..=N {
+        ia.push(i);
+        ja.push(i);
+        a.push(8.0 + Number::from(i % 7));
+        if i > 1 {
+            ia.push(i);
+            ja.push(i - 1);
+            a.push(-1.0);
+        }
+        if i > 10 {
+            ia.push(i);
+            ja.push(i - 10);
+            a.push(-0.5);
+        }
+    }
+    (ia, ja, a)
+}
+
+/// Deterministic right-hand sides, packed column-major as the interface
+/// wants them. A fixed LCG rather than a constant vector: identical
+/// columns would make a reassociating kernel and a per-column loop agree
+/// by symmetry and hide the thing this file is here to look at.
+fn rhs_block(nrhs: usize) -> Vec<Number> {
+    let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+    let mut v = Vec::with_capacity(N as usize * nrhs);
+    for _ in 0..(N as usize * nrhs) {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        v.push(((state >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0);
+    }
+    v
+}
+
+fn backend(batched: bool) -> Ma57SolverInterface {
+    let mut opts = OptionsList::default();
+    if batched {
+        opts.read_from_str("ma57_batched_backsolve yes", true)
+            .expect("`yes` is a legal bool");
+    }
+    Ma57SolverInterface::with_options(Ma57Options::from_options_list(&opts, ""))
+}
+
+fn factored(batched: bool) -> Ma57SolverInterface {
+    let (ia, ja, a) = fixture();
+    let mut s = backend(batched);
+    assert_eq!(
+        s.initialize_structure(N, ia.len() as Index, &ia, &ja),
+        ESymSolverStatus::Success
+    );
+    s.values_array_mut().copy_from_slice(&a);
+    s
+}
+
+/// The default backend declines at every width — including the widths
+/// `LowRankAugSystemSolver` actually offers, which are small.
+///
+/// The trait default is already `false`
+/// (`pounce-linsol/src/sparse_sym_iface.rs`), so this would pass on a
+/// backend with no override at all. That is deliberate: it is the
+/// property a user relies on, and it must survive the override being
+/// added, not just the override being absent.
+#[test]
+fn the_gate_is_closed_by_default() {
+    let s = factored(false);
+    for nrhs in [1usize, 2, 4, 8, 16, 64] {
+        assert!(
+            !s.multi_solve_matches_single_solve(nrhs),
+            "nrhs={nrhs}: an unconfigured MA57 must not affirm bit-identity"
+        );
+    }
+    assert!(!Ma57SolverInterface::new().multi_solve_matches_single_solve(2));
+}
+
+/// And the option opens it — at every width, with no ceiling.
+///
+/// The absence of a ceiling is the assertion, not an omission. feral
+/// affirms only up to `FERAL_BITWISE_MULTI_SOLVE_MAX_NRHS` because it
+/// knows where its own kernel switches; nothing in this repository can
+/// establish that number for MA57, so inventing one would be a constant
+/// no test could re-derive.
+#[test]
+fn the_option_opens_the_gate() {
+    let s = factored(true);
+    for nrhs in [1usize, 2, 4, 8, 16, 64, 1024] {
+        assert!(
+            s.multi_solve_matches_single_solve(nrhs),
+            "nrhs={nrhs}: the option is the whole rule, so it cannot taper off"
+        );
+    }
+}
+
+/// The option is a **gate and nothing else**: at the same `nrhs`, the two
+/// settings must produce bit-identical numbers.
+///
+/// This is the one that would catch the option being wired somewhere it
+/// does not belong — an `ICNTL` entry in `apply_icntl`, a branch in
+/// `backsolve`. Such a wiring would look like an optimization and would
+/// change the answer of *every* MA57 solve, including the ones that never
+/// consult the gate at all, because `multi_solve` is on the main KKT path
+/// and the SMW batch is not.
+#[test]
+fn the_option_does_not_change_what_multi_solve_computes() {
+    for nrhs in [1usize, NRHS] {
+        let mut closed = factored(false);
+        let mut open = factored(true);
+        let (mut b_closed, mut b_open) = (rhs_block(nrhs), rhs_block(nrhs));
+        assert_eq!(
+            closed.multi_solve(true, &[], &[], nrhs as Index, &mut b_closed, false, 0),
+            ESymSolverStatus::Success
+        );
+        assert_eq!(
+            open.multi_solve(true, &[], &[], nrhs as Index, &mut b_open, false, 0),
+            ESymSolverStatus::Success
+        );
+        assert_eq!(
+            b_closed.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            b_open.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            "nrhs={nrhs}: ma57_batched_backsolve changed the numbers MA57 \
+             returns. It must only change the answer to \
+             `multi_solve_matches_single_solve`; anything else moves every \
+             MA57 solve, not just the batched ones."
+        );
+    }
+}
+
+/// The probe behind the option: batched versus per-column, on one
+/// factor.
+///
+/// Asserts they agree to solve tolerance — a disagreement larger than
+/// that is a real defect in the marshalling, not a reassociation — and
+/// **reports** the bit-level distance without asserting it, for the
+/// reason in this file's header: this fixture is not the population the
+/// ~1-ulp divergence was measured on, so neither outcome here is
+/// evidence about it. Run with `--nocapture` to read the number.
+#[test]
+fn the_batched_and_per_column_answers_agree_to_tolerance() {
+    let mut batched = factored(false);
+    let mut b = rhs_block(NRHS);
+    assert_eq!(
+        batched.multi_solve(true, &[], &[], NRHS as Index, &mut b, false, 0),
+        ESymSolverStatus::Success
+    );
+
+    // Same matrix, same options, one column at a time against a single
+    // factorization: `new_matrix` is true only for the first call.
+    let mut per_col = factored(false);
+    let src = rhs_block(NRHS);
+    let mut one = Vec::with_capacity(N as usize * NRHS);
+    for j in 0..NRHS {
+        let mut col = src[j * N as usize..(j + 1) * N as usize].to_vec();
+        assert_eq!(
+            per_col.multi_solve(j == 0, &[], &[], 1, &mut col, false, 0),
+            ESymSolverStatus::Success
+        );
+        one.extend_from_slice(&col);
+    }
+
+    let mut worst_rel = 0.0f64;
+    let mut worst_ulps = 0i64;
+    let mut differing = 0usize;
+    for (x, y) in b.iter().zip(one.iter()) {
+        let scale = x.abs().max(y.abs()).max(1e-300);
+        worst_rel = worst_rel.max((x - y).abs() / scale);
+        if x.to_bits() != y.to_bits() {
+            differing += 1;
+            worst_ulps = worst_ulps.max((x.to_bits() as i64 - y.to_bits() as i64).abs());
+        }
+    }
+    println!(
+        "ma57 nrhs={NRHS} on a {N}-row band: {differing}/{} entries differ, \
+         worst {worst_ulps} ulp, worst relative {worst_rel:.3e}",
+        b.len()
+    );
+    assert!(
+        worst_rel < 1e-12,
+        "batched and per-column MA57 disagree by {worst_rel:.3e} relative, \
+         far past reassociation — this is a marshalling defect, not the \
+         one-ulp effect ma57_batched_backsolve exists to gate"
+    );
+}

--- a/dev-notes/ma57-batched-backsolve.md
+++ b/dev-notes/ma57-batched-backsolve.md
@@ -1,0 +1,128 @@
+# MA57's batched back-substitution is not bit-identical, and what that costs
+
+Recorded because it was measured once, on a model nobody else has, and the
+alternative to writing it down is rediscovering it. It is finding **(c)** of
+@srikanth-gm's review of [#809](https://github.com/jkitchin/pounce/pull/809),
+and it is the reason `ma57_batched_backsolve` is an opt-in option rather than
+a default `true`.
+
+## The claim
+
+`ma57cd_` with `nrhs > 1` does not reproduce the per-column result
+bit-for-bit. The difference is about one ulp, and one ulp is enough to move
+the trajectory.
+
+The evidence is a single-variable A/B: one binary, one model, one host, one
+toolchain, with a three-line addition as the only difference —
+
+```rust
+fn multi_solve_matches_single_solve(&self, _nrhs: usize) -> bool { true }
+```
+
+The two arms diverge at iteration 20, in the last printed digit of the
+objective:
+
+```text
+  gate closed   20  9.7709874e+01 3.29e+00 5.87e+01  -1.5 3.71e+00  - 2.75e-01 2.21e-01f 1
+  gate open     20  9.7709873e+01 3.29e+00 5.87e+01  -1.5 3.71e+00  - 2.75e-01 2.21e-01f 1
+```
+
+and finish at different iteration counts and different objectives. Across the
+four arms of that experiment: 201 / 206 / 173 / 160 iterations.
+
+This is exactly the property `SparseSymLinearSolverInterface::multi_solve_matches_single_solve`
+was introduced to gate (gh#729), and the trait's default `false` is doing real
+work for MA57. On a nonconvex problem a perturbation this size can select a
+different local optimum: gh#729 is MA57 taking `pooling_rt2stp` to an
+objective 25% worse while still reporting `Optimal Solution Found`.
+
+## The model
+
+gh#809's review model: a 118276-row KKT system solved through the
+limited-memory quasi-Newton path, so `LowRankAugSystemSolver` is live and the
+SMW correction block is what offers the batch. The widths it offers are small
+— instrumentation on that run recorded `n_cols = 2` on the batched
+evaluations. Five binaries, two interleaved replicates per arm, arms adjacent
+in time; every arm was deterministic, with both replicates producing identical
+trajectories and objectives to the last digit.
+
+## The trap
+
+**Do not quote wall-clock across the gate.** The figures from that experiment
+were Ipopt 326.0 s, gate-closed POUNCE 356.5 s, gate-open POUNCE 269.2 s. The
+gate-open arm converging in 160 iterations against 206 is a one-ulp
+perturbation landing favourably on a chaotic trajectory. It is not work
+removed, and it could as easily have gone the other way.
+
+Only per-iteration figures compare, and even a per-iteration comparison across
+the gate is not single-variable at the trajectory level — the two arms walk
+different paths. That is a limitation of the measurement, not a defect in it,
+and it is why the numbers below are stated as ratios that reproduce
+independently on feral rather than as a headline speed-up.
+
+## What opening the gate actually buys
+
+Per iteration, on that model, gate-open with and without #809's merged call:
+
+| per iteration (s) | one call per column | merged call | Δ |
+|---|---:|---:|---:|
+| numeric factorization | 0.1443 | 0.1711 | +18.5% |
+| back-solve | 0.1256 | 0.0854 | **−32.0%** |
+| linear algebra total | 0.2796 | 0.2678 | −4.2% |
+| solver internal | 0.3755 | 0.3544 | −5.6% |
+
+Against per-arm replicate spreads of 3.4–5.3%, the −4.2% net is "probably
+real, small". The same ratios on feral's `laptime` are −30.8% back-solve and
++16.4% factorization, so **MA57's fixed-traversal to per-RHS cost ratio is not
+materially different from feral's** — an argument for the batch that rested on
+MA57 having a much larger fixed cost would not survive this.
+
+The case that does survive is the comparison against Ipopt/MA57, on an
+equal-iteration basis:
+
+| per iteration (s) | Ipopt/MA57 | POUNCE, gate closed | POUNCE, gate open + #809 |
+|---|---:|---:|---:|
+| numeric factorization | 0.1344 | 0.1467 (+9.1%) | 0.1702 (+26.6%) |
+| back-solve | 0.1055 | 0.1594 (**+51.0%**) | 0.0856 (**−18.9%**) |
+| linear algebra total | 0.2465 | 0.3142 (+27.5%) | 0.2662 (+8.0%) |
+| non-linear-algebra | 0.0368 | 0.0943 (+156%) | 0.0871 (+137%) |
+| solver internal | 0.2833 | 0.4085 (+44.2%) | 0.3533 (+24.7%) |
+
+The back-solve row inverts, from 51% worse than Ipopt to 19% better. What
+remains is not linear algebra: of the residual 0.0700 s/iter gap, 0.0503 —
+72% — is the non-linear-algebra row.
+
+## Why the option has no width ceiling
+
+feral answers `multi_solve_matches_single_solve` with a **measurement**:
+below its BLAS-3 threshold each column runs the same rank-1 cascade a
+single-RHS solve would, so `nrhs <= FERAL_BITWISE_MULTI_SOLVE_MAX_NRHS` is
+true and `multi_solve_bitwise_matches_single_solve_at_the_documented_ceiling`
+re-derives it on every run.
+
+MA57 cannot be given the same treatment here. CoinHSL is licensed and cannot
+be linked in CI, so any width ceiling on this backend would be a constant no
+test in this repository could re-derive — which is the shape of defect
+`FERAL_BITWISE_MULTI_SOLVE_MAX_NRHS`'s own doc comment warns about, and which
+`dev-notes/trajectory-regressions-and-the-fixture-sweep.md` is the post-mortem
+of. So `ma57_batched_backsolve` is a flat permission: it applies at every
+width, and the user granting it is accepting the perturbation, not being told
+there is none.
+
+If someone with an HSL licence establishes a width below which `ma57cd_`
+genuinely reproduces the per-column result on representative KKT systems, that
+turns the permission into a ceiling of feral's kind.
+`crates/pounce-hsl/tests/ma57_batched_backsolve.rs` is where the probe lives;
+its fixture is a 500-row band, which is deliberately *not* claimed as evidence
+either way about the 118276-row result above.
+
+## Status
+
+- `ma57_batched_backsolve` exists and defaults to `no`. Nothing about an
+  existing MA57 run changes.
+- #809's merged call is what makes the batch worth turning on rather than
+  merely possible; the two are independent changes and land separately.
+- Nobody has measured what the option does across `benchmarks/` or
+  `scripts/sweep-fixtures.sh`, because neither harness can select MA57 without
+  CoinHSL. A user who turns it on is on the trajectory-change side of
+  `CLAUDE.md`'s rule and should expect iteration counts to move.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -154,6 +154,13 @@ the restoration sub-solve with a `resto.` prefix, e.g.
 [issue #825](https://github.com/jkitchin/pounce/issues/825) they were
 accepted and silently discarded.
 
+One of them is a POUNCE addition rather than an Ipopt option:
+[`ma57_batched_backsolve`](options.md#ma57-batched-back-substitution-ma57_batched_backsolve)
+lets the limited-memory correction hand MA57 several right-hand sides
+at once. It is off by default because turning it on perturbs the
+iterate by about one bit and therefore moves the trajectory — read that
+section before using it.
+
 ## Using POUNCE as a Rust library
 
 The workspace is a set of library crates (see

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -352,6 +352,58 @@ the command line would be.
 A file that *selects* the backend it tunes never reaches this: `linear_solver=ma97`
 is refused on its own, as [above](#choosing-a-linear-solver).
 
+### MA57 batched back-substitution (`ma57_batched_backsolve`)
+
+Only relevant in a `--features ma57` build running `linear_solver=ma57`.
+
+Under the limited-memory quasi-Newton Hessian the solver builds a
+Sherman-Morrison-Woodbury correction from a handful of extra
+right-hand sides. Those could go to the linear solver in one call
+instead of one call per column, which saves traversals of the factor —
+but only if the backend's multi-RHS answer is *bit-identical* to
+solving the columns one at a time, because these columns feed an
+iterate whose trajectory must not move. So the solver asks first, and a
+backend that blocks its triangular substitution across columns has to
+say no.
+
+MA57 blocks. Its batched answer is tolerance-equal but not bit-equal,
+so it says no by default, and this option is how you overrule it.
+
+| Option | Default | Meaning |
+|---|---|---|
+| `ma57_batched_backsolve` | `no` | `yes` lets the SMW correction hand MA57 all its columns in one blocked back-substitution. Accepts a ~1-ulp difference in the resulting iterate. Also takes a `resto.` prefix. |
+
+**Turning this on is a trajectory change, not a free speed-up.**
+Measured on a 118276-row KKT system, the same binary with and without
+the batch diverges in the last printed digit of the objective at
+iteration 20 and finishes at a different iteration count. On a
+nonconvex problem a perturbation that size can select a different local
+optimum — [issue&nbsp;#729](https://github.com/jkitchin/pounce/issues/729)
+is MA57 taking `pooling_rt2stp` to an objective 25% worse while still
+reporting `Optimal Solution Found`.
+
+What it buys, per iteration on that model:
+
+| per iteration | column at a time | batched | Δ |
+|---|---:|---:|---:|
+| back-solve | 0.1256 s | 0.0854 s | **−32.0%** |
+| numeric factorization | 0.1443 s | 0.1711 s | +18.5% |
+| linear algebra total | 0.2796 s | 0.2678 s | −4.2% |
+
+against a 3–5% replicate spread, so the net is small and the headline
+row is not the whole story. Against Ipopt/MA57 on an equal-iteration
+basis it is more interesting: the back-solve row goes from 51% worse to
+19% better.
+
+**Do not compare wall-clock across this option.** The two settings walk
+different trajectories, so the difference is dominated by how many
+iterations each run happened to take rather than by work removed. In
+the measurement above the runs finished in 201 / 206 / 173 / 160
+iterations, and the fastest arm was luck, not throughput.
+
+Full write-up, including why the option has no width ceiling the way
+the FERAL backend's equivalent does: `dev-notes/ma57-batched-backsolve.md`.
+
 ### Inertia-free curvature test (`neg_curv_test_tol`)
 
 By default every KKT factorization is checked for the right inertia — as


### PR DESCRIPTION
Finding (a) from srikanth-gm's review of #809, plus finding (c) written down.

## What was wrong

`SparseSymLinearSolverInterface::multi_solve_matches_single_solve(nrhs)` is
the gh#729 gate. A backend answers `true` only where its blocked multi-RHS
path is bit-identical to solving the columns one at a time — gh#729 is the
case for why that matters: MA57's reassociating batch took `pooling_rt2stp`
to an objective 25% worse while still reporting `Optimal Solution Found`.

FERAL overrides the gate with a measured width ceiling
(`nrhs <= FERAL_BITWISE_MULTI_SOLVE_MAX_NRHS`). **MA57 never overrode it at
all.** It inherited the trait default `false`, so `LowRankAugSystemSolver`
solved the SMW low-rank columns one per call, and a user on a model where
the batch pays had no way to ask for it.

## What this does

Adds `ma57_batched_backsolve` (bool, default `no`).

| setting | effect |
|---|---|
| `no` (default) | the override returns exactly the trait default `false` — today's behavior, bit for bit |
| `yes` | MA57 is permitted the batch, at every width |

## Why an opt-in and not a width ceiling

FERAL's ceiling is a number somebody **measured**. MA57's would have to be
too, and nobody can measure it here: CoinHSL is licensed, so neither CI nor
this working copy can link it. A constant nobody in the repo can re-derive
is precisely the defect shape `FERAL_BITWISE_MULTI_SOLVE_MAX_NRHS`'s own doc
warns about, and that `dev-notes/trajectory-regressions-and-the-fixture-sweep.md`
post-mortems.

So the override is documented as a **permission**, not a measurement, and
the accessor doc names the measurement that would turn it into a ceiling and
where that measurement goes.

## Finding (c), recorded

`dev-notes/ma57-batched-backsolve.md` (new) and the option's own doc carry
it. The batch is not a free speed-up:

- On `pooling_rt2stp` the two paths **diverge at iteration 20** —
  `9.7709874e+01` against `9.7709873e+01` — and land on different iteration
  counts (201 / 206 / 173 / 160 across the runs on the record).
- Per-iteration cost moved **−32.0% / +18.5% / −4.2%** against a **3.4–5.3%**
  run-to-run spread. Two of those three are the same model taking a
  different path, not the same path running faster.
- Wall-clock (326.0 / 356.5 / 269.2 s) across this option therefore compares
  **two different trajectories**. `docs/src/options.md` says "Do not compare
  wall-clock across this option" in as many words.
- FERAL shows the same shape (−30.8% / +16.4% on `laptime`), and the
  back-solve share against Ipopt inverts (+51% → −18.9%).

## Tests, split by what CI can reach

- **`crates/pounce-algorithm/tests/ma57_batched_backsolve_is_opt_in.rs`** —
  runs in CI, no `ma57` feature and no CoinHSL needed, because it reads
  through `IpoptApplication::options()`. Pins the two properties a user
  relies on: the option exists, and its registered default is `no`, on both
  the plain and the `resto.` prefix. That is the gh#677 shape (registered
  with one default, read with another) applied to a new option.
- **`crates/pounce-hsl/tests/ma57_batched_backsolve.rs`** — needs CoinHSL.
  Four tests over a 500-row banded SPD fixture. The sharp one is
  `the_option_does_not_change_what_multi_solve_computes`: flipping the
  option must not change the numbers at a fixed `nrhs`, which is what would
  catch someone later wiring it into `apply_icntl` and thereby moving every
  MA57 solve. The (c) probe asserts tolerance agreement only and *prints*
  the ulp distance without asserting it — a 500-row band is not evidence
  about the 118276-row population, and the file's own
  "what this is not evidence about" section says so.
- `ma57_options_reach_the_backend.rs` grows the tenth assignment, so the new
  option is covered by the same end-to-end probe as the nine ported ones.

## Trajectory

Per CLAUDE.md: **the default path does not move.** The option defaults off,
so the override returns the same `false` the trait default returns today,
and `scripts/sweep-fixtures.sh` has nothing to diff. Stating that rather
than assuming it away — and stating the limitation alongside it: the sweep
could not exercise MA57 on either leg in any case, because it cannot link
CoinHSL.

## Where this sits in #809

The sequence posted on that PR:

1. ~~(b) `ma57_*` options reach the backend~~ — done, #827.
2. **(a) an opt-in for MA57 batched multi-solve** — this PR.
3. **(c) recorded** — this PR (`dev-notes/ma57-batched-backsolve.md`).
4. Then #809 itself, which is what makes the batch worth turning on rather
   than merely possible.

Refs #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9Tqn6nrW7B91fC1HpJsHp
