### PR TITLE
fix(casadi): build and code-generate against CasADi 3.8, unpin CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,24 +578,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
-      # PINNED, deliberately against this job's own design (gh #782).
-      # Everything below derives the version it builds against from the
-      # installed wheel, so that a CasADi release bumps this job
-      # automatically. 3.8.0 (2026-08-25) exercised that and turned the job
-      # red on both runners in two independent ways: the Linux wheel appears
-      # to be built with the new libstdc++ ABI, against `casadi/Makefile`'s
-      # hardcoded `CXX11_ABI ?= 0`, so every `std::string`-taking symbol goes
-      # undefined at link; and macOS -- no dual-ABI there at all -- fails the
-      # code-generation check instead. Every PR opened that day failed this
-      # job regardless of its contents.
-      #
-      # `3.7.*` still tracks patch releases within the last known-good minor.
-      # Remove the pin when gh #782 is fixed; the auto-tracking is the point
-      # of the job and this pin is the thing standing in its way.
+      # Unpinned, which is the point of this job: everything below derives
+      # the version it builds against from the installed wheel, so a CasADi
+      # release bumps this job automatically and breaks here rather than in
+      # a user's build. 3.8.0 (2026-08-25) exercised that and cost a day of
+      # red PRs; both causes are fixed (gh #782) and the pin it needed is
+      # gone. What remains true is that a CasADi release can turn this job
+      # red on a PR that did not touch it -- that is the trade this job
+      # exists to make.
       - name: Install CasADi
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "casadi==3.7.*" numpy
+          python -m pip install casadi numpy
 
       # The tag has to match the installed wheel exactly; `make fetch-src`
       # derives it from `casadi.__version__` rather than pinning a literal,
@@ -649,10 +643,15 @@ jobs:
         run: |
           cd casadi/wheel && ./build.sh
           python -m venv /tmp/casadi-wheel-env
-          # Same pin as the install step above (gh #782): the wheel under
-          # test was built against 3.7, so resolving a newer CasADi here
-          # would test a pairing the build never produced.
-          /tmp/casadi-wheel-env/bin/pip install -q "casadi==3.7.*" dist/pounce_casadi-*.whl
+          # Pin to the exact CasADi `build.sh` just built against, whatever
+          # that resolved to. `build.sh` stages the plugin for the
+          # *installed* casadi, so resolving independently here would test a
+          # pairing the build never produced -- which is what the version
+          # literal that used to sit here was defending against, less
+          # precisely (gh #782).
+          ver=$(python -c "import casadi; print(casadi.__version__)")
+          echo "wheel was built against casadi $ver"
+          /tmp/casadi-wheel-env/bin/pip install -q "casadi==$ver" dist/pounce_casadi-*.whl
           /tmp/casadi-wheel-env/bin/python - <<'PY'
           import casadi as ca
           import pounce_casadi  # registers the plugin in-process
@@ -726,24 +725,29 @@ jobs:
           print("wheel solves with the build tree hidden, x* =", sol)
           PY
 
-  # Compile the convexify name shim against every spelling of CasADi's
-  # runtime helper (gh#668). Cheap and hermetic: no CasADi, no Rust, no
-  # link step — mock declarations and a compiler.
+  # Compile the source-compatibility shims against every shape of CasADi
+  # they have to survive. Cheap and hermetic: no CasADi, no Rust, no link
+  # step — mock declarations and a compiler.
   #
-  # This job exists because the job above cannot cover it. CasADi renamed
-  # `convexify_eval` to `casadi_convexify_eval` after 3.7.2, and any one
-  # CasADi declares exactly one of the two, so a build against a real
-  # CasADi compiles one overload of the shim and leaves the other
-  # unchecked — and it is the *unchecked* one that most users get, since
-  # the wheel ships plugins for 3.6 and 3.7 and both take the fallback.
-  # The mock is what lets one runner compile both.
+  # This job exists because the job above cannot cover either shim. A build
+  # against a real CasADi compiles exactly one branch of each, and it is
+  # routinely the *other* branch that users get:
+  #
+  #  - the convexify name shim (gh#668). CasADi renamed `convexify_eval` to
+  #    `casadi_convexify_eval` after 3.7.2, and any one CasADi declares one
+  #    of the two. The wheel ships plugins for 3.6 and 3.7, both of which
+  #    take the fallback, while this workflow builds against current.
+  #  - the codegen memory request (gh#782). It cannot be marked `override`
+  #    — 3.7 declares no such virtual — so nothing checks that it binds,
+  #    and when it silently stopped binding on 3.8 the symptom was a C
+  #    compile error inside generated code.
   #
   # Windows is here and nowhere else in this workflow: the Windows wheel is
   # built with MSVC, and MSVC's two-phase lookup is the likeliest of the
   # three to disagree about a dependent name that is not declared. That is
-  # the whole mechanism this shim rests on.
-  convexify-name-shim:
-    name: CasADi convexify name shim (${{ matrix.os }})
+  # the whole mechanism the convexify shim rests on.
+  casadi-source-compat:
+    name: CasADi source compat shims (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -759,6 +763,10 @@ jobs:
         if: runner.os != 'Windows'
         run: python3 casadi/tests/convexify_compat/run.py
 
+      - name: Compile against every codegen-memory shape
+        if: runner.os != 'Windows'
+        run: python3 casadi/tests/codegen_mem_compat/run.py
+
       # `cl` is only on PATH inside a developer shell, and vswhere ships with
       # every runner image, so no extra action is needed to find it.
       - name: Compile against every spelling (MSVC)
@@ -769,3 +777,4 @@ jobs:
           if not defined VSPATH (echo could not locate a Visual Studio install & exit /b 1)
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
           python casadi\tests\convexify_compat\run.py --cxx cl
+          python casadi\tests\codegen_mem_compat\run.py --cxx cl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,54 @@ changes.
   @srikanth-gm, whose measurements on a 59 939-variable CasADi collocation
   model put POUNCE/MA57 within 1.6% of Ipopt/MA57 on wall time while spending
   41% more per iteration on back-solve; this addresses part of that row.
+- **The CasADi plugin builds and code-generates against CasADi 3.8, and the
+  CI pin that was hiding it is gone** (gh#782). 3.8.0 broke the plugin
+  parity job two ways on the day it shipped, and neither was what it looked
+  like.
+
+  *Code generation.* Through 3.7, CasADi decided whether to emit a
+  per-instance memory array for a function from `!codegen_mem_type().empty()`.
+  3.8 split that decision into a new virtual, `codegen_needs_mem()`, which
+  defaults to `false`. The plugin answered only the old question, so 3.8
+  stopped declaring the `<name>_mem` array while the plugin's emitted bodies
+  went on referring to it, and generated C failed to compile with `use of
+  undeclared identifier`. The plugin now answers the new question. It cannot
+  say `override` doing so — 3.7 declares no such virtual and `override`
+  there is a hard error — so nothing in the compiler checks that the member
+  binds to anything, which is the same unchecked-binding shape that produced
+  the defect. `casadi/tests/codegen_mem_compat/` is the check instead: it
+  extracts the declaration from the plugin source (not a copy, which would
+  drift) and compiles it against a mock base in all three shapes — virtual
+  absent, virtual present, virtual whose signature moved — asserting through
+  a base pointer which of them actually bind. Adding `override` turns the
+  3.7 leg red; deleting the member fails the extraction.
+
+  *The Linux link.* Not an ABI change in CasADi, which is what it appeared
+  to be. 3.8.0 added a `manylinux_2_28` wheel next to the `manylinux2014`
+  one, and pip chooses between them on the machine's glibc. Measured on the
+  published artifacts, the 2_28 build of 3.8.0 exports 855 `casadi::`
+  symbols spelled `__cxx11` and none spelled `Ss`; the manylinux2014 build
+  of **the same version** is exactly the other way round, as is 3.7.2, which
+  ships no 2_28 wheel at all. So the string ABI is a property of the wheel
+  the runner resolves, not of the release, and `casadi/Makefile`'s hardcoded
+  `CXX11_ABI ?= 0` could not have been right for both. It is now measured
+  from the installed `libcasadi.so`'s own exported symbols on Linux, and
+  left at 0 where the macro is inert (macOS libc++, Windows). The probe
+  looks for `__cxx11` **on casadi's symbols specifically**: libstdc++'s
+  transactional clones of `std::logic_error` carry that spelling in every
+  build, old ABI included, so the naive grep answers 1 for everything.
+  `make -C casadi abi-flags` now prints what was decided and from which
+  file.
+
+  With both fixed, `casadi==3.7.*` comes back out of `ci.yml` and the job
+  tracks CasADi releases again, which is what it is for. The wheel-smoke
+  step now pins to the exact version `build.sh` just built against rather
+  than to a version literal. One thing worth knowing while chasing an ABI
+  mismatch, now recorded in the Makefile: the plugin is a `-shared` link and
+  so builds clean against a CasADi it cannot talk to — the executable
+  `test_output_interleaving` is what turns the mismatch into a list of
+  names, and without it the first symptom is CasADi reporting `Plugin
+  'pounce' is not found` at dlopen.
 
 - **`ma57_batched_backsolve`: MA57 can now be let into the batched
   back-substitution, and the cost of doing so is written down.** Under the

--- a/casadi/Makefile
+++ b/casadi/Makefile
@@ -87,10 +87,33 @@ DEFS := -DWITH_DL -DWITH_DEEPBIND -DUSE_CXX11 -DHAVE_MKSTEMPS \
         -DCASADI_VERSION=$(VER_MAJOR)$(VER_MINOR) \
         -DCASADI_IS_RELEASE=1
 
-# The pip wheels are built against the pre-C++11 libstdc++ string ABI.
-# Override with CXX11_ABI=1 for a CasADi you built yourself with the
-# modern ABI.
-CXX11_ABI ?= 0
+# Which libstdc++ string ABI the CasADi being built against uses. This is
+# NOT a property of the CasADi version, and assuming it was is what broke
+# every PR for a day (gh#782): casadi 3.8.0 added a `manylinux_2_28` wheel
+# alongside the `manylinux2014` one, and pip picks between them on the
+# machine's glibc. The 2_28 build of 3.8.0 exports 855 `casadi::` symbols
+# spelled with `__cxx11` and none with the old `Ss`; the manylinux2014
+# build of THE SAME VERSION is the other way round. So the answer changes
+# with the runner, not with the release, and it has to be measured.
+#
+# Measure it on casadi's own exported symbols. A bare `__cxx11` grep is
+# wrong: libstdc++'s transactional clones of `std::logic_error` carry that
+# spelling in every build, old ABI included (213 of them in the wheels
+# checked), so the naive probe answers 1 for everything.
+#
+# macOS is libc++, where the macro is inert; Windows has no libstdc++
+# either. Both keep the historical 0, and no probe runs.
+#
+# With no `nm` the probe yields 0, which is the value this file assumed
+# unconditionally until now — a wrong answer there is no more wrong than
+# before, and `make abi-flags` prints what was decided.
+ifeq ($(UNAME_S),Linux)
+  CASADI_SO   ?= $(firstword $(wildcard $(CASADI_LIB)/libcasadi.so $(CASADI_LIB)/libcasadi.so.*))
+  CXX11_ABI   ?= $(shell nm -D --defined-only "$(CASADI_SO)" 2>/dev/null \
+                   | grep -qE '_ZN6casadi.*__cxx11' && echo 1 || echo 0)
+else
+  CXX11_ABI ?= 0
+endif
 DEFS      += -D_GLIBCXX_USE_CXX11_ABI=$(CXX11_ABI)
 
 CXXFLAGS ?= -O2 -std=c++17 -fPIC -Wall
@@ -137,6 +160,7 @@ fetch-src:
 ## with DEFS above when a plugin fails to load.
 abi-flags:
 	@echo "installed casadi $(CASADI_VER) at $(CASADI_LIB)"
+	@echo "detected _GLIBCXX_USE_CXX11_ABI=$(CXX11_ABI)$(if $(filter Linux,$(UNAME_S)), (from $(CASADI_SO)), (not applicable on $(UNAME_S)))"
 	@$(PYTHON) -c "import casadi; print(casadi.CasadiMeta.compiler_flags())"
 
 $(PLUGIN): casadi_nlpsol_pounce.cpp pounce_runtime.hpp convexify_compat.hpp
@@ -157,6 +181,12 @@ install: all
 uninstall:
 	rm -f $(CASADI_LIB)/$(PLUGIN)
 
+# Worth knowing when an ABI mismatch is what you are chasing: this
+# executable, not the plugin, is the one that reports it. A `-shared` link
+# leaves undefined symbols to be resolved at load time and succeeds, so the
+# plugin builds clean against a CasADi it cannot talk to, and the first
+# symptom is CasADi's `Plugin 'pounce' is not found` at dlopen. Linking an
+# executable is what turns the same mismatch into a list of names.
 $(TEARTEST): $(TEARTEST).cpp $(PLUGIN)
 	$(CXX) $(CXXFLAGS) $(DEFS) $(INCLUDES) -o $@ $< \
 	  -L$(CASADI_LIB) -lcasadi $(RPATH)
@@ -170,12 +200,16 @@ examples: all
 	  CASADIPATH=$(CURDIR) $(PYTHON) $$f || exit 1; \
 	done
 
-## Compile `convexify_compat.hpp` against every spelling of CasADi's
-## convexify runtime helper (gh#668). Needs no CasADi and no solver
-## library -- mock declarations and a compiler -- so it runs anywhere,
-## and it covers the overload the installed CasADi does not exercise.
+## Compile the source-compatibility shims against every shape of CasADi
+## they have to survive: `convexify_compat.hpp` against both spellings of
+## the convexify runtime helper (gh#668), and the plugin's codegen memory
+## request against a base class that does and does not declare the virtual
+## it binds to (gh#782). Needs no CasADi and no solver library -- mock
+## declarations and a compiler -- so both run anywhere, and each covers the
+## branch the installed CasADi does not exercise.
 compat:
 	$(PYTHON) tests/convexify_compat/run.py
+	$(PYTHON) tests/codegen_mem_compat/run.py
 
 clean:
 	rm -f $(PLUGIN) $(TEARTEST)

--- a/casadi/casadi_nlpsol_pounce.cpp
+++ b/casadi/casadi_nlpsol_pounce.cpp
@@ -100,6 +100,38 @@ namespace casadi {
     void codegen_init_mem(CodeGenerator& g) const override;
     void codegen_free_mem(CodeGenerator& g) const override;
     std::string codegen_mem_type() const override { return "struct casadi_pounce_data"; }
+    /// CasADi 3.8 asks a second question before it emits per-instance memory
+    /// in generated code (gh#782). Through 3.7 the question was implicit:
+    /// `CodeGenerator` treated a non-empty `codegen_mem_type()` as the
+    /// request, so the override above was the whole declaration. 3.8 split
+    /// the request out into this virtual, which defaults to `false` — so the
+    /// `<name>_mem` array stops being declared while `codegen_mem()` keeps
+    /// expanding to `<name>_mem[mem]` in the bodies below, and the generated
+    /// C fails to compile on `use of undeclared identifier`.
+    ///
+    /// Deliberately NOT marked `override`: 3.7 and earlier declare no such
+    /// virtual, and `override` there is a hard error. Without it this is an
+    /// override where the virtual exists and an unused member where it does
+    /// not, so one spelling serves both — the same reasoning as
+    /// `convexify_compat.hpp`, which detects the fact rather than the
+    /// version. `tests/codegen_mem_compat/` is what keeps the unused branch
+    /// from rotting: it compiles this very declaration, extracted from this
+    /// file, against a mock base in all three shapes — virtual absent,
+    /// virtual present, and a virtual whose signature has drifted — and
+    /// asserts through a base pointer which of them actually bind.
+    ///
+    /// Clang notices the missing `override` on a class that uses it
+    /// elsewhere. That warning is the binding working, not a defect, and
+    /// there is nowhere to put the keyword that is correct on both CasADis,
+    /// so it is silenced here and checked by the test above instead.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+    bool codegen_needs_mem() const { return true; }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
     /// Emit the `p.…` assignments that describe the problem to the runtime.
     void set_pounce_prob(CodeGenerator& g) const;
     /// Refuse, at generation time, the options the generated code cannot

--- a/casadi/test_parity.py
+++ b/casadi/test_parity.py
@@ -13,6 +13,7 @@ number moved".
 import itertools
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -27,10 +28,39 @@ QUIET_IPOPT = {"ipopt": {"print_level": 0}, "print_time": False}
 failures = []
 
 
-def check(name, ok, detail=""):
+def check(name, ok, detail="", log=""):
     print(f"{'PASS' if ok else 'FAIL'}  {name}{'  — ' + detail if detail else ''}")
+    # Verbatim, indented, and never truncated. A check that carries a log
+    # carries it because the one-line summary cannot be trusted to contain
+    # the answer, and this output's only reader is a CI log.
+    for line in log.strip().splitlines():
+        print(f"      | {line}")
     if not ok:
         failures.append(name)
+
+
+def first_error(stderr):
+    """The line a compiler failure is actually about.
+
+    Deliberately not `splitlines()[-1]`, which is what this used to be:
+    clang finishes with `1 error generated.` and MSVC with a summary, so
+    the last line reports the *count* and discards the diagnostic. gh#782
+    is what that cost — a code generation break against CasADi 3.8 whose
+    CI log read, in full, `FAIL  generated C compiles — 1 error
+    generated.` The defect had to be reproduced locally to learn anything
+    at all about it, and the log it left behind was evidence of nothing
+    beyond its own existence.
+
+    Callers pass the whole of `stderr` to `check(log=...)` as well; this
+    is the summary that sits on the FAIL line, not a substitute for it.
+    """
+    lines = stderr.strip().splitlines()
+    for line in lines:
+        # `error:` covers gcc and clang; `error C2065:` is MSVC, which also
+        # writes `fatal error C1083:`.
+        if "error:" in line.lower() or re.search(r"\berror [A-Z]?\d+\b", line):
+            return line.strip()[:200]
+    return lines[0].strip()[:200] if lines else "(the compiler said nothing)"
 
 
 def close(a, b, tol=1e-6):
@@ -1106,7 +1136,8 @@ def test_codegen_matches_the_interpreted_solve():
         try:
             G = _compile_generated(S, d, "cg_plain")
         except subprocess.CalledProcessError as exc:
-            check("generated C compiles", False, exc.stderr.strip().splitlines()[-1][:120])
+            check("generated C compiles", False, first_error(exc.stderr),
+                  log=exc.stderr)
             return
         check("generated C compiles and links against libpounce_cinterface", True)
         got = G(x0=[0.5, 0.5], p=1.5, lbx=-ca.inf, ubx=ca.inf, lbg=-ca.inf, ubg=0,
@@ -1455,7 +1486,7 @@ def test_codegen_reproduces_the_finite_difference_hessian():
                 G = _compile_generated(S, d, f"cg_fd_{pattern}")
             except subprocess.CalledProcessError as exc:
                 check(f"codegen fd/{pattern} compiles", False,
-                      exc.stderr.strip().splitlines()[-1][:120])
+                      first_error(exc.stderr), log=exc.stderr)
                 continue
             check(f"codegen fd/{pattern} compiles", True)
             got = G(x0=[0.5, 0.5, 0.5], lbx=-ca.inf, ubx=ca.inf,

--- a/casadi/tests/codegen_mem_compat/mock_casadi.hpp
+++ b/casadi/tests/codegen_mem_compat/mock_casadi.hpp
@@ -1,0 +1,68 @@
+// Mock stand-in for the part of CasADi's `FunctionInternal` that decides
+// whether generated code gets a per-instance memory array (gh#782).
+//
+// The plugin answers that question with a member function whose binding to
+// the base class is *not* checked by the compiler: it cannot be marked
+// `override`, because CasADi 3.7 and earlier declare no such virtual and
+// `override` is a hard error there. So the member silently overrides on one
+// CasADi and silently does not on another, and only one of those two states
+// is compiled on any one machine.
+//
+// That is the same shape as `convexify_compat.hpp`'s problem and it gets the
+// same treatment: mock the declaration, compile every state on one machine.
+//
+// Faithful to the real header in the only things the binding depends on --
+// namespace, the class the plugin derives from, and the exact signature
+// (`bool codegen_needs_mem() const`, virtual, const-qualified, no
+// parameters). Everything else about `FunctionInternal` is deliberately
+// absent; nothing here is called for its behaviour.
+//
+// Define exactly one of:
+//
+//   MOCK_HAS_NEEDS_MEM       CasADi >= 3.8: the virtual exists, and the
+//                            plugin's member must bind to it.
+//   MOCK_NEEDS_MEM_MISMATCH  a hypothetical future CasADi that keeps the
+//                            name and changes the signature. The plugin's
+//                            member then hides rather than overrides, which
+//                            is the failure this test exists to make
+//                            visible -- it is what an unchecked binding
+//                            costs, and the probe reports it rather than
+//                            the generated C reporting it three layers
+//                            later as `use of undeclared identifier`.
+//   (neither)                CasADi <= 3.7: no such virtual. The member must
+//                            still compile, which is what forbids `override`.
+
+#ifndef POUNCE_MOCK_CASADI_CODEGEN_MEM_HPP
+#define POUNCE_MOCK_CASADI_CODEGEN_MEM_HPP
+
+#include <string>
+
+namespace casadi {
+
+  /// Opaque: the plugin's member takes no arguments and this test never
+  /// generates code, so nothing here needs a definition.
+  class CodeGenerator;
+
+  class FunctionInternal {
+  public:
+    virtual ~FunctionInternal() {}
+
+    /// Through CasADi 3.7 this was the whole request: `CodeGenerator`
+    /// treated a non-empty return as "emit a memory array for this
+    /// function". 3.8 kept it as the *type* and moved the request to
+    /// `codegen_needs_mem()`.
+    virtual std::string codegen_mem_type() const { return ""; }
+
+#if defined(MOCK_HAS_NEEDS_MEM)
+    virtual bool codegen_needs_mem() const { return false; }
+#elif defined(MOCK_NEEDS_MEM_MISMATCH)
+    virtual bool codegen_needs_mem(int variant) const {
+      (void) variant;
+      return false;
+    }
+#endif
+  };
+
+}  // namespace casadi
+
+#endif  // POUNCE_MOCK_CASADI_CODEGEN_MEM_HPP

--- a/casadi/tests/codegen_mem_compat/probe.cpp
+++ b/casadi/tests/codegen_mem_compat/probe.cpp
@@ -1,0 +1,85 @@
+// Compile the plugin's `codegen_needs_mem` declaration against mock CasADi
+// declarations, in every state a real CasADi can present (gh#782).
+//
+// The declaration under test is not reproduced here. `run.py` extracts it
+// verbatim from `casadi_nlpsol_pounce.cpp` into `plugin_member.inc` and puts
+// that file on the include path, so editing the plugin edits the test's
+// subject. A copy would drift, and a drifted copy of *this* declaration is
+// precisely the defect: the binding it asserts is one the compiler does not
+// check.
+//
+// Built once per declaration state; see `mock_casadi.hpp` for the states and
+// `run.py` for what each one must print.
+
+#include "mock_casadi.hpp"
+
+#include <cstdio>
+
+namespace casadi {
+
+  /// Mirrors `PounceInterface`'s shape where the binding is decided: it
+  /// derives from `FunctionInternal`, it answers `codegen_mem_type()` with a
+  /// non-empty type, and it carries the plugin's own spelling of the
+  /// memory request.
+  class PounceInterfaceProbe : public FunctionInternal {
+  public:
+    std::string codegen_mem_type() const override {
+      return "struct casadi_pounce_data";
+    }
+
+    // Extracted from the plugin by run.py. Deliberately included rather
+    // than copied.
+    //
+    // Both suppressions below are the shadow of the thing under test, not
+    // sloppiness, and the plugin carries the first one for the same reason.
+    // A member that binds to a base virtual without saying `override` is
+    // what `-Winconsistent-missing-override` is for, and a member that
+    // fails to bind because the signature moved is what
+    // `-Woverloaded-virtual` is for. Each fires in exactly one of the cases
+    // below, and this file is compiled `-Werror`, so leaving them on would
+    // turn both interesting cases into "did not compile" and lose the
+    // distinction the test is here to draw. The verdict comes from
+    // `base_call` instead, which separates them by what the program does.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#pragma clang diagnostic ignored "-Woverloaded-virtual"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+#include "plugin_member.inc"
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+  };
+
+}  // namespace casadi
+
+int main() {
+  casadi::PounceInterfaceProbe probe;
+  const casadi::FunctionInternal* base = &probe;
+
+  // What the plugin's own code sees. True in every state -- this is the
+  // uninteresting half, and it is here so that a member that failed to
+  // compile is distinguishable from one that answered wrongly.
+  std::printf("direct_call=%s\n", probe.codegen_needs_mem() ? "true" : "false");
+
+  // What CasADi sees. This is the whole test: `CodeGenerator` asks through
+  // a base-class pointer, so a member that does not override answers
+  // `false` here however emphatically it returns `true` above -- and
+  // `false` is what stops the `<name>_mem` array being emitted while
+  // `codegen_mem()` keeps referring to it.
+#if defined(MOCK_HAS_NEEDS_MEM)
+  std::printf("base_call=%s\n", base->codegen_needs_mem() ? "true" : "false");
+#elif defined(MOCK_NEEDS_MEM_MISMATCH)
+  std::printf("base_call=%s\n", base->codegen_needs_mem(0) ? "true" : "false");
+#else
+  (void) base;
+  std::printf("base_call=absent\n");
+#endif
+
+  return 0;
+}

--- a/casadi/tests/codegen_mem_compat/probe.cpp
+++ b/casadi/tests/codegen_mem_compat/probe.cpp
@@ -30,30 +30,18 @@ namespace casadi {
     // Extracted from the plugin by run.py. Deliberately included rather
     // than copied.
     //
-    // Both suppressions below are the shadow of the thing under test, not
-    // sloppiness, and the plugin carries the first one for the same reason.
-    // A member that binds to a base virtual without saying `override` is
-    // what `-Winconsistent-missing-override` is for, and a member that
-    // fails to bind because the signature moved is what
-    // `-Woverloaded-virtual` is for. Each fires in exactly one of the cases
-    // below, and this file is compiled `-Werror`, so leaving them on would
-    // turn both interesting cases into "did not compile" and lose the
-    // distinction the test is here to draw. The verdict comes from
-    // `base_call` instead, which separates them by what the program does.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winconsistent-missing-override"
-#pragma clang diagnostic ignored "-Woverloaded-virtual"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
+    // Two warnings are the expected shadow of the thing under test rather
+    // than defects — a member binding to a base virtual without saying
+    // `override` is what `-Winconsistent-missing-override` is for, and one
+    // failing to bind because the signature moved is what
+    // `-Woverloaded-virtual` is for — and each fires in exactly one of the
+    // cases. `run.py` disables those two on the command line, because a
+    // `#pragma` here cannot: GCC attributes `-Woverloaded-virtual` to the
+    // *base* declaration in `mock_casadi.hpp`, so a suppression wrapped
+    // around this include never covers it. The verdict comes from
+    // `base_call` instead, which separates the cases by what the program
+    // does rather than by what the compiler says about it.
 #include "plugin_member.inc"
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
   };
 
 }  // namespace casadi

--- a/casadi/tests/codegen_mem_compat/run.py
+++ b/casadi/tests/codegen_mem_compat/run.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Compile the plugin's codegen memory request against every CasADi shape (gh#782).
+
+`PounceInterface::codegen_needs_mem()` cannot be marked `override`: CasADi
+3.7 and earlier declare no such virtual, and `override` there is a hard
+error. So the compiler does not check that it binds to anything, and the
+consequence of it not binding is silent -- CasADi stops emitting the
+`<name>_mem` array while the plugin's generated bodies keep referring to
+it, and the failure surfaces as a C compile error in generated code, on
+whichever CasADi the user happens to have.
+
+That is exactly the state CasADi 3.8 introduced, and the state the plugin
+was in when 3.8.0 shipped. On any one machine only one of the shapes below
+is compiled, so this compiles all of them against mock declarations, with
+no CasADi installed and nothing linked.
+
+    python3 run.py                 # every compiler found on PATH
+    python3 run.py --cxx g++       # just this one
+
+The declaration under test is extracted from the plugin source rather than
+copied, so this test follows edits to the plugin.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PROBE = os.path.join(HERE, "probe.cpp")
+PLUGIN = os.path.normpath(os.path.join(HERE, "..", "..",
+                                       "casadi_nlpsol_pounce.cpp"))
+
+# (label, defines, expected base_call)
+#
+# `base_call` is what CasADi's CodeGenerator sees, asking through a
+# base-class pointer. `true` is the only answer that emits the memory
+# array.
+CASES = [
+    ("casadi <= 3.7 (no such virtual)", [], "absent"),
+    ("casadi >= 3.8 (virtual present)", ["MOCK_HAS_NEEDS_MEM"], "true"),
+    ("signature drift", ["MOCK_NEEDS_MEM_MISMATCH"], "false"),
+]
+
+# The plugin builds as C++17 (see the Makefile). The declaration uses
+# nothing past C++11, and a downstream tree may be on an older standard.
+STANDARDS = ["c++11", "c++14", "c++17"]
+
+
+def extract_member():
+    """The plugin's own declaration of the memory request, verbatim.
+
+    Deliberately strict: this test is worth nothing if it silently falls
+    back to a copy, so anything it cannot identify is an error naming the
+    file rather than a default.
+    """
+    with open(PLUGIN, encoding="utf-8") as fh:
+        lines = fh.readlines()
+
+    hits = [ln for ln in lines
+            if re.search(r"\bbool\s+codegen_needs_mem\s*\(", ln)]
+    if len(hits) != 1:
+        raise SystemExit(
+            f"error: expected exactly one declaration of codegen_needs_mem "
+            f"in {PLUGIN}, found {len(hits)}. If it moved or grew a body "
+            f"across several lines, teach this extractor about it -- do not "
+            f"copy it here.")
+
+    decl = hits[0]
+    if "{" not in decl or "}" not in decl:
+        raise SystemExit(
+            f"error: the declaration in {PLUGIN} is not a one-line inline "
+            f"definition; this extractor cannot carry it verbatim.")
+    return decl
+
+
+def compilers(requested):
+    if requested:
+        return list(requested)
+    found = [c for c in ("g++", "clang++") if shutil.which(c)]
+    # MSVC builds the Windows wheel. It is on PATH only inside a developer
+    # shell.
+    if shutil.which("cl"):
+        found.append("cl")
+    return found
+
+
+def command(cxx, std, defines, incdir, out, is_msvc):
+    if is_msvc:
+        # /W4 without /WX: an unrelated warning in a future toolset should
+        # not fail a test about virtual binding.
+        return (["cl", "/nologo", "/EHsc", "/W4", f"/std:{std}",
+                 f"/I{incdir}"]
+                + [f"/D{d}" for d in defines]
+                + [PROBE, f"/Fe:{out}", f"/Fo:{out}.obj"])
+    return ([cxx, f"-std={std}", "-Wall", "-Wextra", "-Werror", "-I", incdir]
+            + [f"-D{d}" for d in defines] + [PROBE, "-o", out])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cxx", action="append", default=[],
+                    help="compiler to use (repeatable); default: all found")
+    args = ap.parse_args()
+
+    found = compilers(args.cxx)
+    if not found:
+        print("error: no C++ compiler found (looked for g++, clang++, cl)",
+              file=sys.stderr)
+        return 2
+
+    member = extract_member()
+    print(f"declaration under test, from {os.path.relpath(PLUGIN, HERE)}:")
+    print(f"    {member.strip()}\n")
+
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        with open(os.path.join(tmp, "plugin_member.inc"), "w",
+                  encoding="utf-8") as fh:
+            fh.write(member)
+
+        for cxx in found:
+            # exact match: "clang++" also begins with "cl"
+            is_msvc = os.path.basename(cxx).lower() in ("cl", "cl.exe")
+            for std in STANDARDS:
+                if is_msvc and std == "c++11":
+                    continue  # MSVC has no /std:c++11; c++14 is its floor
+                for label, defines, expect in CASES:
+                    out = os.path.join(tmp, "probe.exe")
+                    for stale in (out, out + ".obj"):
+                        if os.path.exists(stale):
+                            os.remove(stale)
+                    build = subprocess.run(
+                        command(cxx, std, defines, tmp, out, is_msvc),
+                        capture_output=True, text=True, cwd=tmp)
+                    what = f"{cxx:8s} {std:6s} {label:33s}"
+
+                    if build.returncode != 0:
+                        # The `casadi <= 3.7` case failing to compile is the
+                        # signature this test was written for: it is what an
+                        # `override` on the member looks like.
+                        print(f"{what} FAIL: did not compile")
+                        print((build.stderr or build.stdout).strip()[:2000])
+                        failures += 1
+                        continue
+
+                    run = subprocess.run([out], capture_output=True, text=True)
+                    got = {}
+                    for line in run.stdout.splitlines():
+                        if "=" in line:
+                            k, v = line.split("=", 1)
+                            got[k.strip()] = v.strip()
+
+                    if run.returncode != 0 or got.get("base_call") != expect:
+                        print(f"{what} FAIL: expected base_call={expect}, got "
+                              f"{got.get('base_call') or '(nothing)'}")
+                        print((run.stdout + run.stderr).strip()[:2000])
+                        failures += 1
+                    elif got.get("direct_call") != "true":
+                        print(f"{what} FAIL: the member itself answered "
+                              f"{got.get('direct_call')}, not true")
+                        failures += 1
+                    else:
+                        print(f"{what} ok (base_call={expect})")
+
+    print()
+    if failures:
+        print(f"{failures} failure(s)")
+        return 1
+    print("the codegen memory request binds on every CasADi shape")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/casadi/tests/codegen_mem_compat/run.py
+++ b/casadi/tests/codegen_mem_compat/run.py
@@ -88,15 +88,45 @@ def compilers(requested):
     return found
 
 
-def command(cxx, std, defines, incdir, out, is_msvc):
-    if is_msvc:
+def kind_of(cxx):
+    """Which compiler this really is, asked rather than assumed.
+
+    Naming it from the executable is how you get this wrong: `g++` on macOS
+    is Apple clang, so a matrix that trusts the name reports a GNU column it
+    never compiled — and the two disagree about exactly the diagnostics
+    below.
+    """
+    if os.path.basename(cxx).lower() in ("cl", "cl.exe"):
+        return "msvc"
+    try:
+        out = subprocess.run([cxx, "--version"], capture_output=True,
+                             text=True).stdout.lower()
+    except OSError:
+        return "gcc"
+    return "clang" if "clang" in out else "gcc"
+
+
+def command(cxx, std, defines, incdir, out, kind):
+    if kind == "msvc":
         # /W4 without /WX: an unrelated warning in a future toolset should
         # not fail a test about virtual binding.
         return (["cl", "/nologo", "/EHsc", "/W4", f"/std:{std}",
                  f"/I{incdir}"]
                 + [f"/D{d}" for d in defines]
                 + [PROBE, f"/Fe:{out}", f"/Fo:{out}.obj"])
-    return ([cxx, f"-std={std}", "-Wall", "-Wextra", "-Werror", "-I", incdir]
+    # The two diagnostics an unchecked binding is *supposed* to raise; see
+    # probe.cpp. Off on the command line rather than by pragma, because GCC
+    # attributes -Woverloaded-virtual to the base declaration and a pragma
+    # around the derived member does not reach it. -Werror stays on for
+    # everything else. The clang-only spelling is passed only to clang: GCC
+    # accepts unknown -Wno-* silently until some other diagnostic fires, and
+    # then reports it, which under -Werror is a failure with a confusing
+    # cause.
+    suppress = ["-Wno-overloaded-virtual"]
+    if kind == "clang":
+        suppress.append("-Wno-inconsistent-missing-override")
+    return ([cxx, f"-std={std}", "-Wall", "-Wextra", "-Werror"] + suppress
+            + ["-I", incdir]
             + [f"-D{d}" for d in defines] + [PROBE, "-o", out])
 
 
@@ -123,10 +153,10 @@ def main():
             fh.write(member)
 
         for cxx in found:
-            # exact match: "clang++" also begins with "cl"
-            is_msvc = os.path.basename(cxx).lower() in ("cl", "cl.exe")
+            kind = kind_of(cxx)
+            print(f"{cxx} is {kind}")
             for std in STANDARDS:
-                if is_msvc and std == "c++11":
+                if kind == "msvc" and std == "c++11":
                     continue  # MSVC has no /std:c++11; c++14 is its floor
                 for label, defines, expect in CASES:
                     out = os.path.join(tmp, "probe.exe")
@@ -134,7 +164,7 @@ def main():
                         if os.path.exists(stale):
                             os.remove(stale)
                     build = subprocess.run(
-                        command(cxx, std, defines, tmp, out, is_msvc),
+                        command(cxx, std, defines, tmp, out, kind),
                         capture_output=True, text=True, cwd=tmp)
                     what = f"{cxx:8s} {std:6s} {label:33s}"
 

--- a/casadi/wheel/README.md
+++ b/casadi/wheel/README.md
@@ -80,8 +80,15 @@ directory accumulates, so that is:
 # in a platform's build image, once per supported casadi minor
 pip install 'casadi==3.6.*' && POUNCE_CASADI_STAGE_ONLY=1 ./build.sh
 pip install 'casadi==3.7.*' && POUNCE_CASADI_STAGE_ONLY=1 ./build.sh
-./build.sh          # one wheel carrying both
+pip install 'casadi==3.8.*' && POUNCE_CASADI_STAGE_ONLY=1 ./build.sh
+./build.sh          # one wheel carrying all of them
 ```
+
+The minors staged here and the `casadi` bound in `pyproject.toml` are one
+statement made twice, and they have to agree. A minor inside the bound with
+no `_plugins/<minor>/` staged installs cleanly and then fails at `import
+pounce_casadi`, which is a worse failure than not resolving at all — pip has
+already told the user it worked. 3.8 was added to both together (gh#782).
 
 Per-platform build notes:
 

--- a/casadi/wheel/README.md
+++ b/casadi/wheel/README.md
@@ -85,8 +85,15 @@ pip install 'casadi==3.7.*' && POUNCE_CASADI_STAGE_ONLY=1 ./build.sh
 
 Per-platform build notes:
 
-- **Linux** — inside a manylinux image, `-D_GLIBCXX_USE_CXX11_ABI=0` to match
-  the CasADi wheels (the Makefile's default), then `auditwheel` **excluding**
+- **Linux** — inside a manylinux image, `-D_GLIBCXX_USE_CXX11_ABI` set to
+  match the CasADi wheel being built against. Do not assume 0: casadi
+  publishes both a `manylinux2014` build (old ABI) and, from 3.8.0, a
+  `manylinux_2_28` build (new ABI) of the *same version*, and pip picks
+  between them on the image's glibc (gh#782). The Makefile measures it from
+  the installed `libcasadi.so` and `make -C casadi abi-flags` prints what it
+  decided; a wheel staged against the wrong one links clean — a `-shared`
+  link tolerates undefined symbols — and fails at the user's `dlopen` as
+  `Plugin 'pounce' is not found`. Then `auditwheel` **excluding**
   `libcasadi` (it must resolve to the user's installed copy at runtime, not be
   vendored). `auditwheel repair` also does the manylinux retag, so
   `POUNCE_CASADI_PLAT_NAME` is not needed when it runs — but note it *refuses*

--- a/casadi/wheel/build.sh
+++ b/casadi/wheel/build.sh
@@ -32,7 +32,7 @@ try:
 except ImportError:
     sys.exit(
         "error: casadi is not installed in this environment.\n"
-        "       pip install 'casadi>=3.7,<3.8' and re-run."
+        "       pip install casadi and re-run."
     )
 version = getattr(casadi, "__version__", None)
 if version is None:

--- a/casadi/wheel/pyproject.toml
+++ b/casadi/wheel/pyproject.toml
@@ -9,7 +9,12 @@ description = "POUNCE as a CasADi nlpsol plugin"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
-dependencies = ["casadi>=3.7,<3.8"]
+# One bound per CasADi minor this wheel can carry a plugin for. CasADi does
+# no version handshake, so the plugin is built per minor and `pounce_casadi`
+# dispatches on `casadi.__version__` at import; a minor outside this range
+# has no `_plugins/<minor>/` to find. 3.8 joined the range once the plugin
+# built and code-generated against it (gh#782).
+dependencies = ["casadi>=3.7,<3.9"]
 
 [project.urls]
 Homepage = "https://github.com/jkitchin/pounce"


### PR DESCRIPTION
Fixes #782.

CasADi 3.8.0 broke the plugin parity job two ways on the day it shipped. Both
are fixed here and the `casadi==3.7.*` pin comes out, so the job goes back to
tracking releases, which is what it is for.

**Neither cause was what the issue guessed**, so the diagnosis is worth reading
before the diff.

## 1. Code generation — a virtual that split in two

The CI log's `1 error generated.` carries no diagnostic because
`test_parity.py` reports `exc.stderr.splitlines()[-1]`, and for clang the last
line is the count. Reproduced locally against 3.8.0, the real error is:

```
cg_plain.c:978:33: error: use of undeclared identifier 'cg_plain_f0_mem'
  struct casadi_pounce_data* d=&casadi_f0_mem[mem];
```

Through 3.7, CasADi decided whether a function gets a per-instance memory
array in generated code from `!codegen_mem_type().empty()` —
`code_generator.cpp:279,1145,1165`. 3.8 replaced every one of those with a new
virtual `f->codegen_needs_mem()`, which defaults to **`false`**
(`function_internal.hpp:925`). The plugin answers only the old question
(`codegen_mem_type()`), so 3.8 never emits `codegen_checkout`, the
`<name>_mem` array is never declared, and `codegen_mem()` goes on expanding to
`casadi_f0_mem[mem]` in `codegen_body` / `codegen_init_mem` /
`codegen_free_mem`.

**Not macOS-specific** — the defect is in generated C, so Linux reaches it too
once the link works. The issue's open question is answered.

The fix is one line, and it cannot say `override`: 3.7 declares no such
virtual and `override` there is a hard error. Virtualness is inherited, so the
bare spelling overrides where the virtual exists and is an unused member where
it does not — the same "detect the fact, not the version" reasoning
`convexify_compat.hpp` sets out. The cost is that **nothing in the compiler
checks the binding**, which is the shape that produced the defect in the first
place, so the check is supplied separately.

`casadi/tests/codegen_mem_compat/` compiles the declaration — **extracted from
the plugin source, not copied**, since a drifted copy is precisely the failure
mode — against a mock base in all three shapes, asserting through a base
pointer which of them actually bind:

| shape | `base_call` |
|---|---|
| casadi ≤ 3.7, no such virtual | `absent`, and it must still compile |
| casadi ≥ 3.8, virtual present | `true` — the override took |
| signature drift | `false` — hidden, not overridden |

Mutation-checked, both red:

- add `override` → the ≤ 3.7 leg fails to compile, and only that leg;
- delete the member (the gh#782 defect itself) → extraction fails loudly,
  naming the file.

18/18 across `{g++, clang++} × {c++11, c++14, c++17}`.

## 2. The Linux link — the wheel, not the version

The issue reads this as 3.8.0 switching to the new libstdc++ ABI. It did not.
Measured on the published artifacts (exported `casadi::` symbols, `*UND*`
excluded):

| wheel | `__cxx11` | `Ss` | ABI |
|---|--:|--:|---|
| 3.7.2 manylinux2014 | 0 | 741 | old |
| 3.8.0 **manylinux2014** | 0 | 855 | **old** |
| 3.8.0 **manylinux_2_28** | 855 | 0 | **new** |

Same version, two ABIs. 3.8.0 *added* a `manylinux_2_28` variant and pip picks
on the runner's glibc — the failing run's log confirms which one it took:
`Downloading casadi-3.8.0-cp311-abi3-manylinux_2_28_x86_64.whl`. 3.7.2 ships
no 2_28 wheel, which is the only reason the pin works.

So the ABI follows the wheel, not the release, and no version-keyed rule can
be right. The Makefile measures it instead, from the installed library's own
exported symbols. The `_ZN6casadi` restriction is load-bearing: libstdc++'s
transactional clones of `std::logic_error` carry `__cxx11` in **every** build
(213 of them in the old-ABI wheels here), so a bare `grep __cxx11` answers 1
for everything. Run verbatim against all three real wheels the probe gives
`0`, `0`, `1`.

Also recorded, because it is what made this confusing: only
`test_output_interleaving` failed to link — **the plugin itself "built
fine"**, because a `-shared` link tolerates undefined symbols. A plugin built
against the wrong ABI links clean and then fails at `dlopen`, which CasADi
reports as the unhelpful `Plugin 'pounce' is not found`.

## Verification

On macOS, with the final source:

| | CasADi 3.8.0 | CasADi 3.7.2 |
|---|---|---|
| `make -C casadi test` | **126 PASS / 0 FAIL** | **126 PASS / 0 FAIL** |
| `make -C casadi examples` | pass | pass |
| build warnings | 0 | 0 |

And on CI, against an **unpinned** CasADi — this is the Linux evidence the
first draft of this description said it did not have:

- ubuntu-latest resolved `casadi-3.8.0-cp311-abi3-manylinux_2_28_x86_64.whl`,
  the new-ABI variant, exactly as the failing run did;
- the probe chose `-D_GLIBCXX_USE_CXX11_ABI=1` on both compile lines, so the
  detection did the work rather than the old default happening to be right;
- **126 PASS / 0 FAIL**, including `generated C compiles and links against
  libpounce_cinterface`;
- macOS the same, and the compat shims green on all three runners.

Whole run green.

## Also here

- The wheel-smoke step pins to the exact version `build.sh` just built
  against, rather than a version literal — `build.sh` stages for the
  *installed* casadi, so that is the pairing worth testing.
- `casadi/wheel/README.md` said to build Linux wheels with
  `-D_GLIBCXX_USE_CXX11_ABI=0` "to match the CasADi wheels". That is no longer
  true for a 2_28 image, and following it would ship a wheel that fails at
  `dlopen`.
- The compat job now covers both shims, so it is renamed `CasADi source compat
  shims`. `main` is unprotected, so no required-check name breaks.
- `make -C casadi abi-flags` prints the detected ABI and the file it read.
- **The wheel could not depend on the CasADi it was built against.**
  `pounce-casadi` declared `casadi>=3.7,<3.8`, so the smoke step's `pip
  install casadi==3.8.0 pounce_casadi-*.whl` was unsatisfiable — the only job
  step that still failed once the two fixes above were in. The bound is one
  half of a statement made twice, the other half being the minors `build.sh`
  stages, and a minor inside the bound with nothing staged installs cleanly
  and then fails at import, after pip has said it worked. Both halves gain
  3.8.

## Two things this found about the tests themselves

- **`test_parity.py` threw away the diagnostic** and is fixed here.
  It summarized a failed codegen compile as `stderr.splitlines()[-1]`,
  which for clang is `1 error generated.`, so the entire CI record of the
  break read `FAIL  generated C compiles — 1 error generated.` That is why
  #782 had to be reproduced locally before anything could be said about it.
  The FAIL line now carries the first real `error:` line (or MSVC's `error
  C####`) and the whole of stderr follows verbatim and untruncated.
  Demonstrated by reverting the plugin fix and rerunning against 3.8.0:

  ```
  FAIL  generated C compiles  — cg_plain.c:978:33: error: use of undeclared identifier 'cg_plain_f0_mem'
        | cg_plain.c:978:33: error: use of undeclared identifier 'cg_plain_f0_mem'
        |   978 |   struct casadi_pounce_data* d=&casadi_f0_mem[mem];
        |   ...
  ```

  The three remaining `splitlines()[-1]` uses read CasADi `RuntimeError`
  messages, where the last line genuinely is the message; those are left.
- The first version of the new compat job passed on macOS and Windows and
  failed on ubuntu, because a `#pragma` cannot suppress GCC's
  `-Woverloaded-virtual` (GCC attributes it to the *base* declaration). It
  passed locally because `g++` on macOS is Apple clang, so the matrix
  reported a GNU column it had never compiled. `run.py` now asks each
  compiler what it is and prints the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXuHz55zzpfSMGN6wSzHCk
