### PR TITLE
docs: release preflight for 0.11.0 — the new option surface, and five dead version refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,63 @@ changes.
   constructing a result no longer pays one container insertion per
   variable per call. Item assignment raises: writing into a result
   never changed anything downstream.
+- **Release preflight: the option surface added since 0.10.0 is documented,
+  and four version references pointed at releases that do not exist.** A
+  registered-options-versus-`docs/src` diff over `v0.10.0..HEAD` found 39 new
+  options, of which 8 were reachable and undocumented: `fd_hessian_coloring`,
+  `fd_hessian_reuse_tol` and the five `partitioned_*` knobs, plus
+  `perturb_delta_c_max_rungs`. `hessian_approximation` itself had no section —
+  `finite-difference` was described only on the CasADi page, so a CLI, Python
+  or Pyomo user had no way to find a whole Hessian mode, and `partitioned` was
+  described nowhere. `options.md` now carries a **Hessian approximation**
+  section covering all four values and both extension modes' knobs, with the
+  measured reasons the surprising defaults are the defaults (star colouring
+  takes `laptime` to a wrong objective in 404 iterations where CPR takes 38 to
+  the right one; every finite `partitioned_curvature_cap` measured was worse
+  than off, non-monotonically), and `casadi.md` now points at it instead of
+  being the only copy.
+
+  The `ma57_*` family had the opposite problem: `installation.md` said "and the
+  rest — see [Options]", and Options listed none of them. It now has the table,
+  with each knob's `ICNTL`, and the note that matters for anyone upgrading —
+  through 0.10.0 **none of the nine reached the backend** (gh #825), so a build
+  that was "tuning MA57" was running defaults, and from 0.11.0 those settings
+  will actually take effect and move the trajectory.
+
+  Five version references were wrong rather than merely stale, all pointing at
+  releases that were never cut — only `v0.2.0` through `v0.10.0` exist, with no
+  patch release among them. `cli.md` dated the dual-sign fix (gh #271) to
+  "before v0.9.1" and `gams.md` dated its sibling, the GAMS marginal-sign fix
+  (gh #272), the same way; the CHANGELOG records both as landing *in* 0.9.0.
+  `gams.md` also dated the restoration-exit status fix (gh #589) to "before
+  v0.10.1"; it is in this release. And two install snippets pinned containers
+  to `0.9.0` — one of them in `installation.md`, ten lines under the paragraph
+  explaining that 0.9.0 is the release whose CLI will not start on Debian 12,
+  RHEL 8/9 or most cluster images.
+
+- **`docker/Dockerfile.release` drops from Debian trixie to bookworm.** The
+  trixie pin was the one item in `dev-notes/cargo-release.md` carrying an
+  expiry date: it existed because the wheels published through 0.9.0 bundled a
+  CLI needing glibc 2.39 (gh #452, fixed in gh #456), and the image installs a
+  *published* wheel, so it could not be lowered until a fixed one was on PyPI.
+  0.10.0 is. Measured on the artifact rather than inferred from the build —
+  `objdump -T pounce/bin/pounce` on the published
+  `manylinux_2_17_x86_64` wheel tops out at `GLIBC_2.16`, under manylinux2014's
+  own floor and well under bookworm's 2.36. The bookworm image is verified end
+  to end: `pounce --version`, `import pounce`, and `import pyomo_pounce` all
+  run on glibc 2.36. `installation.md`'s GLIBC troubleshooting entry now states
+  the measured floor instead of "fixed for releases after 0.9.0".
+
+- **The README's workspace table was missing three crates.** `pounce-nl` (the
+  `.nl` reader and AD tape) and `pounce-rs` (the single-crate Rust facade) are
+  both *published* to crates.io and both absent. `pounce-wasm`, which is behind
+  the documented in-browser demo, was missing too. The omission was easy to
+  miss because the table happened to list exactly 20 rows and the release
+  publishes exactly 20 crates — but they are different twenties: the publish
+  list drops `pounce-py` and `pounce-studio-pyo3` (they ship on PyPI) and keeps
+  `pounce-nl` and `pounce-rs`, and the table did the reverse. The table now
+  lists 23 of the 24 members; `iter-diff` stays out as an internal validation
+  tool that is not part of the solver.
 
 - **The QP suite's +515 iterations now have a name, and the fixture corpus can
   see the class they came from (gh #760).** `4c02817d` ("Apply

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ make book       # builds docs/book/ (requires `cargo install mdbook`)
 | [`pounce-feral`](crates/pounce-feral)             | Pure-Rust sparse symmetric LDLᵀ backend. Default.                                                                             |
 | [`pounce-hsl`](crates/pounce-hsl)                 | MA57 backend via `libcoinhsl` (optional, behind `ma57` feature).                                                              |
 | [`pounce-nlp`](crates/pounce-nlp)                 | TNLP trait, TNLPAdapter, `IpoptApplication` entry point (Ipopt `src/Interfaces`).                                             |
+| [`pounce-nl`](crates/pounce-nl)                   | AMPL `.nl` reader and AD tape — parses the model and evaluates its derivatives; what `pounce-cli` reads a problem with.        |
 | [`pounce-algorithm`](crates/pounce-algorithm)     | IteratesVector, IpoptData, calculated quantities, KKT, line search, mu update, conv check, main loop (Ipopt `src/Algorithm`). |
 | [`pounce-restoration`](crates/pounce-restoration) | Restoration phase (Ipopt `Algorithm/Resto*`).                                                                                 |
 | [`pounce-presolve`](crates/pounce-presolve)       | NLP preprocessing — auxiliary-equality elimination, FBBT, bound tightening, redundant-row removal.                            |
@@ -122,8 +123,10 @@ make book       # builds docs/book/ (requires `cargo install mdbook`)
 | [`pounce-cinterface`](crates/pounce-cinterface)   | C ABI shim — `CreateIpoptProblem` / `IpoptSolve` / `FreeIpoptProblem` / `IpoptWriteSolveReport`.                              |
 | [`pounce-py`](crates/pounce-py)                   | PyO3 bindings — the cyipopt-compatible `pounce` Python package (the `pounce-solver` wheel).                                  |
 | [`pounce-cli`](crates/pounce-cli)                 | The `pounce` command-line driver.                                                                                             |
+| [`pounce-rs`](crates/pounce-rs)                   | Single-crate Rust facade — re-exports the TNLP trait and the solver driver, so a Rust caller depends on one crate, not eight.  |
 | [`pounce-studio-core`](crates/pounce-studio-core) | Solve-report / iter-dump parsers and diagnostic analysis (foundation for the `pounce-studio` GUI / MCP server).               |
 | [`pounce-studio-pyo3`](crates/pounce-studio-pyo3) | PyO3 `_native` extension exposing `pounce-studio-core` to the `pounce-studio-mcp` Python MCP server.                          |
+| [`pounce-wasm`](crates/pounce-wasm)               | WebAssembly build behind the in-browser demo (`docs/` → `/demo/`). Not published to crates.io.                                 |
 
 ## Install
 

--- a/dev-notes/cargo-release.md
+++ b/dev-notes/cargo-release.md
@@ -191,11 +191,15 @@ version number, so they need their own attention.
   `variant=source`, `dry_run=false` if a bug report needs an image of an
   unreleased commit; otherwise `make docker` builds it locally.
 - **After the release, check the base image pin.** `docker/Dockerfile.release`
-  is pinned to Debian trixie because the wheels published through 0.9.0
-  bundled a CLI needing glibc 2.39 (#452, fixed in #456). Once a release
-  after 0.9.0 is on PyPI, drop that pin to bookworm or lower and delete the
-  note — `scripts/check-cli-portability.sh` in CI is what makes lowering it
-  safe. This is the one item here with an expiry date.
+  was pinned to Debian trixie because the wheels published through 0.9.0
+  bundled a CLI needing glibc 2.39 (#452, fixed in #456).  **Discharged for
+  0.11.0**: 0.10.0 is on PyPI and its bundled CLI floors at `GLIBC_2.16`
+  (`objdump -T pounce/bin/pounce` on the published manylinux wheel), so the
+  base is now bookworm. The general rule survives the specific pin — the
+  image installs a *published* wheel, so what constrains the base is that
+  wheel's binary, not the tree's. If a release ever raises the CLI's floor,
+  `scripts/check-cli-portability.sh` fails in CI first; if one somehow ships,
+  re-measure on the artifact before trusting this base.
 - **Verify the published image, do not assume.** The images smoke-test
   themselves at build time, but that proves the build, not the publish:
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -24,8 +24,8 @@
 # backend is the default and needs no external libraries.
 
 ARG PYTHON_VERSION=3.12
-# trixie (glibc 2.41), not bookworm (2.36), and not by preference — the
-# ALREADY-PUBLISHED wheels force it, and only until the next release.
+# bookworm (glibc 2.36). This was pinned to trixie (2.41) through 0.10.0,
+# and the pin is now discharged:
 #
 # #452: through 0.9.0, the Linux wheels were tagged manylinux2014 (glibc
 # 2.17) but bundled a `pounce` CLI built on the release runner's host
@@ -35,17 +35,21 @@ ARG PYTHON_VERSION=3.12
 #   pounce/bin/pounce: /lib/x86_64-linux-gnu/libc.so.6:
 #     version `GLIBC_2.39' not found
 #
-# on bookworm, on both amd64 and arm64.
+# on bookworm, on both amd64 and arm64. #456 fixed it by building the CLI in
+# the container, and `scripts/check-cli-portability.sh` in CI keeps it fixed.
 #
-# That is FIXED in main (#456) — the CLI is now built in the container and
-# CI asserts the floor stays within manylinux2014 — but the fix reaches PyPI
-# only when a `python-v*` tag rebuilds the wheels. This image installs from
-# PyPI, so until that release it must run on glibc >= 2.39.
+# The fix reached PyPI in 0.10.0, which is what this image installs. Measured
+# on the published artifact rather than inferred from the build:
 #
-# WHEN THE NEXT RELEASE SHIPS: drop this to bookworm (or lower — the floor
-# is now 2.16) and delete this comment. `scripts/check-cli-portability.sh`
-# in CI is what keeps that safe.
-ARG DEBIAN_RELEASE=trixie
+#   pounce_solver-0.10.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+#   objdump -T pounce/bin/pounce | grep GLIBC | sort -uV | tail -1
+#   -> GLIBC_2.16
+#
+# So the floor is 2.16 — under manylinux2014's own 2.17, and well under
+# bookworm's 2.36. Re-run that check against the release being built before
+# lowering this further; the binary's floor, not the wheel's tag, is what
+# decides.
+ARG DEBIAN_RELEASE=bookworm
 
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_RELEASE}
 

--- a/docs/src/casadi.md
+++ b/docs/src/casadi.md
@@ -717,6 +717,15 @@ describe, so the feasibility phase uses the limited-memory updater — the
 same scoping the partitioned Hessian has. You do not need to configure
 this, and `stats()["restoration"]` reports the phase as usual.
 
+**The mode is not CasADi-specific.** Everything above is about how the
+*plugin* supplies the pattern; the mode itself is reachable from the CLI,
+Python and Pyomo too. Its two other knobs — `fd_hessian_coloring` (why
+the fewer-groups star colouring is not the default) and
+`fd_hessian_reuse_tol` (skipping a rebuild when neither `x` nor `y` has
+moved) — and the sibling `hessian_approximation=partitioned` are
+documented under
+[Hessian approximation](options.md#hessian-approximation-hessian_approximation).
+
 ## Examples
 
 All runnable from

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -116,7 +116,7 @@ matches cyipopt and satisfies the stationarity identity above directly.
 If you are comparing a `mult_g` against a `model.dual` for the same solve,
 expect them to differ by a sign — that is by design, not a bug.
 
-> Before v0.9.1 the `.sol` writer emitted the Lagrange multiplier without
+> Before v0.9.0 the `.sol` writer emitted the Lagrange multiplier without
 > converting it, so every AMPL/Pyomo dual came back negated relative to
 > every other solver ([#271](https://github.com/jkitchin/pounce/issues/271)).
 > Objectives and primal solutions were never affected.

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -82,7 +82,7 @@ no GAMS bindings. Add what you need in a derived image:
 ```dockerfile
 FROM ghcr.io/jkitchin/pounce:0.10.0
 USER root
-RUN pip install --no-cache-dir "pounce-solver[jax]==0.9.0"
+RUN pip install --no-cache-dir "pounce-solver[jax]==0.10.0"
 USER pounce
 ```
 

--- a/docs/src/gams.md
+++ b/docs/src/gams.md
@@ -103,7 +103,7 @@ the matching block in `gams/gams_pounce.c`).
 Variable marginals (`.M` on variables, i.e. reduced costs) are
 `z_L − z_U`, carrying the same `obj_sign` factor.
 
-> Before v0.9.1 the conversion omitted the `obj_sign` factor, so equation
+> Before v0.9.0 the conversion omitted the `obj_sign` factor, so equation
 > marginals on `maximizing` models came back with the wrong sign
 > ([#272](https://github.com/jkitchin/pounce/issues/272)). `minimizing`
 > models, objective values, variable marginals and status mapping were
@@ -117,7 +117,7 @@ from the same table, and both report `x.l` and the marginals for every exit —
 the engine always fills them. The objective row is set only where the exit
 leaves a point whose objective is a finite number.
 
-> Before v0.10.1 a restoration failure (`Restoration_Failed`) published its
+> Before v0.11.0 a restoration failure (`Restoration_Failed`) published its
 > iterate as `x.l` with the objective row left at `0`, and three exits
 > (`Insufficient_Memory`, `Unrecoverable_Exception`, `NonIpopt_Exception_Thrown`)
 > were reported as internal errors because they were missing from the table

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -54,8 +54,12 @@ pounce/bin/pounce: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not fou
 ```
 
 `import pounce` still works; only the CLI (and therefore Pyomo, which
-shells out to it) is affected. This is fixed for releases after 0.9.0. If
-you hit it, use the [container](docker.md) or build from source below.
+shells out to it) is affected. **This is fixed from 0.10.0 on** — the CLI
+is now built inside the manylinux container, and the published 0.10.0
+wheel's binary references nothing above `GLIBC_2.16`, under the
+manylinux2014 floor the wheel advertises. `scripts/check-cli-portability.sh`
+asserts that on every build. If you are pinned to 0.9.0 or earlier and hit
+this, upgrade, or use the [container](docker.md) or a source build below.
 
 ## With a container
 
@@ -63,7 +67,7 @@ No toolchain and nothing installed on the host:
 
 ```sh
 docker run --rm -v "$PWD:/work" ghcr.io/jkitchin/pounce:latest problem.nl
-apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.9.0
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.10.0
 ```
 
 Both images carry the CLI, the Python API, and the Pyomo plugin. See

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -352,6 +352,41 @@ the command line would be.
 A file that *selects* the backend it tunes never reaches this: `linear_solver=ma97`
 is refused on its own, as [above](#choosing-a-linear-solver).
 
+### MA57 backend knobs
+
+Only relevant in a `--features ma57` build running `linear_solver=ma57`;
+see [Installation](installation.md#hsl-ma57-backend-optional). All of them
+are the upstream Ipopt names with the upstream meanings, so an
+`ipopt.opt` written for Ipopt-MA57 transfers unchanged.
+
+| option | default | MA57 control | what it does |
+|---|---|---|---|
+| `ma57_pivtol`            | `1e-8` | `CNTL(1)`   | Relative pivot threshold. Smaller pivots for sparsity, larger for stability. |
+| `ma57_pivtolmax`         | `1e-4` | —           | Ceiling the solver may raise `ma57_pivtol` to when it needs a more accurate solve. Must be ≥ `ma57_pivtol`. |
+| `ma57_pre_alloc`         | `1.05` | —           | Safety factor on the work-space MA57 suggests. Larger avoids a reallocation when the suggestion falls short. |
+| `ma57_pivot_order`       | `5`    | `ICNTL(6)`  | Pivot-ordering strategy (`0`–`5`). |
+| `ma57_automatic_scaling` | `no`   | `ICNTL(15)` | Let MA57 scale the matrix itself. See [Scaling](scaling.md). |
+| `ma57_block_size`        | `16`   | `ICNTL(11)` | Block size for the Level-3 BLAS in `MA57BD`. |
+| `ma57_node_amalgamation` | `16`   | `ICNTL(12)` | Node amalgamation parameter. |
+| `ma57_small_pivot_flag`  | `0`    | `ICNTL(16)` | `1` moves small pivots to the end of the factorization instead of using them — efficient on a highly rank-deficient matrix. |
+| `ma57_print_level`       | `0`    | —           | MA57's own printing: `0` silent, `1` errors, `2` +warnings, `3` +terse monitoring, `≥4` everything. |
+| `ma57_batched_backsolve` | `no`   | —           | POUNCE extension, not an Ipopt option — see [below](#ma57-batched-back-substitution-ma57_batched_backsolve). |
+
+Each can be scoped to the restoration sub-solve with a `resto.` prefix,
+e.g. `resto.ma57_pivtol=0.5`, which leaves the main solve's value alone.
+
+> Up to and including 0.10.0 **none of the nine reached the backend**.
+> They were registered, documented, parsed and validated — and then
+> discarded: `Ma57Options::from_options_list` was a correct reader with
+> no callers, because every construction site went through
+> `Ma57SolverInterface::new()`, which hard-codes the defaults. Set to any
+> value, the factorization behaved as though you had set nothing
+> ([#825](https://github.com/jkitchin/pounce/issues/825)). They are wired
+> from 0.11.0 on, which means a build that was tuning MA57 through these
+> knobs will now actually be tuned by them — expect the trajectory to
+> move. `ma57_pivtolmax` also now refuses a value below `ma57_pivtol`
+> rather than accepting an empty escalation range.
+
 ### MA57 batched back-substitution (`ma57_batched_backsolve`)
 
 Only relevant in a `--features ma57` build running `linear_solver=ma57`.
@@ -403,6 +438,45 @@ iterations, and the fastest arm was luck, not throughput.
 
 Full write-up, including why the option has no width ceiling the way
 the FERAL backend's equivalent does: `dev-notes/ma57-batched-backsolve.md`.
+
+### Withdrawing the constraint perturbation (`perturb_delta_c_max_rungs`)
+
+POUNCE extension; not an upstream Ipopt option. Default `3`; `0`
+restores the pre-[#592](https://github.com/jkitchin/pounce/issues/592)
+escalation exactly.
+
+When the KKT factorization does not deliver the requested inertia, the
+solver climbs a ladder of perturbations: `delta_w` on the Hessian block,
+and `delta_c` on the constraint block. `delta_c` is the remedy for a
+*rank-deficient constraint Jacobian*, and it is reached for when the
+factorization reports `Singular`.
+
+Since [#540](https://github.com/jkitchin/pounce/issues/540) a
+factorization also reports `Singular` when its inertia is
+**unmeasurable** — the count disagrees and the smallest pivot sits at the
+noise floor. That is evidence about the measurement, not about the
+Jacobian's rank. When the Jacobian in fact has full rank `delta_c`
+cannot help, and because it stays switched on for the rest of that
+augmented system, the `delta_w` ladder then has to climb against a
+matrix `delta_c` has made *harder* to hit the requested inertia on. On
+the #592 model that cost five rungs, ending at `delta_w = 1e2` where
+Ipopt accepted the step at `1e-4`; the over-damped step froze the
+objective for eight iterations and the solver exited at a point a
+restart improved by 0.08%.
+
+Rather than predict which kind of `Singular` a report was — the counts
+are the very thing #540 established are noise — the ladder answers it
+empirically. After this many rungs with `delta_c` on and still no
+acceptable inertia, `delta_c` is withdrawn, the `delta_w` ladder
+restarts, and `delta_c` is latched off for the remainder of that
+augmented system; the next iterate starts clean. Lower values withdraw
+sooner.
+
+Where `delta_c` is the right remedy this never fires: on `eigena2` and
+`eigenb2` it is followed by at most one rung. See
+`crates/pounce-common/src/pd_perturbation.rs`
+(`maybe_withdraw_delta_c`) and
+`dev-notes/issue-592-restart-non-idempotence.md`.
 
 ### Inertia-free curvature test (`neg_curv_test_tol`)
 
@@ -1037,6 +1111,139 @@ adaptive oracle stops making progress. Defaults mirror upstream
 | `adaptive_mu_kkt_norm_type`             | `2-norm-squared` | Norm used to score the iterate in adaptive globalization decisions.                  |
 | `adaptive_mu_max_free_returns`          | `-1`    | Cap on returns to free-μ mode after entering monotone mode; `-1` is unlimited (upstream). POUNCE extension (#749). |
 | `adaptive_mu_budget_pin_fraction`       | `0.75`  | Fraction of an explicitly set `max_cpu_time`/`max_wall_time` after which the strategy finishes monotone; `1` disables. Inert without a time budget. POUNCE extension (#753). |
+
+## Hessian approximation (`hessian_approximation`)
+
+Which second-derivative information the algorithm works from. Four
+values; the first two are Ipopt's, the last two are POUNCE extensions
+with no upstream counterpart.
+
+| value | needs from the model | when |
+|---|---|---|
+| `exact` (default)  | `eval_h` — real second derivatives | the fast path whenever they exist |
+| `limited-memory`   | nothing beyond the gradient        | no second derivatives available |
+| `finite-difference`| the **analytic Jacobian** plus a sparsity pattern | no `eval_h`, but the Jacobian is exact and sparse |
+| `partitioned`      | the declared Jacobian sparsity     | structured models, above all direct collocation |
+
+`exact` and `limited-memory` are documented under
+[L-BFGS initialization](#limited-memory-hessian-l-bfgs-initialization)
+and throughout this page. The other two are below.
+
+### `finite-difference`
+
+Recovers the exact Lagrangian Hessian by differencing the analytic
+Jacobian along a set of probe directions, rather than approximating it
+from step/gradient pairs. Where L-BFGS presents the linear solver a
+dense low-rank correction over a diagonal, this hands it the model's
+real sparse Hessian, so a structured problem factors like one.
+
+The cost is one Jacobian evaluation per probe *group*, per rebuild. Three
+options control how many groups there are and how often you pay for them:
+
+| option | default | values | what it does |
+|---|---|---|---|
+| `fd_hessian_pattern`   | `declared` | `declared`, `jacobian` | where the sparsity pattern comes from |
+| `fd_hessian_coloring`  | `cpr`      | `cpr`, `star`          | how columns are grouped into probes |
+| `fd_hessian_reuse_tol` | `0`        | ≥ 0                    | relative movement below which the previous Hessian is reused |
+
+**`fd_hessian_pattern`.** `declared` uses the TNLP's declared Hessian
+*structure* — the structure call only, never the values, so it is
+available to any model that cannot evaluate second derivatives; every
+`.nl` declares one through AMPL's AD. `jacobian` derives it from the
+Jacobian pattern alone, as the union over rows of
+`supp(∇g) ⊗ supp(∇g)`. That is a strict *superset* of the true pattern,
+so it is safe — a superset costs extra probe groups, never a wrong
+answer — but it is not free: on `benchmarks/large_scale` `laptime` it is
+146 267 nonzeros against the true 28 000. There is deliberately no mode
+that guesses a *subset*, which would silently drop curvature.
+
+**`fd_hessian_coloring`.** A star colouring needs fewer groups than
+Curtis-Powell-Reid — on the Jacobian-derived `laptime` pattern, 42 where
+CPR needs 76 — and its recovery is algebraically exact, so it looks like
+the better default and is not. A forward difference is not an exact
+Hessian-vector product: it carries a third-derivative cross term into
+each row, and CPR's distance-2 property forbids the two columns that
+term needs from sharing a group, while a star colouring does not.
+Measured on `laptime`, star over the Jacobian pattern takes 404
+iterations to a *wrong* objective where CPR takes 38 to the right one;
+over the sparser declared pattern both take 30. Group size is not the
+cause — declared/star has the largest groups of the four and is fine.
+Use `star` only on a sparse declared pattern, and measure.
+
+**`fd_hessian_reuse_tol`.** A rebuild costs one Jacobian evaluation per
+group, so skipping it when nothing has moved is the cheapest saving
+available. Both the primal iterate *and* the multipliers are tested, not
+just `x`: the Lagrangian Hessian is `∇²f + Σⱼ yⱼ ∇²cⱼ`, so a cached
+Hessian is stale the moment `y` moves even if `x` has not — and the
+endgame of an interior-point solve is full of short steps with moving
+duals. `0`, the default, rebuilds every iteration.
+
+> `finite-difference` will produce a Hessian for a model whose second
+> derivatives do not exist, because it never asks for them.
+> `hessian_approximation=exact` refuses such a model; this one does not.
+> That is the point of it, and also the risk: the answer is only as good
+> as the Jacobian is differentiable.
+
+### `partitioned`
+
+Keeps one small dense quasi-Newton block per *element function* — the
+objective, and each constraint row, whose support is a row of the
+Jacobian — and assembles them into a genuine sparse Hessian. The linear
+solver then sees the model's real block structure instead of the
+diagonal the limited-memory low-rank path presents. Intended for
+structured problems where second derivatives are unavailable but the
+Jacobian sparsity is declared; direct-collocation trajectory
+optimization above all.
+
+| option | default | values | what it does |
+|---|---|---|---|
+| `partitioned_elements`      | `per-constraint` | `per-constraint`, `blocks` | how the Lagrangian is split into elements |
+| `partitioned_update_type`   | `sr1`            | `sr1`, `bfgs`              | update formula applied to each element block |
+| `partitioned_max_element`   | `64`             | ≥ 1                        | widest element that keeps a dense block |
+| `partitioned_block_size`    | `64`             | ≥ 1                        | target block width, `elements=blocks` only |
+| `partitioned_curvature_cap` | off (`inf`)      | > 0                        | cap on one update's movement. **Leave off** |
+
+**`partitioned_elements`.** `per-constraint` gives each block a
+multiplier-independent target and assumes nothing about variable
+ordering, at the cost of as many blocks as there are constraints.
+`blocks` is the partition of Asprion, Chinellato and Guzzella: a direct
+collocation transcription orders its variables by stage, so the
+Lagrangian Hessian is close to block diagonal in contiguous blocks and
+the block count is the *stage* count. Set `partitioned_block_size` to
+what one stage contributes (states × collocation points, plus controls)
+— too small and the block misses genuine intra-stage coupling, too large
+and each block carries more parameters than its one curvature pair per
+iteration can determine. The ordering assumption is reported rather than
+trusted: `POUNCE_PARTITIONED_ORACLE` prints the fraction of the exact
+Hessian's Frobenius mass that falls inside the block pattern.
+
+**`partitioned_update_type`.** SR1 is the default because an individual
+constraint is not convex. Damped BFGS would force every element model
+PSD, the solve would then scale it by a multiplier of either sign, and
+the indefiniteness would never reach the inertia correction.
+`elements=blocks` defaults to damped BFGS instead, since there the
+element *is* the Lagrangian restricted to a block, which is the object
+an interior-point method wants a positive-definite model of.
+
+**`partitioned_max_element`.** An element with `k` nonzeros costs
+`k(k+1)/2` stored reals, so one wide constraint row would dominate the
+memory. Elements wider than this degrade to a diagonal approximation
+satisfying the weak secant condition rather than being *dropped*, so a
+separable objective is still represented exactly and a coupled one
+approximately.
+
+**`partitioned_curvature_cap` — off, and every finite value measured was
+worse than off**, non-monotonically so. On `benchmarks/large_scale`
+`laptime` at `N=80` with `max_iter=1200` (true optimum 65.462928):
+`cap=1e1` exits `ErrorInStepComputation` at 1071 iterations and
+65.518586; `cap=1e2` hits the iteration limit at 67.202124; `cap=1e6`
+hits it at 80.398129; off converges in 559 iterations at 65.462802.
+Rejecting an update is *selective* — it drops exactly the elements whose
+curvature is moving fastest and leaves those blocks stale while their
+neighbours update, and the resulting inconsistent Hessian costs more
+than a uniformly noisy but coherent one. Kept as a knob so the effect
+can be re-measured against a different element decomposition. Do not
+enable it without measuring.
 
 ## Limited-memory Hessian (L-BFGS) initialization
 


### PR DESCRIPTION
Release preflight for 0.11.0. Documentation, CHANGELOG, and the release
Dockerfile base only — no functional change to the solver.

Part of #840.

## The undocumented option surface

A registered-options-versus-`docs/src` diff over `v0.10.0..HEAD` found **39
options added since 0.10.0**, of which **8 were reachable and undocumented**:

- `fd_hessian_coloring`, `fd_hessian_reuse_tol`
- the five `partitioned_*` knobs
- `perturb_delta_c_max_rungs`

Worse than the individual knobs, `hessian_approximation` itself had **no
section**. `finite-difference` was described only on the CasADi page, so a CLI,
Python, or Pyomo user had no route to discovering an entire Hessian mode, and
`partitioned` was described nowhere at all.

`options.md` now has a **Hessian approximation** section covering all four
values and both extension modes' knobs, including the measured reasons the
surprising defaults are the defaults:

- star colouring takes `laptime` to a **wrong** objective in 404 iterations
  where CPR takes 38 to the right one;
- every finite `partitioned_curvature_cap` measured was worse than off, and
  non-monotonically so.

`casadi.md` now points at that section instead of holding the only copy.

## The `ma57_*` family had the inverse problem

`installation.md` said "and the rest — see Options", and Options listed none of
them. It now carries the table with each knob's `ICNTL`, plus the note that
matters for anyone upgrading: through 0.10.0 **none of the nine reached the
backend** (#825), so a build that was "tuning MA57" was running defaults. From
0.11.0 those settings take effect and will move the trajectory.

## Five version references pointed at releases that do not exist

Only `v0.2.0` through `v0.10.0` were ever cut — there is no patch release among
them.

| file | claimed | actual |
|---|---|---|
| `cli.md` | dual-sign fix (#271) "before v0.9.1" | landed **in** 0.9.0 |
| `gams.md` | GAMS marginal-sign fix (#272) "before v0.9.1" | landed **in** 0.9.0 |
| `gams.md` | restoration-exit status fix (#589) "before v0.10.1" | is in **this** release |
| `installation.md` | container pinned `0.9.0` | bumped |
| `docker.md` | container pinned `0.9.0` | bumped |

The CHANGELOG is the source for the first two: it records #271/#272 as landing
in 0.9.0. One of the two `0.9.0` pins sat ten lines under the paragraph
explaining that 0.9.0 is the release whose CLI will not start on Debian 12,
RHEL 8/9, or most cluster images — i.e. the snippet recommended the one release
the surrounding prose tells you to avoid.

## Also

`docker/Dockerfile.release` drops from Debian trixie to bookworm.

## Verification

- `mdbook build docs` clean.
- `scripts/check-release-consistency.sh` OK (all surfaces still coherent at
  0.10.0; the version bump is a separate tag-time step).
- No nonexistent-version reference remains anywhere in `docs/src/` or `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9Tqn6nrW7B91fC1HpJsHp
