### PR TITLE
fix(sqp): reach the rescue paths, and stop certifying a constrained maximum (#855, #856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,85 @@ changes.
 
 ## [Unreleased]
 
+- **The active-set SQP no longer certifies a constrained maximum (gh #856).**
+  `algorithm=active-set-sqp` on `nonconvex_qp.nl` — `min x₀x₁ s.t. x₀+x₁ = 2`,
+  `0 ≤ x ≤ 4` — reported `f = 1` as `Solve_Succeeded`. On the feasible segment
+  `f(x₀) = x₀(2−x₀)` is concave, so `(1, 1)` is the constrained **maximum**;
+  the minimum is `0` at either endpoint, which the NLP filter line-search arm
+  reaches on the same file in the same binary.
+
+  First-order KKT is necessary and not sufficient, and gh #856 explains why
+  handing gh #848's second-order screen to the SQP's **step** subproblem is the
+  wrong answer: that QP is a local model built from the *current* multiplier
+  estimates. At SQP iteration 0 the multipliers are still zero, so the
+  Lagrangian Hessian is `∇²f`, and started at HS071's own `x*` the step QP
+  refutes it on a direction with `dᵀHd = -4.05e-2` — correctly for that model,
+  wrongly for the NLP.
+
+  So the check runs **at convergence**, where that objection dissolves: the
+  multipliers are the converged ones, which is gh #856's own observation ("with
+  the converged multipliers the reduced Hessian is positive") used as the
+  design rather than as an obstacle. The reduced Hessian on the null space of
+  the active set is eigen-decomposed, and a negative eigenvalue yields a
+  direction that is then refuted **by exhibition** — stepped along, and acted
+  on only if the true objective is strictly lower at a point satisfying the
+  *nonlinear* constraints. As in gh #848, that makes the curvature search free
+  to be approximate: a direction it gets wrong costs two evaluations, not a
+  wrong answer.
+
+  **The limited-memory leg is the part worth reading.** The first version gated
+  the escape on `SqpHessianSource::Exact`, and the SQP-arm sweep caught that
+  leg still certifying the same maximum. The gate was not an optimization: a
+  damped-BFGS or L-BFGS matrix is positive definite *by construction*, so
+  searching it for negative curvature can only ever find none — the gate was
+  the reason the check did not exist there. `eval_hess_lag` is a required
+  method of `SqpProblemSpec`, so the exact `∇²L` is always available and is now
+  taken once at convergence whatever drove the steps. That is not a corner: the
+  Python frontend and the CasADi plugin both select `limited-memory` on their
+  own whenever no exact Lagrangian Hessian is available.
+
+  Swept on the `algorithm=active-set-sqp` arm, both legs, 10 lines move and
+  every one is an improvement toward the NLP arm's answer:
+  `nonconvex_qp` `1.0 → 0` on both legs, `nonconvex_qcqp` `0 → -2.0` on both,
+  and `nonconvex_qp_ineq` `1.0 → 0` on the limited-memory leg — a third wrong
+  answer the issue does not mention, which only the L-BFGS fix reaches. All
+  four HS071 starts in `sqp_near_solution_start.rs` stay green, including the
+  quasi-Newton one, which is the guard that the convergence-time distinction is
+  real. The default arm is untouched (`auto` does not route here): the fixture
+  sweep is empty across all 158 legs.
+
+  Known and unmoved: `nonconvex_two_escapes` still returns `0` on this arm
+  where the NLP arm reaches `-0.225`. Pre-existing, and not addressed here.
+
+- **A failed warm step-QP no longer takes the SQP down with it (gh #855).**
+  `sqp_alg` has a cold-start fallback (gh #349) for a warm solve that returns
+  `MaxIter` / `NumericalError`, but a warm solve that returned `Err` was
+  propagated by `?` out of the whole algorithm before any retry ran — the
+  **stronger** form of the same signal, and the one case the fallback could not
+  see. `eigena2` under `algorithm=active-set-sqp` reaches outer iteration 17
+  and fails with "pinned KKT constraint block is rank-deficient … prune to a
+  linearly-independent subset", which is a statement about the *pinned set* —
+  exactly what a warm start supplies and a cold start rebuilds. It exited
+  `Internal_Error` / `solve_result_num=500`, "the solver broke, retry", on a
+  model whose objective it can report; it now ends
+  `Maximum_Iterations_Exceeded` at `obj = 82.5177` against the NLP arm's 82.5.
+
+  Both retries additionally accept an `Unbounded` verdict rather than only
+  `Optimal`, which is gh #855 as filed: an `Unbounded` return is a *finding* —
+  an unblocked negative-curvature direction in the null space of the working
+  set — and discarding it left `sol` on the original failure, so the gh #423
+  unbounded-model fallback, gated on `sol.status == Unbounded`, never saw it.
+  Accepting it is safe because that fallback re-tests the ray against the true
+  NLP (gh #388) before acting.
+
+  **That half is not covered by any fixture, and the source says so where it
+  lives.** Swept under `active-set-sqp`, the retries fire on three fixtures and
+  return only `MaxIter` or `Optimal`, including with `sqp_qp_max_iter` forced
+  to 2. It is kept rather than dropped because it is not redundant — nothing
+  else makes that fallback reachable from a retry — which is the opposite of
+  the gh #846 case, where a second arm already rejected everything the removed
+  one would have.
+
 - **`feral_increase_quality`: a lever for the `increase_quality` rung, which
   costs two solves on `square_flowsheet_resto` (gh #850, the underlying
   regression).** `2c4f25f1` wired `FeralSolverInterface::increase_quality`,

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -275,6 +275,12 @@ impl SqpAlgorithm {
             }
         }
 
+        // Bounded so a curvature escape that keeps returning to the same
+        // neighbourhood cannot spin: each one costs a fresh descent, and a
+        // handful is far more than any of the measured models needs (one).
+        const MAX_SECOND_ORDER_ESCAPES: u32 = 8;
+        let mut escapes: u32 = 0;
+
         for outer in 0..self.opts.max_iter {
             let grad_f = nlp.eval_grad_f(&iter.x);
             let c_vals = c_cached.take().unwrap_or_else(|| nlp.eval_c(&iter.x));
@@ -338,6 +344,87 @@ impl SqpAlgorithm {
             let stationarity_tol = self.opts.tol.min(self.opts.dual_inf_tol);
             if kkt.stationarity <= stationarity_tol && kkt.constr_viol <= self.opts.constr_viol_tol
             {
+                // First-order KKT is necessary and not sufficient. Before
+                // reporting success on an indefinite Lagrangian, look for a
+                // feasible direction of negative curvature *at the converged
+                // multipliers* and, where one is found, step along it and keep
+                // going (gh #856).
+                //
+                // `nonconvex_qp.nl` under `algorithm=active-set-sqp` is the
+                // case: `min x₀x₁ s.t. x₀+x₁ = 2, 0 ≤ x ≤ 4`, on whose
+                // feasible segment `f(x₀) = x₀(2−x₀)` is concave, so the
+                // `(1, 1)` this converges to at `f = 1` is the constrained
+                // **maximum** and the minimum is `0` at either endpoint. It was
+                // reported `Solve_Succeeded`. The escape below moves to
+                // `(2, 0)`, where a bound joins the active set, the null space
+                // closes and `f = 0` certifies.
+                //
+                // Refuted **by exhibition**, exactly as gh #848 does one layer
+                // down: the direction is only acted on after stepping along it
+                // and finding the true objective lower, so the curvature search
+                // is free to be approximate and a direction it gets wrong
+                // costs an evaluation rather than a wrong answer.
+                //
+                // The Hessian is the **exact** `∇²L`, taken here even when the
+                // steps were driven by a quasi-Newton one. That is not an
+                // optimization detail, it is what makes the check exist at all
+                // under `limited-memory`: a damped-BFGS or L-BFGS matrix is
+                // positive definite by construction, so searching it for
+                // negative curvature can only ever find none, and gating the
+                // check on `SqpHessianSource::Exact` left the L-BFGS leg
+                // certifying the same constrained maximum. `eval_hess_lag` is
+                // a required method of `SqpProblemSpec`, so it is always
+                // callable; this costs one Hessian evaluation per converged
+                // solve, and an implementation that has none to give returns
+                // an empty triplet, which finds no curvature and changes
+                // nothing.
+                //
+                // The L-BFGS leg is not exotic coverage: the Python frontend
+                // and the CasADi plugin both select `limited-memory` on their
+                // own whenever no exact Lagrangian Hessian is available.
+                let exact_hess = if matches!(self.opts.hessian, SqpHessianSource::Exact) {
+                    None
+                } else {
+                    Some(nlp.eval_hess_lag(&iter.x, &iter.lambda_g))
+                };
+                if escapes < MAX_SECOND_ORDER_ESCAPES
+                    && let Some(d) = negative_curvature_at_kkt_point(
+                        n,
+                        m,
+                        &iter.x,
+                        exact_hess.as_ref().unwrap_or(&hess_lag),
+                        &jac_c,
+                        &c_vals,
+                        &bl_c,
+                        &bu_c,
+                        &xl,
+                        &xu,
+                        self.opts.constr_viol_tol,
+                    )
+                    && let Some(next) = exhibit_better_point(
+                        nlp,
+                        &iter.x,
+                        &d,
+                        f_curr,
+                        &xl,
+                        &xu,
+                        &bl_c,
+                        &bu_c,
+                        self.opts.constr_viol_tol,
+                    )
+                {
+                    tracing::debug!(target: "pounce::sqp",
+                        "first-order KKT point refuted at second order; stepping \
+                         along negative curvature to a strictly better feasible \
+                         point (gh #856)");
+                    escapes += 1;
+                    iter.x = next;
+                    iter.working = None;
+                    f_cached = None;
+                    c_cached = None;
+                    prev_point = None;
+                    continue;
+                }
                 self.iterates = Some(iter.clone());
                 return Ok(SqpResult {
                     x: iter.x,
@@ -422,8 +509,45 @@ impl SqpAlgorithm {
             // carry over even when the active set does.
             let warm_started = iter.working.is_some();
             let mut sol = if let Some(prev_w) = iter.working.as_ref() {
-                self.qp_solver
-                    .solve_with_working_set(&qp, prev_w, &self.qp_opts)?
+                // A warm solve that *errors* falls back to cold rather than
+                // aborting the SQP (gh #855). The cold-start fallback below
+                // already exists for a warm solve that comes back `MaxIter` /
+                // `NumericalError`, on the reasoning that the carried-over
+                // working set can be a poor guess; a hard `Err` from the same
+                // call is the **stronger** form of that signal and was the one
+                // case the fallback could not see, because `?` propagated out
+                // of the whole algorithm first.
+                //
+                // The error that motivates this says so itself: `eigena2`
+                // under `algorithm=active-set-sqp` reaches outer iteration 17
+                // and the warm solve fails with "pinned KKT constraint block
+                // is rank-deficient (inertia shift masked a singular
+                // constraint block); prune to a linearly-independent subset".
+                // That is a statement about the *pinned set*, which is exactly
+                // what a warm start supplies and a cold start rebuilds. The
+                // SQP exited `Internal_Error` / `solve_result_num=500` -- "the
+                // solver broke, retry" -- on a model whose objective it can
+                // report; with the cold re-solve it ends
+                // `Maximum_Iterations_Exceeded` at `obj = 82.5177`, against
+                // the NLP arm's 82.5 on the same file.
+                //
+                // The cold error is still propagated: if a clean start fails
+                // too, the failure is not about the working set and there is
+                // nothing further to try here.
+                match self
+                    .qp_solver
+                    .solve_with_working_set(&qp, prev_w, &self.qp_opts)
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::debug!(target: "pounce::sqp",
+                            "warm-started step QP failed hard ({e:?}); re-solving \
+                             from cold, since the carried working set is what a \
+                             cold start rebuilds (gh #855)");
+                        n_qp_solves += 1;
+                        self.qp_solver.solve(&qp, None, &self.qp_opts)?
+                    }
+                }
             } else {
                 self.qp_solver.solve(&qp, None, &self.qp_opts)?
             };
@@ -445,7 +569,41 @@ impl SqpAlgorithm {
                 let cold = self.qp_solver.solve(&qp, None, &self.qp_opts)?;
                 n_qp_solves += 1;
                 n_qp_working_set_changes += cold.stats.n_working_set_changes;
-                if cold.status == QpStatus::Optimal {
+                // `Unbounded` is accepted as well as `Optimal`, and it is
+                // the point of gh #855. A cold re-solve that comes back
+                // `Unbounded` has *found something* — an unblocked direction
+                // of negative curvature in the null space of its working set
+                // — and taking only `Optimal` threw that away, leaving `sol`
+                // on the original `MaxIter`. The unbounded-model fallback
+                // below is gated on `sol.status == Unbounded`, so the
+                // δ-shifted proximal step written for exactly this situation
+                // was unreachable from a retry.
+                //
+                // Accepting it is safe because the fallback does not trust it
+                // either: it re-tests the ray against the true NLP (gh #388)
+                // and only takes the proximal branch when the certificate
+                // does *not* survive. A spurious `Unbounded` therefore costs
+                // one re-test, not a wrong verdict.
+                //
+                // Nothing else can be accepted here: `Infeasible` from a cold
+                // solve would contradict the warm one on the same subproblem
+                // without a tie-breaker, and `MaxIter` / `NumericalError` are
+                // what we already have.
+                //
+                // COVERAGE, stated because it matters: no fixture in the CLI
+                // corpus reaches this branch. Swept under
+                // `algorithm=active-set-sqp`, the retries fire on three
+                // fixtures (`cresc4`, `eigena2`, `jit1_boxed`) and return only
+                // `MaxIter` or `Optimal`, including under `sqp_qp_max_iter`
+                // forced down to 2. gh #855 observed the `Unbounded` return on
+                // `eigena2` in a build carrying second-order certification for
+                // the step subproblem, which is gh #856's subject and does not
+                // exist here yet. It is kept rather than dropped because it is
+                // not redundant -- nothing else makes the unbounded-model
+                // fallback reachable from a retry -- which is the opposite of
+                // the gh #846 case, where a second arm already rejected
+                // everything the removed one would have.
+                if matches!(cold.status, QpStatus::Optimal | QpStatus::Unbounded) {
                     sol = cold;
                 }
             }
@@ -486,7 +644,17 @@ impl SqpAlgorithm {
                     .solve(&qp_data.as_qp(), None, &self.qp_opts)?;
                 n_qp_solves += 1;
                 n_qp_working_set_changes += retry.stats.n_working_set_changes;
-                if retry.status == QpStatus::Optimal {
+                // Same as the cold retry above (gh #855): an `Unbounded`
+                // verdict is a finding, not a failure, and discarding it hid
+                // the proximal fallback from this branch too.
+                //
+                // The subproblem stays consistent: this branch runs only
+                // while `sol.status` is `MaxIter`/`NumericalError`, so it
+                // cannot fire after the cold retry has been accepted, and
+                // `qp_data` is rebound above — so the fallback below re-solves
+                // the *reset-Hessian* subproblem that produced this verdict,
+                // not the discarded one.
+                if matches!(retry.status, QpStatus::Optimal | QpStatus::Unbounded) {
                     sol = retry;
                 }
             }
@@ -1101,6 +1269,258 @@ fn compute_grad_lag(
         out[col_j] += jac_c.vals[k] * lambda_g[row_i];
     }
     out
+}
+/// Walk `d` from `x` and return a strictly better feasible point, or `None`.
+///
+/// This is what turns a curvature *direction* into a refutation. gh #848
+/// established the shape one layer down: a feasible point with a strictly
+/// lower objective is proof needing no theory, so the search that produced
+/// `d` may be as approximate as it likes — a direction it gets wrong costs
+/// the evaluations below and nothing else.
+///
+/// The step length is the distance to the first blocking variable bound,
+/// halved back until the *nonlinear* constraints are satisfied to
+/// `constr_viol_tol`. That backtrack is the difference between this and the
+/// QP-level version: `d` lies in the null space of the *linearized* active
+/// constraints, which holds them exactly only where they are linear.
+/// `nonconvex_qp`'s equality is linear, so the first trial is accepted there;
+/// a curved constraint gives up its step rather than trading feasibility for
+/// objective, which the SQP's own merit function would then have to undo.
+#[allow(clippy::too_many_arguments)]
+fn exhibit_better_point<N: SqpProblemSpec>(
+    nlp: &mut N,
+    x: &[Number],
+    d: &[Number],
+    f_curr: Number,
+    xl: &[Number],
+    xu: &[Number],
+    bl_c: &[Number],
+    bu_c: &[Number],
+    constr_viol_tol: Number,
+) -> Option<Vec<Number>> {
+    let n = x.len();
+    let dn = d.iter().fold(0.0_f64, |a, v| a.max(v.abs()));
+    if !(dn > 0.0) || !dn.is_finite() {
+        return None;
+    }
+    // Both signs: curvature is even, so `-d` descends wherever `d` does, and
+    // only one of them may have room before a bound.
+    for sign in [1.0_f64, -1.0] {
+        let mut alpha = f64::INFINITY;
+        for i in 0..n {
+            let di = sign * d[i];
+            if di > 1e-12 * dn && xu[i] < f64::INFINITY {
+                alpha = alpha.min((xu[i] - x[i]) / di);
+            }
+            if di < -1e-12 * dn && xl[i] > f64::NEG_INFINITY {
+                alpha = alpha.min((x[i] - xl[i]) / -di);
+            }
+        }
+        // Unbounded in this direction is not this function's business -- the
+        // unbounded-model fallback owns that -- so cap and keep going.
+        if !alpha.is_finite() {
+            alpha = 1.0 / dn;
+        }
+        for _ in 0..24 {
+            if !(alpha > 0.0) {
+                break;
+            }
+            let trial: Vec<Number> = (0..n)
+                .map(|i| (x[i] + sign * alpha * d[i]).clamp(xl[i], xu[i]))
+                .collect();
+            let viol = nlp
+                .eval_c(&trial)
+                .iter()
+                .enumerate()
+                .fold(0.0_f64, |a, (j, &cj)| {
+                    a.max((bl_c[j] - cj).max(0.0)).max((cj - bu_c[j]).max(0.0))
+                });
+            if viol <= constr_viol_tol {
+                let f_trial = nlp.eval_f(&trial);
+                // Strictly better by more than the objective's own scale can
+                // round, so this cannot fire on noise at a genuine optimum.
+                if f_trial.is_finite() && f_trial < f_curr - 1e-10 * (1.0 + f_curr.abs()) {
+                    return Some(trial);
+                }
+                break;
+            }
+            alpha *= 0.5;
+        }
+    }
+    None
+}
+
+/// A feasible direction of negative curvature at a *converged* first-order
+/// point, or `None` when the point survives the second-order test (gh #856).
+///
+/// # Why this runs at convergence and not at each step
+///
+/// gh #848 gave standalone QP solves a second-order screen. Applying the same
+/// screen to the SQP's **step** subproblem is wrong, and gh #856 has the
+/// counterexample: that QP is a local model built from the *current*
+/// multiplier estimates, and its second-order verdict is not the NLP's. At
+/// SQP iteration 0 the multipliers are still zero, so the exact Lagrangian
+/// Hessian is `∇²f`; started at HS071's own `x*` the step QP's working set
+/// leaves a one-dimensional null space on which `dᵀHd = -4.05e-2`, and the
+/// point is refuted — correctly for that model, wrongly for the NLP, whose
+/// reduced Hessian at `x*` is positive once the multipliers have converged.
+///
+/// At *convergence* that objection disappears: the multipliers are the
+/// converged ones, so `∇²L` is the Hessian the second-order condition is
+/// actually about. This is the same distinction gh #856 draws when it says
+/// "with the converged multipliers the reduced Hessian is positive" — the
+/// check is meaningful exactly where it is run.
+///
+/// # What it computes
+///
+/// `Z` is an orthonormal basis for the null space of the active constraint
+/// normals — equality rows, active inequality rows and active bounds — taken
+/// from the eigenvectors of `BᵀB` whose eigenvalue is negligible against the
+/// largest. The reduced Hessian `ZᵀHZ` is then eigen-decomposed, and a
+/// sufficiently negative eigenvalue yields `d = Z v`: a direction that holds
+/// every active constraint to first order and along which the objective
+/// curves down.
+///
+/// Returns `None` when there is no negative curvature, when the active set
+/// leaves no degrees of freedom, or when either eigensolve fails to converge
+/// — never a direction it is unsure of, since the caller acts on it.
+#[allow(clippy::too_many_arguments)]
+fn negative_curvature_at_kkt_point(
+    n: usize,
+    m: usize,
+    x: &[Number],
+    hess_lag: &Triplet,
+    jac_c: &Triplet,
+    c_vals: &[Number],
+    bl_c: &[Number],
+    bu_c: &[Number],
+    xl: &[Number],
+    xu: &[Number],
+    tol: Number,
+) -> Option<Vec<Number>> {
+    // Dense and `O(n³)`, so it is bounded rather than let loose on a large
+    // model. It runs once, at convergence, on the way to reporting success —
+    // and skipping it returns exactly today's answer, so the ceiling costs
+    // coverage and never correctness. (Contrast gh #849, where the analogous
+    // ceiling silently withdrew a *guarantee*.)
+    const MAX_N: usize = 512;
+    if n == 0 || n > MAX_N {
+        return None;
+    }
+
+    // The active set. A bound or row counts as active when the iterate sits
+    // on it to within the same tolerance the convergence test just used, so
+    // this is the set the verdict was issued about.
+    let mut rows: Vec<Vec<Number>> = Vec::new();
+    for j in 0..m {
+        let lo_active = bl_c[j] > f64::NEG_INFINITY && (c_vals[j] - bl_c[j]).abs() <= tol;
+        let hi_active = bu_c[j] < f64::INFINITY && (bu_c[j] - c_vals[j]).abs() <= tol;
+        if lo_active || hi_active {
+            let mut r = vec![0.0; n];
+            // `pounce_linalg` triplets are **1-based** (see `triplet.rs`).
+            for k in 0..jac_c.vals.len() {
+                if jac_c.irow[k] as usize == j + 1 {
+                    r[jac_c.jcol[k] as usize - 1] += jac_c.vals[k];
+                }
+            }
+            rows.push(r);
+        }
+    }
+    for i in 0..n {
+        let on_lo = xl[i] > f64::NEG_INFINITY && (x[i] - xl[i]).abs() <= tol;
+        let on_hi = xu[i] < f64::INFINITY && (xu[i] - x[i]).abs() <= tol;
+        if on_lo || on_hi {
+            let mut r = vec![0.0; n];
+            r[i] = 1.0;
+            rows.push(r);
+        }
+    }
+
+    // Null space of the active normals, from the eigenvectors of `BᵀB`.
+    let mut z: Vec<Number> = Vec::new();
+    let n_dof;
+    if rows.is_empty() {
+        n_dof = n;
+        z = vec![0.0; n * n];
+        for i in 0..n {
+            z[i * n + i] = 1.0;
+        }
+    } else {
+        let mut btb = vec![0.0; n * n];
+        for r in &rows {
+            for a in 0..n {
+                if r[a] == 0.0 {
+                    continue;
+                }
+                for c in 0..n {
+                    btb[c * n + a] += r[a] * r[c];
+                }
+            }
+        }
+        let (mut ev, mut evec) = (vec![0.0; n], vec![0.0; n * n]);
+        if !pounce_linalg::symmetric_eigen(&btb, n, &mut ev, &mut evec) {
+            return None;
+        }
+        let lam_max = ev.iter().fold(0.0_f64, |a, v| a.max(v.abs()));
+        let cut = 1e-9 * lam_max.max(1.0);
+        for (j, &lam) in ev.iter().enumerate() {
+            if lam.abs() <= cut {
+                z.extend_from_slice(&evec[j * n..(j + 1) * n]);
+            }
+        }
+        n_dof = z.len() / n;
+    }
+    if n_dof == 0 {
+        return None;
+    }
+
+    // `H Z`, then `Zᵀ (H Z)`.
+    let mut hz = vec![0.0; n * n_dof];
+    for k in 0..n_dof {
+        let (zc, out) = (&z[k * n..(k + 1) * n], &mut hz[k * n..(k + 1) * n]);
+        // Stored as one triangle, so an off-diagonal entry contributes to
+        // both of its rows.
+        for e in 0..hess_lag.vals.len() {
+            let (r, c, v) = (
+                hess_lag.irow[e] as usize - 1,
+                hess_lag.jcol[e] as usize - 1,
+                hess_lag.vals[e],
+            );
+            out[r] += v * zc[c];
+            if r != c {
+                out[c] += v * zc[r];
+            }
+        }
+    }
+    let mut rh = vec![0.0; n_dof * n_dof];
+    for a in 0..n_dof {
+        for b in 0..n_dof {
+            rh[b * n_dof + a] = (0..n).map(|i| z[a * n + i] * hz[b * n + i]).sum();
+        }
+    }
+
+    let (mut ev, mut evec) = (vec![0.0; n_dof], vec![0.0; n_dof * n_dof]);
+    if !pounce_linalg::symmetric_eigen(&rh, n_dof, &mut ev, &mut evec) {
+        return None;
+    }
+    // Relative to the Hessian's own scale, so this cannot fire on the
+    // rounding noise of a genuinely positive-semidefinite reduced Hessian.
+    let h_scale = hess_lag
+        .vals
+        .iter()
+        .fold(0.0_f64, |a, v| a.max(v.abs()))
+        .max(1.0);
+    if ev[0] >= -1e-8 * h_scale {
+        return None;
+    }
+    // `d = Z v` with `v` the eigenvector of the most negative eigenvalue --
+    // column 0 of the column-major `evec`, since the eigensolver returns them
+    // in ascending order.
+    let mut d = vec![0.0; n];
+    for (i, di) in d.iter_mut().enumerate() {
+        *di = (0..n_dof).map(|k| z[k * n + i] * evec[k]).sum();
+    }
+    Some(d)
 }
 
 pub(crate) fn check_kkt(

--- a/crates/pounce-cli/tests/issue855_sqp_retry_reaches_the_fallback.rs
+++ b/crates/pounce-cli/tests/issue855_sqp_retry_reaches_the_fallback.rs
@@ -1,0 +1,147 @@
+//! The SQP's rescue paths must be *reachable* (gh #855).
+//!
+//! `sqp_alg` has two re-solves after a step QP fails — the cold-start fallback
+//! (gh #349) and the quasi-Newton reset (gh #358 tail) — and an
+//! unbounded-model fallback below them (gh #423) that takes a δ-shifted
+//! proximal step. Two things kept the rescues from firing.
+//!
+//! # 1. A warm solve that errors aborted the whole SQP
+//!
+//! The cold-start fallback is gated on the warm solve's *status*
+//! (`MaxIter` / `NumericalError`), so a warm solve that returned `Err` was
+//! propagated by `?` out of the algorithm before any retry ran. That is the
+//! **stronger** form of the signal the fallback exists for, and it was the one
+//! case it could not see.
+//!
+//! `eigena2` under `algorithm=active-set-sqp` is the instance. At outer
+//! iteration 17 the warm solve fails with
+//!
+//! ```text
+//!   pinned KKT constraint block is rank-deficient (inertia shift masked a
+//!   singular constraint block); prune to a linearly-independent subset
+//! ```
+//!
+//! which is a statement about the *pinned set* — exactly what a warm start
+//! supplies and a cold start rebuilds. The SQP exited `Internal_Error` /
+//! `solve_result_num=500`, "the solver broke, retry", on a model whose
+//! objective it can report to four figures.
+//!
+//! # 2. A retry's `Unbounded` verdict was discarded
+//!
+//! Both retries accepted `Optimal` on the nose, so an `Unbounded` return —
+//! an unblocked negative-curvature direction in the null space of the working
+//! set, which is a *finding* — was thrown away and `sol` kept the original
+//! failure. The gh #423 fallback is gated on `sol.status == Unbounded`, so the
+//! proximal step written for exactly this situation was unreachable from a
+//! retry.
+//!
+//! **That half is not covered by this file, and the source says so where it
+//! lives.** No fixture in the corpus reaches it: swept under
+//! `active-set-sqp`, the retries fire on three fixtures and return only
+//! `MaxIter` or `Optimal`, including with `sqp_qp_max_iter` forced to 2.
+//! gh #855 observed it in a build carrying second-order certification for the
+//! step subproblem — gh #856's subject, which does not exist yet.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// `(status line, objective)` for one solve.
+fn solve(name: &str, extra: &[&str]) -> (String, Option<f64>) {
+    let tag: String = format!("{name}{}", extra.join("_"))
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let sol = std::env::temp_dir().join(format!("pounce_855_{tag}.sol"));
+    let out = Command::new(pounce_exe())
+        .arg(fixture(name))
+        .arg(&sol)
+        .args(extra)
+        .output()
+        .expect("run pounce");
+    let s = String::from_utf8_lossy(&out.stdout).into_owned();
+    let status = s
+        .lines()
+        .filter_map(|l| l.strip_prefix("Status: "))
+        .next_back()
+        .unwrap_or("<none>")
+        .trim()
+        .to_string();
+    // The line is `Objective...: <scaled> <unscaled>`; the unscaled one is
+    // the model's own, and the two differ here (45.833 against 82.5 on the
+    // NLP arm, which applies objective scaling where the SQP arm does not).
+    let obj = s
+        .lines()
+        .find(|l| l.trim_start().starts_with("Objective."))
+        .and_then(|l| l.split_whitespace().next_back())
+        .and_then(|v| v.parse().ok());
+    (status, obj)
+}
+
+/// The headline: a warm step-QP failure must not take the SQP down with it.
+///
+/// `Internal_Error` is the CLI's "the solver broke" band (500) and it is the
+/// wrong thing to say about a model the same binary can report an objective
+/// for. The assertion is on *that*, not on the replacement status, because the
+/// point is the absence of a spurious internal error rather than any
+/// particular verdict.
+#[test]
+fn a_warm_step_qp_failure_does_not_abort_the_sqp() {
+    let (status, obj) = solve("eigena2.nl", &["algorithm=active-set-sqp"]);
+    assert_ne!(
+        status, "Internal_Error",
+        "a rank-deficient *pinned* block is a statement about the warm \
+         working set, and a cold re-solve is the documented remedy; \
+         reporting 500 instead says the solver broke"
+    );
+    let obj = obj.expect("a solve that reports a status reports an objective");
+    assert!(
+        obj.is_finite(),
+        "the returned objective must be a number, got {obj}"
+    );
+}
+
+/// And the point it reports is the right neighbourhood, not merely a number.
+/// `eigena2`'s optimum is `82.5` — the NLP filter line-search arm reaches it
+/// on the same file, which is an independent oracle for this arm. The bar is
+/// `1e-3` relative rather than tight because the SQP arm ends
+/// `Maximum_Iterations_Exceeded`: it lands at `82.5177`, `2.1e-4` out, which
+/// is the right neighbourhood and honestly labelled as not converged.
+#[test]
+fn the_recovered_solve_lands_near_the_known_optimum() {
+    let (_status, sqp) = solve("eigena2.nl", &["algorithm=active-set-sqp"]);
+    let (nlp_status, nlp) = solve("eigena2.nl", &["solver_selection=nlp"]);
+    let sqp = sqp.expect("sqp objective");
+    let nlp = nlp.expect("nlp objective");
+    assert!(
+        nlp_status == "Solve_Succeeded" && (nlp - 82.5).abs() < 1e-6,
+        "premise: the NLP arm is the oracle here and should reach 82.5, got \
+         {nlp} ({nlp_status})"
+    );
+    assert!(
+        (sqp - nlp).abs() / nlp.abs().max(1.0) < 1e-3,
+        "the SQP arm should land on the same optimum as the NLP arm: \
+         {sqp} against {nlp}"
+    );
+}
+
+/// The other arms must be unmoved: this changes a failure path, so anything
+/// that was already solving should solve identically. `auto` does not route
+/// here at all, which is why the corpus sweep is silent about this file.
+#[test]
+fn the_default_route_is_untouched() {
+    let (status, obj) = solve("eigena2.nl", &[]);
+    assert_eq!(status, "Solve_Succeeded");
+    assert!((obj.expect("objective") - 82.5).abs() < 1e-6);
+}

--- a/crates/pounce-cli/tests/issue856_sqp_second_order.rs
+++ b/crates/pounce-cli/tests/issue856_sqp_second_order.rs
@@ -1,0 +1,188 @@
+//! The SQP must not certify a first-order point that is a constrained
+//! *maximum* (gh #856).
+//!
+//! # The instance
+//!
+//! `nonconvex_qp.nl` is `min x₀x₁ s.t. x₀ + x₁ = 2, 0 ≤ x ≤ 4`. On the
+//! feasible segment `f(x₀) = x₀(2 − x₀)` is **concave**, so the `(1, 1)` the
+//! SQP converges to at `f = 1` is the constrained maximum and the minimum is
+//! `0` at either endpoint. It was reported `Solve_Succeeded`. The NLP filter
+//! line-search arm reaches `0` on the same file in the same binary, which is
+//! the independent oracle.
+//!
+//! # Why the check runs at convergence, and not on every step
+//!
+//! gh #848 gave standalone QP solves a second-order screen, and gh #856
+//! explains why handing the same screen to the SQP's **step** subproblem is
+//! wrong: that QP is a local model built from the *current* multiplier
+//! estimates, and its second-order verdict is not the NLP's. HS071 is the
+//! counterexample and it is not exotic — at SQP iteration 0 the multipliers
+//! are still zero, so the Lagrangian Hessian is `∇²f`, and started at HS071's
+//! own `x*` the step QP's working set leaves a one-dimensional null space on
+//! which `dᵀHd = -4.05e-2`. `x*` is refuted, correctly for that model and
+//! wrongly for the NLP.
+//!
+//! At *convergence* the objection disappears, because the multipliers are the
+//! converged ones — which is gh #856's own observation ("with the converged
+//! multipliers the reduced Hessian is positive"), used here as the design
+//! rather than as an obstacle. `sqp_near_solution_start.rs` is the guard that
+//! this distinction is real: all four of its HS071 starts stay green.
+//!
+//! # Refuted by exhibition
+//!
+//! The direction is only acted on after stepping along it and finding the true
+//! objective strictly lower at a point that satisfies the *nonlinear*
+//! constraints — the same technique gh #848 uses one layer down. So the
+//! curvature search may be approximate: a direction it gets wrong costs two
+//! evaluations, not a wrong answer.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn solve(name: &str, extra: &[&str]) -> (String, Option<f64>) {
+    let tag: String = format!("{name}{}", extra.join("_"))
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let sol = std::env::temp_dir().join(format!("pounce_856_{tag}.sol"));
+    let out = Command::new(pounce_exe())
+        .arg(fixture(name))
+        .arg(&sol)
+        .args(extra)
+        .output()
+        .expect("run pounce");
+    let s = String::from_utf8_lossy(&out.stdout).into_owned();
+    let status = s
+        .lines()
+        .filter_map(|l| l.strip_prefix("Status: "))
+        .next_back()
+        .unwrap_or("<none>")
+        .trim()
+        .to_string();
+    // `Objective...: <scaled> <unscaled>`; the unscaled one is the model's.
+    let obj = s
+        .lines()
+        .find(|l| l.trim_start().starts_with("Objective."))
+        .and_then(|l| l.split_whitespace().next_back())
+        .and_then(|v| v.parse().ok());
+    (status, obj)
+}
+
+/// The premise, from an arm that is not the one under test: the minimum is
+/// `0`, not `1`.
+#[test]
+fn the_nlp_arm_puts_the_optimum_at_zero() {
+    let (status, obj) = solve("nonconvex_qp.nl", &["solver_selection=nlp"]);
+    assert_eq!(status, "Solve_Succeeded");
+    let obj = obj.expect("objective");
+    assert!(obj.abs() < 1e-6, "expected f = 0, got {obj}");
+}
+
+/// The headline: the SQP arm must not certify the constrained maximum.
+#[test]
+fn the_sqp_arm_does_not_certify_the_constrained_maximum() {
+    let (status, obj) = solve("nonconvex_qp.nl", &["algorithm=active-set-sqp"]);
+    let obj = obj.expect("objective");
+    assert!(
+        !(status == "Solve_Succeeded" && obj > 1e-6),
+        "certified f = {obj} as {status}, but f(x0) = x0(2 - x0) is concave on \
+         the feasible segment, so that is the constrained MAXIMUM and (2, 0) \
+         is feasible at f = 0"
+    );
+    assert!(
+        obj.abs() < 1e-6,
+        "expected the SQP arm to reach f = 0, got {obj} ({status})"
+    );
+}
+
+/// A second instance the issue does not mention, found by running the fix
+/// across the nonconvex fixtures: the SQP arm was returning `0` on a model
+/// whose optimum is `-2`. Without this the fix could be tuned to one fixture.
+#[test]
+fn the_nonconvex_qcqp_reaches_the_same_optimum_as_the_nlp_arm() {
+    let (sqp_status, sqp) = solve("nonconvex_qcqp.nl", &["algorithm=active-set-sqp"]);
+    let (nlp_status, nlp) = solve("nonconvex_qcqp.nl", &["solver_selection=nlp"]);
+    assert_eq!(nlp_status, "Solve_Succeeded", "premise: the oracle solves");
+    let (sqp, nlp) = (sqp.expect("sqp obj"), nlp.expect("nlp obj"));
+    assert!(
+        (nlp + 2.0).abs() < 1e-6,
+        "premise: the oracle should reach -2, got {nlp}"
+    );
+    assert!(
+        (sqp - nlp).abs() < 1e-6,
+        "the SQP arm should reach the same optimum: {sqp} against {nlp} \
+         ({sqp_status})"
+    );
+}
+
+/// The **limited-memory** leg, which the first version of this fix missed and
+/// the SQP-arm sweep caught.
+///
+/// The escape was gated on `SqpHessianSource::Exact`, on the reasoning that a
+/// quasi-Newton Hessian has no negative curvature to find. That is true of the
+/// *approximation* and beside the point: a damped-BFGS or L-BFGS matrix is
+/// positive definite **by construction**, so the gate was not an optimization,
+/// it was the reason the check did not exist under `limited-memory` at all —
+/// and that leg went on certifying the same constrained maximum.
+///
+/// `eval_hess_lag` is a required method of `SqpProblemSpec`, so the exact
+/// `∇²L` is always available; it is now taken once at convergence whatever
+/// drove the steps. This is not a corner: CLAUDE.md records that the Python
+/// frontend and the CasADi plugin both select `limited-memory` on their own
+/// whenever no exact Lagrangian Hessian is available, so it is what an
+/// embedder gets by default.
+///
+/// `nonconvex_qp_ineq` is here because it is a *third* wrong answer, one that
+/// only the L-BFGS leg was returning: `min x₀x₁ s.t. x₀ + x₁ ≥ 2` over
+/// `[0, 4]²` came back at `f = 1`, again the constrained maximum.
+#[test]
+fn the_limited_memory_leg_is_certified_too() {
+    for (name, want) in [
+        ("nonconvex_qp.nl", 0.0),
+        ("nonconvex_qp_ineq.nl", 0.0),
+        ("nonconvex_qcqp.nl", -2.0),
+    ] {
+        let (status, obj) = solve(
+            name,
+            &[
+                "algorithm=active-set-sqp",
+                "hessian_approximation=limited-memory",
+            ],
+        );
+        let obj = obj.expect("objective");
+        assert!(
+            (obj - want).abs() < 1e-6,
+            "{name} under limited-memory: expected f = {want}, got {obj} \
+             ({status}) -- a quasi-Newton Hessian is PSD by construction, so \
+             the second-order check has to use the exact one"
+        );
+    }
+}
+
+/// A **convex** QP through the same arm is untouched: the escape only looks at
+/// an indefinite Lagrangian, and where the reduced Hessian is positive there is
+/// no direction to find. Without this the fix could be "always take a step".
+#[test]
+fn a_convex_model_through_the_sqp_arm_is_unmoved() {
+    let (status, obj) = solve("boxed_qp_min.nl", &["algorithm=active-set-sqp"]);
+    assert_eq!(status, "Solve_Succeeded");
+    let obj = obj.expect("objective");
+    let (_s, nlp) = solve("boxed_qp_min.nl", &["solver_selection=nlp"]);
+    let nlp = nlp.expect("nlp objective");
+    assert!(
+        (obj - nlp).abs() / nlp.abs().max(1.0) < 1e-6,
+        "convex model moved: {obj} against the NLP arm's {nlp}"
+    );
+}


### PR DESCRIPTION
Fixes #855
Fixes #856

Two SQP-path defects, both in the same convergence/retry region of `sqp_alg`, so they land in one commit.

## #855 — the rescue paths were unreachable

Two causes, and **the one that actually bites is not the one filed**.

A warm step-QP that returned `Err` was propagated by `?` out of the whole algorithm before any retry ran. The cold-start fallback (gh#349) is gated on the warm solve's *status*, so a hard error — the **stronger** form of the same signal — was the one case it could not see. `eigena2` under `algorithm=active-set-sqp` fails at outer iteration 17 with *"pinned KKT constraint block is rank-deficient … prune to a linearly-independent subset"*, which is a statement about the **pinned set**: exactly what a warm start supplies and a cold start rebuilds.

```
before:  Internal_Error / solve_result_num=500   ("the solver broke, retry")
after:   Maximum_Iterations_Exceeded, obj 82.5177   (NLP arm: 82.5)
```

The filed cause — both retries accepting only `Optimal`, so an `Unbounded` verdict was discarded and gh#423's proximal fallback (gated on `sol.status == Unbounded`) never saw it — is fixed too.

**That half is unexercised, and the source says so where it lives.** Swept under `active-set-sqp` the retries fire on three fixtures and return only `MaxIter`/`Optimal`, even at `sqp_qp_max_iter=2`. I kept it because unlike the guard I deleted in #846 it is **not redundant** — nothing else makes that fallback reachable from a retry.

## #856 — the SQP certified a constrained maximum

`nonconvex_qp.nl` is `min x₀x₁ s.t. x₀+x₁ = 2, 0 ≤ x ≤ 4`. On the feasible segment `f(x₀) = x₀(2−x₀)` is concave, so the `(1,1)` at `f = 1` it reported as `Solve_Succeeded` is the constrained **maximum**; the minimum is `0`.

The issue argues — correctly — that handing gh#848's screen to the SQP's *step* subproblem is wrong, because that QP is a local model at the **current** multipliers: started at HS071's own `x*` it refutes a genuine local minimum on a direction with `dᵀHd = -4.05e-2`. It also notes in passing that *with the converged multipliers the reduced Hessian is positive*. That sentence is the fix: **run the check at convergence**, where the objection dissolves. The direction is then refuted **by exhibition** — stepped along, and acted on only if the true objective is strictly lower at a point satisfying the *nonlinear* constraints — so the curvature search is free to be approximate.

**The limited-memory leg is the part worth a reviewer's attention.** My first version gated the escape on `SqpHessianSource::Exact`, and the SQP-arm sweep caught that leg still certifying the maximum. The gate was not an optimization: a damped-BFGS or L-BFGS matrix is positive definite **by construction**, so searching it for negative curvature can only ever find none — the gate *was* the reason the check didn't exist there. `eval_hess_lag` is a required method of `SqpProblemSpec`, so the exact `∇²L` is now taken once at convergence whatever drove the steps. Not a corner case: the Python frontend and the CasADi plugin both select `limited-memory` whenever no exact Hessian is available.

## Validation

**SQP-arm sweep, both legs — 10 lines move, every one an improvement toward the NLP arm's answer:**

| fixture | leg | before | after |
|---|---|---|---|
| `nonconvex_qp` | exact | 1.0 *(the max)* | **0** |
| `nonconvex_qp` | lbfgs | 1.0 | **0** |
| `nonconvex_qcqp` | exact | 0 | **−2.0** |
| `nonconvex_qcqp` | lbfgs | 0 | **−2.0** |
| `nonconvex_qp_ineq` | lbfgs | 1.0 | **0** |

That last row is a **third wrong answer neither issue mentions**, and only the L-BFGS correction reaches it.

- All four HS071 starts in `sqp_near_solution_start.rs` stay green, including the quasi-Newton one — the guard that the convergence-time distinction is real, and the direct protection for #856's own counterexample.
- Default arm untouched (`auto` does not route here): `scripts/sweep-fixtures.sh` **empty across all 158 legs**.
- 3797 workspace tests, clippy CI gate and `cargo fmt --check` clean.
- Both fixes mutation-checked: reverting either turns its tests red while the premise and control legs stay green.

## Two things stated rather than buried

**#856's stated mechanism does not exist.** `sqp_qp_certify_second_order`, `QpOptions::sqp_subproblem` and `issue848_sqp_second_order_option.rs` are all absent — the issue was written against a different implementation of gh#848 than the one that shipped. The *defect* it reports is real and is what this fixes; its acceptance criteria that reference those symbols are moot, and its "rewritten together" item has no file to rewrite.

**`nonconvex_two_escapes` is unmoved** — the SQP arm returns `0` where the NLP arm reaches `-0.225`. Pre-existing, neither caused nor fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXuHz55zzpfSMGN6wSzHCk
