### PR TITLE
fix(sens): let the path walk take a weakly active bound back (#852)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,57 @@ changes.
 
 ## [Unreleased]
 
+- **`mode="path"` takes a weakly active bound back instead of walking
+  out of the box (gh #852).** On the coupled kink
+  `min (x - p)² + 0.1(y - 1)²` s.t. `y = 2x + 1`, `x ≥ 0`, held at
+  `p = 0`, a step to `p = -1` under `degeneracy="one_sided"` returned
+  `x = 0` — put there by the caller's clamp — with `y = 2/7` against
+  the re-solve's `1`. `fix_relax` got the same model right on the same
+  option, so this was not the one-sided trade: it was the walk finding
+  **no breakpoint at all** and leaving the crossing coordinate outside
+  its bound for a clamp that moves that coordinate and nothing coupled
+  to it.
+
+  `step_along_path` barred every base-active bound from its reach
+  scan. For a strongly active bound that is right and stays right —
+  its `σ` is order `1/mu`, its variable cannot move, and a Schur hold
+  on top would enforce the same bound twice through a near-singular
+  complement. A **weakly** active bound is the other thing entirely:
+  its `σ` is order *one*, a finite penalty that bends the direction
+  and enforces nothing, so a perturbation pressing into it walks the
+  variable straight out with nothing to stop it. The exclusion now
+  reads the activity classifier rather than the multiplier-against-
+  slack test, and a weak row is reachable: the walk holds it at the
+  fraction the variable arrives, and the coordinates behind it
+  re-optimize under the hold, which is what `fix_relax` was doing
+  differently.
+
+  A re-held weak row also **leaves the factorization**, the treatment
+  `initial_holds` already gets. While the hold stands the two are
+  indistinguishable — the hold takes the coordinate's movement to zero
+  and `σ` multiplies exactly that — so this half is invisible until
+  the hold *drops* one breakpoint later and the coordinate moves
+  again, where a stale order-one `σ` damps it: measured on a
+  three-breakpoint QP, `x` lands at 0.191 against the re-solve's 0.26,
+  wrong by 26% with every fraction in the record still correct.
+  `crates/pounce-sensitivity/tests/issue_852_path_reholds_a_weak_bound.rs`
+  is five tests on two models: one per branch the reach scan can now
+  take — weak-and-pressed-into, weak-and-left, strongly-active, and
+  the drop — plus one asserting the fixtures land in *different*
+  activity classes, so a model that drifts into its partner's class
+  cannot take the evidence with it. Each branch's entry in the file's
+  mutation table was run. A rule that branches is only tested by a
+  fixture per branch.
+
+  Reachable from `estimate(mode="path")` under
+  `degeneracy="one_sided"`, which is where it was found, and from
+  `parametric_step_path` / `parametric_step_path_decided` directly.
+  `degeneracy="directional"` never produced it: it holds exactly the
+  rows the perturbation holds. The CSTR figures in
+  `docs/src/sensitivity.md` are unchanged, re-measured across the fix
+  — there the thresholds' bound is one the step leaves, not one it
+  presses into.
+
 - **The active-set SQP no longer certifies a constrained maximum (gh #856).**
   `algorithm=active-set-sqp` on `nonconvex_qp.nl` — `min x₀x₁ s.t. x₀+x₁ = 2`,
   `0 ≤ x ≤ 4` — reported `f = 1` as `Solve_Succeeded`. On the feasible segment

--- a/crates/pounce-sensitivity/src/boundcheck.rs
+++ b/crates/pounce-sensitivity/src/boundcheck.rs
@@ -1164,6 +1164,13 @@ pub struct PathSegment {
     /// from this fraction on, `false` when it left it: either a bound
     /// active at the base whose multiplier reached zero, or a hold
     /// this path added earlier whose multiplier crossed zero.
+    ///
+    /// A weakly active bound can be recorded `true` at a fraction of
+    /// essentially zero, and that does not contradict the variable
+    /// having been on it at the base point: what the working set
+    /// gained there is the HOLD. Undecided, the bound sat in the
+    /// factorization as an order-one penalty that does not enforce it
+    /// (gh#852).
     pub pinned: bool,
 }
 
@@ -1213,6 +1220,15 @@ struct PathHold {
 /// Dropping a hold needs no re-factorization at all, since the hold is
 /// a Schur row rather than a term in the held factor.
 ///
+/// `weak_rows` names the bound-multiplier rows the activity
+/// classifier could not certify as strongly active. Those rows sit in
+/// the factorization with an order-one sigma that bends the direction
+/// without enforcing the bound, so the walk is allowed to reach one
+/// and hold it, releasing the row as it does. Every other base-active
+/// bound stays unreachable: its sigma is order `1/mu`, its variable
+/// cannot move off the bound, and a Schur hold there would enforce
+/// the same bound twice through a near-singular complement.
+///
 /// Returns the accumulated step and the breakpoints crossed. When
 /// `max_iter` segments are used before the target is reached, the
 /// remainder is taken in one step under the active set reached, since
@@ -1230,6 +1246,7 @@ pub fn step_along_path<B>(
     max_iter: usize,
     forced_active: &[usize],
     initial_holds: &[(usize, bool)],
+    weak_rows: &[usize],
 ) -> Result<(Vec<Number>, Vec<PathSegment>), String>
 where
     B: crate::backsolver::SensBacksolver + Clone,
@@ -1332,7 +1349,10 @@ where
     // bound is genuinely active for the first stretch. Deciding those
     // rows at fraction zero released them a sixth of a step early on
     // the CSTR held at 75% of the breakpoint fraction, and overshot
-    // tenfold against the walk's own release.
+    // tenfold against the walk's own release. A leaver is not a
+    // one-way door, though: `weak_rows` keeps it reachable, so a
+    // direction that turns out to press into it is a breakpoint and
+    // the walk takes the bound back there (gh#852).
     let mut holds: Vec<PathHold> = initial_holds
         .iter()
         .map(|&(row, lower)| PathHold {
@@ -1393,12 +1413,15 @@ where
             }
         };
 
-        // A free variable reaching a bound. A bound the held
-        // factorization still enforces is not reachable this way: its
-        // variable sits essentially on it already, and holding it AGAIN
-        // through a Schur row would enforce the same bound twice. Such
-        // a bound leaves the active set only through its own
-        // multiplier's release below.
+        // A free variable reaching a bound, or a weakly active one
+        // reaching it again. A bound the held factorization actually
+        // enforces is not reachable this way: its variable sits
+        // essentially on it already, and holding it AGAIN through a
+        // Schur row would enforce the same bound twice. Such a bound
+        // leaves the active set only through its own multiplier's
+        // release below. "Actually enforces" is the distinction the
+        // `factor_holds` comment below draws, and it is narrower than
+        // "active at the base".
         for i in 0..n_x {
             if holds.iter().any(|h| h.row == i) || changed_here.contains(&i) {
                 continue;
@@ -1406,9 +1429,22 @@ where
             // Base activity was decided once, at the table above; only
             // the released exclusion is live, since a released bound
             // left the factorization mid-path.
+            //
+            // A weakly active row is the exception, and gh#852 is what
+            // it costs to leave it out. Its sigma is order ONE, not
+            // order 1/mu: the factorization carries the bound as a
+            // finite penalty that bends the direction and does not
+            // enforce anything, so a direction that drives the
+            // variable outside its bound does exactly that, with no
+            // breakpoint to stop it. Excluding it here left the
+            // coupled kink's walk with nothing to report and the
+            // crossing coordinate outside its box, repaired downstream
+            // only by a clamp, which moves that coordinate and leaves
+            // every neighbour at the one-sided value.
             let factor_holds = |lower_side: bool| -> bool {
                 let side = if lower_side { 0 } else { 1 };
-                base_active_row[i][side].is_some_and(|r| !released.contains(&r))
+                base_active_row[i][side]
+                    .is_some_and(|r| !released.contains(&r) && !weak_rows.contains(&r))
             };
             let v = x_curr[i] + acc[i];
             if d[i] < 0.0 && lo[i] > NO_BOUND_LO && !factor_holds(true) {
@@ -1475,6 +1511,35 @@ where
         let (var_row, lower) = match ev {
             Event::ReachLower | Event::ReachUpper => {
                 let lower = ev == Event::ReachLower;
+                // A weakly active bound the walk reaches leaves the
+                // factorization at the same fraction, which is the
+                // treatment `initial_holds` already gets and for the
+                // same reason: from here on the Schur hold is what
+                // enforces the bound, and the row's order-one sigma is
+                // a second, softer copy of it built at a base point
+                // whose direction no longer applies. While the hold
+                // stands the two are indistinguishable -- the hold
+                // takes the coordinate's movement to zero and sigma
+                // multiplies exactly that -- so what the release is
+                // for is the fraction AFTER the hold drops, where the
+                // coordinate moves again and a stale order-one sigma
+                // damps it. The base-activity table is not the test
+                // here: sigma is in the factor for every bound, and a
+                // weak row lands on either side of that table's
+                // multiplier-against-slack comparison.
+                let reached_row = bound_rows.as_ref().and_then(|rows| {
+                    rows.iter()
+                        .find(|b| b.var_row == row && b.lower == lower)
+                        .map(|b| b.row)
+                });
+                if can_release
+                    && let Some(r) = reached_row
+                    && weak_rows.contains(&r)
+                    && !released.contains(&r)
+                {
+                    released.push(r);
+                    changed_here.push(r);
+                }
                 holds.push(PathHold {
                     row,
                     lower,

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -892,6 +892,15 @@ impl Solver {
         max_iter: usize,
     ) -> Result<(Vec<Number>, Vec<crate::boundcheck::PathSegment>), SolverError> {
         let rhs_plain = self.parametric_rhs_full(pin_constraint_indices, deltas)?;
+        // Nothing here decides the weak rows -- that is what the
+        // "decided" variant below is for -- but the walk still has to
+        // be told which they are, or it reads their order-one sigma as
+        // a bound the factorization enforces and lets the variable
+        // walk out of its box (gh#852). A relaxed solve shifts the
+        // slacks the classifier reads, so this comes back empty there
+        // and the walk behaves as it did before -- the same silence
+        // `weakly_active_bounds` hands every other caller.
+        let weak_rows: Vec<usize> = self.weakly_active_bounds()?.iter().map(|w| w.row).collect();
         let ctx = self.bound_context(None)?;
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
@@ -905,6 +914,7 @@ impl Solver {
             max_iter,
             &[],
             &[],
+            &weak_rows,
         )
         .map_err(SolverError::SensComputationFailed)?;
         Ok((dx[..ctx.n_x].to_vec(), segments))
@@ -915,7 +925,12 @@ impl Solver {
     /// `held_var_rows` names the var-x rows of the weakly active
     /// bounds the direction holds; every other weakly active bound is
     /// forced into the walk's base-activity table as a leaving row.
-    /// Study surface for an externally solved eq. 14 QP.
+    /// A row left there is still reachable, so a caller that hands in
+    /// an empty held list — every weak row declared a leaver, which is
+    /// what an undecided study of the all-released step does — gets
+    /// the bound back at the fraction the walk finds the direction
+    /// pressing into it, rather than an answer outside the box
+    /// (gh#852). Study surface for an externally solved eq. 14 QP.
     pub fn parametric_step_path_decided(
         &self,
         pin_constraint_indices: &[Index],
@@ -946,6 +961,13 @@ impl Solver {
             .filter(|w| !held.contains(&w.var_row))
             .map(|w| w.row)
             .collect();
+        // Every weak row, held or leaving. For a held one the flag is
+        // inert -- it arrives released and pinned already -- and for a
+        // leaving one it is what lets the walk take the bound back
+        // when the direction turns out to press into it, which is the
+        // whole of an empty held list on a holding perturbation
+        // (gh#852).
+        let weak_rows: Vec<usize> = weak.iter().map(|w| w.row).collect();
         let (dx, segments) = crate::boundcheck::step_along_path(
             &state.backsolver,
             &rhs_plain,
@@ -956,6 +978,7 @@ impl Solver {
             max_iter,
             &forced_active,
             &holds,
+            &weak_rows,
         )
         .map_err(SolverError::SensComputationFailed)?;
         Ok((dx[..ctx.n_x].to_vec(), segments))

--- a/crates/pounce-sensitivity/tests/issue_852_path_reholds_a_weak_bound.rs
+++ b/crates/pounce-sensitivity/tests/issue_852_path_reholds_a_weak_bound.rs
@@ -1,0 +1,634 @@
+//! gh#852: the walk has to be able to take a weakly active bound BACK.
+//!
+//! A weakly active bound is in the factorization with a sigma of order
+//! ONE, not order `1/mu`. That is the whole content of the kink: the
+//! bound is carried as a finite penalty, so it bends the direction
+//! without enforcing anything, and a direction that presses into it
+//! walks the variable straight out of its box. `step_along_path` used
+//! to bar every base-active bound from its reach scan, on the correct
+//! reasoning that a strongly held bound cannot be reached — its
+//! variable is already on it and cannot move — and the weak rows went
+//! out with it. On the holding side of the coupled kink below the walk
+//! then found no breakpoint at all: zero segments, `x` outside its
+//! lower bound, and a caller left to clamp. A clamp moves the crossing
+//! coordinate only, so `y`, which the equality ties to it, kept the
+//! one-sided value 2/7 against the re-solve's 1.
+//!
+//! The fix narrows the exclusion to bounds the classifier certifies as
+//! strongly active, so this file has to reach BOTH sides of that
+//! branch — the rule `sens_invariance_legs.rs` states and gh#756 paid
+//! for. Three tests, one per branch the reach scan can now take:
+//!
+//! 1. weak bound, direction presses IN: the walk re-holds it and the
+//!    coupled neighbour follows (the defect);
+//! 2. weak bound, direction presses OUT: the walk still releases it,
+//!    and the new reach event does not pre-empt that release;
+//! 3. strongly active bound, direction presses IN: the exclusion is
+//!    still in force, nothing is re-held, and the answer is unmoved.
+//!
+//! A re-held weak row also leaves the factorization, and that half of
+//! the fix is invisible on the three above: while the hold stands, the
+//! row's order-one sigma multiplies a coordinate the hold has already
+//! taken to zero, so releasing it changes nothing anyone can measure.
+//! It becomes measurable one breakpoint later, where the hold DROPS
+//! and the coordinate moves again — a stale sigma damps it. Test 4 is
+//! a second model built to reach that fraction, and it is the only
+//! thing in the crate that does.
+//!
+//! Mutation table:
+//!
+//! | change | red |
+//! |---|---|
+//! | drop `weak_rows` from `factor_holds` (restore the old exclusion) | 1 |
+//! | drop the base-activity test from `factor_holds` entirely | 3 |
+//! | skip the release of the re-held row in the reach handler | 4 |
+//! | release on `base_active_row` instead of on `weak_rows` | 4 |
+//!
+//! Every number here is checked against a re-solve at the perturbed
+//! parameter, which for these QPs is the exact answer.
+//!
+//! What this file is NOT evidence about:
+//!
+//! * **Scaling.** Both models run unit-scaled. The branch the reach
+//!   scan takes is a set membership plus the sign of `d[i]`, and
+//!   `sens_invariance_legs.rs` leg 1 already pins that the weak set
+//!   itself is unmoved by a change of variables; the Python side
+//!   carries a `user-scaling` arm on the same coupled kink.
+//! * **The magnitude of test 1's answer.** At an exact kink the
+//!   converged base point sits `O(sqrt(mu))` off the solution, which
+//!   here is 8.5e-6 — inside that test's 1e-5 tolerance. So a
+//!   predictor that returned the base point unchanged would clear the
+//!   two `x`/`y` bounds there. It would not clear the assertion that
+//!   `y` moved off 2/7, and it would not clear the record assertion,
+//!   which is what carries that test. Tests 2 and 4 have no such
+//!   margin: their answers are 0.71 and 0.26 against a base of ~1e-5.
+//! * **Index spaces.** Both models keep the parameter in the x block,
+//!   so var-x rows and model columns coincide. `cd_split_pin_mapping.rs`
+//!   and `sens_invariance_legs.rs` leg 3 own that dimension. (The one
+//!   new cross-space read, `WeakBound::row` against a bound-multiplier
+//!   row, is checked by mutation: swapping it for `var_row` in either
+//!   caller turns tests 1 and 4 red.)
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::TNLP;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+};
+use pounce_sensitivity::Solver;
+
+/// The kink, coupled to an interior variable through an equality, with
+/// the parameter carried as a third variable pinned by one:
+///
+/// ```text
+/// min  (x - p)^2 + 0.1 (y - 1)^2
+/// s.t. g0 = p            (the pin)
+///      g1: y - 2x - 1 = 0
+///      0 <= x <= 10,  -50 <= y <= 50
+/// ```
+///
+/// Along the equality the objective is `(x - p)^2 + 0.4 x^2`, so the
+/// unconstrained minimizer is `x = p / 1.4` and the solution is
+///
+/// ```text
+/// p <= 0:  x = 0,        y = 1
+/// p >= 0:  x = p / 1.4,  y = 2 p / 1.4 + 1
+/// ```
+///
+/// At `p = 0` those two branches meet: `x` sits on its lower bound
+/// with a vanishing multiplier, the canonical kink, and the coupling
+/// is what makes the defect visible — a clamp can put `x` back on its
+/// bound, but only a re-optimization moves `y` with it.
+struct CoupledKink {
+    p_nominal: Number,
+}
+
+impl TNLP for CoupledKink {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 3,
+            m: 2,
+            nnz_jac_g: 3,
+            nnz_h_lag: 4,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = 0.0;
+        b.x_u[0] = 10.0;
+        b.x_l[1] = -50.0;
+        b.x_u[1] = 50.0;
+        b.x_l[2] = -1.0e19;
+        b.x_u[2] = 1.0e19;
+        b.g_l[0] = self.p_nominal;
+        b.g_u[0] = self.p_nominal;
+        b.g_l[1] = 0.0;
+        b.g_u[1] = 0.0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.5;
+        sp.x[1] = 2.0;
+        sp.x[2] = self.p_nominal;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let (xx, y, p) = (x[0], x[1], x[2]);
+        Some((xx - p) * (xx - p) + 0.1 * (y - 1.0) * (y - 1.0))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (xx, y, p) = (x[0], x[1], x[2]);
+        g[0] = 2.0 * (xx - p);
+        g[1] = 0.2 * (y - 1.0);
+        g[2] = -2.0 * (xx - p);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[2];
+        g[1] = x[1] - 2.0 * x[0] - 1.0;
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let rs: [Index; 3] = [0, 1, 1];
+                let cs: [Index; 3] = [2, 0, 1];
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 1.0;
+                values[1] = -2.0;
+                values[2] = 1.0;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Lower triangle. Both constraints are linear, so lambda
+        // contributes nothing and only the objective appears.
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let rs: [Index; 4] = [0, 1, 2, 2];
+                let cs: [Index; 4] = [0, 1, 0, 2];
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 2.0 * obj_factor;
+                values[1] = 0.2 * obj_factor;
+                values[2] = -2.0 * obj_factor;
+                values[3] = 2.0 * obj_factor;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn configured() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("tol", 1e-10, true, false)
+        .unwrap();
+    // The activity classifier reads slacks, and a relaxed solve shifts
+    // them, which makes `weakly_active_bounds` return nothing and the
+    // fix under test inert. The corresponding Python surface takes the
+    // same care.
+    app.options_mut()
+        .set_numeric_value("bound_relax_factor", 0.0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    app
+}
+
+fn solved_at(p: Number) -> Solver {
+    let mut solver = Solver::new(
+        configured(),
+        Rc::new(RefCell::new(CoupledKink { p_nominal: p })) as Rc<RefCell<dyn TNLP>>,
+    );
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve at p={p} failed: {status:?}",
+    );
+    solver
+}
+
+/// `(x, y)` at the exact solution for `p`.
+fn resolve_at(p: Number) -> [Number; 2] {
+    let solver = solved_at(p);
+    let x = solver.converged().expect("converged state").x.clone();
+    [x[0], x[1]]
+}
+
+/// Solve at `p0`, then walk and repair to `p0 + dp`. Returns the
+/// walk's `(x, y)`, the base-point repair's `(x, y)`, and the walk's
+/// breakpoint record.
+fn walk_and_repair(
+    p0: Number,
+    dp: Number,
+) -> (
+    [Number; 2],
+    [Number; 2],
+    Vec<pounce_sensitivity::boundcheck::PathSegment>,
+) {
+    let solver = solved_at(p0);
+    let base = solver.converged().expect("converged state").x.clone();
+    let (fixed, _, _) = solver
+        .parametric_step_bounded(&[0], &[dp], 8, None)
+        .expect("parametric_step_bounded");
+    let (walked, segs) = solver
+        .parametric_step_path(&[0], &[dp], 8)
+        .expect("parametric_step_path");
+    (
+        [base[0] + walked[0], base[1] + walked[1]],
+        [base[0] + fixed[0], base[1] + fixed[1]],
+        segs,
+    )
+}
+
+/// The var-x row of `x`, whose bound is the one in question. The pin
+/// variable is not removed from the x block here, so var-x rows and
+/// model columns coincide; the file asserts on row 0 only, which is
+/// `x` under either reading.
+const X_ROW: usize = 0;
+
+#[test]
+fn the_walk_reholds_a_weak_bound_the_perturbation_presses_into() {
+    // The defect. dp = -1 from the kink: the true solution keeps x on
+    // its bound and leaves y at 1. Before the fix the walk reported no
+    // breakpoint, left x at -5/14, and y at 2/7.
+    let truth = resolve_at(-1.0);
+    let (walked, fixed, segs) = walk_and_repair(0.0, -1.0);
+
+    assert!(
+        (truth[0]).abs() < 1e-6 && (truth[1] - 1.0).abs() < 1e-6,
+        "the re-solve should hold the bound: {truth:?}",
+    );
+    let err = (walked[0] - truth[0])
+        .abs()
+        .max((walked[1] - truth[1]).abs());
+    assert!(
+        err < 1e-5,
+        "the walk should reproduce the re-solve, off by {err}: \
+         walk {walked:?} against {truth:?} (segments {segs:?})",
+    );
+    // What made the wrong answer wrong: y, not x. A clamp gets x right
+    // on its own, so an assertion on x alone passes over the defect.
+    assert!(
+        (walked[1] - 1.0).abs() < 1e-5,
+        "the coupled neighbour has to follow the re-held bound, got y = {} \
+         (the pre-fix value was 2/7 = {})",
+        walked[1],
+        2.0 / 7.0,
+    );
+    // The repair mode was always right here; the walk now agrees with it.
+    let gap = (walked[0] - fixed[0])
+        .abs()
+        .max((walked[1] - fixed[1]).abs());
+    assert!(
+        gap < 1e-5,
+        "path and fix_relax should agree on this model, apart by {gap}: \
+         walk {walked:?}, repair {fixed:?}",
+    );
+    // The re-hold is a breakpoint, and the record has to name it: the
+    // working set gained a hold it did not have at the base point.
+    let reheld: Vec<_> = segs
+        .iter()
+        .filter(|s| s.var_row == X_ROW && s.pinned && s.lower)
+        .collect();
+    assert_eq!(
+        reheld.len(),
+        1,
+        "one re-hold of x's lower bound expected, record {segs:?}",
+    );
+    assert!(
+        reheld[0].at < 1e-3,
+        "at an exact kink the bound is taken essentially at once, got {}",
+        reheld[0].at,
+    );
+}
+
+#[test]
+fn the_walk_still_releases_a_weak_bound_the_perturbation_leaves() {
+    // The other side of the same kink, and the branch the new reach
+    // event must not pre-empt: dp = +1 frees x, and the record has to
+    // read "leaves", not "reaches".
+    let truth = resolve_at(1.0);
+    let (walked, _, segs) = walk_and_repair(0.0, 1.0);
+
+    assert!(
+        (truth[0] - 1.0 / 1.4).abs() < 1e-6,
+        "the re-solve should leave the bound: {truth:?}",
+    );
+    let err = (walked[0] - truth[0])
+        .abs()
+        .max((walked[1] - truth[1]).abs());
+    assert!(
+        err < 1e-5,
+        "the walk should reproduce the re-solve, off by {err}: \
+         walk {walked:?} against {truth:?} (segments {segs:?})",
+    );
+    let departures: Vec<_> = segs.iter().filter(|s| !s.pinned).collect();
+    assert_eq!(
+        departures.len(),
+        1,
+        "one departure expected, record {segs:?}",
+    );
+    assert_eq!(departures[0].var_row, X_ROW, "record {segs:?}");
+    assert!(
+        !segs.iter().any(|s| s.pinned),
+        "nothing should be re-held on the releasing side, record {segs:?}",
+    );
+}
+
+#[test]
+fn a_strongly_active_bound_is_still_barred_from_the_reach_scan() {
+    // The branch the exclusion still covers. Held at p = -0.5 the same
+    // bound is strongly active, multiplier 1.0 against a slack of order
+    // mu, and pressing further in changes nothing: the factorization's
+    // order-1/mu sigma is what holds the variable, and a Schur hold on
+    // top of it would enforce the bound twice through a near-singular
+    // complement. Narrowing the exclusion to weak rows has to leave
+    // this alone.
+    let truth = resolve_at(-1.0);
+    let (walked, _, segs) = walk_and_repair(-0.5, -0.5);
+
+    assert!(
+        walked[0].abs() < 1e-6 && (walked[1] - 1.0).abs() < 1e-6,
+        "the held solution is unmoved by pressing further into the bound, \
+         got {walked:?} against {truth:?}",
+    );
+    assert!(
+        segs.is_empty(),
+        "a strongly active bound is not a breakpoint: nothing enters and \
+         nothing leaves, record {segs:?}",
+    );
+}
+
+/// The second model: a weak bound the walk re-holds and then DROPS,
+/// which is the only place the release half of the fix is visible.
+///
+/// ```text
+/// min  0.5 x^2 + 0.5 w^2 + 0.8 x w - p (0.5 x + w)
+/// s.t. g0 = p             (the pin)
+///      0 <= x <= 10,  -50 <= w <= 0.3
+/// ```
+///
+/// The Hessian `[[1, 0.8], [0.8, 1]]` is positive definite, so at
+/// `p = 0` the minimizer is the origin: `x` on its lower bound with a
+/// vanishing multiplier — the same kink as above — and `w` strictly
+/// inside its box.
+///
+/// Toward `p = 1` the walk crosses three breakpoints, each of them
+/// hand-computable:
+///
+/// * fraction 0: the unconstrained direction is
+///   `(0.5 - 0.8) / (1 - 0.64) < 0` in `x`, so the perturbation
+///   presses into the weak bound and the walk re-holds it.
+/// * fraction 0.3: with `x` held, `w` tracks `p` one for one and
+///   reaches its upper bound `0.3`.
+/// * fraction 0.48: with `w` held at `0.3`, stationarity in `x` wants
+///   `x = 0.5 p - 0.8 (0.3)`, which reaches zero at `p = 0.48`. The
+///   hold's multiplier crosses zero there and the bound is dropped.
+///
+/// Past that last fraction `x` is free and rises at `dx/dp = 0.5` to
+/// `0.26` at `p = 1`. That rate is the assertion: with the row
+/// released it is `0.5`; with the row's weak sigma left in the factor
+/// it is `0.5 / (1 + sigma)`, and the walk lands at 0.191 instead —
+/// an answer that is wrong by 26% while every breakpoint in the
+/// record is still at the right fraction.
+struct DroppedKink {
+    p_nominal: Number,
+}
+
+const XW_COUPLING: Number = 0.8;
+const X_PULL: Number = 0.5;
+const W_UPPER: Number = 0.3;
+
+impl TNLP for DroppedKink {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 3,
+            m: 1,
+            nnz_jac_g: 1,
+            nnz_h_lag: 5,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = 0.0;
+        b.x_u[0] = 10.0;
+        b.x_l[1] = -50.0;
+        b.x_u[1] = W_UPPER;
+        b.x_l[2] = -1.0e19;
+        b.x_u[2] = 1.0e19;
+        b.g_l[0] = self.p_nominal;
+        b.g_u[0] = self.p_nominal;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.1;
+        sp.x[1] = 0.1;
+        sp.x[2] = self.p_nominal;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let (xx, w, p) = (x[0], x[1], x[2]);
+        Some(0.5 * xx * xx + 0.5 * w * w + XW_COUPLING * xx * w - p * (X_PULL * xx + w))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (xx, w, p) = (x[0], x[1], x[2]);
+        g[0] = xx + XW_COUPLING * w - p * X_PULL;
+        g[1] = w + XW_COUPLING * xx - p;
+        g[2] = -(X_PULL * xx + w);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[2];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 2;
+            }
+            SparsityRequest::Values { values } => values[0] = 1.0,
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let rs: [Index; 5] = [0, 1, 1, 2, 2];
+                let cs: [Index; 5] = [0, 1, 0, 0, 1];
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = obj_factor;
+                values[1] = obj_factor;
+                values[2] = obj_factor * XW_COUPLING;
+                values[3] = -obj_factor * X_PULL;
+                values[4] = -obj_factor;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn dropped_kink_solver(p: Number) -> Solver {
+    let mut solver = Solver::new(
+        configured(),
+        Rc::new(RefCell::new(DroppedKink { p_nominal: p })) as Rc<RefCell<dyn TNLP>>,
+    );
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve at p={p} failed: {status:?}",
+    );
+    solver
+}
+
+#[test]
+fn a_re_held_weak_row_leaves_the_factor_so_the_drop_moves_at_the_right_rate() {
+    let truth = {
+        let s = dropped_kink_solver(1.0);
+        let x = s.converged().expect("converged state").x.clone();
+        [x[0], x[1]]
+    };
+    assert!(
+        (truth[0] - 0.26).abs() < 1e-6 && (truth[1] - W_UPPER).abs() < 1e-6,
+        "the re-solve should be (0.26, 0.3): {truth:?}",
+    );
+
+    let solver = dropped_kink_solver(0.0);
+    let base = solver.converged().expect("converged state").x.clone();
+    let (walked, segs) = solver
+        .parametric_step_path(&[0], &[1.0], 8)
+        .expect("parametric_step_path");
+    let end = [base[0] + walked[0], base[1] + walked[1]];
+
+    // The record first, so a failure says which breakpoint moved.
+    let record: Vec<(Number, usize, bool)> =
+        segs.iter().map(|s| (s.at, s.var_row, s.pinned)).collect();
+    assert_eq!(
+        segs.len(),
+        3,
+        "re-hold, w's bound, then the drop: three breakpoints, got {record:?}",
+    );
+    assert!(
+        segs[0].var_row == X_ROW && segs[0].pinned && segs[0].at < 1e-3,
+        "first: the weak bound is re-held essentially at once, {record:?}",
+    );
+    assert!(
+        segs[1].var_row == 1 && segs[1].pinned && (segs[1].at - 0.3).abs() < 1e-3,
+        "second: w reaches its upper bound at 0.3, {record:?}",
+    );
+    assert!(
+        !segs[2].pinned && segs[2].var_row == X_ROW && (segs[2].at - 0.48).abs() < 1e-3,
+        "third: the hold on x drops at 0.48, {record:?}",
+    );
+
+    // And the number the release buys. Leaving the weak row in the
+    // factor damps x over the last 0.52 of the path and lands it at
+    // 0.191; the assertion is tight enough to separate the two.
+    let err = (end[0] - truth[0]).abs().max((end[1] - truth[1]).abs());
+    assert!(
+        err < 1e-4,
+        "the walk should reproduce the re-solve past the drop, off by {err}: \
+         walk {end:?} against {truth:?} (the un-released value is x = 0.191)",
+    );
+}
+
+#[test]
+fn the_fixtures_take_different_branches() {
+    // The three reach-scan branches are told apart by the activity
+    // classifier and by nothing else, so this asserts the split rather
+    // than assuming it. A fixture that drifted into its partner's
+    // class would take the evidence with it and leave every test in
+    // this file green — which is the failure `sens_invariance_legs.rs`
+    // describes and gh#756 shipped.
+    let kink = solved_at(0.0);
+    let weak = kink.weakly_active_bounds().expect("classify at the kink");
+    assert_eq!(
+        weak.len(),
+        1,
+        "the kink has exactly one weakly active bound: {weak:?}",
+    );
+    assert!(
+        weak[0].var_row == X_ROW && weak[0].lower,
+        "and it is x's lower bound: {weak:?}",
+    );
+
+    let held = solved_at(-0.5);
+    let strong = held.weakly_active_bounds().expect("classify off the kink");
+    assert!(
+        strong.is_empty(),
+        "at p = -0.5 the same bound is strongly active, which is the only \
+         thing that makes the third test a test: {strong:?}",
+    );
+
+    let dropped = dropped_kink_solver(0.0);
+    let weak_dropped = dropped
+        .weakly_active_bounds()
+        .expect("classify the drop model");
+    assert!(
+        weak_dropped.iter().any(|w| w.var_row == X_ROW && w.lower),
+        "the drop model's x bound has to be weak too, or the fourth test \
+         never reaches the reach scan's new branch: {weak_dropped:?}",
+    );
+}

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -455,6 +455,23 @@ at 0.0018, and `fix_relax` reaches 0.0018 either way because its own
 release test happens to read the right sign there, a favorable read
 that `directional` replaces with a guarantee.
 
+Undecided is not the same as unenforced, though. Whichever side the
+thresholds lean toward, `path` under `"one_sided"` keeps every
+weakly active bound inside the box: a perturbation that presses into
+one is a breakpoint like any other, the walk takes the bound back
+there, and the coordinates coupled to it re-optimize behind the hold.
+Before that (gh#852) the walk saw no breakpoint at all on such a
+perturbation, and the variable left its box for a caller's clamp to
+put back — which moves the crossing coordinate and nothing else, so
+on `min (x - p)^2 + 0.1 (y - 1)^2` with `y = 2x + 1` and `x >= 0`,
+held at the kink `p = 0`, a step to `p = -1` came back with `x = 0`
+against a `y` of 2/7 where the answer is 1. What `"one_sided"` gives
+up at a kink is the choice of side, not feasibility; on that model
+`path` and `fix_relax` now both reproduce the re-solve, and `linear`
+is the one that still cannot, since a clamp is all it has. The CSTR
+figures above are unchanged by it: there the thresholds' bound is one
+the step leaves, not one it presses into.
+
 The cost is gated by the condition, and budgeted by
 `degeneracy_iter` (default 16): the released solve, one further
 back-solve per engaged row, and one more to recover the direction all

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -2151,6 +2151,14 @@ def estimate_report(model, perturb, max_iter=None,
 #: it without a model counterpart), `bound` is "lower" or "upper", and
 #: `action` is "reaches" when the variable arrives at the bound and is
 #: held there, "leaves" when it comes off it.
+#:
+#: A weakly active bound can be recorded as "reaches" at a fraction of
+#: essentially zero, which does not contradict the variable having been
+#: on that bound at the base point: what the working set gained there
+#: is the *hold*. Undecided, such a bound sits in the factorization as
+#: an order-one penalty that bends the step without enforcing anything,
+#: so a perturbation pressing into it is a breakpoint like any other
+#: (gh#852).
 ActiveSetChange = namedtuple(
     "ActiveSetChange", ["fraction", "var", "bound", "action"])
 

--- a/pyomo-pounce/tests/test_degeneracy.py
+++ b/pyomo-pounce/tests/test_degeneracy.py
@@ -261,3 +261,75 @@ def test_the_coupled_variable_follows_the_decided_side():
             f"target {target}, mode {mode}")
         assert est[m.y] == pytest.approx(pyo.value(exact.y), abs=1e-4), (
             f"target {target}, mode {mode}")
+
+
+def test_one_sided_path_keeps_the_coupled_kink_inside_its_box():
+    """gh#852. `degeneracy="one_sided"` gives up the choice of side at
+    a kink; it does not give up feasibility. The walk used to find no
+    breakpoint when the perturbation pressed into a weakly active
+    bound -- the factorization's order-one sigma bends the direction
+    without enforcing anything -- so `x` left its box and the clamp
+    put it back, moving `x` alone and leaving `y`, which the equality
+    ties to it, at the one-sided 2/7.
+
+    The three modes are not interchangeable here and the assertions
+    say so separately: `linear` is still lossy by construction, which
+    is what keeps this from passing vacuously, and `path` now agrees
+    with `fix_relax` and the re-solve."""
+    m = coupled_kink()
+    exact = coupled_kink(-1.0)
+    assert pyo.value(exact.x) == pytest.approx(0.0, abs=1e-6)
+    assert pyo.value(exact.y) == pytest.approx(1.0, abs=1e-6)
+
+    for mode in ("fix_relax", "path"):
+        est = estimate(m, [(m.p, -1.0)], mode=mode, degeneracy="one_sided")
+        assert est[m.x] == pytest.approx(0.0, abs=1e-4), f"mode={mode}"
+        assert est[m.y] == pytest.approx(1.0, abs=1e-4), (
+            f"mode={mode}: the coupled neighbour has to follow the held "
+            f"bound, got {est[m.y]} (the pre-fix path value was 2/7)")
+
+    # The runnable before: a single linear map plus a clamp cannot do
+    # this, which is why the mode matters rather than the option.
+    with pytest.warns(UserWarning, match="linear step leaves"):
+        lossy = estimate(
+            m, [(m.p, -1.0)], mode="linear", degeneracy="one_sided")
+    assert lossy[m.x] == pytest.approx(0.0, abs=1e-4), "the clamp gets x right"
+    assert abs(lossy[m.y] - 1.0) > 0.5, (
+        f"linear's clamp cannot move y, expected it to stay near 2/7, "
+        f"got {lossy[m.y]}")
+
+    # And the walk records the hold it took, at the kink's own fraction.
+    rec = active_set_changes(m, [(m.p, -1.0)], degeneracy="one_sided")
+    assert [(c.var, c.bound, c.action) for c in rec] == [
+        (m.x, "lower", "reaches")], f"record: {rec}"
+    assert rec[0].fraction == pytest.approx(0.0, abs=1e-3)
+
+
+def test_one_sided_path_reholds_the_kink_under_user_scaling():
+    """The scaling leg for the same repair. Which branch the walk's
+    reach scan takes is a set membership plus the sign of a direction
+    entry, and both are meant to be properties of the model rather than
+    of the units it is written in — the invariance the crate's
+    `leg_scaling_*` legs assert for the weak set itself.
+
+    Under `x~ = d . x` the barrier diagonal carries `d^-2`, so a rule
+    that had leaned on a bare `Sigma` anywhere would move here and
+    nowhere else."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=0.0, mutable=True)
+    m.x = pyo.Var(bounds=(0.0, 10.0), initialize=0.5)
+    m.y = pyo.Var(bounds=(-50.0, 50.0), initialize=1.0)
+    m.link = pyo.Constraint(expr=m.y == 2 * m.x + 1)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + 0.1 * (m.y - 1.0) ** 2)
+    m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+    m.scaling_factor[m.x] = 1000.0
+    m.scaling_factor[m.y] = 0.001
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(
+        m, options={"tol": 1e-10, "nlp_scaling_method": "user-scaling"})
+    assert pyo.value(m.x) == pytest.approx(0.0, abs=1e-4)
+
+    est = estimate(m, [(m.p, -1.0)], mode="path", degeneracy="one_sided")
+    assert est[m.x] == pytest.approx(0.0, abs=1e-4)
+    assert est[m.y] == pytest.approx(1.0, abs=1e-4), (
+        f"the repair has to survive a change of variables, got {est[m.y]}")


### PR DESCRIPTION
Fixes #852.

## What was wrong

On the coupled kink `min (x - p)² + 0.1(y - 1)²` s.t. `y = 2x + 1`, `x ≥ 0`,
held at `p = 0`, a step to `p = -1` under `degeneracy="one_sided"`:

| mode | `x` | `y` | |
|---|---|---|---|
| re-solve | 0 | 1 | the answer |
| `fix_relax` | 0 | 1 | right |
| `linear` | 0 (clamped) | 2/7 | the documented trade |
| `path` | 0 (clamped) | 2/7 | **wrong** |

`fix_relax` got it right on the same option, so this was never the one-sided
trade. The walk found **no breakpoint at all** — `estimate` warned "path
applied 0 active-set change(s) and still leaves the bounds for ['x']" — and
the crossing coordinate left its box for the caller's clamp, which moves that
coordinate and nothing coupled to it.

The issue's own first-step question is answered by @devin-griff's comment and
confirmed here: `one_sided` fails the same way and never touches
`parametric_step_path_decided`, so the defect is on the plain
`parametric_step_path` surface too and has been reachable from `estimate()`
on `main` all along.

## Why

`step_along_path` barred **every** base-active bound from its reach scan. For a
strongly active bound that is right and stays right: its `σ` is order `1/mu`,
its variable cannot move off the bound, and a Schur hold on top would enforce
the same bound twice through a near-singular complement.

A **weakly** active bound is a different object. Its `σ` is order *one* — the
whole content of a kink — so the factorization carries it as a finite penalty
that bends the direction and enforces nothing. A perturbation pressing into it
walks the variable straight out of the box with no breakpoint to stop it.

## The fix

Two halves, in `crates/pounce-sensitivity/src/boundcheck.rs`:

1. The reach-scan exclusion now reads the activity classifier
   (`weak_rows`, a new argument fed from `weakly_active_bounds()` by both
   callers) rather than the multiplier-against-slack table. A weak row is
   reachable: the walk holds it at the fraction the variable arrives, and the
   coordinates behind it re-optimize under the hold — which is what
   `fix_relax` was doing differently.
2. A re-held weak row also **leaves the factorization**, the treatment
   `initial_holds` already gets. While the hold stands the two are
   indistinguishable — the hold takes the coordinate's movement to zero and
   `σ` multiplies exactly that. It becomes visible one breakpoint later, where
   the hold *drops* and the coordinate moves again: on the three-breakpoint QP
   in the new test file, a stale order-one `σ` damps `x` to 0.191 against the
   re-solve's 0.26, wrong by 26% with every fraction in the record still
   correct.

`degeneracy="directional"` is unaffected — it holds exactly the rows the
perturbation holds — and a strongly active bound is unaffected.

## Tests

`crates/pounce-sensitivity/tests/issue_852_path_reholds_a_weak_bound.rs`, two
models, five tests: one per branch the reach scan can now take
(weak-and-pressed-into, weak-and-left, strongly-active, the drop) plus
`the_fixtures_take_different_branches`, which asserts the classifier's verdict
on each model instead of assuming it. Every number is checked against a
re-solve at the perturbed parameter, exact for these QPs.

The file's mutation table was run entry by entry:

| mutation | red |
|---|---|
| restore the old exclusion (drop `weak_rows` from `factor_holds`) | the re-hold test |
| drop the base-activity test from `factor_holds` entirely | the strongly-active test |
| skip the release of the re-held row | the drop test |
| release on `base_active_row` instead of on `weak_rows` | the drop test |
| `WeakBound::var_row` for `WeakBound::row` in either caller | the re-hold and drop tests |

`pyomo-pounce/tests/test_degeneracy.py` adds the issue's own reproduction at
the Python surface, including the `linear` arm as the runnable *before*, and a
`user-scaling` arm.

## `/sens-review`

| # | class | verdict | evidence |
|---|-------|---------|----------|
| 1 | index space | PASS | the one new cross-space read is a table lookup (`bound_rows.iter().find`); no new direct indexing. Mutation-checked: `.var_row` for `.row` turns two tests red |
| 2 | frame and scaling | PASS | no comparison against `Sigma`; the branch is a set membership plus a sign. Leg 1 pins the weak set's invariance; new `user-scaling` arm at `d = (1000, 0.001)` on the coupled kink |
| 3 | absolute thresholds | PASS, limit recorded | no new constant. A null step clears the re-hold test's `x`/`y` bounds (base offset 8.5e-6 inside 1e-5) — recorded in the file's not-evidence-about section; that test rides on its record assertion, and the other two answers are 0.71 and 0.26 against a base of ~1e-5 |
| 4 | doc drift | PASS | amended the `initial_holds` paragraph, the reach-scan preamble, `PathSegment::pinned`, `parametric_step_path_decided`, `ActiveSetChange`, `docs/src/sensitivity.md`. The CSTR figures in that page were **re-measured** across the fix, not assumed: bit-identical, both probe controls, both directions |
| 5 | silently wrong while reporting success | PASS | this is the class the defect was in. All five tests read an outside number (a fresh re-solve). Not added to `sens_resolve_oracle.rs`: neither of its fixtures reaches this branch — one is an `m = 1` weak kink with no coupled neighbour, where a clamp hides the defect, the other a strongly active release |
| 6 | which branch | PASS | four branch tests plus the split assertion; mutation table run |
| 7 | populations | N/A | no new threshold — the weak/strong split reuses `weakly_active_bounds()` |
| 8 | which binary | PASS | every Python number from a freshly `maturin develop --release`-built in-tree `.so`. The staleness guard fired once and was answered with a rebuild, never `POUNCE_SKIP_EXT_STALE_CHECK=1`. The CSTR before/after rebuilt on each side of a `git stash` |

## Not run, and why

`scripts/sweep-fixtures.sh`. The diff is confined to `pounce-sensitivity`,
which runs after the solve and is not on any solver trajectory; no solve
reaches this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXuHz55zzpfSMGN6wSzHCk
