### PR TITLE
qp(active-set): certify second order, and escape the saddle instead of stopping on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,19 +236,24 @@ changes.
   **The docs now say what the verdict means.** `dispatch.rs`'s `NonconvexQp`
   comment, `solve_qp_active_set_inertia`'s doc, and the `pounce.qp` guard
   message all claimed a local-optimum guarantee and pointed users at this engine
-  as the remedy for the very failure they warn about. An `Optimal` on an
-  indefinite `P` now says what it is: first-order KKT holds and no second-order
-  counterexample was found — a refutation, not a proof, and strictly weaker than
-  the NLP path's local guarantee.
+  as the remedy for the very failure they warn about. What this screen alone
+  earns is a refutation, not a proof: first-order KKT holds and no second-order
+  counterexample was found. The engine-side certification below strengthens
+  that where it concludes, and the docs state the joint verdict — see the
+  companion entry.
 
   The convex arm is untouched: the caller's own `HessianInertia::Psd` claim is
   the gate, so the screen never runs on the path every existing consumer uses.
-  `scripts/sweep-fixtures.sh` is empty across all 158 fixture-legs — which is
-  expected and is *not* evidence about this path, since no nonconvex-QP fixture
-  is routed to `qp-active-set` and `auto` still sends the class to the NLP arm.
-  That is CLAUDE.md's rule verbatim, and
+  `scripts/sweep-fixtures.sh` is empty across all 158 fixture-legs on
+  `solver_selection=auto`, which is expected and is *not* evidence about this
+  path — `auto` sends the nonconvex-QP class to the NLP arm, so the default
+  corpus never reaches the screen. That is CLAUDE.md's rule verbatim, and
   `crates/pounce-convex/tests/issue848_indefinite_second_order.rs` is the
-  evidence that is.
+  evidence that is. Forcing the arm does reach it, and the companion entry
+  below has those numbers: on `solver_selection=qp-active-set` 80 of the 158
+  legs reach the engine and this screen fires on one of them,
+  `nonconvex_qp_ineq`, which it demotes from a `SolveSucceeded` at the
+  constrained maximum to an `InternalError`.
 
 - **The `.nl` reader refuses non-finite numbers instead of silently dropping
   them (gh #847).** `str::parse::<f64>()` accepts `inf`, `-inf` and `nan`, and
@@ -409,6 +414,207 @@ changes.
   declared unbounded, where `dp = -5` predicts `x = -1` — plus an in-domain leg
   so "always fail" is not a passing fix, and a unit test on `residual_norm`
   for the mid-loop branch the fixture cannot reach.
+- **The active-set engine certifies second order itself, and escapes the
+  saddle instead of stopping on it** (gh #848). The companion entry above adds
+  a screen that *refutes* a bad verdict from outside the engine, by exhibiting
+  a better feasible point. This adds the check inside it, where the answer can
+  still be improved rather than only labelled. The two are not redundant, and
+  the entry above and `solve_qp_active_set_inertia`'s doc both say which class
+  each one reaches.
+
+  Every `QpStatus::Optimal` the engine produced was a *first-order* verdict —
+  vanishing projected gradient, sign-admissible working-set multipliers — and
+  §4.5 inertia control does not upgrade it, because shifting `H` to `H + δI`
+  makes the local model convex without moving the point. The doc comment on
+  `solve_qp_active_set_inertia` asserted otherwise ("what it returns for an
+  indefinite `P` is therefore a **local** solution, exactly as the NLP
+  filter-IPM's `optimal` is local on a nonconvex NLP"), and that claim was
+  repeated in `docs/src/choosing-a-solver.md`, `docs/src/python.md`, and three
+  places in the Python frontend. All are corrected.
+
+  `pounce-qp` now runs a second-order test at the point it is about to certify
+  and follows a witness off it, the classical nonconvex active-set move
+  (Nocedal-Wright §16.4). The test produces a **witness** — a direction `d`
+  with `A_W d = 0` and `dᵀHd < 0`, both checked explicitly — rather than
+  inferring from the inertia shift or a backend inertia count, because the
+  shift ladder fires on a singular reduced Hessian too and a singular reduced
+  Hessian is a *weak minimum* that must not be rejected. The witness is found
+  by shift-and-invert on the active-set KKT matrix, with the shift bisected
+  down from the ladder's own bracket: the ladder's `inertia_shift_factor = 100`
+  overshoots `|λ_min|` by up to two orders and flattens the spectrum, which is
+  why a first draft of this reusing the ladder's shift found nothing on
+  `diag(1, −1)`.
+
+  At a first-order point `∇q(x)ᵀd = 0`, so both signs of the witness descend
+  and the engine takes the one with more room. If nothing blocks it, the QP is
+  unbounded below and `d` is the certificate — which gives
+  `pounce-convex`'s `ray_certifies_unbounded` `dᵀPd < 0` branch (gh #791) its
+  first reachable producer; it had been written for exactly this case and
+  never reached, because every `Unbounded` the engine produced came from the
+  zero-curvature branch. Otherwise the step ends on a new row or bound, which
+  joins the working set, and the solve resumes; running out of escapes
+  downgrades to `IterationLimit` rather than staying `Optimal`.
+
+  `pounce-convex::verify_status` takes the finding as a new argument
+  (`QpStats::second_order`, a `SecondOrderVerdict`). It has to be told: that
+  function re-derives its verdict from the returned *point*, everything it
+  measures is a first-order residual, and the point is first-order clean by
+  construction — so without the channel it would have promoted the refuted
+  saddle straight back to `Optimal`, undoing the fix one layer up.
+  `crates/pounce-convex/tests/issue848_saddle_not_optimal.rs` pins that both
+  ways on the same point.
+
+  The unbounded exit — and only that one — answers to
+  `QpOptions::certify_recession_ray`. The SQP's unbounded-model fallback (gh
+  #423) sets that flag and re-solves precisely because a caller with nowhere
+  to go needs the δ-shifted proximal step rather than a recession verdict, and
+  an escape that ignored the flag sent the re-solve straight back `Unbounded`,
+  leaving the outer loop with no step at all — gh #419 verbatim, through a
+  door gh #423 had not closed. Caught by the fixture sweep, not by a unit
+  test: on `eigenb2` under `algorithm=active-set-sqp` (110 free variables, 55
+  equalities, nothing that can ever block a direction) 200 iterations at
+  `f = 1.6013` collapsed to 1 iteration at `f = 24.026` and
+  `Search_Direction_Becomes_Too_Small`. The *finding* still travels when the
+  flag declines the action, so a caller reading `stats.second_order` still
+  sees the point refuted. Blocked escapes run either way: they end on a new
+  row with a strictly lower objective and no certificate is involved.
+
+  The escape loop terminates on **measured objective progress**, not on the
+  working set growing. Growing it was the original argument and it is wrong:
+  the resume is a full solve and may drop what the escape pinned, and on an
+  indefinite `H` it does more than that — the inner loop's steps come from the
+  δ-shifted KKT of §4.5, whose model has the saddle as its *minimum*, so the
+  re-solve walks back uphill to the point the escape just left. That is
+  gh #848's "the start point is ignored entirely" met from the inside. Left
+  alone it spins the whole budget on one fixed point: on HS071's first step QP
+  all 20 escapes reported an identical working set, an identical direction,
+  `α = 1.4935` and `obj = −1.4116e-7`, each having stepped to `obj = −4.52e-2`
+  and been walked back. The guard stops after the first round without
+  progress, keeps the better of the two points, and returns `MaxIter`.
+
+  Costs nothing on the convex path: the test is gated on
+  `hessian_inertia != Psd`, which the convex driver never sets. `QpOptions`
+  gains `certify_second_order` (default `true`) plus `neg_curv_max_escapes`,
+  `neg_curv_probe_iters`, `neg_curv_shift_refinements` and `neg_curv_tol`;
+  the off switch is pinned by a test that asserts the saddle comes back
+  without it, so it is known to be a real switch rather than a field nothing
+  reads.
+
+  **Scope: standalone QP solves, not the SQP's step subproblem.** On by
+  default in `QpOptions::default()` — `solver_selection=qp-active-set`,
+  `pounce.qp.solve_qp(method="active-set")`, `ParametricActiveSetSolver` used
+  directly — which is every entry point gh #848 reports, and where the QP *is*
+  the question. Off by default in the new `QpOptions::sqp_subproblem()`, which
+  the SQP path uses, because there the QP is a *local model* built from the
+  current multiplier estimates and its second-order verdict is not the NLP's.
+  HS071 is the counterexample and it is not exotic: at iteration 0 the
+  multipliers are still zero, so `∇²L` is `∇²f`, whose reduced Hessian on the
+  working set's null space is negative (`dᵀHd = −4.046e-2`) at a point that is
+  a local minimum of the NLP. Started at `x*` that cost five outer iterations
+  where one sufficed, and from `x* + 1e-8·e₀` — which is every warm start,
+  gh #484 — the subproblem came back `QpIterationLimit` at iteration 0.
+  Modifying the Hessian rather than following the curvature is the textbook
+  answer for an SQP step (Nocedal-Wright §18.4); doing that is **gh #856**,
+  and until it lands `algorithm=active-set-sqp` can still report a constrained
+  *maximum* as `Solve_Succeeded`. That is a known and owned gap, not an
+  oversight — but it is deliberately **not pinned by a test**, and the reason
+  is worth recording. The obvious fixture for it, `nonconvex_qp.nl`, has three
+  first-order KKT points (`(1,1)` at `obj = 1`, and `(0,2)`/`(2,0)` at
+  `obj = 0`) and is exactly symmetric under swapping the two variables, so
+  which one an active-set method returns is a tie broken by the arithmetic
+  rather than a verdict fixed by the specification. macOS/arm64 breaks it
+  toward the maximum, ubuntu-latest/x86-64 toward an endpoint. A first draft
+  of the test asserted the macOS answer and went red on CI. A defect whose
+  manifestation is a tie cannot be pinned; it can only be described.
+
+  **New option `sqp_qp_certify_second_order`** (default `no`) turns it on for
+  the SQP subproblem from the CLI, AMPL, Pyomo and GAMS. It does not affect
+  standalone QP solves, which certify unconditionally. It is pinned end-to-end
+  by `crates/pounce-cli/tests/issue848_sqp_second_order_option.rs`, which
+  asserts the *objective* moves between the two settings. It does that on
+  `nonconvex_two_escapes.nl` rather than on `nonconvex_qp.nl`, per the tie
+  above: there the default's stopping point `A = (0,0)` is forced by exact
+  cancellation (the model is even in `x₁`, so `∂f/∂x₁` is zero bit-for-bit on
+  `x₁ = 0`) rather than chosen from equals, and the check moves the answer to
+  the global minimum `−6752.25`. The assertion is on the strict improvement,
+  not on either endpoint's exact value —
+  `convex_option_readers_match_the_registry` pins that the registry and the
+  reader agree on which values are legal, which is a different claim from
+  "setting it changes the answer", and it is the second claim that gh #677 and
+  the `sqp_qp_use_homotopy` no-op both failed.
+
+  **Fixture sweep** (`scripts/sweep-fixtures.sh`, both legs, four arms,
+  baselined against this release's other gh #848 change rather than against
+  0.10.0 — the two land together, so the interesting question is what *this*
+  half adds).
+
+  Two arms are byte-identical across all 158 fixture-legs. `solver_selection=auto`
+  is identical and is *uninformative rather than reassuring*: 42 of the 79
+  fixtures route to the convex arm, which is always `Psd`-gated, and the rest
+  to the NLP filter line-search, so the default corpus reaches the new code
+  zero times. `algorithm=active-set-sqp` at its default is identical too, and
+  that one **is** informative — it reaches the engine, and says the
+  certification is inert until asked for.
+
+  `solver_selection=qp-active-set` is the arm whose default behaviour this
+  changes. Forcing every fixture down it, 80 of the 158 legs reach
+  `active-set-QP-(pounce-qp)` and 78 are rejected as a class mismatch before a
+  solve. Exactly one line moves, on both legs:
+
+  ```text
+  nonconvex_qp_ineq   InternalError    it=1  obj=0.99999998
+                   -> SolveSucceeded   it=0  obj=-4.00000004e-08
+  ```
+
+  That is the two guards composing. `0.99999998` is the constrained *maximum*
+  of `min x₀·x₁ s.t. x₀ + x₁ ≥ 2`; the exhibition screen already refused to
+  call it `Optimal`, which is the `InternalError`, but refusing is all it could
+  do — it reports a verdict about a point, and the point was still the maximum,
+  still printed above the failure. The engine-side check escapes to the
+  minimum instead, and the screen then finds nothing to refute. The fixture is
+  gh #797's second one, fixed there on the NLP route and here on the QP route.
+  The two legs are bit-identical to each other on both binaries: the leg name
+  selects an *NLP* Hessian approximation and a standalone QP has an exact `H`
+  either way, so `lbfgs` is a duplicate here, not a second data point.
+
+  Three legs-worth of `InternalError` on that arm — `convex_qp_qscfxm1`,
+  `convex_qp_share1b`, `lp_degen2`, both legs each — are unchanged by this and
+  are not #848: they are PSD, so neither guard runs, and what they hit is the
+  documented rank-detection limitation on a degenerate LP forced down a route
+  `auto` would not choose.
+
+  `algorithm=active-set-sqp sqp_qp_certify_second_order=yes` **cannot be swept
+  against the baseline at all**, and the raw diff saying "158 lines moved" is
+  an artifact worth naming: the option does not exist on the baseline, which
+  rejects it with `OPTION_INVALID` and emits no JSON for any fixture. The
+  comparison that means something is option-off against option-on on the same
+  binary. Four fixtures move there, all on the `exact` leg — the `lbfgs` leg
+  cannot move, because `SqpHessianSource::Lbfgs` declares `Psd` and the check
+  never runs. `nonconvex_qp` `1 → 0`, `nonconvex_qcqp` `0 → −2` and
+  `nonconvex_two_escapes` `0 → −6752.25` are the rest of the gh #797 corpus,
+  the same defect on the same models. `eigena2` goes from `Internal_Error` at
+  iteration 0 with no objective to `Maximum_Iterations_Exceeded` at iteration 1
+  with a point: its warm-started subproblem exhausts the QP iteration budget,
+  and the cold-start retry that used to rescue it with a saddle now refuses to
+  certify one, so the honest budget verdict stands instead of a step that made
+  the next linearization's pinned KKT rank-deficient. Neither run converges;
+  400 with a point beats 500 with none. Nothing else moves.
+
+  Sitting behind `eigena2` is a gap this change did not open and does not
+  close: the cold-start and quasi-Newton retries in
+  `pounce-algorithm::sqp::sqp_alg` keep a retry only `if status ==
+  QpStatus::Optimal`, so an `Unbounded` verdict from a retry is discarded and
+  never reaches the gh #423 proximal fallback, which is gated on the *first*
+  solve's status. Filed as gh #855.
+
+  **Rust API (breaking):** `pounce_convex::verify_status` /
+  `pounce_rs::convex::verify_status` gains a third parameter,
+  `second_order: SecondOrderVerdict`, between `ray` and `sol`. Callers
+  composing `back_translate` + `verify_status` by hand pass
+  `qsol.stats.second_order`; `back_translate_verified` and
+  `solve_qp_active_set{,_inertia}` are unchanged. `SecondOrderVerdict` is
+  re-exported from both crates.
+
 - **`estimate()` and `gradient()` no longer re-parse variable names on
   every call.** The sensitivity session now keeps the variable data
   objects the solve resolves when it loads its solution back, in

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -1192,7 +1192,7 @@ impl Default for AlgorithmBuilder {
             output: OutputOptions::default(),
             warm: WarmStartOptions::default(),
             sqp: crate::sqp::SqpOptions::default(),
-            sqp_qp: pounce_qp::QpOptions::default(),
+            sqp_qp: pounce_qp::QpOptions::sqp_subproblem(),
             init: InitOptions::default(),
             kkt_schur: None,
         }
@@ -1765,7 +1765,7 @@ mod tests {
                             output: OutputOptions::default(),
                             warm: WarmStartOptions::default(),
                             sqp: crate::sqp::SqpOptions::default(),
-                            sqp_qp: pounce_qp::QpOptions::default(),
+                            sqp_qp: pounce_qp::QpOptions::sqp_subproblem(),
                             init: InitOptions::default(),
                             kkt_schur: None,
                         }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -6002,7 +6002,8 @@ mod tests {
              sqp_qp_anti_cycling bland\n\
              sqp_qp_use_schur_updates yes\n\
              sqp_qp_max_schur_updates_before_refactor 12\n\
-             sqp_qp_use_homotopy yes\n",
+             sqp_qp_use_homotopy yes\n\
+             sqp_qp_certify_second_order yes\n",
         )
         .expect("every sqp_qp_* option must be registered (gh #360)");
 
@@ -6019,9 +6020,16 @@ mod tests {
         assert!(qp.use_schur_updates);
         assert_eq!(qp.max_schur_updates_before_refactor, 12);
         assert!(qp.use_homotopy);
+        // gh #848. Off by default on this path (see
+        // `QpOptions::sqp_subproblem`), so the value that proves the wire is
+        // live is `yes` — asserting the default would pass on a reader that
+        // never ran.
+        assert!(qp.certify_second_order);
 
-        // Untouched options must keep the pounce-qp defaults, not be
-        // overwritten with zeros by the "explicitly set" gate.
+        // Untouched options must keep the SQP subproblem base, not be
+        // overwritten with zeros by the "explicitly set" gate. That base is
+        // `QpOptions::default()` in every field but one; the exception is
+        // asserted below.
         let mut app = IpoptApplication::new();
         app.initialize().unwrap();
         app.initialize_with_options_str("algorithm active-set-sqp\n")
@@ -6040,6 +6048,11 @@ mod tests {
             qp.max_schur_updates_before_refactor,
             defaults.max_schur_updates_before_refactor
         );
+        // Off by default *on the SQP path*, and deliberately different from
+        // `QpOptions::default()` — which is what a standalone `solve_qp`
+        // gets, and where it is on. gh #848 / gh #856.
+        assert!(!qp.certify_second_order);
+        assert!(pounce_qp::QpOptions::default().certify_second_order);
     }
 
     /// The other direction of the gh #360 guard: every **registered**
@@ -6076,6 +6089,7 @@ mod tests {
         // round-trip assertions in the sister test.
         let mut read_by_the_reader = vec![
             "sqp_qp_anti_cycling".to_string(),
+            "sqp_qp_certify_second_order".to_string(),
             "sqp_qp_elastic_gamma".to_string(),
             "sqp_qp_feas_tol".to_string(),
             "sqp_qp_max_iter".to_string(),

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -47,15 +47,17 @@ impl SqpAlgorithm {
     pub fn new(qp_solver: ParametricActiveSetSolver, opts: SqpOptions) -> Self {
         Self {
             qp_solver,
-            qp_opts: QpOptions::default(),
+            qp_opts: QpOptions::sqp_subproblem(),
             opts,
             iterates: None,
             filter: SqpFilter::new(),
         }
     }
 
-    /// Override the per-call QP-solver options. Defaults are the
-    /// `pounce_qp::QpOptions::default()` (which include the
+    /// Override the per-call QP-solver options. Defaults are
+    /// `pounce_qp::QpOptions::sqp_subproblem()` — `QpOptions::default()`
+    /// with second-order certification off, for the reason given there
+    /// (which include the
     /// `use_schur_updates = false` and `anti_cycling = Expand`
     /// from Phase 5a.2). Callers can pin tighter tolerances or
     /// flip `use_schur_updates = true` for warm-started workloads.

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -787,6 +787,30 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
     )?;
 
     r.add_bool_option(
+        "sqp_qp_certify_second_order",
+        "Check second-order optimality before certifying the SQP's nonconvex QP subproblem.",
+        false,
+        "SQP subproblem only (algorithm=active-set-sqp). Every `Optimal` the \
+         active-set engine returns is a *first-order* verdict — vanishing \
+         projected gradient, sign-admissible working-set multipliers — which \
+         a saddle point of an indefinite Hessian satisfies exactly. When true \
+         the engine also produces a direction `d` with `A_W d = 0` and \
+         `d'Hd < 0` before certifying, and follows it to the next blocking \
+         row (gh #848). Standalone QP solves \
+         (solver_selection=qp-active-set, pounce.qp.solve_qp) do that \
+         unconditionally and are not affected by this option: there the QP is \
+         the question. Here it is a *local model*, whose second-order verdict \
+         is not the NLP's — at iteration 0 the multipliers are still zero, so \
+         HS071 started at its own solution reports negative curvature and \
+         needs five iterations instead of one. Yes fixes real wrong answers \
+         on this path (a constrained maximum reported as Solve_Succeeded) and \
+         costs that; making it the default needs Hessian modification first \
+         (gh #856). The check is skipped outright when the Hessian is known \
+         positive semidefinite, so quasi-Newton runs pay nothing either way. \
+         Default no.",
+    )?;
+
+    r.add_bool_option(
         "sqp_qp_use_homotopy",
         "Trace the parametric homotopy on a cold convex-QP solve.",
         false,

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -118,8 +118,20 @@ pub enum ProblemClass {
     /// Quadratic objective with an indefinite (sense-adjusted) Hessian and
     /// **linear** constraints. `auto` falls through to the NLP solver for a
     /// local minimum; `solver_selection=qp-active-set` solves it directly with
-    /// the `pounce-qp` active-set engine, which controls the inertia of the
-    /// reduced Hessian and is documented to take an indefinite `H` (gh #786).
+    /// the `pounce-qp` active-set engine, which takes an indefinite `H`
+    /// (gh #786) and returns a *local* minimum.
+    ///
+    /// What "local minimum" means on that path is narrower than it reads, and
+    /// was narrower still before gh #848. The §4.5 inertia control shifts
+    /// `H -> H + delta*I` so the *local model* is convex; it does not move the
+    /// iterate, and at a saddle `g = 0` makes the shifted step zero. So the
+    /// engine used to stop there and certify `Optimal` on the first-order
+    /// evidence alone — vanishing projected gradient, sign-admissible
+    /// working-set multipliers — which a saddle, and the constrained *maximum*
+    /// of `min x0*x1` on `x0 + x1 = 2`, satisfy exactly. The engine now
+    /// exhibits a direction `d` with `A_W d = 0` and `d'Hd < 0` and follows it
+    /// before certifying, so an `Optimal` here is second-order. It is still
+    /// only local: nothing on this path rules out a better minimum elsewhere.
     ///
     /// The linear-constraints half of that is load-bearing, not descriptive:
     /// both consumers reach the model through
@@ -674,13 +686,19 @@ fn classify_inner(prob: &NlProblem) -> (ProblemClass, ClassReason) {
 /// the strict saddle `x = 0`, `f = 0`, where `x = (1, -1)` is feasible at
 /// `f = -4`.
 ///
-/// The engine now screens a claimed optimum for negative curvature and, where
-/// it finds a feasible direction along which it can *exhibit* a strictly
-/// better point, refuses the verdict (`active_set::refute_indefinite_optimum`).
-/// That is a **refutation, not a proof**: an `Optimal` here means first-order
-/// KKT holds and no second-order counterexample was found, which is strictly
-/// weaker than the NLP filter-IPM's local guarantee. Say that, rather than
-/// claiming parity the engine does not have.
+/// Second-order evidence is now part of the verdict, from two guards that
+/// cover different classes (both described on
+/// [`pounce_convex::solve_qp_active_set_inertia`]). The engine certifies the
+/// reduced Hessian on its working set's null space and, where it finds a
+/// witness of negative curvature, escapes along it and returns the *better
+/// point* — so the fix is usually a better answer rather than a worse status.
+/// The driver then screens what comes back by exhibition, which reaches the
+/// degenerate-active-bound class the first cannot, and refuses a verdict only
+/// where it holds a strictly better feasible point in hand.
+///
+/// Local, still, and not even that in general: seeing past every working set
+/// is the NP-hard part of nonconvex QP. `sqp_qp_certify_second_order` turns
+/// the engine-side check off.
 pub fn resolve_solver(
     class: ProblemClass,
     selection: SolverSelection,

--- a/crates/pounce-cli/tests/convex_option_readers_match_the_registry.rs
+++ b/crates/pounce-cli/tests/convex_option_readers_match_the_registry.rs
@@ -179,6 +179,10 @@ const PROBES: &[(&str, &[Probe])] = &[
         "sqp_qp_use_homotopy",
         &[Probe::Str("yes"), Probe::Str("no")],
     ),
+    (
+        "sqp_qp_certify_second_order",
+        &[Probe::Str("yes"), Probe::Str("no")],
+    ),
 ];
 
 #[test]

--- a/crates/pounce-cli/tests/issue848_sqp_second_order_option.rs
+++ b/crates/pounce-cli/tests/issue848_sqp_second_order_option.rs
@@ -1,0 +1,151 @@
+//! gh #848 — `sqp_qp_certify_second_order` is a real switch, end to end.
+//!
+//! The second-order check that stops the active-set engine certifying a
+//! saddle point lives in `pounce-qp`. It is on for every standalone QP solve
+//! and **off** for the SQP's step subproblem, because those two callers ask
+//! the engine different questions — see `QpOptions::sqp_subproblem`, and
+//! gh #856 for what turning it on here needs first.
+//!
+//! Off-by-default makes the switch matter more, not less. It is a
+//! *trajectory* change on every route that hands the engine an indefinite
+//! Hessian, so it needs a user-reachable switch — and a switch nothing reads
+//! is worse than none, because its documentation describes behaviour that does
+//! not exist. That is gh #677 (`limited_memory_initialization` was registered
+//! and never read) and the `sqp_qp_use_homotopy` no-op found while writing the
+//! warm-start benchmark. Both were invisible to
+//! `convex_option_readers_match_the_registry`, which pins that a value the
+//! registry accepts is never rejected by a reader — a different claim from
+//! "setting it changes the answer".
+//!
+//! So this file asserts the answer moves, on fixtures where the two
+//! behaviours give *different objectives* rather than different iteration
+//! counts. `pounce-qp`'s own
+//! `issue848_second_order_certification::the_check_can_be_switched_off_and_then_the_saddle_comes_back`
+//! pins the engine-level behaviour; what is only reachable from here is the
+//! plumbing between the CLI option registry and that reader.
+//!
+//! ## Which fixture can carry which claim
+//!
+//! `nonconvex_qp.nl` is `min x₀·x₁ s.t. x₀ + x₁ = 2, 0 ≤ x ≤ 4` (gh #797). On
+//! the feasible segment `f(x₀) = x₀(2 − x₀)` is concave, so the interior
+//! stationary point `(1, 1)` is the constrained **maximum** at `obj = 1` and
+//! the minimum `obj = 0` sits at either endpoint. With the check on, the arm
+//! reaches the minimum — that claim is portable and is
+//! `turning_it_on_stops_the_sqp_arm_certifying_the_constrained_maximum`.
+//!
+//! What is **not** portable is the *default's* answer on that fixture, and the
+//! first version of this file asserted it. All three of `(1, 1)`, `(0, 2)` and
+//! `(2, 0)` satisfy first-order KKT, so which one an active-set method returns
+//! is decided by the working-set path and not by the specification — and the
+//! model is exactly symmetric under swapping `x₀` and `x₁`, so that path turns
+//! on a tie. Both architectures break it, and they break it differently:
+//! macOS/arm64 returns the maximum `1` (20 of 20 runs, debug and release);
+//! ubuntu-latest/x86-64 returns `0`, which is how the assertion failed in
+//! CI run 33287729052. `nonconvex_two_escapes.py`'s own docstring names the
+//! mechanism from the other side — "exactly the symmetry that makes
+//! `nonconvex_qp.nl` converge onto its constrained maximum". A tie is not a
+//! defect manifestation you can pin; the record of what the default costs
+//! lives in prose here and on gh #856, not in an assertion that is true on
+//! half the machines that run it.
+//!
+//! `nonconvex_two_escapes.nl` (gh #805) carries the switch-is-real claim
+//! instead, because its default answer is reached by exact cancellation
+//! rather than by a tie. The model is even in `x₁`, so `∂f/∂x₁` vanishes
+//! identically on `x₁ = 0`, and `∂f/∂x₀` vanishes identically at `x₀ = 0` —
+//! both in exact arithmetic and in floating point, where the products are
+//! zero bit-for-bit. From the start `(0, 1)` the arm is driven onto `A =
+//! (0, 0)`, `f = 0`, in one iteration and stops there: a genuine first-order
+//! point, and the pre-#797 answer. With the check on it reaches the global
+//! minimum at the corner, `f = −6752.25`. That is a gap of nearly four
+//! orders of magnitude, so the test asserts the *strict improvement* rather
+//! than either endpoint's exact value — a switch that stops being read fails
+//! it, and a tie broken the other way on some future target does not.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn objective(args: &[&str]) -> f64 {
+    let out = Command::new(pounce_exe())
+        .args(args)
+        .output()
+        .expect("spawn pounce");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(out.status.code(), Some(0), "must solve:\n{combined}");
+    let line = combined
+        .lines()
+        .find(|l| l.starts_with("Objective"))
+        .unwrap_or_else(|| panic!("no objective line in:\n{combined}"));
+    line.split_whitespace()
+        .nth(1)
+        .and_then(|t| t.parse().ok())
+        .unwrap_or_else(|| panic!("unparseable objective line {line:?}"))
+}
+
+#[test]
+fn turning_it_on_stops_the_sqp_arm_certifying_the_constrained_maximum() {
+    let f = fixture("nonconvex_qp.nl");
+    let f = f.to_str().unwrap();
+    let on = objective(&[
+        f,
+        "--no-sol",
+        "algorithm=active-set-sqp",
+        "sqp_qp_certify_second_order=yes",
+    ]);
+    assert!(
+        on.abs() < 1e-6,
+        "with the check on the SQP must reach the minimum 0, not the interior \
+         stationary point 1; got {on}"
+    );
+}
+
+/// The option is plumbed from the CLI registry through to the engine, and
+/// setting it changes the answer — gh #677's lesson, asserted rather than
+/// assumed.
+///
+/// This is the claim `nonconvex_qp.nl` cannot carry: see the module docs for
+/// why its default answer is a tie that macOS and Linux break differently.
+/// Here the default's stopping point is forced by exact cancellation, so what
+/// separates the two settings is a real ~6752-wide improvement and not luck.
+#[test]
+fn the_switch_is_not_a_no_op_end_to_end() {
+    let f = fixture("nonconvex_two_escapes.nl");
+    let f = f.to_str().unwrap();
+    let off = objective(&[f, "--no-sol", "algorithm=active-set-sqp"]);
+    let on = objective(&[
+        f,
+        "--no-sol",
+        "algorithm=active-set-sqp",
+        "sqp_qp_certify_second_order=yes",
+    ]);
+    assert!(
+        on < off - 1.0,
+        "setting sqp_qp_certify_second_order=yes must change the answer, and \
+         change it for the better: the default stops at the ridge point A \
+         (f = 0) and the check must escape it. Got off={off}, on={on}. If \
+         these are equal the option is being registered and not read, which \
+         is gh #677's shape."
+    );
+    assert!(
+        (on + 6752.25).abs() < 1e-3,
+        "with the check on the arm should reach the global minimum at the \
+         corner, f = -6752.25; got {on}. A different value means the escape \
+         ladder changed — see nonconvex_two_escapes.py, which documents which \
+         answer each rung gives."
+    );
+}

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -81,7 +81,7 @@ use pounce_linsol::SparseSymLinearSolverInterface;
 use pounce_qp::{
     ActiveSetOverrides, BoundStatus, ConsStatus, HessianInertia, ParametricActiveSetSolver,
     QpOptions as ActiveSetOptions, QpProblem as ActiveSetProblem, QpSolver,
-    QpStatus as ActiveSetStatus, QpWarmStart, WorkingSet,
+    QpStatus as ActiveSetStatus, QpWarmStart, SecondOrderVerdict, WorkingSet,
 };
 
 use crate::ipm::{FARKAS_RESID_TOL, QpOptions, dot, finite_or_failed, inf_norm};
@@ -153,21 +153,55 @@ where
 /// The active-set engine handles indefinite Hessians by construction: §4.5
 /// inertia control shifts the H block until the reduced KKT factor has the
 /// right inertia, so phase-2 descends on a locally convex model and the point
-/// it reaches satisfies the **first-order** conditions of the *original* QP.
+/// it reaches satisfies the first-order conditions of the *original* QP.
 ///
-/// That is where the guarantee stops, and it used to be overstated here as
-/// "a local solution, exactly as the NLP filter-IPM's `optimal` is local on a
-/// nonconvex NLP". Inertia control is a property of each *factorization*, not
-/// a second-order test at the point finally returned, and on
-/// `P = [[1, 5], [5, 1]]` over `[-1, 1]²` the engine reported `Optimal` at the
-/// strict saddle `x = 0` while `x = (1, -1)` is feasible at `f = -4` (gh #848).
+/// **First-order conditions are not local optimality**, and this doc comment
+/// used to say they were — "what it returns for an indefinite `P` is therefore
+/// a local solution, exactly as the NLP filter-IPM's `optimal` is local on a
+/// nonconvex NLP". The analogy does not hold, and the gap is the whole of
+/// gh #848: on an indefinite `P` a **saddle point** satisfies the first-order
+/// conditions exactly — vanishing projected gradient, sign-admissible
+/// multipliers — and the inertia shift is what walks *to* one rather than what
+/// prevents it. Shifting `H` to `H + δI` makes the model locally convex; it
+/// does not make the model's stationary point a minimizer of `H`. The engine
+/// reported `Optimal` at objective `0` on `min ½xᵀ[[1,5],[5,1]]x` over
+/// `[−1,1]²`, whose minimum is `−4`. Begun at `x0 = [0.99, −0.99]`
+/// (`f = −3.92`) it still returned `f ≈ 0`, so it moved **uphill** and
+/// certified the result.
 ///
-/// A claimed optimum is now screened for negative curvature by
-/// [`refute_indefinite_optimum`], which refuses the verdict where it can
-/// *exhibit* a strictly better feasible point, and returns the unboundedness
-/// certificate where the direction is a feasible recession one. That is a
-/// **refutation, not a proof**: an `Optimal` on an indefinite `P` means
-/// first-order KKT holds and no counterexample was found.
+/// Two guards now stand between that and an `Optimal`, and they are not
+/// redundant — each covers a class the other cannot see.
+///
+/// * **Certification, in the engine** (`pounce-qp`'s `negcurv`). At a
+///   first-order point it asks whether `ZᵀHZ` is positive definite on
+///   `null(A_W)`, and answers with a witness: `d` with `A_W d = 0` checked
+///   explicitly and `dᵀHd < 0` evaluated against `H`. It is the guard that can
+///   *improve* the answer — the engine escapes along the witness, re-solves,
+///   and returns the better point. A witness it cannot get off downgrades the
+///   status; a probe that cannot conclude leaves the first-order verdict
+///   standing, never claiming a certificate it does not hold.
+///   [`verify_status`] is handed the finding through `QpStats::second_order`,
+///   because it cannot re-derive it: the returned point is first-order clean
+///   by construction. `certify_second_order` turns it off, and it costs
+///   nothing under [`HessianInertia::Psd`], where it never runs.
+///
+/// * **Refutation by exhibition, here** ([`refute_indefinite_optimum`]). This
+///   one searches the free set and then unrestrictedly, so it is *not* limited
+///   to the working set's null space — and it demotes only after walking the
+///   direction and evaluating a strictly better feasible point, so no false
+///   demotion is available to it. Where the direction is a feasible recession
+///   one it returns the unboundedness certificate instead.
+///
+/// The second exists because the first has a blind spot with a name: negative
+/// curvature behind a **degenerate active bound**. A bound whose multiplier is
+/// exactly zero stays in the working set — the drop rule needs a multiplier
+/// that violates its sign condition by more than `opt_tol` — and the null space
+/// the certification searches is then too small. `pounce-qp`'s `negcurv`
+/// module carries the worked example.
+///
+/// What neither gives is a **global** solution, and seeing past every working
+/// set is the NP-hard part of nonconvex QP, which a status check must not
+/// pretend to do.
 ///
 /// Two things this driver does for the convex case change under
 /// [`HessianInertia::Indefinite`]:
@@ -189,7 +223,12 @@ where
 /// The unboundedness certificate ([`ray_certifies_unbounded`]) needed no
 /// switch: it accepts a feasible recession direction of *negative curvature*,
 /// which is unreachable for a PSD `P` and is the way a nonconvex QP runs off
-/// to `−∞`.
+/// to `−∞`. Until the second-order test existed, though, nothing ever handed
+/// it such a ray — every `Unbounded` the engine produced came from the
+/// zero-curvature branch, so the negative-curvature one was written and
+/// unreachable (gh #791). The escape is its producer:
+/// `crates/pounce-convex/tests/issue848_saddle_not_optimal.rs` reaches it on
+/// `min ½(x₀² − x₁²)` with both variables free.
 ///
 /// Not offered on [`ActiveSetSession`](crate::active_set_session::ActiveSetSession):
 /// that surface warm-starts one problem from the last, and the homotopy it
@@ -906,12 +945,34 @@ where
     };
 
     let mut sol = back_translate(prob, &qsol);
-    sol.status = verify_status(qsol.status, qsol.unbounded_ray.as_deref(), &sol, prob, opts);
-    // `verify_status` re-derives *first-order* KKT, which is equivalent to
-    // global optimality for a convex QP and merely necessary for an indefinite
-    // one. So an `Optimal` claimed under `HessianInertia::Indefinite` gets a
-    // second-order screen as well (gh #848). Nothing reaches it on the PSD path
-    // -- the caller's own claim is the gate -- so the convex arm pays nothing.
+    sol.status = verify_status(
+        qsol.status,
+        qsol.unbounded_ray.as_deref(),
+        qsol.stats.second_order,
+        &sol,
+        prob,
+        opts,
+    );
+    // Two second-order guards, and they cover different classes (gh #848).
+    //
+    // The engine's own certification is upstream of here and is the one that
+    // can *improve* the answer: it works on `null(A_W)` for the working set it
+    // stopped at, and where it finds a witness it escapes along it and returns
+    // the better point rather than a verdict about the worse one. Its finding
+    // arrives through `qsol.stats.second_order`, which `verify_status` cannot
+    // re-derive -- the point it is handed is first-order clean by construction.
+    //
+    // What that check cannot see is negative curvature hidden behind a
+    // degenerate active bound: a bound whose multiplier is exactly zero stays
+    // in the working set, and the null space searched is then too small
+    // (`pounce-qp`'s `negcurv` module carries the worked example). This screen
+    // is not restricted to that null space -- it searches the free set and then
+    // unrestrictedly -- so that class is exactly what it reaches.
+    //
+    // It is safe to stack because it never demotes on a *direction*: it walks
+    // the direction and evaluates, and demotes only having exhibited a strictly
+    // better feasible point. A `Certified` verdict it disagrees with is one
+    // where it holds the counterexample.
     if inertia == HessianInertia::Indefinite && sol.status == QpStatus::Optimal {
         if let Some(demoted) = refute_indefinite_optimum(prob, &sol, opts) {
             debug_trace(|| format!("indefinite optimum refuted by exhibition -> {demoted:?}"));
@@ -1059,7 +1120,14 @@ pub fn back_translate_verified(
     opts: &QpOptions,
 ) -> QpSolution {
     let mut sol = back_translate(prob, qsol);
-    sol.status = verify_status(qsol.status, qsol.unbounded_ray.as_deref(), &sol, prob, opts);
+    sol.status = verify_status(
+        qsol.status,
+        qsol.unbounded_ray.as_deref(),
+        qsol.stats.second_order,
+        &sol,
+        prob,
+        opts,
+    );
     let sol = finite_or_failed(prob, sol);
     if crate::deadline::expired() {
         crate::ipm::mark_timed_out(sol)
@@ -1320,6 +1388,17 @@ fn adjudicated_kkt_error(prob: &QpProblem, sol: &QpSolution, tol: f64, obj_const
 ///   the phase-1 multipliers ([`certifies_primal_infeasible`], with
 ///   [`feasibility_probe`] as a second attempt) and only reported when it holds.
 ///   A claim that cannot be backed is downgraded to an honest "did not solve".
+/// * **A KKT-clean point can still not be a minimum.** The residual this
+///   function bands is a *first-order* one, and on an indefinite `P` a saddle
+///   point satisfies the first-order conditions exactly — vanishing projected
+///   gradient, sign-admissible multipliers, zero complementarity. So the
+///   verification above, applied on its own to
+///   [`solve_qp_active_set_inertia`]'s inputs, does not merely fail to catch
+///   the saddle: it *promotes* it, overriding whatever non-`Optimal` status
+///   the engine assigned after refuting it. That is gh #848, and the reason
+///   this function needs `second_order` — the engine's finding cannot be
+///   re-derived from the returned point, because the returned point is
+///   first-order clean by construction.
 ///
 /// The `Optimal` / `OptimalInaccurate` / fail banding mirrors the IPM's
 /// post-loop verdict (`hsde.rs`): within `tol` is clean, within `1e3·tol` is
@@ -1330,12 +1409,37 @@ fn adjudicated_kkt_error(prob: &QpProblem, sol: &QpSolution, tol: f64, obj_const
 pub fn verify_status(
     engine: ActiveSetStatus,
     ray: Option<&[f64]>,
+    second_order: SecondOrderVerdict,
     sol: &QpSolution,
     prob: &QpProblem,
     opts: &QpOptions,
 ) -> QpStatus {
     let err = adjudicated_kkt_error(prob, sol, opts.tol, opts.obj_constant);
-    let solved_to = |e: f64| solved_band(e, opts.tol);
+    // A refuted point is never salvaged by its residual, on any arm.
+    //
+    // Every promotion in this function runs through `solved_to`, and every one
+    // of them reads the *first-order* KKT residual. That residual is exactly
+    // what a saddle point of an indefinite `P` satisfies — the engine's own
+    // `QpStatus::Optimal` at the saddle was the gh #848 defect, and re-deriving
+    // the same conditions here reproduces it rather than catching it. So when
+    // the engine hands back a witness direction of negative curvature, the band
+    // is closed: `solved_to` returns `None` and each arm falls to its own
+    // honest non-verdict (`MaxIter` -> `IterationLimit`, `TimeLimit` ->
+    // `TimeLimit`, the rest -> `NumericalFailure`).
+    //
+    // The `Unbounded` arm's certificate check is deliberately *upstream* of
+    // this: a ray that stands up is a proof about the model, and negative
+    // curvature along a recession direction is the very thing it proves
+    // (`ray_certifies_unbounded`'s `dᵀPd < 0` branch, gh #791). Refusing that
+    // one would discard the strongest verdict available.
+    let refuted = second_order == SecondOrderVerdict::NegativeCurvature;
+    let solved_to = |e: f64| {
+        if refuted {
+            None
+        } else {
+            solved_band(e, opts.tol)
+        }
+    };
 
     match engine {
         // Trust, but verify.
@@ -2572,15 +2676,36 @@ mod tests {
         let sol = projection_optimum();
 
         assert_eq!(
-            verify_status(ActiveSetStatus::TimeLimit, None, &sol, &prob, &opts),
+            verify_status(
+                ActiveSetStatus::TimeLimit,
+                None,
+                SecondOrderVerdict::NotChecked,
+                &sol,
+                &prob,
+                &opts
+            ),
             QpStatus::Optimal,
             "an optimal point does not stop being optimal because the clock ran out"
         );
         // The iteration cap has always been salvaged this way; the two budgets
         // must now reach the same verdict on the same point.
         assert_eq!(
-            verify_status(ActiveSetStatus::MaxIter, None, &sol, &prob, &opts),
-            verify_status(ActiveSetStatus::TimeLimit, None, &sol, &prob, &opts),
+            verify_status(
+                ActiveSetStatus::MaxIter,
+                None,
+                SecondOrderVerdict::NotChecked,
+                &sol,
+                &prob,
+                &opts
+            ),
+            verify_status(
+                ActiveSetStatus::TimeLimit,
+                None,
+                SecondOrderVerdict::NotChecked,
+                &sol,
+                &prob,
+                &opts
+            ),
             "the two budgets must agree on an identical point"
         );
     }
@@ -2599,7 +2724,14 @@ mod tests {
         };
 
         assert_eq!(
-            verify_status(ActiveSetStatus::TimeLimit, None, &sol, &prob, &opts),
+            verify_status(
+                ActiveSetStatus::TimeLimit,
+                None,
+                SecondOrderVerdict::NotChecked,
+                &sol,
+                &prob,
+                &opts
+            ),
             QpStatus::TimeLimit
         );
     }
@@ -2662,7 +2794,14 @@ mod tests {
             "below the crossover the absolute residual must be used unchanged"
         );
         assert_eq!(
-            verify_status(ActiveSetStatus::Optimal, None, &sol, &prob, &opts),
+            verify_status(
+                ActiveSetStatus::Optimal,
+                None,
+                SecondOrderVerdict::NotChecked,
+                &sol,
+                &prob,
+                &opts
+            ),
             QpStatus::OptimalInaccurate
         );
     }
@@ -2688,7 +2827,14 @@ mod tests {
             "test setup: the absolute residual must be outside every band"
         );
         assert_eq!(
-            verify_status(ActiveSetStatus::Optimal, None, &sol, &prob, &opts),
+            verify_status(
+                ActiveSetStatus::Optimal,
+                None,
+                SecondOrderVerdict::NotChecked,
+                &sol,
+                &prob,
+                &opts
+            ),
             QpStatus::Optimal
         );
     }
@@ -2711,7 +2857,14 @@ mod tests {
             "a non-optimal point must not be rescued by the scale-relative arm"
         );
         assert_eq!(
-            verify_status(ActiveSetStatus::Optimal, None, &sol, &prob, &opts),
+            verify_status(
+                ActiveSetStatus::Optimal,
+                None,
+                SecondOrderVerdict::NotChecked,
+                &sol,
+                &prob,
+                &opts
+            ),
             QpStatus::NumericalFailure
         );
     }
@@ -2780,7 +2933,14 @@ mod tests {
         );
 
         assert_eq!(
-            verify_status(ActiveSetStatus::Optimal, None, &sol, &prob, &opts),
+            verify_status(
+                ActiveSetStatus::Optimal,
+                None,
+                SecondOrderVerdict::NotChecked,
+                &sol,
+                &prob,
+                &opts
+            ),
             QpStatus::NumericalFailure,
             "a constraint violation is a constraint violation at any scale"
         );

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -77,6 +77,11 @@ pub use pounce_qp::ActiveSetOverrides;
 // `QpProblem` field it fills; re-exported so a caller reaching the active-set
 // driver through this crate does not have to depend on `pounce-qp` directly.
 pub use pounce_qp::HessianInertia;
+// The engine's second-order finding, the third argument [`verify_status`]
+// needs and the one thing about the returned point that cannot be re-derived
+// from it (gh #848). Defined in `pounce-qp` next to the `QpStats` field it
+// fills; re-exported for the same reason `HessianInertia` is.
+pub use pounce_qp::SecondOrderVerdict;
 pub use psd_certificate::{PsdCertificateError, certify_psd_lower_triangle};
 pub use qp::{
     BoxScreen, NEG_INF, POS_INF, QpIterate, QpProblem, QpResiduals, QpSolution, QpStatus, Triplet,

--- a/crates/pounce-convex/tests/issue769_active_set_session.rs
+++ b/crates/pounce-convex/tests/issue769_active_set_session.rs
@@ -499,6 +499,7 @@ fn an_external_caller_can_translate_solve_and_read_back() {
     by_hand.status = verify_status(
         qsol.status,
         qsol.unbounded_ray.as_deref(),
+        qsol.stats.second_order,
         &by_hand,
         &prob,
         &opts,

--- a/crates/pounce-convex/tests/issue848_saddle_not_optimal.rs
+++ b/crates/pounce-convex/tests/issue848_saddle_not_optimal.rs
@@ -1,0 +1,233 @@
+//! gh #848 at the convex driver: a first-order-clean saddle must not come back
+//! `Optimal`, and the engine's second-order finding is the only channel that
+//! can say so.
+//!
+//! `pounce-qp` refuses the saddle in [`pounce_qp::QpSolver::solve`] (see
+//! `pounce-qp/tests/issue848_second_order_certification.rs`). That refusal is
+//! not enough on its own, because this crate does not propagate the engine's
+//! status — [`verify_status`] re-derives a verdict from the *returned point*,
+//! and everything it measures is a first-order residual. A saddle of an
+//! indefinite `P` satisfies those conditions exactly, so the re-derivation
+//! would overwrite the refusal with `Optimal`: the guard one layer down would
+//! be undone by the guard one layer up. `QpStats::second_order` is what stops
+//! that, and `the_residual_alone_would_promote_the_refuted_point` is the test
+//! that this file's other assertions are actually earning something.
+//!
+//! It is also where gh #791's `dᵀPd < 0` branch in `ray_certifies_unbounded`
+//! gets its first producer. That branch was written for "the indefinite
+//! Hessians `solve_qp_active_set_inertia` admits" and, until the escape
+//! existed, nothing ever handed it a ray: the engine's `Unbounded` exits all
+//! came from zero-curvature directions.
+//!
+//! ## Which branch each test reaches
+//!
+//! | test | engine status in | verdict | what it catches |
+//! |---|---|---|---|
+//! | `a_saddle_of_an_indefinite_qp_is_not_reported_optimal` | `Optimal` after a successful escape | `Certified` | the escape not running under this driver at all |
+//! | `an_unbounded_indefinite_qp_certifies_dual_infeasible` | `Unbounded` | `NegativeCurvature` | the `dᵀPd < 0` ray branch losing its producer, or the ray being dropped in translation |
+//! | `the_residual_alone_would_promote_the_refuted_point` | `MaxIter` | both | the whole wiring being a no-op because the point is KKT-clean |
+//! | `a_convex_qp_is_untouched` | `Optimal` | `NotChecked` | the guard leaking onto the PSD path it must cost nothing on |
+//!
+//! The first three run on an **indefinite** claim, which is the only claim
+//! that reaches any of this: under `HessianInertia::Psd` the engine never runs
+//! the test and `second_order` stays `NotChecked`, which `solved_to` treats
+//! exactly as it always did.
+
+use pounce_convex::{
+    ActiveSetOverrides, HessianInertia, QpOptions, QpProblem, QpSolution, QpStatus,
+    SecondOrderVerdict, Triplet, solve_qp_active_set_inertia, verify_status,
+};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+// The engine's own status enum. `verify_status` takes it — it is the verdict
+// being adjudicated, not the one being returned — and it is a different type
+// from this crate's `QpStatus`, which is what comes back.
+use pounce_qp::QpStatus as ActiveSetStatus;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn solve_indefinite(prob: &QpProblem) -> QpSolution {
+    let mut mk = backend;
+    solve_qp_active_set_inertia(
+        prob,
+        &QpOptions::default(),
+        &ActiveSetOverrides::default(),
+        HessianInertia::Indefinite,
+        &mut mk,
+    )
+}
+
+/// `min ½xᵀPx` over `[−1, 1]²` with `P = [[1, 5], [5, 1]]` and `c = 0`.
+///
+/// The origin is stationary (`Px + c = 0`) with an empty working set, so it is
+/// first-order optimal on every measure this crate applies — and it is a
+/// saddle: `P` has eigenvalues `6` and `−4`, and along `(1, −1)/√2` the
+/// objective falls. The true minimum is at the corners `±(1, −1)`, where
+/// `½(1 − 10 + 1) = −4`.
+fn saddle_box_qp() -> QpProblem {
+    QpProblem {
+        n: 2,
+        p_lower: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(1, 0, 5.0),
+            Triplet::new(1, 1, 1.0),
+        ],
+        c: vec![0.0, 0.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![-1.0, -1.0],
+        ub: vec![1.0, 1.0],
+    }
+}
+
+#[test]
+fn a_saddle_of_an_indefinite_qp_is_not_reported_optimal() {
+    let sol = solve_indefinite(&saddle_box_qp());
+    assert_eq!(sol.status, QpStatus::Optimal, "x = {:?}", sol.x);
+    assert!(
+        (sol.obj - (-4.0)).abs() < 1e-7,
+        "expected the corner minimum −4, got {} at {:?} — 0.0 is the saddle",
+        sol.obj,
+        sol.x
+    );
+    // Either corner is a global minimum; both have `|x₀| = |x₁| = 1` with
+    // opposite signs.
+    assert!(
+        (sol.x[0].abs() - 1.0).abs() < 1e-7
+            && (sol.x[1].abs() - 1.0).abs() < 1e-7
+            && sol.x[0] * sol.x[1] < 0.0,
+        "expected a corner ±(1, −1), got {:?}",
+        sol.x
+    );
+}
+
+/// `min ½(x₀² − x₁²)`, both variables free. Nothing blocks travel along the
+/// `x₁` axis and the objective falls quadratically: unbounded below, and the
+/// only witness is a direction of **negative curvature** — `Pd ≈ 0` is false
+/// along it, so the zero-curvature half of `ray_certifies_unbounded` cannot
+/// certify this and the `dᵀPd < 0` half must.
+fn unbounded_indefinite_qp() -> QpProblem {
+    QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, -1.0)],
+        c: vec![0.0, 0.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    }
+}
+
+#[test]
+fn an_unbounded_indefinite_qp_certifies_dual_infeasible() {
+    let sol = solve_indefinite(&unbounded_indefinite_qp());
+    assert_eq!(
+        sol.status,
+        QpStatus::DualInfeasible,
+        "expected the ray to certify unboundedness, got {:?} at {:?} (obj {})",
+        sol.status,
+        sol.x,
+        sol.obj
+    );
+}
+
+/// The mutation guard for everything above: on the *same point*, the residual
+/// band promotes to `Optimal` when the verdict is `NotChecked` and refuses
+/// when it is `NegativeCurvature`.
+///
+/// Without this, a wiring that silently dropped the verdict would still leave
+/// the two tests above green for the wrong reason (`pounce-qp` having escaped
+/// before the point ever got here), and the one case this crate has to handle
+/// on its own — an engine that refuted the point but could not get off it,
+/// which is `MaxIter` with a live witness — would be unguarded.
+#[test]
+fn the_residual_alone_would_promote_the_refuted_point() {
+    let prob = saddle_box_qp();
+    let opts = QpOptions::default();
+    // The saddle, exactly: stationary, feasible, no bound active, so every
+    // multiplier is zero and every first-order residual is zero.
+    let saddle = QpSolution {
+        status: QpStatus::Optimal,
+        x: vec![0.0, 0.0],
+        y: vec![],
+        z: vec![],
+        z_lb: vec![0.0; 2],
+        z_ub: vec![0.0; 2],
+        obj: 0.0,
+        iters: 0,
+        iterates: Vec::new(),
+    };
+
+    assert_eq!(
+        verify_status(
+            ActiveSetStatus::MaxIter,
+            None,
+            SecondOrderVerdict::NotChecked,
+            &saddle,
+            &prob,
+            &opts
+        ),
+        QpStatus::Optimal,
+        "the first-order residual at a saddle is clean — this is the defect, \
+         and it must stay reproducible or the assertion below proves nothing"
+    );
+    assert_eq!(
+        verify_status(
+            ActiveSetStatus::MaxIter,
+            None,
+            SecondOrderVerdict::NegativeCurvature,
+            &saddle,
+            &prob,
+            &opts
+        ),
+        QpStatus::IterationLimit,
+        "a refuted point is not salvaged by its residual"
+    );
+    // `Certified` is not a third state here: it must behave exactly like the
+    // unrefuted case, or certifying a genuine minimum would cost it its status.
+    assert_eq!(
+        verify_status(
+            ActiveSetStatus::MaxIter,
+            None,
+            SecondOrderVerdict::Certified,
+            &saddle,
+            &prob,
+            &opts
+        ),
+        QpStatus::Optimal
+    );
+}
+
+/// `min (x₀−3)² + (x₁−2)²  s.t.  x₀ + x₁ ≤ 4`, solved under the PSD claim the
+/// convex driver always makes. The verdict stays `NotChecked` and the banding
+/// is the one it always was.
+#[test]
+fn a_convex_qp_is_untouched() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+        c: vec![-6.0, -4.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+        h: vec![4.0],
+        lb: vec![],
+        ub: vec![],
+    };
+    let mut mk = backend;
+    let sol = solve_qp_active_set_inertia(
+        &prob,
+        &QpOptions::default(),
+        &ActiveSetOverrides::default(),
+        HessianInertia::Psd,
+        &mut mk,
+    );
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!((sol.obj - (-12.5)).abs() < 1e-8, "obj = {}", sol.obj);
+}

--- a/crates/pounce-qp/src/lib.rs
+++ b/crates/pounce-qp/src/lib.rs
@@ -45,6 +45,7 @@ pub mod error;
 pub mod factor;
 pub(crate) mod homotopy;
 pub mod kkt;
+pub mod negcurv;
 pub mod options;
 pub mod problem;
 pub mod qps;
@@ -63,8 +64,12 @@ pub use kkt::{
     assemble_equality_plus_bounds, h_times_x, is_all_equality_constraints, is_pure_box,
     is_pure_equality_no_bounds, rhs_equality_only,
 };
+pub use negcurv::SecondOrder;
 pub use options::{ActiveSetOverrides, AntiCyclingChoice, QpAlgorithm, QpOptions};
-pub use problem::{HessianInertia, ParametricSource, QpProblem, QpSolution, QpStats, QpWarmStart};
+pub use problem::{
+    HessianInertia, ParametricSource, QpProblem, QpSolution, QpStats, QpWarmStart,
+    SecondOrderVerdict,
+};
 pub use qps::{QpsModel, parse_qps};
 pub use solver::{ParametricActiveSetSolver, QpSolver};
 pub use working_set::{BoundStatus, ConsStatus, WorkingSet};

--- a/crates/pounce-qp/src/negcurv.rs
+++ b/crates/pounce-qp/src/negcurv.rs
@@ -1,0 +1,413 @@
+//! Second-order certification for the active-set engine (gh #848).
+//!
+//! # Why a first-order test is not enough
+//!
+//! Every exit in [`crate::solver`] that returns [`QpStatus::Optimal`] does so
+//! on a **first-order** argument: the projected gradient vanishes and the
+//! multipliers of the working set carry admissible signs. On a positive
+//! semi-definite `H` that is the whole story — a KKT point of a convex QP is a
+//! global minimizer. On an indefinite `H` it is not: a saddle point satisfies
+//! exactly the same conditions.
+//!
+//! The failure is not hypothetical and it is not rare. Take
+//!
+//! ```text
+//!     min  ½ xᵀ [[1 5]; [5 1]] x        (eigenvalues −4 and 6)
+//!     s.t. −1 ≤ x ≤ 1
+//! ```
+//!
+//! whose minimum is `−4`, attained at `(1, −1)` and `(−1, 1)`.
+//! [`crate::solver::ParametricActiveSetSolver`] starts box-constrained solves
+//! from the projection of the origin into the box, which here *is* the saddle.
+//! The gradient is already zero, so the very first iterate reports
+//! `‖p‖∞ ≤ opt_tol` with an empty working set and the solve returns
+//! `Optimal` at `x = 0`, `obj = 0` — the *maximum along one eigendirection*,
+//! certified as a solution. Inertia control does not save it: §4.5 shifts the
+//! `H` block until the reduced KKT factors, which supplies a descent direction
+//! for a nonzero right-hand side, and the right-hand side here is zero.
+//!
+//! # The test
+//!
+//! At a first-order point with working set `W`, the point is a local minimum
+//! iff the reduced Hessian `Zᵀ H Z` is positive semi-definite, where `Z` spans
+//! `null(A_W)`. This module answers the complementary question — *is there a
+//! feasible direction of strictly negative curvature?* — and answers it with a
+//! **witness** rather than an inference:
+//!
+//! * `d` with `A_W d = 0`, `E_W d = 0` (checked explicitly), and
+//! * `dᵀ H d < 0` (evaluated directly against `H`, not read off a factor).
+//!
+//! A verdict of [`SecondOrder::NegativeCurvature`] therefore never rests on a
+//! backend's inertia count being trustworthy, and never rests on an inference
+//! from `δ > 0`. That matters because `δ > 0` is *ambiguous*: the §4.5 ladder
+//! shifts on `WrongInertia` **and** on `Singular`, and a singular reduced
+//! Hessian is a weak minimum — a point this module must not reject. Only a
+//! direction in hand distinguishes the two.
+//!
+//! # How the witness is found
+//!
+//! By shift-and-invert, on the machinery §4.5 already owns. For a shift `δ`
+//! large enough that
+//!
+//! ```text
+//!     K_δ = [ H + δI   A_Wᵀ ]
+//!           [ A_W       0   ]
+//! ```
+//! factors with the inertia of a minimizer, the reduced matrix
+//! `Zᵀ(H + δI)Z` is positive definite with eigenvalues `λᵢ(ZᵀHZ) + δ`.
+//! Solving `K_δ [d; y] = [v; 0]` yields a `d` automatically in `null(A_W)`,
+//! and the map `v ↦ d` is `Z (Zᵀ(H+δI)Z)⁻¹ Zᵀ`. Iterating it is **inverse
+//! iteration**: it converges to the eigenvector of the smallest eigenvalue of
+//! `Zᵀ(H+δI)Z`, which is the eigenvector of the *most negative* eigenvalue of
+//! `ZᵀHZ` — exactly the direction wanted.
+//!
+//! Its rate is `(λ₂ + δ)/(λ_min + δ)` per step, and that is why this module
+//! does **not** simply reuse the shift `§4.5` settled on. The ladder
+//! multiplies by `inertia_shift_factor` (100) until a shift works, so it
+//! overshoots `|λ_min|` by up to two orders of magnitude, and an overshot
+//! shift flattens the spectrum: on `H = diag(1, −1)` the ladder stops at
+//! `δ = 100`, giving `diag(101, 99)` and a rate of `1.02` per step. Several
+//! hundred back-solves would be needed to separate a direction that is one
+//! factorization away from being exact — and the first draft of this module,
+//! which did reuse the shift, missed that fixture for precisely that reason.
+//!
+//! So the shift is refined first. The ladder brackets `|λ_min|` between the
+//! step that worked and the one before it, and `neg_curv_shift_refinements`
+//! geometric bisections on that bracket — each one factorization, each
+//! answering the same yes/no inertia question the ladder asks — narrow it to
+//! `|λ_min| · (1 + 100^(2^−r))`. At the default `r = 8` that is a 1.8%
+//! overshoot, `λ_min + δ` is under 2% of `|λ_min|`, and the iteration
+//! separates the direction in one or two back-solves.
+//!
+//! Two more consequences worth stating, because both are load-bearing:
+//!
+//! * **The unshifted factor succeeding is a certificate of the opposite
+//!   verdict.** `K₀` having exactly `|W|` negative eigenvalues *is* the
+//!   statement that `ZᵀHZ ≻ 0`, so that case returns
+//!   [`SecondOrder::Certified`] immediately. On a PSD problem it is the only
+//!   branch reachable, so the whole module costs one factorization there —
+//!   and the `HessianInertia::Psd` gate means it does not even cost that.
+//! * **The seed must not be symmetric.** Inverse iteration from a vector that
+//!   happens to *be* an eigenvector is stationary. On the `[[1,5];[5,1]]`
+//!   model, `v = (1, 1)` is the eigenvector for `+6`, so an all-ones seed
+//!   probes the one direction that can never turn negative. The seed is
+//!   therefore a fixed deterministic pseudo-random vector — deterministic
+//!   because a solver that reports a different status on a re-run is worse
+//!   than one that misses a saddle.
+//!
+//! # What this module is *not* evidence about
+//!
+//! Failure to find a witness is reported as [`SecondOrder::NotChecked`], never
+//! as `Certified`. The probe is a sufficient test for rejection and nothing
+//! more: an exhausted iteration budget, a backend failure, or a rank-deficient
+//! constraint block whose masked null direction fails the explicit `A_W d = 0`
+//! check all land there, and all leave the engine's first-order verdict
+//! standing. That is deliberate — the alternative is downgrading correct
+//! answers on weak minima, which is a wrong verdict about the user's model.
+//!
+//! One class is worth naming because it looks like it should be covered and is
+//! not: **negative curvature hidden behind a degenerate active bound**. The
+//! test asks about `null(A_W)` for the working set the engine stopped at, so a
+//! row or bound sitting in that set with a zero multiplier hides whatever lies
+//! on the other side of it. On
+//!
+//! ```text
+//!     min ½x₁² − ½x₂²   s.t.  −1 ≤ x₁ ≤ 1,  x₂ ≥ 0
+//! ```
+//!
+//! the origin is stationary, `x₂`'s bound is active with multiplier exactly
+//! zero — so the drop rule, which needs a multiplier that violates its sign
+//! condition by more than `opt_tol`, leaves it in — and the null space is the
+//! `x₁` axis, on which the curvature is `+1`. The verdict is `Certified`, and
+//! the point is not a local minimum. Seeing it requires searching over working
+//! sets rather than within one, which for an indefinite QP is the NP-hard part
+//! of the problem and not something a certification pass should be pretending
+//! to do. What this module removes is the class where the answer is visible
+//! from where the engine already stands.
+
+use crate::error::QpError;
+use crate::kkt::{KktTriplet, a_times_x, assemble_active_set_kkt, h_times_x};
+use crate::options::QpOptions;
+use crate::problem::{HessianInertia, QpProblem};
+use crate::solver::ParametricActiveSetSolver;
+use crate::working_set::WorkingSet;
+use pounce_common::Number;
+
+/// The verdict of the second-order test at a first-order point.
+///
+/// The rejecting variant carries its own witness, so a caller acting on it is
+/// acting on a direction it can re-check rather than on this module's word.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SecondOrder {
+    /// No verdict. The engine's first-order finding stands unchanged.
+    ///
+    /// Reached when the check is switched off, when `H` is claimed PSD (there
+    /// is nothing to find), when the probe budget runs out, and when the
+    /// backend or the factor declines to cooperate. Never a claim that the
+    /// point *is* a minimum.
+    NotChecked,
+    /// The reduced Hessian on `null(A_W)` is positive definite: the point is a
+    /// local minimum of the QP, not merely a stationary point of it.
+    Certified,
+    /// A feasible direction of strictly negative curvature, `A_W d = 0` and
+    /// `dᵀHd < 0`, normalized to `‖d‖₂ = 1`. The point is a saddle or a
+    /// maximum along `d`; it is not a local minimum, at any tolerance.
+    NegativeCurvature(Vec<Number>),
+}
+
+/// A fixed 64-bit-state xorshift, used only to seed the inverse iteration.
+///
+/// Deterministic on purpose (see the module docs): reproducibility of a
+/// *status* outranks the marginally better coverage of a fresh random seed.
+/// `Math.random`-grade quality is irrelevant here — the seed only has to avoid
+/// being an eigenvector of the reduced Hessian, and any vector with a nonzero
+/// component along the sought eigendirection works.
+fn probe_seed(n: usize) -> Vec<Number> {
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut v = Vec::with_capacity(n);
+    for _ in 0..n {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        // Map to (-1, 1) with a deterministic mantissa.
+        let u = (state >> 11) as f64 / (1u64 << 53) as f64;
+        v.push(2.0 * u - 1.0);
+    }
+    v
+}
+
+/// `dᵀHd`, evaluated against the problem's own `H`.
+fn curvature(qp: &QpProblem<'_>, d: &[Number]) -> Number {
+    let hd = h_times_x(qp.h, d);
+    hd.iter().zip(d.iter()).map(|(a, b)| a * b).sum()
+}
+
+/// Largest magnitude of any stored entry, the scale a curvature is compared
+/// against. `H` stores one triangle only, which does not matter for a max.
+fn inf_scale(vals: &[Number]) -> Number {
+    vals.iter().fold(0.0_f64, |a, v| a.max(v.abs()))
+}
+
+/// Normalize in place to `‖d‖₂ = 1`. Returns `false` if `d` is zero or
+/// non-finite, in which case it is not a usable direction.
+fn normalize(d: &mut [Number]) -> bool {
+    let nrm = d.iter().map(|v| v * v).sum::<Number>().sqrt();
+    if !nrm.is_finite() || nrm <= 0.0 {
+        return false;
+    }
+    for v in d.iter_mut() {
+        *v /= nrm;
+    }
+    d.iter().all(|v| v.is_finite())
+}
+
+/// Is `d` genuinely in the null space of the working set's rows?
+///
+/// Checked rather than assumed. A KKT whose *constraint* block is rank
+/// deficient cannot be repaired by any `H`-block shift, but a large enough
+/// shift can stop the backend flagging it — the masking `factor_pinned_primal`
+/// documents around `δ ≈ 1e8`. The solve then returns a plausible vector that
+/// satisfies nothing, and stepping along it would leave the feasible set. This
+/// is the guard that turns that into a `NotChecked`.
+fn stays_on_the_working_set(qp: &QpProblem<'_>, working: &WorkingSet, d: &[Number]) -> bool {
+    // `d` is normalized, so `‖d‖∞ ≤ 1` and an absolute slack scaled by the
+    // data is the right comparison.
+    let slack = 1e-7;
+    for (i, status) in working.bounds.iter().enumerate() {
+        if status.is_active() && d[i].abs() > slack {
+            return false;
+        }
+    }
+    if qp.m == 0 {
+        return true;
+    }
+    let ad = a_times_x(qp.a, d, qp.m);
+    let a_scale = inf_scale(qp.a.values()).max(1.0);
+    for (i, status) in working.constraints.iter().enumerate() {
+        if status.is_active() && ad[i].abs() > slack * a_scale {
+            return false;
+        }
+    }
+    true
+}
+
+impl ParametricActiveSetSolver {
+    /// Decide whether the first-order point described by `working` is a local
+    /// minimum, and produce a witness when it is not. See the module docs for
+    /// the mechanism and for the deliberate asymmetry between the verdicts.
+    ///
+    /// Costs one factorization of the active-set KKT plus at most
+    /// `opts.neg_curv_probe_iters` back-substitutions, and only when
+    /// `qp.hessian_inertia` is not [`HessianInertia::Psd`] — so the convex arm
+    /// pays nothing by construction.
+    ///
+    /// Leaves `self.linsol` holding the factor of the probed KKT. Callers that
+    /// need their own cached factor afterwards must re-establish it.
+    pub(crate) fn second_order_verdict(
+        &mut self,
+        qp: &QpProblem<'_>,
+        working: &WorkingSet,
+        opts: &QpOptions,
+    ) -> Result<SecondOrder, QpError> {
+        if !opts.certify_second_order || qp.hessian_inertia == HessianInertia::Psd {
+            return Ok(SecondOrder::NotChecked);
+        }
+        let n = qp.n;
+        if n == 0 {
+            return Ok(SecondOrder::Certified);
+        }
+
+        let active_cons: Vec<usize> = (0..qp.m)
+            .filter(|&i| working.constraints[i].is_active())
+            .collect();
+        let active_bounds: Vec<usize> = (0..n).filter(|&i| working.bounds[i].is_active()).collect();
+        let k = active_cons.len() + active_bounds.len();
+        if k >= n {
+            // The working set pins every degree of freedom: `null(A_W)` is
+            // trivial (or the rows are dependent, which is not this module's
+            // business), so there is no direction to move along and the point
+            // is a minimum of the QP restricted to it.
+            return Ok(SecondOrder::Certified);
+        }
+
+        let mut kkt = assemble_active_set_kkt(qp, &active_cons, &active_bounds);
+        let dim = n + k;
+        let seed = probe_seed(n);
+        let expected = k as i32;
+
+        // Attempt zero: unshifted. Success here is the `Certified` verdict —
+        // the KKT carrying exactly `k` negative eigenvalues *is* the statement
+        // that the reduced Hessian is positive definite.
+        let mut rhs = vec![0.0; dim];
+        rhs[..n].copy_from_slice(&seed);
+        match self
+            .linsol
+            .factorize_and_solve(&kkt, &mut rhs, Some(expected))
+        {
+            Ok(()) => return Ok(SecondOrder::Certified),
+            Err(ref e) if e.is_recoverable_factorization_failure() => {}
+            // A hard backend failure is an absence of evidence, not a verdict.
+            Err(_) => return Ok(SecondOrder::NotChecked),
+        }
+
+        // Climb §4.5's ladder for a shift that does factor, keeping the
+        // bracket: `hi` works, `hi / inertia_shift_factor` did not, so
+        // `|λ_min|` lies between them.
+        let mut current = 0.0;
+        let mut hi = None;
+        let mut next = opts.inertia_shift_initial;
+        for _ in 0..opts.inertia_max_shifts {
+            if crate::deadline::expired() {
+                return Err(QpError::DeadlineExpired);
+            }
+            match self.try_shift(&mut kkt, &mut current, next, n, &seed, expected, dim) {
+                Ok(true) => {
+                    hi = Some(next);
+                    break;
+                }
+                Ok(false) => next *= opts.inertia_shift_factor,
+                Err(e) => return Err(e),
+            }
+        }
+        let Some(mut hi) = hi else {
+            // No shift in the ladder's reach makes the reduced Hessian
+            // definite. `factorize_with_inertia_control` calls that a hard
+            // error; here it is simply no verdict.
+            return Ok(SecondOrder::NotChecked);
+        };
+
+        if hi <= opts.inertia_shift_initial {
+            // The very first rung worked, so `|λ_min| < inertia_shift_initial`
+            // — a negative eigenvalue at the level of the rounding noise in
+            // the factor. There is nothing here worth rejecting a solve over,
+            // and the bracket below has no lower end to bisect against.
+            return Ok(SecondOrder::NotChecked);
+        }
+
+        let mut lo = hi / opts.inertia_shift_factor;
+        for _ in 0..opts.neg_curv_shift_refinements {
+            if crate::deadline::expired() {
+                return Err(QpError::DeadlineExpired);
+            }
+            let mid = (lo * hi).sqrt();
+            if !(mid > lo && mid < hi) {
+                break;
+            }
+            match self.try_shift(&mut kkt, &mut current, mid, n, &seed, expected, dim) {
+                Ok(true) => hi = mid,
+                Ok(false) => lo = mid,
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Land on the tightest shift known to work, so `self.linsol` holds
+        // the factor the iteration below back-solves against and `rhs` holds
+        // the first iterate.
+        let mut rhs = vec![0.0; dim];
+        rhs[..n].copy_from_slice(&seed);
+        kkt.add_h_diagonal_shift(n, hi - current);
+        if self
+            .linsol
+            .factorize_and_solve(&kkt, &mut rhs, Some(expected))
+            .is_err()
+        {
+            return Ok(SecondOrder::NotChecked);
+        }
+
+        // A shift was needed at all, so `ZᵀHZ` is indefinite, singular, or the
+        // constraint block is rank deficient. Only a witness separates them.
+        let h_scale = inf_scale(qp.h.values()).max(1.0);
+        let threshold = -opts.neg_curv_tol * h_scale;
+
+        let mut d = rhs[..n].to_vec();
+        for _ in 0..opts.neg_curv_probe_iters {
+            if crate::deadline::expired() {
+                return Err(QpError::DeadlineExpired);
+            }
+            if !normalize(&mut d) {
+                return Ok(SecondOrder::NotChecked);
+            }
+            if curvature(qp, &d) < threshold && stays_on_the_working_set(qp, working, &d) {
+                return Ok(SecondOrder::NegativeCurvature(d));
+            }
+            // One more step of inverse iteration against the cached factor.
+            let mut step = vec![0.0; dim];
+            step[..n].copy_from_slice(&d);
+            if self.linsol.resolve(&mut step).is_err() {
+                return Ok(SecondOrder::NotChecked);
+            }
+            d.copy_from_slice(&step[..n]);
+        }
+        Ok(SecondOrder::NotChecked)
+    }
+
+    /// Move `kkt`'s `H`-block shift from `*current` to `target` and ask
+    /// whether it factors with `expected` negative eigenvalues. `Ok(false)`
+    /// is the inertia/singularity answer the caller is bracketing on; a hard
+    /// backend failure comes back as `Ok(false)` too, since a shift that
+    /// cannot be factored is a shift that does not work.
+    #[allow(clippy::too_many_arguments)]
+    fn try_shift(
+        &mut self,
+        kkt: &mut KktTriplet,
+        current: &mut Number,
+        target: Number,
+        n: usize,
+        seed: &[Number],
+        expected: i32,
+        dim: usize,
+    ) -> Result<bool, QpError> {
+        kkt.add_h_diagonal_shift(n, target - *current);
+        *current = target;
+        let mut rhs = vec![0.0; dim];
+        rhs[..n].copy_from_slice(seed);
+        match self
+            .linsol
+            .factorize_and_solve(kkt, &mut rhs, Some(expected))
+        {
+            Ok(()) => Ok(true),
+            Err(QpError::DeadlineExpired) => Err(QpError::DeadlineExpired),
+            Err(_) => Ok(false),
+        }
+    }
+}

--- a/crates/pounce-qp/src/options.rs
+++ b/crates/pounce-qp/src/options.rs
@@ -172,6 +172,77 @@ pub struct QpOptions {
     /// Leave this `true` for a standalone `solve_qp`: the *whole point*
     /// of solving a QP is to learn whether it has a minimizer.
     pub certify_recession_ray: bool,
+
+    /// Check the **second-order** conditions before returning
+    /// [`QpStatus::Optimal`](crate::QpStatus::Optimal) on a problem whose
+    /// `H` is not claimed PSD, and escape along negative curvature when the
+    /// check produces a witness (gh #848).
+    ///
+    /// Every `Optimal` exit in the engine is first-order: the projected
+    /// gradient vanishes and the working set's multipliers carry admissible
+    /// signs. On an indefinite `H` a *saddle point* satisfies exactly that,
+    /// and the box-constrained path starts from the projection of the origin
+    /// — which on `½xᵀ[[1,5];[5,1]]x` over `[−1,1]²` *is* the saddle, so the
+    /// solve certified `obj = 0` against a true minimum of `−4`. See
+    /// [`crate::negcurv`] for the test and its deliberate asymmetry: a
+    /// rejection always carries a direction, an inconclusive probe always
+    /// leaves the first-order verdict standing.
+    ///
+    /// `false` restores the pre-#848 behaviour exactly, including on the
+    /// indefinite arm. It is not a performance knob: with
+    /// `HessianInertia::Psd` the whole path is skipped anyway, so the convex
+    /// arm pays nothing either way.
+    ///
+    /// `true` in [`QpOptions::default`], which is what every standalone entry
+    /// point uses — `solver_selection=qp-active-set`,
+    /// `pounce.qp.solve_qp(method="active-set")`, `ParametricActiveSetSolver`
+    /// called directly. Those are the entry points gh #848 reports, and there
+    /// the QP *is* the question being asked. `false` in
+    /// [`QpOptions::sqp_subproblem`], which is a different question — see
+    /// there.
+    pub certify_second_order: bool,
+    /// How many negative-curvature escapes one `solve` may take before it
+    /// gives up and reports the budget rather than the point.
+    ///
+    /// Each escape adds a blocking row or bound to the working set, so a
+    /// monotone run terminates in at most `n + m` of them; the cap is what
+    /// bounds the non-monotone case, where the re-solve drops back out of the
+    /// set it was just pushed into. Exhausting it downgrades the solve to
+    /// `MaxIter` — never to `Optimal`, which is the defect this exists to
+    /// prevent.
+    pub neg_curv_max_escapes: u32,
+    /// Inverse-iteration steps allowed per second-order probe.
+    ///
+    /// Each is one back-substitution against a factor that already exists
+    /// plus one `H·d` product. The iteration converges at the ratio of the
+    /// two smallest eigenvalues of `Zᵀ(H + δI)Z`, and `δ` comes off the §4.5
+    /// ladder, so it overshoots `|λ_min|` by at most `inertia_shift_factor`;
+    /// the worst-case ratio that leaves is about
+    /// `(λ_max + 100|λ_min|)/(99|λ_min|)`. Termination is on the *sign* of
+    /// `dᵀHd`, not on convergence, which is reached long before the
+    /// eigenvector is.
+    pub neg_curv_probe_iters: u32,
+    /// Geometric bisections used to tighten the inertia shift before the
+    /// probe iterates.
+    ///
+    /// The §4.5 ladder brackets `|λ_min|` between the rung that worked and
+    /// the one before it, a factor of `inertia_shift_factor` apart. Each
+    /// refinement halves that bracket on a log scale at the cost of one
+    /// factorization, leaving an overshoot of `100^(2^−r)` — 1.8% at the
+    /// default 8. The overshoot is what sets the inverse iteration's
+    /// convergence rate, so paying here is what keeps `neg_curv_probe_iters`
+    /// small: reusing the ladder's own shift instead leaves rates as bad as
+    /// 1.02 per step on `H = diag(1, −1)`, where the ladder stops at `δ = 100`.
+    pub neg_curv_shift_refinements: u32,
+    /// Relative margin a curvature must clear to count as negative:
+    /// `dᵀHd < −neg_curv_tol · ‖H‖∞` at `‖d‖₂ = 1`.
+    ///
+    /// Relative because the verdict must not depend on the units of the
+    /// objective. The margin is a *rejection* threshold, so erring large is
+    /// the safe direction: it declines to reject a curvature that could be
+    /// rounding noise, and an unrejected point keeps the status the engine
+    /// already assigned it.
+    pub neg_curv_tol: Number,
 }
 
 impl Default for QpOptions {
@@ -195,6 +266,50 @@ impl Default for QpOptions {
             expand_tol_growth: 1e-11,
             expand_tol_max: 1e-7,
             certify_recession_ray: true,
+            certify_second_order: true,
+            neg_curv_max_escapes: 20,
+            neg_curv_probe_iters: 20,
+            neg_curv_shift_refinements: 8,
+            neg_curv_tol: 1e-8,
+        }
+    }
+}
+
+impl QpOptions {
+    /// The defaults for a QP solved as an SQP *step subproblem*, rather than
+    /// as a question in its own right.
+    ///
+    /// Identical to [`QpOptions::default`] except that
+    /// [`certify_second_order`](Self::certify_second_order) is off, and the
+    /// reason is not caution — it is that the two callers are asking different
+    /// questions of the same engine.
+    ///
+    /// A standalone `solve_qp` asks *where is this QP's minimum*, and a
+    /// first-order point that is not one is a wrong answer (gh #848). An SQP
+    /// step QP asks *give me a step*, about a local model built at the current
+    /// iterate from the current multiplier estimates — and that model's
+    /// second-order verdict is not the NLP's. HS071 is the counterexample and
+    /// it is not exotic: at iteration 0 the multipliers are still zero, so
+    /// `∇²L` is `∇²f`, whose reduced Hessian on the working set's null space
+    /// is negative (`dᵀHd = -4.05e-2`) at a point that *is* a local minimum of
+    /// the NLP. Started at `x*`, certification sends the engine chasing that
+    /// curvature to a box bound and back — five outer iterations where one
+    /// sufficed, and `QpIterationLimit` at iteration 0 from `x* + 1e-8·e₀`,
+    /// which is every warm start (gh #484). Modifying the Hessian, not
+    /// following the curvature, is the textbook answer for an SQP step
+    /// (Nocedal-Wright §18.4), and §4.5's δ already is that modification.
+    ///
+    /// Turning it on for the SQP is a supported experiment —
+    /// `sqp_qp_certify_second_order=yes` — and it does fix real wrong answers
+    /// there: `algorithm=active-set-sqp` on `nonconvex_qp.nl` stops reporting
+    /// the constrained *maximum* as `Solve_Succeeded`. Making it the default
+    /// needs the Hessian-modification path first; that is gh #856, not this
+    /// change.
+    #[must_use]
+    pub fn sqp_subproblem() -> Self {
+        Self {
+            certify_second_order: false,
+            ..Self::default()
         }
     }
 }
@@ -235,6 +350,7 @@ pub struct ActiveSetOverrides {
     pub use_schur_updates: Option<bool>,
     pub use_homotopy: Option<bool>,
     pub max_schur_updates_before_refactor: Option<u32>,
+    pub certify_second_order: Option<bool>,
 }
 
 impl ActiveSetOverrides {
@@ -268,6 +384,9 @@ impl ActiveSetOverrides {
         }
         if let Some(v) = self.max_schur_updates_before_refactor {
             o.max_schur_updates_before_refactor = v;
+        }
+        if let Some(v) = self.certify_second_order {
+            o.certify_second_order = v;
         }
     }
 
@@ -375,6 +494,12 @@ impl ActiveSetOverrides {
                 ));
             }
             parsed.max_schur_updates_before_refactor = Some(value);
+        }
+
+        let (_, explicitly_set) = options.get_string_value("sqp_qp_certify_second_order", "")?;
+        if explicitly_set {
+            parsed.certify_second_order =
+                Some(options.get_bool_value("sqp_qp_certify_second_order", "")?.0);
         }
 
         Ok(parsed)

--- a/crates/pounce-qp/src/problem.rs
+++ b/crates/pounce-qp/src/problem.rs
@@ -184,6 +184,43 @@ pub struct QpStats {
     ///
     /// [`QpSolver::solve_parametric`]: crate::QpSolver::solve_parametric
     pub parametric_source: Option<ParametricSource>,
+    /// What the **second-order** test found at the returned point (gh #848).
+    ///
+    /// A summary of [`crate::negcurv::SecondOrder`] without its witness — the
+    /// direction belongs to the escape that consumed it, and when it survives
+    /// as a certificate it survives in [`QpSolution::unbounded_ray`].
+    ///
+    /// Callers that re-derive a status from the returned point need this: a
+    /// saddle point of an indefinite QP satisfies the first-order KKT
+    /// conditions exactly, so *any* verifier built on the KKT residual will
+    /// promote it to `Optimal` no matter what status the engine assigned.
+    /// [`pounce-convex`'s `verify_status`] did precisely that. The field is
+    /// the only channel through which a second-order finding reaches such a
+    /// verifier.
+    ///
+    /// [`pounce-convex`'s `verify_status`]: https://github.com/jkitchin/pounce
+    pub second_order: SecondOrderVerdict,
+}
+
+/// [`crate::negcurv::SecondOrder`] reduced to a verdict, for
+/// [`QpStats::second_order`].
+///
+/// `Default` is [`NotChecked`](SecondOrderVerdict::NotChecked) — the honest
+/// value for every solve that did not run the test, and the reason adding this
+/// field did not have to touch the ~135 `QpSolution` literals in the
+/// workspace: they all build their stats with `..Default::default()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SecondOrderVerdict {
+    /// The test did not run, or ran without reaching a conclusion. Never a
+    /// claim that the point is a minimum.
+    #[default]
+    NotChecked,
+    /// The reduced Hessian on the working set's null space is positive
+    /// definite: the point is a local minimum.
+    Certified,
+    /// A feasible direction of strictly negative curvature exists at the
+    /// returned point. It is not a local minimum, at any tolerance.
+    NegativeCurvature,
 }
 
 /// What a [`QpSolver::solve_parametric`](crate::QpSolver::solve_parametric)

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -16,9 +16,11 @@ use crate::kkt::{
     assemble_equality_plus_bounds, h_times_x, is_all_equality_constraints, is_pure_box,
     is_pure_equality_no_bounds, rhs_equality_only,
 };
+use crate::negcurv::SecondOrder;
 use crate::options::{AntiCyclingChoice, QpOptions};
 use crate::problem::{
     HessianInertia, ParametricSource, QpProblem, QpSolution, QpStats, QpWarmStart,
+    SecondOrderVerdict,
 };
 use crate::working_set::{BoundStatus, ConsStatus, WorkingSet};
 use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
@@ -3681,7 +3683,16 @@ impl QpSolver for ParametricActiveSetSolver {
         opts: &QpOptions,
     ) -> Result<QpSolution, QpError> {
         let _deadline = crate::deadline::enter(opts.time_limit);
-        let out = self.solve_scoped(qp, ws, opts);
+        // The second-order pass sits *here*, outside `solve_scoped`, for two
+        // reasons. It is the one place every route through the engine — box,
+        // equality-only, equality-plus-bounds, general, Schur, elastic,
+        // homotopy — is guaranteed to pass through exactly once, so no inner
+        // loop has to remember it. And its own re-solves call `solve_scoped`
+        // directly, which is what stops an escape from recursing into another
+        // escape (gh #848).
+        let out = self
+            .solve_scoped(qp, ws, opts)
+            .and_then(|sol| self.escape_negative_curvature(qp, sol, opts));
         soften_deadline(qp, ws.map(|w| w.x.as_slice()), out)
     }
 
@@ -4086,6 +4097,317 @@ impl ParametricActiveSetSolver {
         };
         self.solve(qp, Some(&ws), opts)
     }
+
+    /// Refuse to certify a saddle point as a solution, and get off it when
+    /// there is somewhere to go (gh #848).
+    ///
+    /// Runs after the engine has produced its verdict, at the choke point
+    /// every public entry funnels through, so no individual exit in the
+    /// engine's five inner loops has to remember to call it. Only
+    /// `QpStatus::Optimal` is examined: that is the one status whose meaning
+    /// is a *claim about the model* rather than about the solve, and the only
+    /// one a second-order finding can falsify.
+    ///
+    /// The loop is the classical nonconvex active-set move (Nocedal-Wright
+    /// §16.4, "if the reduced Hessian is indefinite … a direction of negative
+    /// curvature is followed to a new constraint"): at a first-order point
+    /// with a witness `d` satisfying `A_W d = 0` and `dᵀHd < 0`,
+    ///
+    /// * `∇q(x)ᵀd = 0`, because at a first-order point the gradient is a
+    ///   combination of the working set's rows and `d` is orthogonal to all of
+    ///   them. So `q(x + αd) = q(x) + ½α²·dᵀHd` **decreases in both
+    ///   directions**. Neither sign is privileged, and the one taken is
+    ///   whichever the feasible set lets travel further — a longer step is
+    ///   strictly more objective decrease, since the decrease is quadratic in
+    ///   `α` with no linear term to trade against.
+    /// * If nothing blocks either sign, `x + αd` is feasible for every `α` and
+    ///   the objective falls without bound: a certified recession ray, which
+    ///   is the `dᵀPd < 0` branch of `pounce-convex`'s `ray_certifies_unbounded`
+    ///   (gh #791) — a branch that had no reachable producer before this.
+    ///   That exit alone answers to
+    ///   [`QpOptions::certify_recession_ray`](crate::QpOptions::certify_recession_ray):
+    ///   a caller that has declined recession verdicts keeps its point and
+    ///   its `Optimal`, and reads the refutation off `stats.second_order`.
+    /// * Otherwise the step ends on a new row or bound, which joins the
+    ///   working set, and the solve resumes from there.
+    ///
+    /// The resume is a full solve, so it may drop what the escape pinned and
+    /// return to where it started; the loop therefore terminates on *measured
+    /// objective progress*, not on the working set growing. Without that it
+    /// spins the budget on one fixed point — see the guard below, and the
+    /// HS071 measurement in it.
+    ///
+    /// Exhausting the budget, or stalling, with a live witness downgrades to
+    /// `QpStatus::MaxIter`. It must not stay `Optimal`: that would be the
+    /// original defect with extra steps. `MaxIter` here is the honest reading
+    /// — the engine refuted the point and did not reach one it can certify.
+    fn escape_negative_curvature(
+        &mut self,
+        qp: &QpProblem<'_>,
+        mut sol: QpSolution,
+        opts: &QpOptions,
+    ) -> Result<QpSolution, QpError> {
+        if !opts.certify_second_order
+            || qp.hessian_inertia == HessianInertia::Psd
+            || sol.status != QpStatus::Optimal
+        {
+            return Ok(sol);
+        }
+
+        for _ in 0..opts.neg_curv_max_escapes {
+            let d = match self.second_order_verdict(qp, &sol.working, opts)? {
+                SecondOrder::Certified => {
+                    sol.stats.second_order = SecondOrderVerdict::Certified;
+                    return Ok(sol);
+                }
+                SecondOrder::NotChecked => return Ok(sol),
+                SecondOrder::NegativeCurvature(d) => d,
+            };
+
+            // Both signs descend; take the one with more room. `partial_cmp`
+            // is not needed — an infinite α on either side is unboundedness
+            // and is caught before the comparison matters.
+            let neg: Vec<Number> = d.iter().map(|v| -v).collect();
+            let fwd = feasible_step_along(qp, &sol.x, &d, &sol.working, opts.feas_tol);
+            let bwd = feasible_step_along(qp, &sol.x, &neg, &sol.working, opts.feas_tol);
+            let (dir, alpha, blocker) = if bwd.0 > fwd.0 {
+                (neg, bwd.0, bwd.1)
+            } else {
+                (d, fwd.0, fwd.1)
+            };
+
+            if !alpha.is_finite() {
+                if !opts.certify_recession_ray {
+                    // The caller wants a point, not a verdict (gh #423) —
+                    // the same opt-out the box path honours at its own
+                    // unblocked-negative-curvature exit, and it has to be
+                    // honoured here for the same reason. The SQP's
+                    // unbounded-model fallback sets this flag and re-solves
+                    // precisely because the *unblocked* case is a statement
+                    // about the linearization: the δ-shifted proximal step
+                    // is a real step and certifying recession instead leaves
+                    // the outer loop with none at all. Without this arm the
+                    // fallback re-solve comes straight back `Unbounded`,
+                    // `sol` never becomes `Optimal`, and the SQP exits
+                    // `QpStepFailed` at iteration 1 — which is gh #419
+                    // verbatim, reached through a door gh #423 did not
+                    // close. Measured on `eigenb2` (110 free variables, 55
+                    // equalities, nothing that can ever block a direction):
+                    // 200 iterations at f = 1.6013 became 1 iteration at
+                    // f = 24.026.
+                    //
+                    // The finding is still reported. It is the *action* that
+                    // is declined, not the fact, and a caller that reads
+                    // `stats.second_order` (`pounce-convex`'s
+                    // `verify_status`) still sees the point refuted. Only
+                    // the unblocked branch is gated: a blocked escape ends
+                    // on a new row with a strictly lower objective and no
+                    // certificate is involved, so it runs either way.
+                    sol.stats.second_order = SecondOrderVerdict::NegativeCurvature;
+                    return Ok(sol);
+                }
+                // Feasible for every step length along a direction the
+                // objective curves *down* along: the QP is unbounded below,
+                // and `dir` is the witness. `obj` follows the convention the
+                // engine's other unbounded exits use.
+                sol.obj = Number::NEG_INFINITY;
+                sol.status = QpStatus::Unbounded;
+                sol.stats.second_order = SecondOrderVerdict::NegativeCurvature;
+                sol.unbounded_ray = Some(dir);
+                return Ok(sol);
+            }
+
+            // Step to the blocker and pin it. A degenerate `α = 0` still
+            // makes progress: the working set grows, so the next probe sees a
+            // strictly smaller null space.
+            let mut x = sol.x.clone();
+            for (xi, di) in x.iter_mut().zip(dir.iter()) {
+                *xi += alpha * di;
+            }
+            let mut working = sol.working.clone();
+            match blocker {
+                Some(Blocker::Bound(i, status)) => {
+                    // Snap to the bound rather than trusting `α·dᵢ`, the same
+                    // drift guard the box path applies to its own ratio test.
+                    match status {
+                        BoundStatus::AtLower => x[i] = qp.xl[i],
+                        BoundStatus::AtUpper => x[i] = qp.xu[i],
+                        _ => {}
+                    }
+                    working.bounds[i] = status;
+                }
+                Some(Blocker::Cons(i, status)) => working.constraints[i] = status,
+                // `α` finite with no blocker is not reachable: `α` starts at
+                // infinity and only a blocker lowers it.
+                None => return Ok(sol),
+            }
+
+            if crate::deadline::expired() {
+                // Keep the point — it is feasible and its objective is no
+                // worse than the one we arrived with — but not the status.
+                // Returning `Optimal` here is exactly the claim the witness
+                // just refuted.
+                sol.x = x;
+                sol.obj = quad_objective(qp, &sol.x);
+                sol.working = working;
+                sol.status = QpStatus::TimeLimit;
+                sol.stats.second_order = SecondOrderVerdict::NegativeCurvature;
+                return Ok(sol);
+            }
+
+            // Resume from the escaped point. `solve_scoped`, not `solve`:
+            // this call must not re-enter the escape, and the deadline scope
+            // is already open.
+            let escaped_obj = quad_objective(qp, &x);
+            let prev_obj = sol.obj;
+            let escaped = (x.clone(), working.clone(), escaped_obj);
+            let ws = QpWarmStart {
+                x,
+                lambda_g: vec![0.0; qp.m],
+                lambda_x: vec![0.0; qp.n],
+                working,
+            };
+            let stats_so_far = sol.stats.clone();
+            let mut next = self.solve_scoped(qp, Some(&ws), opts)?;
+            next.stats.n_working_set_changes += stats_so_far.n_working_set_changes + 1;
+            next.stats.n_refactor += stats_so_far.n_refactor;
+            next.stats.n_schur_updates += stats_so_far.n_schur_updates;
+            next.stats.used_phase1 |= stats_so_far.used_phase1;
+            sol = next;
+
+            if sol.status != QpStatus::Optimal {
+                // The re-solve reached a conclusion of its own — unbounded,
+                // out of iterations, out of time. It is not a first-order
+                // point being passed off as an optimum, so there is nothing
+                // left for the second-order test to falsify.
+                return Ok(sol);
+            }
+
+            // The escape must not be undone by the solve that follows it.
+            //
+            // The loop's termination argument is that the working set grows by
+            // one per escape, so a run ends within `n + m` of them. The resume
+            // is free to *drop* rows again, and on an indefinite `H` it does
+            // more than that: the inner loop's steps come from the δ-shifted
+            // KKT of §4.5, whose model has the saddle as its *minimum*, so the
+            // re-solve walks back uphill to the very point the escape left.
+            // That is the same attraction gh #848 reports from the outside
+            // ("the start point is ignored entirely — all three starts land on
+            // `[0, 0]`"), met here from the inside, and left alone it spins the
+            // whole budget on one fixed point: measured on HS071's first step
+            // QP, all 20 escapes reported an identical working set, an
+            // identical direction, `alpha = 1.4935` and `obj = -1.4116e-7`,
+            // having each stepped to `obj = -4.52e-2` and been walked back.
+            //
+            // So require strict progress, and when there is none stop at the
+            // better of the two points rather than re-deriving it 19 more
+            // times. The status is not `Optimal` either way — the witness
+            // refuted that, and getting off the saddle is what failed here,
+            // not the finding.
+            if sol.obj >= prev_obj - opts.opt_tol * (1.0 + prev_obj.abs()) {
+                let (x_esc, working_esc, obj_esc) = escaped;
+                if obj_esc < sol.obj {
+                    sol.x = x_esc;
+                    sol.obj = obj_esc;
+                    sol.working = working_esc;
+                }
+                sol.status = QpStatus::MaxIter;
+                sol.stats.second_order = SecondOrderVerdict::NegativeCurvature;
+                return Ok(sol);
+            }
+        }
+
+        // Out of escapes with the point still un-certified. Report the budget.
+        sol.status = QpStatus::MaxIter;
+        sol.stats.second_order = SecondOrderVerdict::NegativeCurvature;
+        Ok(sol)
+    }
+}
+
+/// What stopped a step along a negative-curvature direction.
+#[derive(Debug, Clone, Copy)]
+enum Blocker {
+    Bound(usize, BoundStatus),
+    Cons(usize, ConsStatus),
+}
+
+/// The largest `α ≥ 0` keeping `x + α d` feasible, and what stops it.
+///
+/// `INFINITY` with `None` means nothing blocks: `d` is a recession direction
+/// of the feasible set. Rows and bounds already in `working` are skipped —
+/// the witness satisfies `A_W d = 0`, so they neither block nor move, and
+/// including them would let floating-point residual in `A_W d` manufacture a
+/// spurious zero step.
+fn feasible_step_along(
+    qp: &QpProblem<'_>,
+    x: &[Number],
+    d: &[Number],
+    working: &WorkingSet,
+    feas_tol: Number,
+) -> (Number, Option<Blocker>) {
+    let mut alpha = Number::INFINITY;
+    let mut blocker = None;
+    let take = |r: Number, b: Blocker, alpha: &mut Number, blocker: &mut Option<Blocker>| {
+        let r = if r.is_finite() { r.max(0.0) } else { r };
+        if r < *alpha {
+            *alpha = r;
+            *blocker = Some(b);
+        }
+    };
+
+    for i in 0..qp.n {
+        if working.bounds[i].is_active() {
+            continue;
+        }
+        if d[i] < -feas_tol && qp.xl[i] > NLP_LOWER_BOUND_INF {
+            let r = (x[i] - qp.xl[i]) / -d[i];
+            take(
+                r,
+                Blocker::Bound(i, BoundStatus::AtLower),
+                &mut alpha,
+                &mut blocker,
+            );
+        }
+        if d[i] > feas_tol && qp.xu[i] < NLP_UPPER_BOUND_INF {
+            let r = (qp.xu[i] - x[i]) / d[i];
+            take(
+                r,
+                Blocker::Bound(i, BoundStatus::AtUpper),
+                &mut alpha,
+                &mut blocker,
+            );
+        }
+    }
+
+    if qp.m > 0 {
+        let ax = a_times_x(qp.a, x, qp.m);
+        let ad = a_times_x(qp.a, d, qp.m);
+        for i in 0..qp.m {
+            if working.constraints[i].is_active() {
+                continue;
+            }
+            if ad[i] < -feas_tol && qp.bl[i] > NLP_LOWER_BOUND_INF {
+                let r = (ax[i] - qp.bl[i]) / -ad[i];
+                let status = if qp.bl[i] == qp.bu[i] {
+                    ConsStatus::Equality
+                } else {
+                    ConsStatus::AtLower
+                };
+                take(r, Blocker::Cons(i, status), &mut alpha, &mut blocker);
+            }
+            if ad[i] > feas_tol && qp.bu[i] < NLP_UPPER_BOUND_INF {
+                let r = (qp.bu[i] - ax[i]) / ad[i];
+                let status = if qp.bl[i] == qp.bu[i] {
+                    ConsStatus::Equality
+                } else {
+                    ConsStatus::AtUpper
+                };
+                take(r, Blocker::Cons(i, status), &mut alpha, &mut blocker);
+            }
+        }
+    }
+
+    (alpha, blocker)
 }
 
 /// The soft outcome for a cancelled solve: the best point we have, clamped

--- a/crates/pounce-qp/tests/issue848_second_order_certification.rs
+++ b/crates/pounce-qp/tests/issue848_second_order_certification.rs
@@ -1,0 +1,507 @@
+//! gh #848 — the active-set engine must not certify a saddle point as a
+//! solution.
+//!
+//! Every `QpStatus::Optimal` exit in `pounce-qp` is a *first-order* finding:
+//! the projected gradient vanishes and the working set's multipliers carry
+//! admissible signs. On a PSD Hessian that is the whole story. On an
+//! indefinite one it is not — a saddle point satisfies exactly the same
+//! conditions — and the box path's cold start makes the failure the *default*
+//! rather than a corner: it begins at the projection of the origin into the
+//! box, which on a Hessian with zero linear term is the saddle itself. The
+//! gradient there is already zero, so iteration one reports `‖p‖∞ ≤ opt_tol`
+//! with an empty working set and returns. `§4.5` inertia control does not
+//! intervene: it shifts `H` until the reduced KKT factors, which supplies a
+//! descent direction for a nonzero right-hand side, and the right-hand side
+//! here is zero.
+//!
+//! # Which branch each fixture reaches
+//!
+//! `crates/pounce-qp/src/negcurv.rs` has three verdicts and they fail in
+//! opposite directions, so a corpus that reaches only one of them is not
+//! evidence about the others. Each test below names its branch:
+//!
+//! | test | verdict | what it would catch |
+//! |---|---|---|
+//! | `the_saddle_of_an_indefinite_box_qp_is_not_a_solution` | `NegativeCurvature` → escape | the defect itself |
+//! | `an_unblocked_negative_curvature_direction_certifies_unbounded` | `NegativeCurvature` → ray | a missing producer for `ray_certifies_unbounded` (gh #791) |
+//! | `a_genuine_minimum_of_an_indefinite_qp_is_still_certified` | `Certified` | a check that rejects everything |
+//! | `a_weak_minimum_is_not_rejected` | `NotChecked` | the over-rejection the `δ > 0` shortcut would have caused |
+//! | `a_psd_claim_skips_the_check_entirely` | gate | the convex arm paying for this |
+//! | `declining_recession_verdicts_keeps_the_point_and_still_reports_the_finding` | `NegativeCurvature` → ray, declined | gh #423's opt-out being ignored, i.e. gh #419 again |
+//!
+//! `a_weak_minimum_is_not_rejected` is the one that is not a duplicate of
+//! anything else here. The tempting cheap test is "`§4.5` needed a shift ⇒
+//! the reduced Hessian is not PD ⇒ reject", and it is wrong: the shift ladder
+//! fires on `Singular` as well as on `WrongInertia`, and a singular reduced
+//! Hessian is a **weak minimum** — a correct answer that the cheap test would
+//! have downgraded. That is why the module produces a direction and evaluates
+//! `dᵀHd` against `H` rather than inferring from `δ`.
+
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_qp::{
+    HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem, QpSolver, QpStatus,
+    SecondOrderVerdict,
+};
+use std::rc::Rc;
+
+const NEG_INF: f64 = -1e20;
+const POS_INF: f64 = 1e20;
+
+fn new_solver() -> ParametricActiveSetSolver {
+    ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()))
+}
+
+fn no_rows(n: usize) -> GenTMatrix {
+    GenTMatrix::new(GenTMatrixSpace::new(0, n as i32, Vec::new(), Vec::new()))
+}
+
+/// Upper triangle of `[[a, b]; [b, c]]`.
+fn sym2(a: f64, b: f64, c: f64) -> SymTMatrix {
+    let space = SymTMatrixSpace::new(2, vec![1, 1, 2], vec![1, 2, 2]);
+    let mut h = SymTMatrix::new(Rc::clone(&space));
+    h.set_values(&[a, b, c]);
+    h
+}
+
+// ─────────────────────────────────────────────────────────────────
+// The reproducer.
+//
+//     min ½ xᵀ [[1, 5]; [5, 1]] x   s.t.  −1 ≤ x ≤ 1
+//
+// Eigenvalues −4 and 6, eigenvectors (1, −1)/√2 and (1, 1)/√2. The
+// objective is `3t² − 2s²` in those coordinates, so the minimum sits at the
+// two corners the negative eigendirection points at: `(1, −1)` and `(−1, 1)`,
+// both with objective −4.
+//
+// Pre-fix this returned `Optimal` at `x = (0, 0)` with `obj = 0` — the
+// *maximum* along the (1, −1) direction, reported as the answer.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn the_saddle_of_an_indefinite_box_qp_is_not_a_solution() {
+    let h = sym2(1.0, 5.0, 1.0);
+    let a = no_rows(2);
+    let g = [0.0, 0.0];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, 1.0];
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("indefinite box QP must solve");
+
+    assert_eq!(sol.status, QpStatus::Optimal, "x = {:?}", sol.x);
+    assert!(
+        (sol.obj + 4.0).abs() < 1e-7,
+        "objective {} at x = {:?}; the box minimum is −4 at (1, −1) / (−1, 1). \
+         An objective of 0 is the saddle at the origin, which is what gh #848 is.",
+        sol.obj,
+        sol.x
+    );
+    // Both corners are optima; either is a correct answer.
+    let corner = (sol.x[0] - 1.0).abs() < 1e-7 && (sol.x[1] + 1.0).abs() < 1e-7
+        || (sol.x[0] + 1.0).abs() < 1e-7 && (sol.x[1] - 1.0).abs() < 1e-7;
+    assert!(corner, "expected a corner of the box, got {:?}", sol.x);
+    // Having escaped, the point it *landed* on is certified in its own right:
+    // with both bounds active the null space is trivial.
+    assert_eq!(sol.stats.second_order, SecondOrderVerdict::Certified);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// The same defect with nothing to block the escape.
+//
+//     min ½x₁² − ½x₂²   (unbounded box, no rows)
+//
+// The origin is stationary and `(0, 1)` has curvature −1 with nothing to stop
+// it, so the QP is unbounded below. Pre-fix: `Optimal`, `obj = 0`.
+//
+// This is the fixture that gives `pounce-convex`'s `ray_certifies_unbounded`
+// its `dᵀPd < 0` branch a producer (gh #791). That branch was written for
+// "the indefinite Hessians `solve_qp_active_set_inertia` admits" and, until
+// this escape existed, nothing in the engine ever emitted such a ray: every
+// `unbounded_ray` it produced came from a *zero*-curvature direction.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn an_unblocked_negative_curvature_direction_certifies_unbounded() {
+    let h = sym2(1.0, 0.0, -1.0);
+    let a = no_rows(2);
+    let g = [0.0, 0.0];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [NEG_INF, NEG_INF];
+    let xu = [POS_INF, POS_INF];
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("unbounded indefinite QP must return a verdict, not an error");
+
+    assert_eq!(
+        sol.status,
+        QpStatus::Unbounded,
+        "obj = {}, x = {:?}",
+        sol.obj,
+        sol.x
+    );
+    assert_eq!(
+        sol.stats.second_order,
+        SecondOrderVerdict::NegativeCurvature
+    );
+    let d = sol
+        .unbounded_ray
+        .as_ref()
+        .expect("an Unbounded verdict must carry its witness");
+    // The witness is the negative eigendirection, and it is the *curvature*
+    // that certifies here — the gradient is zero, so a zero-curvature ray
+    // would certify nothing.
+    let hd = [d[0], -d[1]];
+    let curv = hd[0] * d[0] + hd[1] * d[1];
+    assert!(curv < -1e-8, "ray {d:?} has curvature {curv}, not negative");
+    // The witness need not *be* the eigenvector — negative curvature is the
+    // whole requirement — but it has to be dominated by the direction that
+    // has it, or `x + td` would eventually curve back up.
+    assert!(
+        d[1].abs() > d[0].abs(),
+        "ray {d:?} is not dominated by the negative eigendirection"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// The `Certified` branch: an indefinite QP whose answer really is a minimum.
+//
+//     min ½x₁² − ½x₂² − ½x₂   s.t. −1 ≤ x ≤ 1
+//
+// Optimum `(0, 1)`, objective −1 (this is gh #416's box fixture). At that
+// point `x₂` is at its upper bound, so the null space is the `x₁` axis and
+// the reduced Hessian is `[1] ≻ 0`. The check must confirm rather than
+// disturb it: a second-order test that rejects everything would pass every
+// other test in this file.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn a_genuine_minimum_of_an_indefinite_qp_is_still_certified() {
+    let h = sym2(1.0, 0.0, -1.0);
+    let a = no_rows(2);
+    let g = [0.0, -0.5];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, 1.0];
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("indefinite box QP must solve");
+
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!(
+        sol.x[0].abs() < 1e-9 && (sol.x[1] - 1.0).abs() < 1e-9,
+        "expected x* = (0, 1), got {:?}",
+        sol.x
+    );
+    assert!((sol.obj + 1.0).abs() < 1e-9, "obj = {}", sol.obj);
+    assert_eq!(sol.stats.second_order, SecondOrderVerdict::Certified);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// The `NotChecked` branch, and the reason the check produces a witness
+// instead of reading `δ`.
+//
+//     min ½x₁²   s.t. −1 ≤ x ≤ 1        (H = diag(1, 0), g = 0)
+//
+// Every point with `x₁ = 0` is a global minimum, objective 0 — a *weak*
+// minimum, the whole `x₂` axis of them. The reduced Hessian at the origin is
+// `diag(1, 0)`: singular, positive semi-definite, and no negative curvature
+// anywhere.
+//
+// The KKT is singular there, so §4.5's ladder shifts and `δ > 0` — the same
+// signal the saddle above produces. Rejecting on `δ > 0` would therefore
+// downgrade this correct answer, which is a wrong verdict about the user's
+// model and strictly worse than the defect being fixed. The probe finds no
+// direction with `dᵀHd < 0` because none exists, reports `NotChecked`, and
+// leaves the engine's finding alone.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn a_weak_minimum_is_not_rejected() {
+    let h = sym2(1.0, 0.0, 0.0);
+    let a = no_rows(2);
+    let g = [0.0, 0.0];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, 1.0];
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        // Claimed indefinite so the gate opens: this is about what the probe
+        // does once it is running, not about whether it runs.
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("semidefinite box QP must solve");
+
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "a weak minimum is still a minimum; x = {:?}, obj = {}",
+        sol.x,
+        sol.obj
+    );
+    assert!(sol.obj.abs() < 1e-9, "obj = {}", sol.obj);
+    assert!(sol.x[0].abs() < 1e-7, "x₁ = {} should be 0", sol.x[0]);
+    assert_ne!(
+        sol.stats.second_order,
+        SecondOrderVerdict::NegativeCurvature,
+        "no direction of negative curvature exists on H = diag(1, 0)"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// A general row, not a bound, stops the escape.
+//
+//     min ½x₁² − ½x₂²   s.t.  −1 ≤ x₂ ≤ 1 (as a *row*),  −10 ≤ x ≤ 10
+//
+// Same saddle at the origin, but the box is slack there and the thing that
+// stops the escape is `A x` rather than `x`. Optimum `(0, ±1)`, objective
+// −0.5; at that point the row is active, the null space is the `x₁` axis, and
+// the reduced Hessian is `[1] ≻ 0`, so the landing point certifies in its own
+// right rather than stalling.
+//
+// This covers `Blocker::Cons`. Without it the ratio test's row arm — the
+// half of `feasible_step_along` that has to fetch `Ax` and `Ad` and pick
+// between `bl` and `bu` — is never executed by this file.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn a_general_row_can_be_the_blocker() {
+    let h = sym2(1.0, 0.0, -1.0);
+    let space = GenTMatrixSpace::new(1, 2, vec![1], vec![2]);
+    let mut a = GenTMatrix::new(space);
+    a.set_values(&[1.0]);
+    let g = [0.0, 0.0];
+    let bl = [-1.0];
+    let bu = [1.0];
+    let xl = [-10.0, -10.0];
+    let xu = [10.0, 10.0];
+    let qp = QpProblem {
+        n: 2,
+        m: 1,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("row-blocked indefinite QP must solve");
+
+    assert_eq!(sol.status, QpStatus::Optimal, "x = {:?}", sol.x);
+    assert!(
+        (sol.obj + 0.5).abs() < 1e-6,
+        "objective {} at x = {:?}; the minimum is −0.5 at (0, ±1)",
+        sol.obj,
+        sol.x
+    );
+    assert!(sol.x[0].abs() < 1e-6, "x₁ = {} should be 0", sol.x[0]);
+    assert!(
+        (sol.x[1].abs() - 1.0).abs() < 1e-6,
+        "x₂ = {} should be ±1 (the row, not a bound, is what stops it)",
+        sol.x[1]
+    );
+    assert_eq!(sol.stats.second_order, SecondOrderVerdict::Certified);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// The gate. A PSD claim skips the check outright, so the convex arm pays
+// nothing for any of the above — no extra factorization, no probe.
+//
+// Same problem as `a_genuine_minimum_of_an_indefinite_qp_is_still_certified`
+// but claimed PSD, which is a *lie* about this `H`. The point is that the
+// verdict is `NotChecked` rather than anything else: the engine took the
+// caller at its word and never ran the test.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn a_psd_claim_skips_the_check_entirely() {
+    let h = sym2(1.0, 0.0, -1.0);
+    let a = no_rows(2);
+    let g = [0.0, -0.5];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, 1.0];
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("QP must solve");
+
+    assert_eq!(sol.stats.second_order, SecondOrderVerdict::NotChecked);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// `certify_second_order = false` restores the pre-#848 behaviour exactly,
+// including the defect. Pinned so the knob is known to be a real off switch
+// rather than a field nothing reads — which is how gh #677 shipped
+// (`limited_memory_initialization` was registered and never read).
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn the_check_can_be_switched_off_and_then_the_saddle_comes_back() {
+    let h = sym2(1.0, 5.0, 1.0);
+    let a = no_rows(2);
+    let g = [0.0, 0.0];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, 1.0];
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let opts = QpOptions {
+        certify_second_order: false,
+        ..QpOptions::default()
+    };
+    let sol = new_solver().solve(&qp, None, &opts).expect("must solve");
+
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!(
+        sol.obj.abs() < 1e-9,
+        "with the check off this is the gh #848 saddle: obj should be 0, got {}",
+        sol.obj
+    );
+    assert_eq!(sol.stats.second_order, SecondOrderVerdict::NotChecked);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// gh #423's opt-out has to survive gh #848.
+//
+// `certify_recession_ray = false` means "give me a point, not a verdict".
+// The box path has honoured it at its own unblocked-negative-curvature exit
+// since gh #423, and the escape has to honour it at the same exit for the
+// same reason — the SQP's unbounded-model fallback sets the flag and
+// re-solves *because* the caller has nowhere to go with an `Unbounded`. A
+// re-solve that comes straight back `Unbounded` leaves the outer loop with no
+// step at all, which is gh #419 verbatim.
+//
+// Measured cost of getting this wrong, on `eigenb2` under
+// `algorithm=active-set-sqp` (110 free variables, 55 equalities, nothing that
+// can ever block a direction): 200 iterations at f = 1.6013 collapsed to 1
+// iteration at f = 24.026, exiting `Search_Direction_Becomes_Too_Small`.
+//
+// The *finding* still travels — only the action is declined — so a caller
+// that reads `stats.second_order` still learns the point is refuted. This
+// pairs with `an_unblocked_negative_curvature_direction_certifies_unbounded`
+// above: same fixture, the two sides of the same branch.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn declining_recession_verdicts_keeps_the_point_and_still_reports_the_finding() {
+    let h = sym2(1.0, 0.0, -1.0);
+    let a = no_rows(2);
+    let g = [0.0, 0.0];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [NEG_INF, NEG_INF];
+    let xu = [POS_INF, POS_INF];
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let opts = QpOptions {
+        certify_recession_ray: false,
+        ..QpOptions::default()
+    };
+    let sol = new_solver().solve(&qp, None, &opts).expect("must solve");
+
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "a caller that declined recession verdicts must still get a usable \
+         point (gh #423); obj = {}, x = {:?}",
+        sol.obj,
+        sol.x
+    );
+    assert!(
+        sol.unbounded_ray.is_none(),
+        "no verdict was asked for, so no certificate should be attached"
+    );
+    assert_eq!(
+        sol.stats.second_order,
+        SecondOrderVerdict::NegativeCurvature,
+        "the action is declined, not the finding"
+    );
+}

--- a/crates/pounce-rs/src/convex.rs
+++ b/crates/pounce-rs/src/convex.rs
@@ -171,14 +171,14 @@ pub use pounce_convex::{
     ActiveSetOverrides, ActiveSetQp, ActiveSetSession, BoxScreen, ConeSpec, HessianInertia,
     NEG_INF, POS_INF, PolyProblem, Polynomial, PresolveNote, PsdCertificateError, QpFactorization,
     QpIterate, QpOptions, QpProblem, QpResiduals, QpSensitivity, QpSolution, QpStatus, QpWarmStart,
-    ReducedHessian, Reuse, SensError, SessionStats, SosBound, SosSolution, Triplet, back_translate,
-    back_translate_verified, certify_psd_lower_triangle, engine_options, screen_variable_box,
-    solve_qp_active_set, solve_qp_active_set_inertia, solve_qp_batch, solve_qp_batch_parallel,
-    solve_qp_batch_parallel_warm, solve_qp_ipm, solve_qp_ipm_debug, solve_qp_ipm_warm,
-    solve_qp_multi_rhs, solve_qp_multi_rhs_parallel, solve_socp_ipm, solve_socp_ipm_debug,
-    solve_socp_ipm_warm, sos_constrained_lower_bound, sos_constrained_lower_bound_opts,
-    sos_lower_bound, sos_lower_bound_opts, sos_minimize, sos_minimize_opts, sos_opts,
-    verify_status,
+    ReducedHessian, Reuse, SecondOrderVerdict, SensError, SessionStats, SosBound, SosSolution,
+    Triplet, back_translate, back_translate_verified, certify_psd_lower_triangle, engine_options,
+    screen_variable_box, solve_qp_active_set, solve_qp_active_set_inertia, solve_qp_batch,
+    solve_qp_batch_parallel, solve_qp_batch_parallel_warm, solve_qp_ipm, solve_qp_ipm_debug,
+    solve_qp_ipm_warm, solve_qp_multi_rhs, solve_qp_multi_rhs_parallel, solve_socp_ipm,
+    solve_socp_ipm_debug, solve_socp_ipm_warm, sos_constrained_lower_bound,
+    sos_constrained_lower_bound_opts, sos_lower_bound, sos_lower_bound_opts, sos_minimize,
+    sos_minimize_opts, sos_opts, verify_status,
 };
 
 /// The underlying crate, for anything not surfaced above.

--- a/docs/src/choosing-a-solver.md
+++ b/docs/src/choosing-a-solver.md
@@ -149,7 +149,23 @@ pounce model.nl solver_selection=qp-active-set   # class: nonconvex QP
 
 Two things to hold onto about the answer. It is **local**: a nonconvex QP can
 have many KKT points, and what you get is the one the active set walked to,
-the same guarantee `minimize` gives on a nonconvex NLP. And the constraints
+the same guarantee `minimize` gives on a nonconvex NLP. It is at least a
+*minimum*, though, which took a fix — inertia control leaves the first-order
+conditions satisfied at a **saddle**, and until
+[issue #848](https://github.com/jkitchin/pounce/issues/848) the engine
+reported one as `optimal` (`min ½xᵀ[[1,5],[5,1]]x` over `[−1,1]²` came back at
+objective `0` against a true minimum of `−4`). From 0.11.0 two guards stand behind an
+`optimal` here. The engine tests the reduced Hessian on its working set's null
+space, and when it finds a feasible direction of negative curvature it follows
+it — to a better point, to an `unbounded` verdict if nothing blocks it, or to
+an honest non-`optimal` status if it runs out of budget. The driver then
+screens the result by *exhibition*, refusing a verdict only where it can walk a
+direction and hand you a strictly better feasible point; that one is not
+confined to the working set's null space, so it reaches negative curvature
+hidden behind a bound whose multiplier is exactly zero, which the first cannot
+see. What you do **not** get is a global minimum, or a guarantee in the case
+where neither guard concludes — the first-order verdict stands there, as it
+always did. And the constraints
 must be **linear** — the curvature this engine controls is the objective's, so
 an indefinite objective over any quadratic *row*, convex row or not, is a
 nonconvex QCQP and goes to the NLP filter-IPM instead (see

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -648,7 +648,7 @@ choice — mirroring the CLI option of the same name:
 | `"lp-ipm"` | Force the convex solver; raise `ValueError` if the problem is not detected as an LP. |
 | `"qp-ipm"` | Force the convex solver; raise `ValueError` if it is not detected as a convex LP/QP. |
 | `"socp"` | Force the conic solver; raise `ValueError` if it is not detected as a convex QCQP. |
-| `"qp-active-set"` | Run the `pounce-qp` active-set engine on a detected LP/QP — the **same engine and route the CLI uses**. Alone among these, it accepts an **indefinite** objective Hessian (a nonconvex QP), for a *local* solution. Raises `ValueError` if the problem is not a detected LP/QP with linear constraints; for the active-set *SQP outer loop* on a general NLP, pass `algorithm="active-set-sqp"`. |
+| `"qp-active-set"` | Run the `pounce-qp` active-set engine on a detected LP/QP — the **same engine and route the CLI uses**. Alone among these, it accepts an **indefinite** objective Hessian (a nonconvex QP), for a *local* solution. Two second-order guards stand behind `optimal` since gh #848 — the engine certifies its working set's null space and escapes any negative curvature it finds there, and the driver refuses a verdict it can beat by exhibiting a better feasible point — so the reported saddles are gone. Neither makes it global, and see [Choosing a solver](choosing-a-solver.md) for the case neither concludes. Raises `ValueError` if the problem is not a detected LP/QP with linear constraints; for the active-set *SQP outer loop* on a general NLP, pass `algorithm="active-set-sqp"`. |
 
 Any other value raises `ValueError`. These are the same six selectors the CLI
 accepts, and matching is case-insensitive, as on the CLI.

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -1272,8 +1272,9 @@ def minimize(
 
     if selection in ("auto", "lp-ipm", "qp-ipm", "qp-active-set"):
         # `qp-active-set` is the one selector with an engine for a nonconvex
-        # QP: `pounce-qp` controls the inertia of the reduced Hessian and
-        # returns a local solution (gh #786). Every other route here requires a
+        # QP: `pounce-qp` controls the inertia of the reduced Hessian (gh #786)
+        # and second-order-certifies the point before calling it optimal
+        # (gh #848). Every other route here requires a
         # PSD Hessian, and `auto` deliberately keeps sending a nonconvex QP to
         # the NLP solver — the detection is our inference, so the general path
         # is the safer default for it.

--- a/python/pounce/_route.py
+++ b/python/pounce/_route.py
@@ -249,7 +249,8 @@ def _fit_objective(fun, grad, hess, probes, rtol, allow_indefinite: bool = False
 
     ``allow_indefinite`` is for the one caller that has an engine for a
     nonconvex QP: `pounce-qp`'s active-set method controls the inertia of the
-    reduced Hessian and returns a local solution (gh #786). It relaxes *only*
+    reduced Hessian (gh #786) and certifies the point it reaches against
+    second-order optimality before reporting it (gh #848). It relaxes *only*
     the curvature test — the model-fit validation above it is what proves the
     problem is a QP at all, and no caller may skip that."""
     P, c, d = _objective_model(fun, grad, hess, probes)

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -521,13 +521,13 @@ def _indefinite_error(lam_min: float) -> ValueError:
         "Hessian and reports a silently-wrong 'optimal' at a saddle point "
         "without one. To solve an indefinite QP, pass method='active-set' — "
         "the pounce-qp parametric active-set engine handles indefinite "
-        "Hessians. Note what its 'optimal' means there: first-order KKT holds "
-        "and a negative-curvature screen found no feasible direction along "
-        "which it could exhibit a better point. That is a refutation rather "
-        "than a proof, so it is weaker than the local-minimum guarantee the "
-        "NLP path (pounce.minimize) gives on the same model. Pass "
-        "check_psd=False to skip this check (e.g. if you know P is PSD and "
-        "want to avoid the O(n^3) eigenvalue cost)."
+        "Hessians. Note what its 'optimal' means there: first-order KKT holds, "
+        "and where the second-order check concludes, the reduced Hessian on the "
+        "working set's null space is positive definite (gh #848). The check looks "
+        "within that working set, not across working sets, so it is weaker than "
+        "the local-minimum guarantee the NLP path (pounce.minimize) gives on the "
+        "same model. Pass check_psd=False to skip this check (e.g. if you know P "
+        "is PSD and want to avoid the O(n^3) eigenvalue cost)."
     )
 
 
@@ -924,9 +924,16 @@ def solve_qp(
 
     The guard is scoped to ``method="ipm"``. Under ``method="active-set"`` an
     indefinite ``P`` is **solved**, not refused — the active-set engine
-    controls the inertia of the reduced Hessian and returns a *local*
-    solution, the same guarantee the NLP filter-IPM gives on a nonconvex NLP
-    (gh #786). The check still runs there when enabled, and its finding is
+    controls the inertia of the reduced Hessian, and then tests the point it
+    reaches for second-order optimality before reporting it (gh #848). That
+    test is what makes ``"optimal"`` mean something here: inertia control
+    alone leaves the first-order conditions satisfied at a *saddle*, which is
+    the same failure this guard refuses on the IPM's behalf. An ``"optimal"``
+    from the active-set engine is a point with no feasible direction of
+    negative curvature on its working set's null space — a local minimum, not
+    a global one, and not proof against the degenerate case where a
+    zero-multiplier bound keeps a direction out of the null space that is
+    searched. The check still runs there when enabled, and its finding is
     what tells the engine to drive an indefinite Hessian; it just does not
     raise. Where it does *not* run — ``check_psd=False``, or the default
     ``None`` above the ``n <= 1500`` cap — the engine is driven exactly as it


### PR DESCRIPTION
Refs #848 — **no closing keyword on purpose**: #848 is already closed by
`1b1d9adc` in #853, which landed the other half of this while this branch was
in flight. This is rebased onto that and composes with it; it does not replace
it. Gives #791's `ray_certifies_unbounded` `dᵀPd < 0` branch its first
reachable producer. Opens #856 for the SQP half, which this deliberately does
not turn on.

## Two guards, and why both

#853 screens a claimed optimum from **outside** the engine and refutes it by
*exhibition*: find a direction of negative curvature, walk it, evaluate, and
demote only if the walk produced a strictly better feasible point. Its own doc
puts the safety property plainly — "there is no false demotion available to
it".

This adds the check **inside** the engine, on `null(A_W)` for the working set
it stopped at, with a witness (`A_W d = 0` and `dᵀHd < 0`, both checked). The
difference that matters is what each can *do* about a saddle. The screen
reports a verdict about a point; it cannot move the point. The engine can
follow the witness and return the better one.

They are not redundant, and neither subsumes the other:

* the engine's check is confined to `null(A_W)`, so it is **blind** to
  negative curvature behind a bound whose multiplier is exactly zero — that
  bound stays in the working set, because the drop rule needs a sign violation
  greater than `opt_tol`. `negcurv.rs` carries the worked example.
* #853's screen searches the free set and then unrestrictedly, so that class
  is exactly what it reaches.

Composed, on the one corpus fixture that reaches either:

```
solver_selection=qp-active-set, nonconvex_qp_ineq
  origin/main   InternalError    it=1  obj=0.99999998      <- the constrained MAXIMUM
  this branch   SolveSucceeded   it=0  obj=-4.00000004e-08 <- the minimum
```

#853 was already refusing to call that maximum `Optimal` — that is the
`InternalError` — but the objective printed above the failure was still the
maximum. The escape reaches the minimum, and then the screen has nothing to
refute.

## The defect

Restated for the record, since #853 fixed the *reporting* of it and this fixes
the *answer*. Every `QpStatus::Optimal` the active-set engine produced was a
**first-order** verdict: vanishing projected gradient, sign-admissible working-set
multipliers. On an indefinite `P` a *saddle point* satisfies exactly that.

```
min ½ xᵀ [[1, 5], [5, 1]] x    s.t.  −1 ≤ x ≤ 1
```

came back `optimal` at objective `0.0`. The true minimum is `−4.0`, at a
corner. The box path makes this the *default* rather than a corner case: it
starts from the projection of the origin into the box, which with a zero
linear term **is** the saddle, so iteration one sees `‖p‖∞ ≤ opt_tol` with an
empty working set and returns.

§4.5 inertia control does not prevent it. Shifting `H → H + δI` makes the
local model convex; it does not move the point. With `g = 0` at the saddle the
right-hand side is `−(Hx + g) = 0` and the step is zero.

The doc comment on `solve_qp_active_set_inertia` asserted the opposite — "what
it returns for an indefinite `P` is therefore a **local** solution, exactly as
the NLP filter-IPM's `optimal` is local on a nonconvex NLP" — and that claim
was repeated in `docs/src/choosing-a-solver.md`, `docs/src/python.md`, and
three places in the Python frontend. All corrected.

## The fix

`crates/pounce-qp/src/negcurv.rs` runs a second-order test at the point the
engine is about to certify, and `escape_negative_curvature` follows the
witness off it — the classical nonconvex active-set move (Nocedal-Wright
§16.4).

**It produces a witness, not an inference.** A direction `d` with `A_W d = 0`
and `dᵀHd < 0`, both checked explicitly, rather than reading the inertia shift
or a backend inertia count. The shift ladder fires on `Singular` as well as
`WrongInertia`, and a singular reduced Hessian is a **weak minimum** — a
correct answer the cheap test would have downgraded.
`a_weak_minimum_is_not_rejected` pins that branch.

**The shift is bisected down from the ladder's bracket.** Shift-and-invert
`K_δ [d; y] = [v; 0]` gives `d ∈ null(A_W)` and the map `v ↦ d` is
`Z(Zᵀ(H+δI)Z)⁻¹Zᵀ`, converging to the eigenvector of the most-negative
eigenvalue of `ZᵀHZ` at rate `(λ₂+δ)/(λ_min+δ)`. The ladder's own
`inertia_shift_factor = 100` overshoots `|λ_min|` by up to two orders and
flattens the spectrum — on `diag(1, −1)` it gives `δ = 100`, hence
`diag(101, 99)` and a rate of 1.02 per step. A first draft reusing the
ladder's shift found nothing on that matrix. Eight geometric bisections of the
ladder's bracket fix it.

**Both signs descend.** At a first-order point `∇q(x)ᵀd = 0`, so
`q(x + αd) = q(x) + ½α²·dᵀHd` falls either way; the engine takes whichever
direction the feasible set lets it travel further, since the decrease is
quadratic with no linear term to trade against.

**Unblocked ⇒ unbounded.** Nothing blocking either sign means the objective
falls without bound and `d` is the certificate. That is #791's `dᵀPd < 0`
branch, written for exactly this case and never reached, because every
`Unbounded` the engine produced came from the zero-curvature branch.

**`verify_status` has to be told.** It re-derives its verdict from the
returned *point*; everything it measures is a first-order residual; the point
is first-order clean by construction. Without a channel it would promote the
refuted saddle straight back to `Optimal`, undoing the fix one layer up. It
takes `QpStats::second_order` as a new third parameter, and one line
(`solved_to` returning `None` when refuted) closes the promotion band on every
arm while leaving the `Unbounded` arm's certificate check upstream, so a
genuine negative-curvature recession ray still yields `DualInfeasible`.
`issue848_saddle_not_optimal.rs::the_residual_alone_would_promote_the_refuted_point`
keeps the defect reproducible in both directions.

## Scope: standalone QP solves, on. The SQP step subproblem, off.

The check is on in `QpOptions::default()` — `solver_selection=qp-active-set`,
`pounce.qp.solve_qp(method="active-set")`, `ParametricActiveSetSolver` used
directly. Those are every entry point #848 reports, and there the QP *is* the
question being asked.

It is off in the new `QpOptions::sqp_subproblem()`, which the SQP path uses,
because there the QP is a **local model** built from the current multiplier
estimates and its second-order verdict is not the NLP's. HS071 is the
counterexample, and it is not exotic. At SQP iteration 0 the multipliers are
still zero, so `∇²L` is `∇²f`. Started **at** `x*` the step QP's working set is
`{x₀ at lower, the inequality, the equality}` — `k = 3`, `n = 4`, a
one-dimensional null space carrying

```
d = (0, −0.6042, 0.7893, −0.1092),   dᵀHd = −4.046e-2
```

so the point is refuted, *correctly for that model*. `x*` is nonetheless a
local minimum of the NLP: with the converged multipliers the reduced Hessian
is positive. Measured on `crates/pounce-algorithm/tests/sqp_near_solution_start.rs`:

| start | before | with certification on |
|---|---|---|
| `x*` | 0–1 outer iterations | 5 |
| `x* + 1e-8·e₀` | `Optimal` | `QpIterationLimit` at iteration 0 |

The second row is every warm start (#484), which is the regime that file
exists for.

Modifying the Hessian rather than following the curvature is the textbook
answer for an SQP step (Nocedal-Wright §18.4), and §4.5's δ already *is* that
modification — what is missing is applying it as a model change the outer loop
knows about, the way #423 already does for the unbounded branch. That is
**#856**. Until it lands, `algorithm=active-set-sqp` can still report a
constrained *maximum* as `Solve_Succeeded`. That is a known and owned gap —
but deliberately **not pinned by a test**, and CI is why.

The first version of this branch did pin it, on `nonconvex_qp.nl`, and that
test went red on ubuntu-latest while passing on macOS. The fixture has three
first-order KKT points — `(1,1)` at `obj = 1`, `(0,2)` and `(2,0)` at
`obj = 0` — and is exactly symmetric under swapping `x0` and `x1`, so which
one an active-set method returns is a **tie broken by the arithmetic**, not a
verdict fixed by the specification. arm64 breaks it toward the maximum
(20 of 20 runs, debug and release); x86-64 toward an endpoint.
`nonconvex_two_escapes.py` names the same mechanism from the other side:
"exactly the symmetry that makes `nonconvex_qp.nl` converge onto its
constrained maximum". A defect whose manifestation is a tie can be described
but not pinned, so #856's cost is now recorded in prose and the
switch-is-real assertion moved to a fixture where the default's stopping
point is forced by exact cancellation rather than chosen from equals.

## The escape loop terminates on progress, not on the working set growing

The original argument was that each escape pins a blocking row, so the working
set grows by one and a run ends within `n + m`. That is wrong: the resume is a
full solve and may drop what the escape pinned. On an indefinite `H` it does
more than that — the inner loop's steps come from the δ-shifted KKT of §4.5,
whose model has the **saddle as its minimum**, so the re-solve walks back
uphill to the point the escape just left. This is #848's "the start point is
ignored entirely — all three starts land on `[0, 0]`" met from the inside.

Traced on HS071's first step QP, all 20 escapes were identical:

```
DBG esc=0  …  nb=1 nc=2  dHd=-4.045985e-2  alpha=1.493457  obj=-1.411614e-7  blk=Bound(2, AtUpper)
DBG esc=1  …  nb=1 nc=2  dHd=-4.045985e-2  alpha=1.493457  obj=-1.411614e-7  blk=Bound(2, AtUpper)
…  ×20
```

— each having stepped to `obj = −4.52e-2` and been walked back to
`−1.4116e-7`. The loop now requires strict objective progress, keeps the
better of the two points when there is none, and returns `MaxIter` after one
wasted round instead of twenty. That makes the loop honest; it does not make
the SQP converge, which is why #856 exists.

## What the sweep found

`scripts/sweep-fixtures.sh`, both legs, four arms, baselined against
`origin/main` at `56c2c003` — i.e. against #853, not against 0.10.0, since the
question is what *this* half adds.

| arm | result |
|---|---|
| `solver_selection=auto` | identical, 158/158 legs |
| `algorithm=active-set-sqp` (default) | identical, 158/158 legs |
| `algorithm=active-set-sqp sqp_qp_certify_second_order=yes` | not comparable — see below |
| `solver_selection=qp-active-set` | **2 legs move** (1 fixture, both legs) |

`auto` being identical is *uninformative rather than reassuring*: 42 of the 79
fixtures route to the convex arm, which is always `Psd`-gated, and the rest to
the NLP filter line-search, so the default corpus reaches the new code zero
times. (Engine split recounts to 37 `cvx-qp` / 5 `cvx-qcqp` / 37 `nlp` per
leg, matching CLAUDE.md.) `algorithm=active-set-sqp` being identical **is**
informative — that arm reaches the engine, so it says the certification is
inert until asked for.

`solver_selection=qp-active-set`: 80 of 158 legs reach
`active-set-QP-(pounce-qp)`; the other 78 are rejected as a class mismatch
before a solve and report no JSON. The one moving line is `nonconvex_qp_ineq`,
shown above, on both legs. It is gh #797's second fixture — fixed there on the
NLP route, here on the QP route. The two legs are bit-identical to each other
on both binaries: the leg name selects an *NLP* Hessian approximation and a
standalone QP has an exact `H` either way, so `lbfgs` is a duplicate here
rather than a second data point.

Three fixtures still report `InternalError` on that arm on **both** binaries —
`convex_qp_qscfxm1`, `convex_qp_share1b`, `lp_degen2`. They are PSD, so
neither guard runs on them; what they hit is the documented rank-detection
limitation on a degenerate LP forced down a route `auto` would not choose. Not
this change, and not #848.

### The certify arm cannot be swept against the baseline, and the raw diff lies

`algorithm=active-set-sqp sqp_qp_certify_second_order=yes` produces a diff of
**158 moved lines**, which looks alarming and means nothing: the option does
not exist on the baseline, which rejects it with `OPTION_INVALID` and emits no
JSON for any fixture. The comparison that carries information is option-off
against option-on **on the same binary**. Four fixtures move there, all on the
`exact` leg — the `lbfgs` leg cannot move, since `SqpHessianSource::Lbfgs`
declares `Psd` and the check never runs:

```
nonconvex_qp           SolveSucceeded it=1 obj=1   -> SolveSucceeded it=1 obj=0
nonconvex_qcqp         SolveSucceeded it=1 obj=0   -> SolveSucceeded it=8 obj=-2
nonconvex_two_escapes  SolveSucceeded it=1 obj=0   -> SolveSucceeded it=4 obj=-6752.25
eigena2                InternalError  it=0 obj=none-> MaximumIterationsExceeded it=1 obj=117.3362264
```

The first three are the rest of the gh #797 corpus — the same defect on the
same models. `eigena2` is the one to read carefully: its warm-started
subproblem exhausts the QP iteration budget, and the cold-start retry that
used to rescue it *with a saddle* now refuses to certify one, so the honest
budget verdict stands instead of a step that made the next linearization's
pinned KKT rank-deficient. Neither run converges; 400 iterations with a point
beats 500 with none.

Behind `eigena2` is a gap this does not open and does not close: the
cold-start and quasi-Newton retries in `pounce-algorithm::sqp::sqp_alg` keep a
retry only `if status == QpStatus::Optimal`, so an `Unbounded` from a retry is
discarded and never reaches the gh #423 proximal fallback, which is gated on
the *first* solve's status. Filed as gh #855.

## Options

`QpOptions` gains `certify_second_order` (default `true`), plus
`neg_curv_max_escapes`, `neg_curv_probe_iters`, `neg_curv_shift_refinements`
and `neg_curv_tol`, and a named constructor `QpOptions::sqp_subproblem()` that
differs from `default()` in exactly that one field.

The user-facing switch is **`sqp_qp_certify_second_order`** (default `no`),
reaching the CLI, AMPL, Pyomo and GAMS. It turns the check **on** for the SQP
subproblem; standalone QP solves certify unconditionally and are unaffected by
it. `issue848_sqp_second_order_option.rs` pins that the *objective* moves
between the two settings, in both directions —
`convex_option_readers_match_the_registry` pins that the registry and the
reader agree on which values are legal, which is a different claim, and it is
the "setting it changes the answer" claim that gh #677 and the
`sqp_qp_use_homotopy` no-op both failed.

The convex path pays nothing: the whole check is gated on
`hessian_inertia != Psd`, which the convex driver never sets.

## Breaking (Rust API)

`pounce_convex::verify_status` / `pounce_rs::convex::verify_status` gains a
third parameter, `second_order: SecondOrderVerdict`, between `ray` and `sol`.
Callers composing `back_translate` + `verify_status` by hand pass
`qsol.stats.second_order`. `back_translate_verified` and
`solve_qp_active_set{,_inertia}` are unchanged. `SecondOrderVerdict` is
re-exported from both crates.

## Tests

* `crates/pounce-qp/tests/issue848_second_order_certification.rs` — 8 tests
  with a branch table: the escape, the recession ray, the recession-ray
  opt-out, `Certified`, `NotChecked` on a weak minimum, a general row as the
  blocker, the `Psd` gate, and the off switch.
* `crates/pounce-convex/tests/issue848_saddle_not_optimal.rs` — 4 tests
  through the public convex path, including the mutation guard that keeps the
  defect reproducible.
* `crates/pounce-cli/tests/issue848_sqp_second_order_option.rs` — the option,
  end to end, both settings. `turning_it_on_...` on `nonconvex_qp.nl`;
  `the_switch_is_not_a_no_op_end_to_end` on `nonconvex_two_escapes.nl`,
  asserting the strict improvement `0 -> -6752.25` rather than either
  endpoint's exact value, per the tie described above.
* `crates/pounce-algorithm/tests/sqp_near_solution_start.rs` — unchanged, and
  green. It is the test that produced the scoping decision above; it was red
  while the check was on for the SQP path.
