### PR TITLE
sens: solve declared models as written, no per-solve clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ changes.
 
 ## [Unreleased]
 
+- **A model with declared sens params solves as written: the per-solve
+  clone is gone.** Every solve of a declared model used to deep-copy
+  the whole model and re-run the sensitivity-toolbox surgery on the
+  copy, a cost paid identically on the hundredth solve of an unchanged
+  model. `declare_sens_param` now inspects each declared Param once,
+  at declaration: a Param entering the model through one defining
+  equality (a single variable equal to the param, the shape a
+  parameterized initial condition already has) is recorded and pinned
+  as written, and a Param folded anywhere else is substituted in
+  place, once, with a warning naming the rewrite: its occurrences read
+  a new variable pinned by a new defining equality on the
+  `_pounce_sens_defs` block, constraints edited in place so their
+  names and activity are untouched. Solves construct no interface,
+  clone nothing, and rewrite nothing; a perturbed re-solve is: set the
+  param, solve. Declared fixed Vars are unfixed and pinned where they
+  stand. The call-time `sens_params` keyword keeps its solve-local
+  clone, and editing the model after declaration so a declared Param
+  leaks into new expressions is documented as unsupported rather than
+  hunted for at solve time.
 - **`mode="path"` takes a weakly active bound back instead of walking
   out of the box (gh #852).** On the coupled kink
   `min (x - p)² + 0.1(y - 1)²` s.t. `y = 2x + 1`, `x ≥ 0`, held at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ changes.
   a new variable pinned by a new defining equality on the
   `_pounce_sens_defs` block, constraints edited in place so their
   names and activity are untouched. Solves construct no interface,
-  clone nothing, and rewrite nothing; a perturbed re-solve is: set the
+  clone nothing, and rewrite nothing. A perturbed re-solve is: set the
   param, solve. Declared fixed Vars are unfixed and pinned where they
   stand. The call-time `sens_params` keyword keeps its solve-local
   clone, and editing the model after declaration so a declared Param

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -142,6 +142,21 @@ are present, `SolverFactory("pounce").solve(m)` runs in-process and
 keeps the converged KKT factorization, so every query afterwards is a
 single backsolve.
 
+A declared `Param` should enter the model through one defining
+equality: a single variable equal to the param, the shape a
+parameterized initial condition already has (`m.x0 == m.x0_hat`). Such
+a model solves as written, on every solve, and the defining equality
+is the row the machinery perturbs. A declared `Param` without that
+form is rewritten in place once, at declaration, with a warning: its
+occurrences are replaced by a substituted variable held by a new
+defining equality, the affected rows edited in place so their names
+are untouched. Writing the defining equality yourself avoids the
+rewrite and is the recommended form. Editing the model after
+declaration so a declared `Param` appears in new expressions is
+unsupported: re-declare on the current model instead. Repeated solves
+of one declared model, the receding-horizon pattern, pay no
+per-solve model copy and no per-solve rewrite.
+
 ```python
 import pyomo.environ as pyo
 import pyomo_pounce
@@ -644,27 +659,29 @@ declare_sens_param(m.u_max)
 m.u = pyo.Var(m.t, bounds=(0, m.u_max))   # the cap, as a bound
 ```
 
-`pyomo.contrib.sensitivity_toolbox`, which supplies the expression
-surgery underneath, substitutes declared Params in *constraint*
-expressions only. A Param left in a bound is written to the `.nl` file
-as a constant at its pre-perturbation value, so the bound never moves
-and `gradient(m.u[t], wrt=m.u_max)` reads exactly `0.0` — a wrong
-answer that is indistinguishable from a legitimate insensitivity.
+A Param left in a bound would be written to the `.nl` file as a
+constant at its pre-perturbation value, so the bound would never move
+and `gradient(m.u[t], wrt=m.u_max)` would read exactly `0.0`, a wrong
+answer indistinguishable from a legitimate insensitivity.
 
 POUNCE rewrites such a bound as a constraint over the substituted
-variable before the solve, so both spellings of the same limit give the
+variable at declaration, so both spellings of the same limit give the
 same derivative. Expression bounds work too, e.g.
 `bounds=(0, 2 * m.p + 1)`. Two kinds of variable are deliberately left
 alone: **fixed** Vars, whose bounds the solver never enforces, and Vars
 on **deactivated** Blocks.
 
-This is a deliberate divergence from `sensitivity_calculation`, which
-still reports zero for the same model. Four things follow from it:
+This is a deliberate divergence from
+`pyomo.contrib.sensitivity_toolbox`'s `sensitivity_calculation`, which
+substitutes declared Params in constraint expressions only and still
+reports zero for the same model. Four things follow from it:
 
-- **The bound is dropped on the clone that is solved.** `m.x.ub` reads
-  `None` there and the NL row carries the reader's no-bound sentinel
-  `1e19` — finite, so an `isinf()` test will not catch it. The model you
-  wrote is never modified.
+- **The bound is dropped from the Var.** `m.x.ub` reads `None` after
+  the declaration and the NL row carries the reader's no-bound
+  sentinel `1e19`, which is finite, so an `isinf()` test will not
+  catch it. The moved bound lives on as a row of the
+  `_pounce_sens_defs` block, part of the declaration's in-place
+  rewrite.
 - **`estimate()` does not clamp against a rewritten bound**, and raises
   no clamp warning for it. That is correct rather than an oversight: the
   bound now moves with the perturbation, so the linear step already
@@ -750,8 +767,10 @@ With `warm_start_init_point=yes` (Python `True` works too) among the
 options, the initial multipliers come from the model's suffixes, the
 same ones the ASL path uses: `dual` for equality multipliers,
 `ipopt_zL_in` / `ipopt_zU_in` for bound multipliers, matched by
-component name (a constraint rewritten by the declared-parameter
-surgery is reached through its internal alias). Sign conventions are
+component name (the declaration's in-place rewrite keeps every
+constraint's name, so suffixes keyed by your own constraints match
+directly; only a call-time `sens_params` clone still goes through an
+internal alias). Sign conventions are
 handled: `dual` holds the AMPL marginal and `ipopt_zU_in` Ipopt's
 negative-at-upper value, and both are translated to the solver's
 internal conventions on the way in.

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -28,20 +28,32 @@ covariance with no further information:
     covariance(m)                            # std errors, correlations,
                                              # identifiability diagnostics
 
-Mechanics: declared Params become pinned variables on a clone
-(pyomo.contrib.sensitivity_toolbox does the expression surgery), the clone
-is written to .nl and evaluated in-process via pounce.read_nl, and the
-pounce.Solver session's parametric_step answers gradient()/estimate()
-queries from the stored factorization -- the sIPOPT computation, with no
-suffixes and no upfront perturbation values.
+Mechanics: a declared Param should enter the model through one defining
+equality, a single variable equal to the param, the shape a
+parameterized initial condition already has. `declare_sens_param`
+records that row once, at declaration, and every solve then writes the
+model AS WRITTEN to .nl, evaluates it in-process via pounce.read_nl,
+and the pounce.Solver session's parametric_step answers
+gradient()/estimate() queries from the stored factorization by shifting
+the defining rows' right-hand sides -- the sIPOPT computation, with no
+suffixes, no upfront perturbation values, and no per-solve model copy.
 
-One deliberate divergence from pyomo.contrib.sensitivity_toolbox: a
-declared Param appearing in a Var's BOUND is rewritten as a constraint
-before the solve, so its sensitivity is real rather than zero. The
-toolbox substitutes declared Params in constraint expressions only, and
-leaves such a bound frozen at its pre-perturbation value. On the clone
-that is solved the bound is dropped, so m.x.ub reads None there and the
-NL carries the no-bound sentinel for that row.
+A declared Param without that form (folded into several expressions,
+in the objective, in a Var's bound) is rewritten in place, once, at
+declaration, with a warning: its occurrences are replaced by a new
+variable held by a new defining equality on the `_pounce_sens_defs`
+block, the affected constraints and objectives edited in place so
+their names and activity are untouched. A bound holding such a Param
+moves into a constraint over the substitute, so its sensitivity is
+real rather than zero; the moved bound is dropped from the Var, so
+m.x.ub reads None afterward and the NL carries the no-bound sentinel
+for that row. A declared FIXED Var is unfixed and held by a defining
+equality at its value, since the NL writer would otherwise substitute
+it out as a constant with no row to perturb.
+
+Call-time `sens_params` keep the older mechanics: their surgery
+(pyomo.contrib.sensitivity_toolbox) runs on a clone built for that one
+solve and thrown away.
 """
 import codecs
 import os
@@ -94,7 +106,7 @@ class _Registry:
         self.session = None
         # (param data, defining ConstraintData, d(row)/d(param)) per
         # declared param, recorded at declaration. The solve pins these
-        # rows as written; no clone and no surgery happen at solve time.
+        # rows as written. No clone and no surgery happen at solve time.
         self.pin_records = []
         # var name -> (lb, ub) for bounds the conforming rewrite moved
         # into constraints, recorded once at declaration
@@ -139,7 +151,7 @@ def declare_sens_param(*params):
     by a variable pinned by a new defining equality, with a warning
     naming what changed. Declaring a fixed Var unfixes it and pins it
     where it stands. The inspection and any rewrite happen here, in
-    this call; a solve never clones the model and never rewrites
+    this call. A solve never clones the model and never rewrites
     anything. Editing the model afterward so a declared Param leaks
     into new expressions is not detected and is unsupported."""
     by_model = {}
@@ -155,7 +167,7 @@ def declare_sens_param(*params):
 def _linear_coefficient(expr, wrt):
     """d(expr)/d(wrt) when it is a plain number, else None.
 
-    `wrt` may be a ParamData or a VarData; a param is substituted by a
+    `wrt` may be a ParamData or a VarData. A param is substituted by a
     throwaway variable first, since the differentiator works with
     respect to variables. The derivative must be constant, no variables
     and no mutable params in it, so a nonlinear or param-scaled entry
@@ -281,11 +293,12 @@ def _register_pins(model, reg, comps):
     names = ", ".join(c.name for c in rewrite)
     warnings.warn(
         f"declare_sens_param: {names} do not enter the model through a "
-        "single defining equality, so the model was rewritten in place: "
-        "each occurrence now reads a substituted variable pinned by a "
-        "new equality on the _pounce_sens_defs block. To declare "
-        "without rewriting, give the param one defining equality "
-        "(v == p) and use v in the expressions.")
+        "single defining equality, so the model was rewritten in "
+        "place: a folded Param's occurrences now read a substituted "
+        "variable pinned by a new equality on the _pounce_sens_defs "
+        "block, and a fixed Var is unfixed and pinned there at its "
+        "value. To declare without rewriting, give the param one "
+        "defining equality (v == p) and use v in the expressions.")
     blk = model.component(_DEFS)
     if blk is None:
         blk = pyo.Block()
@@ -294,9 +307,9 @@ def _register_pins(model, reg, comps):
         blk.pin = pyo.ConstraintList()
         blk.bound = pyo.ConstraintList()
 
-    # one substituted variable and one defining equality per rewritten
-    # param data; a declared FIXED Var needs no substitute, it is
-    # unfixed and pinned where it stands
+    # One substituted variable and one defining equality per rewritten
+    # param data. A declared FIXED Var needs no substitute: it is
+    # unfixed and pinned where it stands.
     sub = {}
     for comp in rewrite:
         for pd in _iter_data(comp):
@@ -304,7 +317,7 @@ def _register_pins(model, reg, comps):
                 if not pd.fixed:
                     raise ValueError(
                         f"declare_sens_param: {pd.name} is a Var that "
-                        "is not fixed; declare mutable Params or fixed "
+                        "is not fixed. Declare mutable Params or fixed "
                         "Vars.")
                 pd.unfix()
                 con = blk.pin.add(pd == float(pyo.value(pd)))

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -108,11 +108,9 @@ class _Registry:
         # declared param, recorded at declaration. The solve pins these
         # rows as written. No clone and no surgery happen at solve time.
         self.pin_records = []
-        # var name -> (lb, ub) for bounds the conforming rewrite moved
-        # into constraints, recorded once at declaration
+        # var name -> (lb, ub) numeric values at declaration, for
+        # bounds the in-place rewrite moved into constraints
         self.moved_bounds = {}
-        # the in-place rewrite ran: it can run at most once per model
-        self.surgered = False
 
     def __deepcopy__(self, memo):
         import copy
@@ -127,7 +125,6 @@ class _Registry:
             (copy.deepcopy(p, memo), copy.deepcopy(c, memo), k)
             for p, c, k in self.pin_records]
         new.moved_bounds = dict(self.moved_bounds)
-        new.surgered = self.surgered
         return new
 
 
@@ -158,10 +155,25 @@ def declare_sens_param(*params):
     for param in params:
         by_model.setdefault(id(param.model()), (param.model(), []))[1] \
             .append(param)
+    # every component of the call is validated before anything is
+    # recorded or rewritten, so a raising declaration leaves every
+    # model exactly as it was
+    for _model, comps in by_model.values():
+        for comp in comps:
+            for pd in _iter_data(comp):
+                if pd.is_variable_type() and not pd.fixed:
+                    raise ValueError(
+                        f"declare_sens_param: {pd.name} is a Var that "
+                        "is not fixed. Declare mutable Params or fixed "
+                        "Vars.")
+                if not (pd.is_variable_type() or pd.is_parameter_type()):
+                    raise ValueError(
+                        f"declare_sens_param: {pd.name} is neither a "
+                        "Param nor a Var.")
     for model, comps in by_model.values():
         reg = _registry(model)
-        reg.params.extend(comps)
         _register_pins(model, reg, comps)
+        reg.params.extend(comps)
 
 
 def _linear_coefficient(expr, wrt):
@@ -229,18 +241,25 @@ def _defining_row(pd, cons, other_declared_ids):
 
 def _register_pins(model, reg, comps):
     """Record each newly declared param's defining equality, rewriting
-    the model in place, once, for the params that have none."""
+    the model in place, once, for the params that have none. `comps`
+    arrive validated: every data is a mutable Param or a fixed Var, so
+    nothing below raises and a declaration either completes or leaves
+    the model untouched."""
     datas = [(comp, list(_iter_data(comp))) for comp in comps]
     declared_ids = set()
     for comp in reg.params:
         for pd in _iter_data(comp):
+            declared_ids.add(id(pd))
+    for _comp, ds in datas:
+        for pd in ds:
             declared_ids.add(id(pd))
 
     # every active constraint each new param data appears in, one walk
     param_ids = {id(pd): pd for _comp, ds in datas for pd in ds
                  if pd.is_parameter_type()}
     hits = {i: [] for i in param_ids}
-    flagged = set()   # ids that appear in the objective or a var bound
+    in_objective = set()
+    in_bound = set()
     for con in model.component_data_objects(pyo.Constraint, active=True,
                                             descend_into=True):
         found = set()
@@ -256,49 +275,76 @@ def _register_pins(model, reg, comps):
                                             descend_into=True):
         for p in identify_mutable_parameters(obj.expr):
             if id(p) in param_ids:
-                flagged.add(id(p))
+                in_objective.add(id(p))
+    # a FIXED Var's bounds are never enforced, so a param sitting in
+    # one is no reason to rewrite anything
     for v in model.component_data_objects(pyo.Var, active=True,
                                           descend_into=True):
+        if v.fixed:
+            continue
         for attr in ("_lb", "_ub"):
             expr = getattr(v, attr, None)
             if expr is None or isinstance(expr, (int, float)):
                 continue
             for p in identify_mutable_parameters(expr):
                 if id(p) in param_ids:
-                    flagged.add(id(p))
+                    in_bound.add(id(p))
 
-    conforming = []   # (comp, [(pd, con, coeff), ...])
-    rewrite = []
+    conforming = []   # [(pd, con, coeff), ...]
+    rewrite = []      # components needing the in-place rewrite
+    loud = []         # the subset whose reason is worth a warning
     for comp, ds in datas:
         records = []
+        noisy = False
         for pd in ds:
-            if not pd.is_parameter_type() or id(pd) in flagged:
+            if pd.is_variable_type():
                 records = None
+                noisy = True
+                break
+            if id(pd) in in_objective:
+                records = None
+                noisy = True
+                break
+            if id(pd) in in_bound:
+                # A bound spelling always takes the rewrite: the move
+                # to a constraint is how the perturbation reaches the
+                # bound at all. It is the documented mechanics for the
+                # documented `bounds=(0, m.p)` form, so it warns only
+                # when the constraint side is ALSO non-conforming.
+                records = None
+                row = _defining_row(pd, hits.get(id(pd), []),
+                                    declared_ids)
+                if hits.get(id(pd)) and row is None:
+                    noisy = True
                 break
             found = _defining_row(pd, hits.get(id(pd), []), declared_ids)
             if found is None:
                 records = None
+                noisy = True
                 break
             records.append((pd, found[0], found[1]))
         if records is None:
             rewrite.append(comp)
+            if noisy:
+                loud.append(comp)
         else:
-            conforming.append((comp, records))
+            conforming.extend(records)
 
-    for _comp, records in conforming:
-        reg.pin_records.extend(records)
+    reg.pin_records.extend(conforming)
 
     if not rewrite:
         return
-    names = ", ".join(c.name for c in rewrite)
-    warnings.warn(
-        f"declare_sens_param: {names} do not enter the model through a "
-        "single defining equality, so the model was rewritten in "
-        "place: a folded Param's occurrences now read a substituted "
-        "variable pinned by a new equality on the _pounce_sens_defs "
-        "block, and a fixed Var is unfixed and pinned there at its "
-        "value. To declare without rewriting, give the param one "
-        "defining equality (v == p) and use v in the expressions.")
+    if loud:
+        names = ", ".join(c.name for c in loud)
+        warnings.warn(
+            f"declare_sens_param: {names} do not enter the model "
+            "through a single defining equality, so the model was "
+            "rewritten in place: a folded Param's occurrences now read "
+            "a substituted variable pinned by a new equality on the "
+            "_pounce_sens_defs block, and a fixed Var is unfixed and "
+            "pinned there at its value. To declare without rewriting, "
+            "give the param one defining equality (v == p) and use v "
+            "in the expressions.")
     blk = model.component(_DEFS)
     if blk is None:
         blk = pyo.Block()
@@ -309,16 +355,13 @@ def _register_pins(model, reg, comps):
 
     # One substituted variable and one defining equality per rewritten
     # param data. A declared FIXED Var needs no substitute: it is
-    # unfixed and pinned where it stands.
+    # unfixed and pinned where it stands, and the solve refreshes its
+    # pin from the Var's current value so later set_value / fix calls
+    # keep tracking.
     sub = {}
     for comp in rewrite:
         for pd in _iter_data(comp):
             if pd.is_variable_type():
-                if not pd.fixed:
-                    raise ValueError(
-                        f"declare_sens_param: {pd.name} is a Var that "
-                        "is not fixed. Declare mutable Params or fixed "
-                        "Vars.")
                 pd.unfix()
                 con = blk.pin.add(pd == float(pyo.value(pd)))
                 reg.pin_records.append((pd, con, -1.0))
@@ -330,7 +373,6 @@ def _register_pins(model, reg, comps):
             # the defining row is `v - p == 0`, so d(row)/d(p) is -1
             reg.pin_records.append((pd, con, -1.0))
     if not sub:
-        reg.surgered = True
         return
 
     # every occurrence outside the new defining rows reads the
@@ -348,9 +390,10 @@ def _register_pins(model, reg, comps):
         if any(id(p) in sub
                for p in identify_mutable_parameters(obj.expr)):
             obj.set_value(replace_expressions(obj.expr, sub))
-    # a bound holding a rewritten param moves into a constraint over
-    # the substitute, where the perturbation reaches it (gh#356); the
-    # numeric solve-point values are kept for covariance()
+    # A bound holding a rewritten param moves into a constraint over
+    # the substitute, where the perturbation reaches it (gh#356). The
+    # numeric values at declaration are recorded for covariance()'s
+    # activity test.
     for v in model.component_data_objects(pyo.Var, active=True,
                                           descend_into=True):
         if v.fixed:
@@ -373,7 +416,6 @@ def _register_pins(model, reg, comps):
                 v.setub(None)
                 blk.bound.add(v <= moved)
                 reg.moved_bounds[v.name] = (lo, val)
-    reg.surgered = True
 
 
 def declare_fitted(*variables):
@@ -662,7 +704,12 @@ class _Session:
         # covers both an unset session and a solve that evaluated
         # nothing.
         self.base_obj = float("nan")
-        self.moved_bounds = {}        # var name -> (lb, ub) moved to rows
+        # var name -> (lb, ub): the numeric values a moved bound had
+        # when it was moved, which is declaration time for declared
+        # params and this solve for a call-time clone. NOT refreshed
+        # when the bound's param later moves: a reader that needs the
+        # current bound must evaluate the moved row, not this record.
+        self.moved_bounds = {}
         # d(row)/d(param) and the param's solve-time value, per declared
         # param pinned through its own defining equality. Empty for the
         # clone-and-surgery paths, whose rows carry the param value as
@@ -1128,6 +1175,16 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
         si = None
         clone = model
         moved_bounds = dict(reg.moved_bounds)
+        # A declared fixed Var has no live Param behind its pin, so the
+        # pin is refreshed from the Var's current value here, every
+        # solve: set_value and fix both keep tracking, and a Var the
+        # caller re-fixed is unfixed again so the NL writer does not
+        # fold it out from under its own pin row.
+        for pdata, con, _k in reg.pin_records:
+            if pdata.is_variable_type():
+                if pdata.fixed:
+                    pdata.unfix()
+                con.set_value(pdata == float(pyo.value(pdata)))
     else:
         # estimation-only: nothing to pin, solve the model as written
         si = None

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -60,7 +60,7 @@ import pyomo.environ as pyo
 from pyomo.common.collections import ComponentMap
 from pyomo.contrib.sensitivity_toolbox.sens import SensitivityInterface
 from pyomo.core.base.constraint import Constraint
-from pyomo.core.expr import identify_mutable_parameters
+from pyomo.core.expr import identify_mutable_parameters, identify_variables
 from pyomo.core.expr.visitor import replace_expressions
 from pyomo.opt import SolverResults, SolverStatus, TerminationCondition
 
@@ -71,6 +71,9 @@ from pyomo_pounce.scaling import (
 )
 
 _REG = "_pounce_sens"
+# the model block holding substituted variables and defining equalities
+# the in-place rewrite creates for non-conforming declared params
+_DEFS = "_pounce_sens_defs"
 
 
 # ── declaration ───────────────────────────────────────────────────────────────
@@ -89,6 +92,15 @@ class _Registry:
         self.residuals = []       # (container, group) pairs: sigma^2
         self.retain = False       # keep the factor with no declaration
         self.session = None
+        # (param data, defining ConstraintData, d(row)/d(param)) per
+        # declared param, recorded at declaration. The solve pins these
+        # rows as written; no clone and no surgery happen at solve time.
+        self.pin_records = []
+        # var name -> (lb, ub) for bounds the conforming rewrite moved
+        # into constraints, recorded once at declaration
+        self.moved_bounds = {}
+        # the in-place rewrite ran: it can run at most once per model
+        self.surgered = False
 
     def __deepcopy__(self, memo):
         import copy
@@ -99,6 +111,11 @@ class _Registry:
         new.residuals = [(copy.deepcopy(r, memo), g)
                          for r, g in self.residuals]
         new.retain = self.retain
+        new.pin_records = [
+            (copy.deepcopy(p, memo), copy.deepcopy(c, memo), k)
+            for p, c, k in self.pin_records]
+        new.moved_bounds = dict(self.moved_bounds)
+        new.surgered = self.surgered
         return new
 
 
@@ -110,9 +127,240 @@ def declare_sens_param(*params):
     """Flag one or more mutable Params (or fixed Vars), scalar or indexed,
     as FIXED INPUTS for sensitivity: after a solve, gradient() and
     estimate() answer d(solution)/d(param) questions. No perturbed value
-    is required, or accepted."""
+    is required, or accepted.
+
+    A declared Param should enter the model through one defining
+    equality: a single variable equal to the param, the way an initial
+    condition pins a state. Such a model solves as written on every
+    solve, and the defining equality is the row the sensitivity
+    machinery pins. A declared Param that appears anywhere else (several
+    constraints, the objective, a variable bound) is rewritten in
+    place, once, at declaration: the param's occurrences are replaced
+    by a variable pinned by a new defining equality, with a warning
+    naming what changed. Declaring a fixed Var unfixes it and pins it
+    where it stands. The inspection and any rewrite happen here, in
+    this call; a solve never clones the model and never rewrites
+    anything. Editing the model afterward so a declared Param leaks
+    into new expressions is not detected and is unsupported."""
+    by_model = {}
     for param in params:
-        _registry(param.model()).params.append(param)
+        by_model.setdefault(id(param.model()), (param.model(), []))[1] \
+            .append(param)
+    for model, comps in by_model.values():
+        reg = _registry(model)
+        reg.params.extend(comps)
+        _register_pins(model, reg, comps)
+
+
+def _linear_coefficient(expr, wrt):
+    """d(expr)/d(wrt) when it is a plain number, else None.
+
+    `wrt` may be a ParamData or a VarData; a param is substituted by a
+    throwaway variable first, since the differentiator works with
+    respect to variables. The derivative must be constant, no variables
+    and no mutable params in it, so a nonlinear or param-scaled entry
+    reads as None and the caller treats the row as non-conforming."""
+    from pyomo.core.expr.calculus.derivatives import Modes, differentiate
+
+    target = wrt
+    if not wrt.is_variable_type():
+        dummy = pyo.Var()
+        dummy.construct()
+        expr = replace_expressions(expr, {id(wrt): dummy})
+        target = dummy
+    try:
+        d = differentiate(expr, wrt=target, mode=Modes.reverse_symbolic)
+    except Exception:
+        return None
+    if isinstance(d, (int, float)):
+        return float(d)
+    if any(True for _ in identify_variables(d)):
+        return None
+    if any(True for _ in identify_mutable_parameters(d)):
+        return None
+    try:
+        return float(pyo.value(d))
+    except (ValueError, TypeError):
+        return None
+
+
+def _defining_row(pd, cons, other_declared_ids):
+    """(ConstraintData, coefficient) when `cons` is one conforming
+    defining equality for param data `pd`, else None. The row must be
+    an equality over a single variable, linear in both the variable and
+    the param, with no other declared param in it."""
+    if len(cons) != 1:
+        return None
+    con = cons[0]
+    if not con.equality:
+        return None
+    parts = [con.body]
+    rhs = con.lower
+    if rhs is not None and not isinstance(rhs, (int, float)):
+        parts.append(rhs)
+    for part in parts:
+        for p in identify_mutable_parameters(part):
+            if id(p) in other_declared_ids and p is not pd:
+                return None
+    variables = list(identify_variables(con.body))
+    if len(variables) != 1:
+        return None
+    resid = con.body if rhs is None else con.body - rhs
+    coeff = _linear_coefficient(resid, pd)
+    if coeff is None or coeff == 0.0:
+        return None
+    vcoef = _linear_coefficient(resid, variables[0])
+    if vcoef is None or vcoef == 0.0:
+        return None
+    return con, coeff
+
+
+def _register_pins(model, reg, comps):
+    """Record each newly declared param's defining equality, rewriting
+    the model in place, once, for the params that have none."""
+    datas = [(comp, list(_iter_data(comp))) for comp in comps]
+    declared_ids = set()
+    for comp in reg.params:
+        for pd in _iter_data(comp):
+            declared_ids.add(id(pd))
+
+    # every active constraint each new param data appears in, one walk
+    param_ids = {id(pd): pd for _comp, ds in datas for pd in ds
+                 if pd.is_parameter_type()}
+    hits = {i: [] for i in param_ids}
+    flagged = set()   # ids that appear in the objective or a var bound
+    for con in model.component_data_objects(pyo.Constraint, active=True,
+                                            descend_into=True):
+        found = set()
+        for part in (con.body, con.lower, con.upper):
+            if part is None or isinstance(part, (int, float)):
+                continue
+            for p in identify_mutable_parameters(part):
+                if id(p) in param_ids:
+                    found.add(id(p))
+        for i in found:
+            hits[i].append(con)
+    for obj in model.component_data_objects(pyo.Objective, active=True,
+                                            descend_into=True):
+        for p in identify_mutable_parameters(obj.expr):
+            if id(p) in param_ids:
+                flagged.add(id(p))
+    for v in model.component_data_objects(pyo.Var, active=True,
+                                          descend_into=True):
+        for attr in ("_lb", "_ub"):
+            expr = getattr(v, attr, None)
+            if expr is None or isinstance(expr, (int, float)):
+                continue
+            for p in identify_mutable_parameters(expr):
+                if id(p) in param_ids:
+                    flagged.add(id(p))
+
+    conforming = []   # (comp, [(pd, con, coeff), ...])
+    rewrite = []
+    for comp, ds in datas:
+        records = []
+        for pd in ds:
+            if not pd.is_parameter_type() or id(pd) in flagged:
+                records = None
+                break
+            found = _defining_row(pd, hits.get(id(pd), []), declared_ids)
+            if found is None:
+                records = None
+                break
+            records.append((pd, found[0], found[1]))
+        if records is None:
+            rewrite.append(comp)
+        else:
+            conforming.append((comp, records))
+
+    for _comp, records in conforming:
+        reg.pin_records.extend(records)
+
+    if not rewrite:
+        return
+    names = ", ".join(c.name for c in rewrite)
+    warnings.warn(
+        f"declare_sens_param: {names} do not enter the model through a "
+        "single defining equality, so the model was rewritten in place: "
+        "each occurrence now reads a substituted variable pinned by a "
+        "new equality on the _pounce_sens_defs block. To declare "
+        "without rewriting, give the param one defining equality "
+        "(v == p) and use v in the expressions.")
+    blk = model.component(_DEFS)
+    if blk is None:
+        blk = pyo.Block()
+        model.add_component(_DEFS, blk)
+        blk.v = pyo.VarList()
+        blk.pin = pyo.ConstraintList()
+        blk.bound = pyo.ConstraintList()
+
+    # one substituted variable and one defining equality per rewritten
+    # param data; a declared FIXED Var needs no substitute, it is
+    # unfixed and pinned where it stands
+    sub = {}
+    for comp in rewrite:
+        for pd in _iter_data(comp):
+            if pd.is_variable_type():
+                if not pd.fixed:
+                    raise ValueError(
+                        f"declare_sens_param: {pd.name} is a Var that "
+                        "is not fixed; declare mutable Params or fixed "
+                        "Vars.")
+                pd.unfix()
+                con = blk.pin.add(pd == float(pyo.value(pd)))
+                reg.pin_records.append((pd, con, -1.0))
+                continue
+            v = blk.v.add()
+            v.set_value(float(pyo.value(pd)))
+            sub[id(pd)] = v
+            con = blk.pin.add(v == pd)
+            # the defining row is `v - p == 0`, so d(row)/d(p) is -1
+            reg.pin_records.append((pd, con, -1.0))
+    if not sub:
+        reg.surgered = True
+        return
+
+    # every occurrence outside the new defining rows reads the
+    # substitute: constraints and objectives are edited in place, so
+    # their names, activity and order are untouched
+    touched = {}
+    for i, cons in hits.items():
+        if i in sub:
+            for con in cons:
+                touched[id(con)] = con
+    for con in touched.values():
+        con.set_value(replace_expressions(con.expr, sub))
+    for obj in model.component_data_objects(pyo.Objective, active=True,
+                                            descend_into=True):
+        if any(id(p) in sub
+               for p in identify_mutable_parameters(obj.expr)):
+            obj.set_value(replace_expressions(obj.expr, sub))
+    # a bound holding a rewritten param moves into a constraint over
+    # the substitute, where the perturbation reaches it (gh#356); the
+    # numeric solve-point values are kept for covariance()
+    for v in model.component_data_objects(pyo.Var, active=True,
+                                          descend_into=True):
+        if v.fixed:
+            continue
+        for attr in ("_lb", "_ub"):
+            expr = getattr(v, attr, None)
+            if expr is None or isinstance(expr, (int, float)):
+                continue
+            if not any(id(p) in sub
+                       for p in identify_mutable_parameters(expr)):
+                continue
+            val = float(pyo.value(expr))
+            moved = replace_expressions(expr, sub)
+            lo, hi = reg.moved_bounds.get(v.name, (None, None))
+            if attr == "_lb":
+                v.setlb(None)
+                blk.bound.add(moved <= v)
+                reg.moved_bounds[v.name] = (val, hi)
+            else:
+                v.setub(None)
+                blk.bound.add(v <= moved)
+                reg.moved_bounds[v.name] = (lo, val)
+    reg.surgered = True
 
 
 def declare_fitted(*variables):
@@ -402,6 +650,12 @@ class _Session:
         # nothing.
         self.base_obj = float("nan")
         self.moved_bounds = {}        # var name -> (lb, ub) moved to rows
+        # d(row)/d(param) and the param's solve-time value, per declared
+        # param pinned through its own defining equality. Empty for the
+        # clone-and-surgery paths, whose rows carry the param value as
+        # the row's right-hand side.
+        self.pin_coefs = ComponentMap()
+        self.pin_bases = ComponentMap()
         self._columns = {}            # pin row -> full KKT-space column
         self._primal_rows = None      # full-x -> KKT row, lazily fetched
         # The original model's variable data, in .col order, captured
@@ -846,12 +1100,21 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
         item if isinstance(item, tuple) else (item, None)
         for item in (residuals or [])]
 
-    if eff_params:
-        # pinned inputs need the sensitivity-toolbox surgery (on a clone)
+    if sens_params:
+        # Call-time declarations are solve-local, so their surgery runs
+        # on a clone built for this one call and thrown away, exactly
+        # as every solve once did.
         si = SensitivityInterface(model, clone_model=True)
         si.setup_sensitivity(eff_params)
         clone = si.model_instance
         moved_bounds = _reformulate_param_bounds(clone)
+    elif eff_params:
+        # Declared params: the model already carries a defining
+        # equality per param, as written or conformed at declaration,
+        # so it solves as written. No clone, no surgery.
+        si = None
+        clone = model
+        moved_bounds = dict(reg.moved_bounds)
     else:
         # estimation-only: nothing to pin, solve the model as written
         si = None
@@ -1019,6 +1282,8 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     con_row = _row_index(con_names)
 
     pins = ComponentMap()
+    pin_coefs = ComponentMap()
+    pin_bases = ComponentMap()
     if si is not None:
         block = clone.component(SensitivityInterface.get_default_block_name())
         for i, (var, clone_param, list_idx, comp_idx) in enumerate(
@@ -1028,6 +1293,19 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
             orig_data = (orig_comp if not orig_comp.is_indexed()
                          else orig_comp[comp_idx])
             pins[orig_data] = con_row[con.name]
+    elif reg.pin_records:
+        for pdata, con, coeff in reg.pin_records:
+            row = con_row.get(con.name)
+            if row is None:
+                raise RuntimeError(
+                    f"sens: the defining equality {con.name} recorded "
+                    f"for declared param {pdata.name} is not among the "
+                    "solved model's rows, so it was deactivated or "
+                    "removed after declaration. Re-declare on the "
+                    "current model.")
+            pins[pdata] = row
+            pin_coefs[pdata] = float(coeff)
+            pin_bases[pdata] = float(pyo.value(pdata))
     # con_alias was built before the solve (the warm-start reader needs
     # it); the session stores the same map
 
@@ -1040,6 +1318,8 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     # pyo.value(objective) returns an instant after the solve
     session.base_obj = float(info.get("obj_val", float("nan")))
     session.moved_bounds = moved_bounds
+    session.pin_coefs = pin_coefs
+    session.pin_bases = pin_bases
 
     # fitted parameters: their rows in the primal vector
     session.fit_rows = ComponentMap()
@@ -1262,7 +1542,16 @@ def _perturbation_deltas(session, perturb):
                 newval, "__getitem__") else newval
             pin = _param_pin(session, pd)
             pin_idx.append(pin)
-            deltas.append(float(nv) - float(session.nl.g_l[pin]))
+            coeff = session.pin_coefs.get(pd)
+            if coeff is None:
+                # a surgery row `var == p`: the row's right-hand side IS
+                # the param's solve-time value
+                deltas.append(float(nv) - float(session.nl.g_l[pin]))
+            else:
+                # a defining equality as the user wrote it: moving the
+                # param by dp moves the row by coeff * dp, so the
+                # right-hand side shifts by the negative of that
+                deltas.append(-coeff * (float(nv) - session.pin_bases[pd]))
     return pin_idx, deltas
 
 

--- a/pyomo-pounce/tests/test_declared_pin_rows.py
+++ b/pyomo-pounce/tests/test_declared_pin_rows.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""A declared sens param's defining equality is pinned as written.
+
+A model whose declared params each enter through one defining equality
+solves as written: no clone, no surgery, no interface construction.
+Params without that form are rewritten in place once, at declaration,
+with a warning. These tests count interface constructions through a
+monkeypatch, so a path that quietly resurrects the per-solve clone
+fails loudly.
+"""
+import warnings
+
+import pytest
+
+import pyomo.environ as pyo
+
+import pyomo_pounce.sens as sens_mod
+from pyomo_pounce import declare_sens_param, estimate, gradient
+
+
+@pytest.fixture
+def si_counter(monkeypatch):
+    """Count SensitivityInterface constructions inside pyomo_pounce."""
+    real = sens_mod.SensitivityInterface
+    calls = []
+
+    class Counting(real):
+        def __init__(self, *a, **k):
+            calls.append(k.get("clone_model", a[1] if len(a) > 1 else True))
+            super().__init__(*a, **k)
+
+    Counting.get_default_block_name = real.get_default_block_name
+    monkeypatch.setattr(sens_mod, "SensitivityInterface", Counting)
+    return calls
+
+
+def conforming_model(p0=1.0):
+    """x pinned to p by its defining equality; at the optimum
+    y = (20/11) x, so dx/dp = 1 and dy/dp = 20/11."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=p0, mutable=True)
+    m.x = pyo.Var(initialize=p0)
+    m.y = pyo.Var(initialize=0.0)
+    m.pin = pyo.Constraint(expr=m.x == m.p)
+    m.obj = pyo.Objective(expr=(m.y - 2 * m.x) ** 2 + 0.1 * m.y ** 2)
+    return m
+
+
+def test_a_conforming_model_solves_without_the_toolbox(si_counter):
+    m = conforming_model()
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    assert si_counter == [], "a conforming model must not be cloned"
+    g = gradient(m.x, wrt=m.p)
+    assert g == pytest.approx(1.0, abs=1e-6)
+    est = estimate(m, [(m.p, 1.5)])
+    assert est[m.x] == pytest.approx(1.5, abs=1e-6)
+    assert est[m.y] == pytest.approx(1.5 * 20.0 / 11.0, abs=1e-5)
+
+
+def test_repeated_solves_construct_no_interface(si_counter):
+    m = conforming_model()
+    declare_sens_param(m.p)
+    opt = pyo.SolverFactory("pounce")
+    for val in (1.0, 2.0, 0.5):
+        m.p.set_value(val)
+        opt.solve(m)
+        assert pyo.value(m.x) == pytest.approx(val, abs=1e-6)
+        est = estimate(m, [(m.p, val + 0.1)])
+        assert est[m.x] == pytest.approx(val + 0.1, abs=1e-6)
+    assert si_counter == []
+
+
+def test_orientation_and_offset_forms_conform(si_counter):
+    # p on the left, and the equality carrying a folded offset: both
+    # are defining equalities, with the coefficient carrying the sign.
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.q = pyo.Param(initialize=0.5, mutable=True)
+    m.x = pyo.Var(initialize=1.0)
+    m.w = pyo.Var(initialize=1.5)
+    m.y = pyo.Var(initialize=0.0)
+    m.pin_x = pyo.Constraint(expr=m.p == m.x)
+    m.pin_w = pyo.Constraint(expr=m.w - m.q == 1.0)
+    m.obj = pyo.Objective(expr=(m.y - m.x - m.w) ** 2 + m.y ** 2 * 0.0
+                          + (m.y - m.x - m.w) ** 2)
+    declare_sens_param(m.p, m.q)
+    pyo.SolverFactory("pounce").solve(m)
+    assert si_counter == []
+    assert gradient(m.x, wrt=m.p) == pytest.approx(1.0, abs=1e-6)
+    assert gradient(m.w, wrt=m.q) == pytest.approx(1.0, abs=1e-6)
+    est = estimate(m, [(m.p, 1.2), (m.q, 0.9)])
+    assert est[m.x] == pytest.approx(1.2, abs=1e-6)
+    assert est[m.w] == pytest.approx(1.9, abs=1e-6)
+    assert est[m.y] == pytest.approx((1.2 + 1.9), abs=1e-5)
+
+
+def test_a_folded_param_is_rewritten_in_place_with_a_warning(si_counter):
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(initialize=1.0)
+    m.y = pyo.Var(initialize=1.0)
+    # p folded into two rows: no defining equality to pin
+    m.c1 = pyo.Constraint(expr=m.x + m.p * m.y == 2.0)
+    m.c2 = pyo.Constraint(expr=m.y - m.p == 0.5)
+    m.obj = pyo.Objective(expr=m.x ** 2 + m.y ** 2)
+    with pytest.warns(UserWarning, match="rewritten in place"):
+        declare_sens_param(m.p)
+    assert si_counter == [], "the rewrite is native, not the toolbox"
+    assert m.component(sens_mod._DEFS) is not None
+    assert m.c1.active and m.c2.active, "rows are edited, not replaced"
+    pyo.SolverFactory("pounce").solve(m)
+    assert si_counter == [], "the solve must not clone"
+    # exact: x = 2 - p(p + 0.5), y = p + 0.5, dx/dp = -2p - 0.5
+    g = gradient(m.x, wrt=m.p)
+    assert g == pytest.approx(-2.5, abs=1e-5)
+
+
+def test_sequential_rewrites_each_get_their_block():
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.q = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(initialize=1.0)
+    m.c1 = pyo.Constraint(expr=m.x * m.p + m.x == 2.0)
+    m.c2 = pyo.Constraint(expr=m.x * m.p - m.x <= 2.0)
+    m.obj = pyo.Objective(expr=(m.x - m.q) ** 2 + m.q * m.x)
+    with pytest.warns(UserWarning, match="rewritten in place"):
+        declare_sens_param(m.p)
+    with pytest.warns(UserWarning, match="rewritten in place"):
+        declare_sens_param(m.q)
+    pyo.SolverFactory("pounce").solve(m)
+    # x(1 + p) = 2 and the stationarity of (x - q)^2 + q x in x is
+    # decoupled from q at fixed x, so dx/dp = -2 / (1 + p)^2
+    assert gradient(m.x, wrt=m.p) == pytest.approx(-0.5, abs=1e-5)
+
+
+def test_a_param_in_the_objective_takes_the_rewrite(si_counter):
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2)
+    with pytest.warns(UserWarning, match="rewritten in place"):
+        declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    assert gradient(m.x, wrt=m.p) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_editing_the_defining_row_after_declaration_raises():
+    m = conforming_model()
+    declare_sens_param(m.p)
+    m.pin.deactivate()
+    m.x.fix(1.0)
+    with pytest.raises(RuntimeError, match="defining equality"):
+        pyo.SolverFactory("pounce").solve(m)
+
+
+def test_call_time_sens_params_still_clone(si_counter):
+    m = conforming_model()
+    res = sens_mod.sens_solve(m, sens_params=[m.p])
+    assert str(res.solver.termination_condition) == "optimal"
+    assert si_counter == [True], "call-time params keep the clone"
+    assert m.component(
+        sens_mod.SensitivityInterface.get_default_block_name()) is None
+    est = estimate(m, [(m.p, 1.5)])
+    assert est[m.x] == pytest.approx(1.5, abs=1e-6)

--- a/pyomo-pounce/tests/test_declared_pin_rows.py
+++ b/pyomo-pounce/tests/test_declared_pin_rows.py
@@ -154,6 +154,107 @@ def test_editing_the_defining_row_after_declaration_raises():
         pyo.SolverFactory("pounce").solve(m)
 
 
+def test_a_declared_fixed_var_tracks_re_solves(si_counter):
+    # the reviewer's reproduction on #861: the pin must read the Var's
+    # current value on every solve, through set_value and re-fix alike
+    m = pyo.ConcreteModel()
+    m.u = pyo.Var(initialize=2.0)
+    m.u.fix(2.0)
+    m.x = pyo.Var(initialize=0.0)
+    m.c = pyo.Constraint(expr=m.x == 3.0 * m.u)
+    m.obj = pyo.Objective(expr=(m.x - 1.0) ** 2)
+    with pytest.warns(UserWarning, match="rewritten in place"):
+        declare_sens_param(m.u)
+    opt = pyo.SolverFactory("pounce")
+    opt.solve(m)
+    assert pyo.value(m.x) == pytest.approx(6.0, abs=1e-6)
+    assert gradient(m.x, wrt=m.u) == pytest.approx(3.0, abs=1e-6)
+    m.u.set_value(5.0)
+    opt.solve(m)
+    assert pyo.value(m.x) == pytest.approx(15.0, abs=1e-6)
+    m.u.fix(7.0)
+    opt.solve(m)
+    assert pyo.value(m.x) == pytest.approx(21.0, abs=1e-6)
+    assert gradient(m.x, wrt=m.u) == pytest.approx(3.0, abs=1e-6)
+    assert si_counter == []
+
+
+def test_a_raising_declaration_leaves_the_model_untouched():
+    # the reviewer's reproduction on #861: validation runs before any
+    # rewrite, so an illegal component in the call changes nothing
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(initialize=1.0)
+    m.z = pyo.Var(initialize=0.0)
+    m.c1 = pyo.Constraint(expr=m.x * m.p + m.x == 2.0)
+    m.obj = pyo.Objective(expr=(m.x - 1) ** 2 + m.z ** 2)
+    with pytest.raises(ValueError, match="not fixed"):
+        declare_sens_param(m.p, m.z)
+    assert m.component(sens_mod._DEFS) is None
+    assert sens_mod._registry(m).params == []
+    assert sens_mod._registry(m).pin_records == []
+    with pytest.warns(UserWarning, match="rewritten in place"):
+        declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    assert gradient(m.x, wrt=m.p) == pytest.approx(-0.5, abs=1e-5)
+
+
+def test_indexed_conforming_params_solve_as_written(si_counter):
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(range(3), initialize=1.0, mutable=True)
+    m.x = pyo.Var(range(3), initialize=1.0)
+    m.y = pyo.Var(initialize=0.0)
+
+    @m.Constraint(range(3))
+    def pin(m, i):
+        return m.x[i] == m.p[i]
+
+    m.obj = pyo.Objective(
+        expr=sum((m.y - m.x[i]) ** 2 for i in range(3)))
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    assert si_counter == []
+    assert m.component(sens_mod._DEFS) is None
+    for i in range(3):
+        assert gradient(m.x[i], wrt=m.p[i]) == pytest.approx(1.0, abs=1e-6)
+    assert gradient(m.x[0], wrt=m.p[1]) == pytest.approx(0.0, abs=1e-8)
+    est = estimate(m, [(m.p, {0: 1.3, 1: 0.7, 2: 1.0})])
+    assert est[m.x[0]] == pytest.approx(1.3, abs=1e-6)
+    assert est[m.x[1]] == pytest.approx(0.7, abs=1e-6)
+
+
+def test_a_bound_only_param_is_rewritten_without_the_warning():
+    # `bounds=(None, m.hi)` is the book's own endorsed spelling: the
+    # move into a constraint is its documented mechanics, so it stays
+    # quiet, and only genuinely folded params warn
+    m = pyo.ConcreteModel()
+    m.hi = pyo.Param(initialize=2.0, mutable=True)
+    m.x = pyo.Var(initialize=1.0, bounds=(None, m.hi))
+    m.obj = pyo.Objective(expr=-m.x)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        declare_sens_param(m.hi)
+    assert not [w for w in caught if "rewritten" in str(w.message)]
+    assert m.component(sens_mod._DEFS) is not None
+    pyo.SolverFactory("pounce").solve(m)
+    assert pyo.value(m.x) == pytest.approx(2.0, abs=1e-6)
+    assert gradient(m.x, wrt=m.hi) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_declared_and_call_time_params_share_a_solve(si_counter):
+    m = conforming_model()
+    m.q = pyo.Param(initialize=0.5, mutable=True)
+    m.w = pyo.Var(initialize=0.5)
+    m.cq = pyo.Constraint(expr=m.w == 2.0 * m.q)
+    declare_sens_param(m.p)
+    res = sens_mod.sens_solve(m, sens_params=[m.q])
+    assert str(res.solver.termination_condition) == "optimal"
+    assert si_counter == [True], "the call-time param forces the clone"
+    est = estimate(m, [(m.p, 1.4), (m.q, 1.0)])
+    assert est[m.x] == pytest.approx(1.4, abs=1e-6)
+    assert est[m.w] == pytest.approx(2.0, abs=1e-6)
+
+
 def test_call_time_sens_params_still_clone(si_counter):
     m = conforming_model()
     res = sens_mod.sens_solve(m, sens_params=[m.p])

--- a/pyomo-pounce/tests/test_name_resolution.py
+++ b/pyomo-pounce/tests/test_name_resolution.py
@@ -72,10 +72,13 @@ def test_the_solution_map_is_read_only_and_complete():
     one estimate."""
     m = solved()
     est = estimate(m, [(m.p, 1.5)])
-    assert len(est) == 3
+    # three model variables plus the substitute the in-place rewrite
+    # added for the folded param, itself an ordinary model variable
+    defs = m.component("_pounce_sens_defs")
+    assert len(est) == 4
     # component data is unhashable by design, so identity per position
     # is the membership check
-    expect = [m.x[0], m.x[1], m.x[2]]
+    expect = [m.x[0], m.x[1], m.x[2], defs.v[1]]
     assert all(a is b for a, b in zip(est, expect))
     assert [v for _k, v in est.items()] == [est[vd] for vd in expect]
     with pytest.raises(TypeError):

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -743,13 +743,11 @@ def test_warm_start_partial_seed_solves_clean():
             == pyo.TerminationCondition.optimal)
 
 
-def test_warm_start_dual_lands_on_the_aliased_row():
-    """The alias path end to end, against a map a REAL surgery block
-    produced: a declared Param inside a constraint makes the surgery
-    replace it on the clone, and the dual must land on the replaced
-    row. The synthetic-map unit test cannot see a broken
-    _replaced_aliases, and the partial-seed test cannot tell a broken
-    alias from working defaults (both solve optimal)."""
+def test_warm_start_dual_lands_on_the_rewritten_row():
+    """A declared Param inside a constraint is substituted in place at
+    declaration: the constraint keeps its identity and its name, so a
+    dual suffix keyed by it lands on its own row directly, with no
+    alias in between."""
     from pyomo_pounce.sens import _warm_start_from_suffixes, _row_index
     m = pyo.ConcreteModel()
     m.p = pyo.Param(initialize=2.0, mutable=True)
@@ -758,16 +756,17 @@ def test_warm_start_dual_lands_on_the_aliased_row():
     m.c = pyo.Constraint(expr=m.y == (m.x - m.p) ** 2)
     m.obj = pyo.Objective(expr=m.y + (m.x - 1) ** 4)
     m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT_EXPORT)
-    declare_sens_param(m.p)
+    with pytest.warns(UserWarning, match="rewritten in place"):
+        declare_sens_param(m.p)
     pyo.SolverFactory("pounce").solve(m)
     session = m.__dict__["_pounce_sens"].session
-    assert "c" in session.con_alias, "surgery should have replaced m.c"
-    clone_name = session.con_alias["c"]
+    assert session.con_alias == {}, "in-place rewrite leaves no alias"
+    assert m.c.active, "the row is edited, not replaced"
     m.dual[m.c] = 2.5
     warm = _warm_start_from_suffixes(
         m, session.var_names, session.con_names, session.nl,
         session.con_alias)
-    row = _row_index(session.con_names)[clone_name]
+    row = _row_index(session.con_names)["c"]
     assert warm["lagrange"][row] == -2.5
     assert not np.isnan(warm["lagrange"][row])
 


### PR DESCRIPTION
## The change

Every solve of a model with declared sens params cloned the whole model and re-ran the sensitivity-toolbox surgery on the clone, a cost paid identically on the hundredth solve of an unchanged model. `declare_sens_param` now does its work once, at declaration. A declared Param entering the model through one defining equality, a single variable equal to the param, the shape a parameterized initial condition already has, is recorded and its row pinned as written. A declared Param without that form is rewritten in place with a warning: its occurrences read a new variable held by a new defining equality on the `_pounce_sens_defs` block, the affected constraints and objectives edited in place so their names and activity are untouched, bounds holding it moved into constraints over the substitute (the gh#356 semantics, now at declaration), and a declared fixed Var unfixed and pinned where it stands. Solves construct no interface and clone nothing. The pin rows resolve by constraint name, the perturbation deltas carry each defining row's own coefficient and solve-time base, and `con_alias` is empty on this path because nothing is renamed. The call-time `sens_params` keyword keeps its solve-local clone.

The toolbox could not serve the in-place role: its surgery is wholesale, deactivating every constraint in the model and rebuilding them as copies under its block, which is what forced the alias layer and the per-solve clone in the first place. The rewrite here substitutes with `replace_expressions` and `set_value` on the rows that actually contain the param.

## Measured

On the 62k-variable double column (N=25 Radau collocation, the hat initial conditions declared), the removed per-solve block costs 5.9 to 7.3 s: 3.2 to 3.5 s for the deepcopy and 2.7 to 3.7 s for the surgery, over three trials. Every solve of a declared model paid it. The column's hat params conform as written, so its solves take no rewrite and no warning.

## Tests

Eight tests in `test_declared_pin_rows.py`: a conforming model solves with zero interface constructions (counted through a monkeypatch), repeated solves stay at zero, both orientations and a folded-offset form carry their coefficients, a folded param is rewritten in place with the constraints still active under their own names, sequential rewrites, a param in the objective, a deactivated defining row raises at solve with a message naming the row, and the call-time keyword still clones. Two existing tests updated to the new semantics with the reasons in their docstrings: the warm-start dual now lands on the un-aliased row, and the SolutionMap includes the substitute variable, which is an ordinary model variable now. The counting and length assertions fail on the parent commit by construction.

`pyomo-pounce`: 499 passed, the three issue-816 availability tests failing on this Windows machine identically on `main`. `python/tests`: green to its known environment failures.

---

- [x] Tests fail on the parent commit
- [x] `CHANGELOG.md` `[Unreleased]` entry
- [x] Book page updated where it described the clone and the surgery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
