### PR TITLE
qp(frontend): validate P's shape before the PSD guard reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,20 @@ changes.
   needed it. `_lower_triangle_coo(P, n)` is handed the caller's `n`
   while emitting index pairs from `P`'s own shape, and
   `_min_eig_lower_coo` then writes them into an `(n, n)` workspace, so
-  only a `P` with **more rows than `n`** went out of bounds: `(3, 3)`,
-  `(4, 4)`, `(5, 7)` and `(7, 5)` all reached `_validate` intact, which
-  is what made the inconsistency visible rather than uniform. It became
-  reachable at default settings when 7bfb3821 (gh #849) made the PSD
-  guard always run instead of switching off above `n = 1500`.
+  what went out of bounds was **a nonzero in the lower triangle at a
+  row index ≥ `n`** — a condition on the fill, not on the shape alone.
+  `np.eye(7, 5)` has no nonzero past row 4 and reached `_validate`
+  intact; `np.ones((7, 5))` did not, on the same commit, for the same
+  shape. `(5, 7)` is safe under any fill, because the lower-triangle
+  filter caps the column at the row. That unevenness is what made the
+  inconsistency visible rather than uniform.
+
+  It was reachable at default settings for every `n ≤ 1500` for as long
+  as the shape guard and the pre-check have coexisted: the gate before
+  7bfb3821 (gh #849) was `check_psd or n <= _PSD_CHECK_AUTO_MAX_N`, and
+  the reported case has `n = 5`. What gh #849 changed is that it became
+  reachable **above** 1500 as well, by making the guard always run
+  instead of switching off there.
 
   The `P`-shape branch is now `_validate_p_shape`, called from
   `_psd_verdict` before it reads `P` as well as from `_validate`. That
@@ -40,10 +49,15 @@ changes.
   rather than returning a wrong answer; the rejection was opaque.
   `python/tests/test_issue862_psd_precheck_masks_p_shape.py` asserts the
   message across all seven entry points under both spellings of
-  `check_psd`, keeps the four sibling shapes pinned so a reordering
-  cannot fix the reported shape while regressing them, and checks that
-  the shape guard was placed *before* the PSD verdict rather than
-  instead of it — an indefinite `P` of the right shape is still refused.
+  `check_psd`, pins every wrong shape under **both** a diagonal and a
+  dense fill so a reordering cannot fix the reported case while
+  regressing the ones that already worked, and checks that the shape
+  guard was placed *before* the PSD verdict rather than instead of it —
+  an indefinite `P` of the right shape is still refused. On the parent
+  commit the file is 17 failed, 9 passed; the nine survivors are the
+  genuinely safe combinations — `(3, 3)`, `(4, 4)` and `(5, 7)` under
+  either fill, `(7, 5)` under the diagonal only, and the two positive
+  controls.
 
 - **`mode="path"` takes a weakly active bound back instead of walking
   out of the box (gh #852).** On the coupled kink

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ changes.
 
 ## [Unreleased]
 
+- **`solve_qp`'s PSD pre-check no longer masks the `P`-shape guard
+  (gh #862).** With `P` shaped `(7, 7)` while `c` fixes `n = 5`, the
+  default path raised a raw `IndexError` out of numpy — `index 5 is out
+  of bounds for axis 0 with size 5` — from inside `_min_eig_lower_coo`.
+  The precise message the frontend already contains for exactly this
+  case, `solve_qp: \`P\` has shape (7, 7) but must be (5, 5)`, was
+  reachable only by passing `check_psd=False`, which skips the
+  pre-check and lets `_validate` run. Two spellings of one malformed
+  input disagreed, and the default was the worse one.
+
+  The pre-check runs before `_build`, and `_build` is what calls
+  `_validate` — so the gh #113 shape guard was behind the guard that
+  needed it. `_lower_triangle_coo(P, n)` is handed the caller's `n`
+  while emitting index pairs from `P`'s own shape, and
+  `_min_eig_lower_coo` then writes them into an `(n, n)` workspace, so
+  only a `P` with **more rows than `n`** went out of bounds: `(3, 3)`,
+  `(4, 4)`, `(5, 7)` and `(7, 5)` all reached `_validate` intact, which
+  is what made the inconsistency visible rather than uniform. It became
+  reachable at default settings when 7bfb3821 (gh #849) made the PSD
+  guard always run instead of switching off above `n = 1500`.
+
+  The `P`-shape branch is now `_validate_p_shape`, called from
+  `_psd_verdict` before it reads `P` as well as from `_validate`. That
+  is one site covering every entry point that checks the Hessian before
+  it builds: `solve_qp` (both `method=`), `solve_qp_batch`,
+  `solve_qp_multi_rhs`, `solve_socp`, `QpFactorization` and
+  `QpSensitivity`. No solve changes — this only decides which exception
+  a rejected input gets. Severity is low by construction: it rejected
+  rather than returning a wrong answer; the rejection was opaque.
+  `python/tests/test_issue862_psd_precheck_masks_p_shape.py` asserts the
+  message across all seven entry points under both spellings of
+  `check_psd`, keeps the four sibling shapes pinned so a reordering
+  cannot fix the reported shape while regressing them, and checks that
+  the shape guard was placed *before* the PSD verdict rather than
+  instead of it — an indefinite `P` of the right shape is still refused.
+
 - **`mode="path"` takes a weakly active bound back instead of walking
   out of the box (gh #852).** On the coupled kink
   `min (x - p)² + 0.1(y - 1)²` s.t. `y = 2x + 1`, `x ≥ 0`, held at

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -587,6 +587,13 @@ def _psd_verdict(P, c, check_psd):
     if check_psd is False:
         return None
     n = np.asarray(c, dtype=np.float64).ravel().shape[0]
+    # Before reading `P`, not after: the guard builds an (n, n) workspace out
+    # of `P`'s own indices, so a mis-shaped `P` reached numpy as an
+    # `IndexError` instead of the message `_validate` is written to give
+    # (gh #862). `_validate` runs later, in `_build` — too late to be the one
+    # that speaks on any entry point that checks the Hessian before it
+    # builds, which is all of them.
+    _validate_p_shape(P, n)
     verdict = _psd_verdict_coo(*_lower_triangle_coo(P, n), n)
     if verdict is None:
         warnings.warn(
@@ -629,6 +636,23 @@ def _mat_shape(mat):
     return sh if len(sh) == 2 else None
 
 
+def _validate_p_shape(P, n: int) -> None:
+    """Reject a ``P`` that is not ``(n, n)``, where ``n`` comes from ``c``.
+
+    Split out of :func:`_validate` because it also has to run *before* the
+    PSD guard, not only before the solve. The guard reads ``P``'s own index
+    pairs and writes them into an ``(n, n)`` workspace
+    (:func:`_lower_triangle_coo` -> :func:`_min_eig_lower_coo`), so a ``P``
+    with more rows than ``n`` indexed out of bounds and surfaced as a raw
+    ``IndexError`` from numpy — the precise message below was unreachable on
+    the default path, and only ``check_psd=False`` (which skips the guard and
+    lets :func:`_validate` run) produced it. See gh #862; the guard being
+    masked is the gh #113 shape check going missing."""
+    psh = _mat_shape(P)
+    if psh is not None and psh != (n, n):
+        raise ValueError(f"solve_qp: `P` has shape {psh} but must be ({n}, {n})")
+
+
 def _validate(P, c, A, b, G, h, lb, ub, n: int) -> None:
     """Reject malformed inputs up front with a precise ``ValueError`` instead
     of a misleading solver status (issue #113): a shape mismatch otherwise
@@ -653,9 +677,7 @@ def _validate(P, c, A, b, G, h, lb, ub, n: int) -> None:
     _finite("lb", lb, allow_inf=True)
     _finite("ub", ub, allow_inf=True)
 
-    psh = _mat_shape(P)
-    if psh is not None and psh != (n, n):
-        raise ValueError(f"solve_qp: `P` has shape {psh} but must be ({n}, {n})")
+    _validate_p_shape(P, n)
 
     for mname, mat, vname, vec in (("A", A, "b", b), ("G", G, "h", h)):
         sh = _mat_shape(mat)

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -588,7 +588,7 @@ def _psd_verdict(P, c, check_psd):
         return None
     n = np.asarray(c, dtype=np.float64).ravel().shape[0]
     # Before reading `P`, not after: the guard builds an (n, n) workspace out
-    # of `P`'s own indices, so a mis-shaped `P` reached numpy as an
+    # of `P`'s own indices, so a mis-shaped `P` could reach numpy as an
     # `IndexError` instead of the message `_validate` is written to give
     # (gh #862). `_validate` runs later, in `_build` — too late to be the one
     # that speaks on any entry point that checks the Hessian before it
@@ -642,12 +642,18 @@ def _validate_p_shape(P, n: int) -> None:
     Split out of :func:`_validate` because it also has to run *before* the
     PSD guard, not only before the solve. The guard reads ``P``'s own index
     pairs and writes them into an ``(n, n)`` workspace
-    (:func:`_lower_triangle_coo` -> :func:`_min_eig_lower_coo`), so a ``P``
-    with more rows than ``n`` indexed out of bounds and surfaced as a raw
-    ``IndexError`` from numpy — the precise message below was unreachable on
-    the default path, and only ``check_psd=False`` (which skips the guard and
-    lets :func:`_validate` run) produced it. See gh #862; the guard being
-    masked is the gh #113 shape check going missing."""
+    (:func:`_lower_triangle_coo` -> :func:`_min_eig_lower_coo`), so a nonzero
+    in the lower triangle at a row index ``>= n`` indexed out of bounds and
+    surfaced as a raw ``IndexError`` from numpy — the precise message below
+    was unreachable on the default path, and only ``check_psd=False`` (which
+    skips the guard and lets :func:`_validate` run) produced it. See gh #862;
+    the guard being masked is the gh #113 shape check going missing.
+
+    That condition is about the *fill*, not only the shape, which is why the
+    check here is on the shape alone: ``np.eye(7, 5)`` has no nonzero past
+    row 4 and used to reach :func:`_validate` intact, while ``np.ones((7, 5))``
+    did not. Rejecting on shape catches both, and catches them before the
+    guard can read either."""
     psh = _mat_shape(P)
     if psh is not None and psh != (n, n):
         raise ValueError(f"solve_qp: `P` has shape {psh} but must be ({n}, {n})")

--- a/python/tests/test_issue862_psd_precheck_masks_p_shape.py
+++ b/python/tests/test_issue862_psd_precheck_masks_p_shape.py
@@ -4,7 +4,7 @@ The shape guard added for gh #113 lives in ``_validate``, which runs inside
 ``_build`` — *after* the PSD pre-check on every entry point that checks the
 Hessian before it builds the problem. The pre-check hands ``_lower_triangle_coo``
 the caller's ``n`` (from ``c``) while emitting index pairs from ``P``'s own
-shape, so a ``P`` with more rows than ``n`` wrote out of bounds inside
+shape, so those pairs were written into an ``(n, n)`` workspace inside
 ``_min_eig_lower_coo`` and surfaced as a raw ``IndexError`` from numpy::
 
     IndexError: index 5 is out of bounds for axis 0 with size 5
@@ -13,10 +13,16 @@ The same malformed input with ``check_psd=False`` — which skips the pre-check
 and lets ``_validate`` run — produced the precise, actionable message. Two
 spellings of one bad input disagreed, and the default was the worse one.
 
-Only ``P`` with **more rows than n** hit it: ``(3, 3)``, ``(4, 4)``, ``(5, 7)``
-and ``(7, 5)`` all reached ``_validate`` intact, which is what made the
-inconsistency visible rather than uniform. Those siblings are asserted here too,
-so a future reordering cannot fix the reported shape while regressing them.
+The condition is **a nonzero in the lower triangle at a row index >= n**, which
+is narrower than "a wrong shape" and narrower than "more rows than ``n``": the
+lower-triangle filter (``ri >= ci``) caps the column at the row, so ``(5, 7)``
+is safe for any fill, while ``(7, 5)`` and ``(7, 7)`` are safe only while
+nothing sits on row 5 or 6. That is why the fill matters and why both are
+parametrized below — ``np.eye(7, 5)`` reached ``_validate`` intact and
+``np.ones((7, 5))`` did not, on the same commit, for the same shape.
+
+The siblings that were genuinely safe are asserted here too, so a future
+reordering cannot fix the reported shape while regressing them.
 
 The fix validates the shape inside ``_psd_verdict`` before it reads ``P``, so
 the single message is what every entry point raises, under either spelling.
@@ -92,20 +98,32 @@ def test_the_two_spellings_agree(name):
     assert str(skipped.value) == str(checked.value)
 
 
-@pytest.mark.parametrize("shape", [(3, 3), (4, 4), (5, 7), (7, 5), (7, 7)])
-def test_every_mis_shaped_P_is_rejected_uniformly(shape):
-    """The siblings that were already correct stay correct.
+def _diag(shape):
+    return np.eye(*shape) * 2.0
 
-    Only `(7, 7)` — more rows than `n` — reached numpy; the guard now speaks
-    for all of them, so a shape that is wrong in any direction gets the one
-    message naming what it is and what it must be.
+
+def _dense(shape):
+    return np.ones(shape)
+
+
+@pytest.mark.parametrize("fill", [_diag, _dense], ids=["diag", "dense"])
+@pytest.mark.parametrize("shape", [(3, 3), (4, 4), (5, 7), (7, 5), (7, 7)])
+def test_every_mis_shaped_P_is_rejected_uniformly(shape, fill):
+    """Every wrong shape gets the one message, under either fill.
+
+    Both fills are here because the pre-check's blast radius depended on the
+    fill and not only on the shape: what reached numpy was a nonzero in the
+    lower triangle at a row index >= `n`. On the parent commit `np.eye(7, 5)`
+    had none — its nonzeros stop at `(4, 4)` — and reached `_validate` intact,
+    while `np.ones((7, 5))` raised `IndexError`. Parametrizing on the diagonal
+    alone therefore recorded `(7, 5)` as a case that already worked, which it
+    did not.
     """
-    P = np.eye(*shape) * 2.0
     with pytest.raises(
         ValueError,
         match=rf"`P` has shape \({shape[0]}, {shape[1]}\) but must be \(5, 5\)",
     ):
-        solve_qp(P=P, c=C)
+        solve_qp(P=fill(shape), c=C)
 
 
 def test_a_correctly_shaped_P_still_solves():

--- a/python/tests/test_issue862_psd_precheck_masks_p_shape.py
+++ b/python/tests/test_issue862_psd_precheck_masks_p_shape.py
@@ -1,0 +1,123 @@
+"""gh #862: the PSD pre-check must not mask the ``P``-shape guard.
+
+The shape guard added for gh #113 lives in ``_validate``, which runs inside
+``_build`` — *after* the PSD pre-check on every entry point that checks the
+Hessian before it builds the problem. The pre-check hands ``_lower_triangle_coo``
+the caller's ``n`` (from ``c``) while emitting index pairs from ``P``'s own
+shape, so a ``P`` with more rows than ``n`` wrote out of bounds inside
+``_min_eig_lower_coo`` and surfaced as a raw ``IndexError`` from numpy::
+
+    IndexError: index 5 is out of bounds for axis 0 with size 5
+
+The same malformed input with ``check_psd=False`` — which skips the pre-check
+and lets ``_validate`` run — produced the precise, actionable message. Two
+spellings of one bad input disagreed, and the default was the worse one.
+
+Only ``P`` with **more rows than n** hit it: ``(3, 3)``, ``(4, 4)``, ``(5, 7)``
+and ``(7, 5)`` all reached ``_validate`` intact, which is what made the
+inconsistency visible rather than uniform. Those siblings are asserted here too,
+so a future reordering cannot fix the reported shape while regressing them.
+
+The fix validates the shape inside ``_psd_verdict`` before it reads ``P``, so
+the single message is what every entry point raises, under either spelling.
+"""
+
+import numpy as np
+import pytest
+
+from pounce import (
+    QpFactorization,
+    QpSensitivity,
+    solve_qp,
+    solve_qp_batch,
+    solve_qp_multi_rhs,
+    solve_socp,
+)
+
+N = 5
+# 7x7 while `c` fixes n = 5: more rows than `n` is the shape that reached numpy.
+P_TOO_BIG = np.eye(7) * 2.0
+C = np.ones(N)
+
+EXPECTED = r"`P` has shape \(7, 7\) but must be \(5, 5\)"
+
+
+def _entry_points():
+    """Every public call that runs the PSD pre-check before ``_build``."""
+    return {
+        "solve_qp": lambda **kw: solve_qp(P=P_TOO_BIG, c=C, **kw),
+        "solve_qp/active-set": lambda **kw: solve_qp(
+            P=P_TOO_BIG, c=C, method="active-set", **kw
+        ),
+        "solve_qp_batch": lambda **kw: solve_qp_batch(
+            [dict(P=P_TOO_BIG, c=C)], **kw
+        ),
+        "solve_qp_multi_rhs": lambda **kw: solve_qp_multi_rhs(
+            P=P_TOO_BIG, cs=[C, 2.0 * C], **kw
+        ),
+        "solve_socp": lambda **kw: solve_socp(
+            P=P_TOO_BIG, c=C, cones=[("nonneg", 1)], G=np.ones((1, N)),
+            h=np.array([1.0]), **kw
+        ),
+        "QpFactorization": lambda **kw: QpFactorization(P=P_TOO_BIG, c=C, **kw),
+        "QpSensitivity": lambda **kw: QpSensitivity(P=P_TOO_BIG, c=C, **kw),
+    }
+
+
+@pytest.mark.parametrize("name", sorted(_entry_points()))
+def test_mis_shaped_P_raises_the_written_ValueError(name):
+    call = _entry_points()[name]
+    # The default path: `check_psd=None` runs the pre-check.
+    with pytest.raises(ValueError, match=EXPECTED):
+        call()
+    # An IndexError is not a ValueError, so the `raises` above already rejects
+    # the regression; assert the exact type too so the reason a failure happened
+    # is legible rather than "did not raise ValueError".
+    try:
+        call()
+    except ValueError:
+        pass
+    except IndexError as exc:  # pragma: no cover - the regression itself
+        pytest.fail(f"{name}: PSD pre-check raised a raw IndexError: {exc}")
+
+
+@pytest.mark.parametrize("name", sorted(_entry_points()))
+def test_the_two_spellings_agree(name):
+    """``check_psd=False`` skips the pre-check; it must reach the same error."""
+    call = _entry_points()[name]
+    with pytest.raises(ValueError, match=EXPECTED) as skipped:
+        call(check_psd=False)
+    with pytest.raises(ValueError, match=EXPECTED) as checked:
+        call()
+    assert str(skipped.value) == str(checked.value)
+
+
+@pytest.mark.parametrize("shape", [(3, 3), (4, 4), (5, 7), (7, 5), (7, 7)])
+def test_every_mis_shaped_P_is_rejected_uniformly(shape):
+    """The siblings that were already correct stay correct.
+
+    Only `(7, 7)` — more rows than `n` — reached numpy; the guard now speaks
+    for all of them, so a shape that is wrong in any direction gets the one
+    message naming what it is and what it must be.
+    """
+    P = np.eye(*shape) * 2.0
+    with pytest.raises(
+        ValueError,
+        match=rf"`P` has shape \({shape[0]}, {shape[1]}\) but must be \(5, 5\)",
+    ):
+        solve_qp(P=P, c=C)
+
+
+def test_a_correctly_shaped_P_still_solves():
+    """The check runs before the guard, so it must not reject a good `P`."""
+    r = solve_qp(P=np.eye(N) * 2.0, c=C)
+    assert r.status == "optimal"
+    np.testing.assert_allclose(r.x, -0.5 * np.ones(N), atol=1e-6)
+
+
+def test_an_indefinite_P_of_the_right_shape_is_still_refused():
+    """The shape check is placed before the PSD verdict, not instead of it."""
+    P = np.eye(N) * 2.0
+    P[0, 0] = -3.0
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        solve_qp(P=P, c=C)


### PR DESCRIPTION
Fixes #862

## Problem

A mis-shaped `P` is rejected — but by numpy, from inside the PSD pre-check,
with an error naming nothing the caller passed:

```python
n = 5
P = np.eye(7) * 2.0          # 7x7, but c sets n = 5
c = np.ones(n)
pounce.solve_qp(P=P, c=c)
```

```
IndexError: index 5 is out of bounds for axis 0 with size 5
```

The precise message the frontend already contains for exactly this input was
reachable only by turning the guard off:

| call | before | after |
|---|---|---|
| `solve_qp(P, c)` | `IndexError` | `ValueError: solve_qp: \`P\` has shape (7, 7) but must be (5, 5)` |
| `solve_qp(P, c, method="active-set")` | `IndexError` | same `ValueError` |
| `solve_qp_batch([dict(P=P, c=c)])` | `IndexError` | same `ValueError` |
| `solve_qp_multi_rhs(P=P, cs=...)` | `IndexError` | same `ValueError` |
| `solve_socp(P=P, c=c, ...)` | `IndexError` | same `ValueError` |
| `QpFactorization(P=P, c=c)` | `IndexError` | same `ValueError` |
| `QpSensitivity(P=P, c=c)` | `IndexError` | same `ValueError` |
| `solve_qp(P, c, check_psd=False)` | `ValueError` (correct) | unchanged |

The oracle is the function's own `_validate`, reached by passing
`check_psd=False` on identical inputs. Two spellings of one malformed input
disagreed, and the default was the worse one.

Severity is low by construction: it rejected rather than returning a wrong
answer. The rejection was opaque, inconsistent with every sibling shape check
in the same function, and reachable from seven public entry points.

## Cause

The PSD pre-check runs before `_build`, and `_build` is what calls `_validate`
— so the gh #113 shape guard sat *behind* the guard that needed it.

`_lower_triangle_coo(P, n)` is handed the caller's `n` (from `c`) while
emitting index pairs from `P`'s own shape; `_min_eig_lower_coo` then writes
those pairs into an `(n, n)` array. What went out of bounds is therefore **a nonzero in the lower triangle at a
row index ≥ `n`** — a condition on the *fill*, not on the shape alone:

| `P` | reaches `_validate`? |
|---|---|
| `(3, 3)`, `(4, 4)`, any fill | yes |
| `(5, 7)`, any fill | yes — the lower-triangle filter caps the column at the row |
| `np.eye(7, 5)` | yes — its nonzeros stop at `(4, 4)` |
| `np.ones((7, 5))` | **no** — `IndexError` |
| `np.eye(7, 7)`, `np.ones((7, 7))` | **no** — `IndexError` |

That unevenness is what made the inconsistency visible rather than uniform.

It was reachable at default settings for every `n ≤ 1500` for as long as the
shape guard and the pre-check have coexisted. The gate before 7bfb3821
(gh #849) was `check_psd or n <= _PSD_CHECK_AUTO_MAX_N`, and the reported case
has `n = 5`, so the pre-check ran; the issue's repro against `7bfb3821^`
raises the same `IndexError`. What gh #849 changed is that it became reachable
**above** 1500 as well.

## Fix

The `P`-shape branch of `_validate` is now `_validate_p_shape(P, n)`, called
from `_psd_verdict` **before** it reads `P`, as well as from `_validate` where
it already lived.

`_psd_verdict` is the one funnel: `solve_qp` calls it directly (both `method=`
values), and `_maybe_check_psd` — which `solve_socp`, `solve_qp_batch`,
`solve_qp_multi_rhs`, `QpFactorization` and `QpSensitivity` all use — calls it
too. One site covers all seven.

Two alternatives were rejected:

- **Add the shape check at each entry point** (the issue's suggested fix, in
  its "or just the `P`-shape branch" reading). Seven call sites is seven
  chances to drift, and the eighth entry point added later gets it wrong
  again. `_psd_verdict` is where the unchecked read happens, so that is where
  the precondition belongs.
- **Call the whole of `_validate` from the pre-check.** It needs
  `A, b, G, h, lb, ub`, which `_maybe_check_psd` does not have and
  `solve_qp_multi_rhs` does not have in the same shape; and `_build` would
  then run it a second time on every successful solve.

The check is placed *after* `_psd_verdict`'s `check_psd is False` early
return, so that path is byte-for-byte unchanged: it still skips the guard
entirely and still gets its error from `_validate` in `_build`. The two now
agree because they run the same function, not because they were separately
made to match.

## Blast radius

No solve changes. This only decides which exception a **rejected** input gets;
every input that solved before still solves, on the same path, with the same
numbers. Nothing in Rust is touched, no trajectory is affected, and the corpus
sweep does not apply — the diff cannot reach an engine.

The one new way to fail is a `P` that is not `(n, n)` and was previously
reaching the PSD guard successfully. There is no such `P`: `_build` rejected
every one of them a few lines later, so this moves the rejection earlier, not
into new territory.

Ordering within the pre-check matters and is asserted: the shape check runs
*before* the PSD verdict, not instead of it, so an indefinite `P` of the right
shape is still refused with the gh #112 message.

## Tests

`python/tests/test_issue862_psd_precheck_masks_p_shape.py`, 21 cases:

- the expected `ValueError` on all seven entry points, on the default path,
  with an explicit `pytest.fail` on `IndexError` so a regression reports the
  reason rather than "did not raise";
- the two spellings of `check_psd` asserted to produce the **same string**,
  per entry point — the property that was broken, stated directly;
- every wrong shape — `(3, 3)`, `(4, 4)`, `(5, 7)`, `(7, 5)`, `(7, 7)` —
  pinned under **both** a diagonal and a dense fill, so a future reordering
  cannot fix the reported case while regressing the ones that already worked,
  and so the fill-dependence above is recorded rather than papered over;
- two positive controls: a well-shaped `P` still solves to `x = -0.5`, and an
  indefinite `P` of the right shape is still refused.

**How I know they bite.** On the parent commit (fix reverted, tests kept):
**17 failed, 9 passed**. The 9 survivors are exactly the genuinely safe
combinations — `(3, 3)`, `(4, 4)` and `(5, 7)` under either fill, `(7, 5)`
under the diagonal *only*, and the two positive controls. That `(7, 5)` splits
across its two fills is the point: the first version of this file parametrized
on `np.eye(*shape)` alone and so recorded `(7, 5)` as a case that already
worked, which it does not. A test file that went all-red would mean the
controls were not controls.

Wider suite: `python/tests` is **982 passed, 40 skipped**. The single failure,
`test_continuation.py::test_step_controller_is_what_the_jax_follower_uses`, is
`ModuleNotFoundError: No module named 'jax'` in this container and is unrelated
to the change (`test_gams_link.py` and `test_phase_envelope_example.py` were
skipped for the same missing-dependency reason).

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — N/A: no user-facing behaviour or
      message is new here; the documented `ValueError` is the one that was
      already written down and is now actually reached.
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` — **not run**.
      The diff is Python-only (`python/pounce/qp.py`, one new test, CHANGELOG);
      no Rust file is touched. Flagging rather than checking a box I did not
      earn.
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now


---
_Generated by [Claude Code](https://claude.ai/code/session_018RwvXSsUqheg4sLCtCL2ud)_
