### PR TITLE
test(cli): give each issue850 report call its own output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+- **A flaky CLI test is made deterministic (no user-facing change).**
+  `crates/pounce-cli/tests/issue850_second_opinion_is_recorded.rs` built
+  its `.sol` and `.json` output paths from the fixture name and the
+  options, so two tests that solve the same fixture with **no** options —
+  `a_promotion_records_what_the_base_solve_did` and
+  `the_true_cost_is_recorded_not_just_the_promoted_rungs` — both landed on
+  `pounce_850_square_flowsheet_resto_nl.json` in the shared temp dir.
+  Cargo runs them on parallel threads, so the loser read a half-written
+  file: not a wrong verdict but a missing one, `string(&json, "status")`
+  finding no key and the assertion reading `left: None`. Observed on CI on
+  2026-08-30, on a branch whose Rust tree was byte-identical to `main`'s.
+
+  Keying on the options was the first attempt at this and the helper's own
+  doc comment described it as the fix; it is one case short, which is why
+  the paths are now unique per **call** — a pid and a counter — rather than
+  per (fixture, options). The pid covers the other half: these files
+  outlive the run, so a repeating name lets `json.exists()` be satisfied by
+  a previous run's leftover while this run is still writing. The files are
+  removed after they are read.
+
+  The path construction is split into `out_paths` so the property can be
+  asserted rather than waited for: `two_calls_with_the_same_arguments_get_own_paths`
+  fails on the previous scheme **by construction**, since the paths were a
+  pure function of the arguments there. A timing window that only opens
+  under load is not something a green run is evidence about, and 25 local
+  re-runs of the old code reproduced nothing.
+
 - **One naming rule for the `pyomo-pounce` sensitivity surface (gh #854).**
   Three of the public names misled. `estimate()` sat beside a
   parameter-estimation feature set (`declare_fitted`, `declare_residual`,

--- a/crates/pounce-cli/tests/issue850_second_opinion_is_recorded.rs
+++ b/crates/pounce-cli/tests/issue850_second_opinion_is_recorded.rs
@@ -63,22 +63,65 @@ fn fixture(name: &str) -> PathBuf {
     p
 }
 
-/// Solve `name` and return its JSON report as untyped text.
+/// The `.sol` and `.json` paths for ONE `report` call, unique per call
+/// rather than per (fixture, options).
 ///
-/// The output paths carry the *options* as well as the fixture name. Three
-/// tests here solve `PROMOTING` — with the rung on, with it off, and for the
-/// cost check — and cargo runs them on parallel threads, so a filename keyed
-/// on the fixture alone has them overwriting each other's report and reading
-/// whichever landed last. That is a race in the test, and it showed up as
-/// exactly one intermittently-red assertion.
-fn report(name: &str, extra: &[&str]) -> String {
+/// Three tests here solve `PROMOTING` — with the rung on, with it off, and
+/// for the cost check — and cargo runs them on parallel threads. Keying the
+/// name on the options was the first attempt at separating them, and it is
+/// one case short: `a_promotion_records_what_the_base_solve_did` and
+/// `the_true_cost_is_recorded_not_just_the_promoted_rungs` both pass no
+/// options at all, so both resolved to `pounce_850_square_flowsheet_resto_nl`
+/// and raced anyway. The symptom is not a wrong verdict but a missing one —
+/// the loser reads a half-written file, `string(&json, "status")` finds no
+/// key, and the assertion reads `left: None`. Seen on CI 2026-08-30.
+///
+/// The counter makes it per call by construction, so a fourth test on the
+/// same fixture and options cannot reintroduce it. The pid is for the other
+/// half: these files live in the shared temp dir and outlive the run, so a
+/// name that repeats across runs lets `json.exists()` be satisfied by a
+/// previous run's leftover while this run's solve is still writing.
+///
+/// Split out of `report` so the property can be asserted directly rather
+/// than waited for — see `two_calls_with_the_same_arguments_get_own_paths`.
+/// A timing bug that only opens under load is not something a green test run
+/// is evidence about.
+fn out_paths(name: &str, extra: &[&str]) -> (PathBuf, PathBuf) {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+
     let dir = std::env::temp_dir();
     let tag: String = format!("{name}{}", extra.join("_"))
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
         .collect();
-    let sol = dir.join(format!("pounce_850_{tag}.sol"));
-    let json = dir.join(format!("pounce_850_{tag}.json"));
+    let unique = format!(
+        "{}_{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    );
+    (
+        dir.join(format!("pounce_850_{tag}_{unique}.sol")),
+        dir.join(format!("pounce_850_{tag}_{unique}.json")),
+    )
+}
+
+/// Two `report` calls that agree on every argument must still write to
+/// different files. This is the race above, stated as a property instead of
+/// a symptom: on the scheme this replaces the paths were a pure function of
+/// `(name, extra)`, so this assertion fails there by construction, which a
+/// re-run of the flaky test could never establish.
+#[test]
+fn two_calls_with_the_same_arguments_get_own_paths() {
+    let (sol_a, json_a) = out_paths(PROMOTING, &[]);
+    let (sol_b, json_b) = out_paths(PROMOTING, &[]);
+    assert_ne!(json_a, json_b, "two calls shared a JSON path");
+    assert_ne!(sol_a, sol_b, "two calls shared a .sol path");
+}
+
+/// Solve `name` and return its JSON report as untyped text.
+fn report(name: &str, extra: &[&str]) -> String {
+    let (sol, json) = out_paths(name, extra);
     let out = Command::new(pounce_exe())
         .arg(fixture(name))
         .arg(&sol)
@@ -92,7 +135,11 @@ fn report(name: &str, extra: &[&str]) -> String {
         "no JSON written for {name}: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    std::fs::read_to_string(&json).expect("read json")
+    let text = std::fs::read_to_string(&json).expect("read json");
+    // Unique names would otherwise leave one pair per test per run behind.
+    let _ = std::fs::remove_file(&json);
+    let _ = std::fs::remove_file(&sol);
+    text
 }
 
 /// Pull `"key": <number>` out of the JSON text. Enough for this file, and it


### PR DESCRIPTION
## Problem

`crates/pounce-cli/tests/issue850_second_opinion_is_recorded.rs` failed on CI on 2026-08-30, on a branch whose Rust tree was **byte-identical to `main`'s** (#863, a Python-only rename):

```
thread 'a_promotion_records_what_the_base_solve_did' panicked at
crates/pounce-cli/tests/issue850_second_opinion_is_recorded.rs:152:5:
assertion `left == right` failed
  left: None
 right: Some("SolveSucceeded")
```

`left: None` is the tell. `string(&json, "status")` returns `None` when the key is **absent**, so this is not a wrong verdict — it is a report that was not fully there when it was read.

## Cause

The helper built its output paths from the fixture name and the options:

```rust
let tag: String = format!("{name}{}", extra.join("_"))…;
let sol  = dir.join(format!("pounce_850_{tag}.sol"));
let json = dir.join(format!("pounce_850_{tag}.json"));
```

Two tests solve `PROMOTING` with **no options at all** —
`a_promotion_records_what_the_base_solve_did` and
`the_true_cost_is_recorded_not_just_the_promoted_rungs` — so both resolve to
`pounce_850_square_flowsheet_resto_nl.json` in the shared temp dir. Cargo runs
them on parallel threads in one process; whichever reads while the other's
`pounce` subprocess is mid-write gets a truncated file.

Worth noting: **the helper's own doc comment already described this race**, and named keying on the options as the fix. That fix is one case short — it separates calls that differ in their options, and these two do not. The comment has been accurate about the symptom and wrong about the coverage ever since.

There is a second, quieter half. These files live in `std::env::temp_dir()` and outlive the run, so a name that repeats across runs lets the `json.exists()` guard be satisfied by a *previous* run's leftover while this run's solve is still writing.

## Fix

Paths are unique per **call** rather than per (fixture, options): a pid and a process-wide atomic counter. The counter closes the intra-run race by construction — a fourth test on the same fixture and options cannot reintroduce it — and the pid closes the stale-leftover half. The files are removed after they are read, since unique names would otherwise leave one pair per test per run behind.

## Why there is a new test rather than just a re-run

A timing window that only opens under load is not something a green run is evidence about. I ran the **pre-fix** code 25 times locally: 0 failures. That says nothing.

So the path construction is split into `out_paths`, and the property is asserted directly:

```rust
#[test]
fn two_calls_with_the_same_arguments_get_own_paths() {
    let (sol_a, json_a) = out_paths(PROMOTING, &[]);
    let (sol_b, json_b) = out_paths(PROMOTING, &[]);
    assert_ne!(json_a, json_b, "two calls shared a JSON path");
    assert_ne!(sol_a, sol_b, "two calls shared a .sol path");
}
```

On the previous scheme the paths were a pure function of `(name, extra)`, so this fails **deterministically** there, not statistically. Verified by reinstating the old scheme with the new test in place:

```
test two_calls_with_the_same_arguments_get_own_paths ... FAILED
assertion `left != right` failed: two calls shared a JSON path
test result: FAILED. 5 passed; 1 failed
```

That is the flake converted into a pin: the next person to key these paths on anything less than the call gets a red test instead of an intermittent one.

## Blast radius

One test file plus a CHANGELOG entry. No `src/` file is touched, no behaviour changes, and nothing outside this file reads these paths.

---

- [x] Tests fail on the parent commit for the stated reason — deterministically, shown above
- [x] `CHANGELOG.md` `[Unreleased]` entry
- [ ] Book page under `docs/src/` — N/A: no user-facing behaviour or message
- [x] `cargo fmt --all --check` clean, `cargo clippy -p pounce-cli --all-targets -D correctness -D suspicious` clean, `cargo test -p pounce-cli` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXuHz55zzpfSMGN6wSzHCk
