### PR TITLE
chore(release): 0.11.0 preparation — version surfaces, CHANGELOG, and two procedure fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ changes.
 
 ## [Unreleased]
 
+
+## [0.11.0] - 2026-08-31
+
 - **Added FBBT support to `pounce-rs`.** `presolve_fbbt=yes` now runs
   feasibility-based bound tightening when an `ExpressionProvider` is
   available; `Solution::fbbt_report` exposes diagnostics and
@@ -17881,7 +17884,8 @@ release.
 - Zenodo metadata (`.zenodo.json`) and `CITATION.cff` for
   archival on every GitHub Release.
 
-[Unreleased]: https://github.com/jkitchin/pounce/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/jkitchin/pounce/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/jkitchin/pounce/releases/tag/v0.11.0
 [0.10.0]: https://github.com/jkitchin/pounce/releases/tag/v0.10.0
 [0.9.0]: https://github.com/jkitchin/pounce/releases/tag/v0.9.0
 [0.8.0]: https://github.com/jkitchin/pounce/releases/tag/v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ changes.
 
 
 ## [0.11.0] - 2026-08-31
+
 - **The negative-curvature escape now finds the witness it is asked for, on
   saddles whose curvature lies along a coordinate axis (gh #797 follow-up).**
   gh #797 added the second-order question and `neg_curv_escapes` to answer it;

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ identifiers:
   - type: doi
     value: "10.5281/zenodo.20387011"
     description: "Concept DOI — always resolves to the latest POUNCE release"
-version: 0.10.0
-date-released: 2026-08-10
+version: 0.11.0
+date-released: 2026-08-31
 authors:
   - family-names: Kitchin
     given-names: John R.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iter-diff"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde_json",
 ]
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-algorithm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cinterface"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-common"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-convex"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "feral",
  "pounce-common",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-feral"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "feral",
  "pounce-common",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-hsl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-l1penalty"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -989,14 +989,14 @@ dependencies = [
 
 [[package]]
 name = "pounce-linalg"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-common",
 ]
 
 [[package]]
 name = "pounce-linsol"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "libloading",
  "libm",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nlp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-observability"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-presolve"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-py"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "faer",
  "feral",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-qp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-common",
  "pounce-feral",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-restoration"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-rs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-sensitivity"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-solve-report"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-pyo3"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-studio-core",
  "pyo3",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "EPL-2.0"
 authors = ["John Kitchin <jkitchin@andrew.cmu.edu>"]
@@ -67,23 +67,23 @@ repository = "https://github.com/jkitchin/pounce"
 # deps lack a registry version). Crates pick these up via
 # `pounce-foo.workspace = true`.
 [workspace.dependencies]
-pounce-common = { path = "crates/pounce-common", version = "0.10.0" }
-pounce-linalg = { path = "crates/pounce-linalg", version = "0.10.0" }
-pounce-linsol = { path = "crates/pounce-linsol", version = "0.10.0" }
-pounce-nlp = { path = "crates/pounce-nlp", version = "0.10.0" }
-pounce-nl = { path = "crates/pounce-nl", version = "0.10.0" }
-pounce-hsl = { path = "crates/pounce-hsl", version = "0.10.0" }
-pounce-feral = { path = "crates/pounce-feral", version = "0.10.0" }
-pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.10.0" }
-pounce-restoration = { path = "crates/pounce-restoration", version = "0.10.0" }
-pounce-presolve = { path = "crates/pounce-presolve", version = "0.10.0" }
-pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.10.0" }
-pounce-qp = { path = "crates/pounce-qp", version = "0.10.0" }
-pounce-convex = { path = "crates/pounce-convex", version = "0.10.0" }
-pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.10.0" }
-pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.10.0" }
-pounce-studio-core = { path = "crates/pounce-studio-core", version = "0.10.0" }
-pounce-observability = { path = "crates/pounce-observability", version = "0.10.0" }
+pounce-common = { path = "crates/pounce-common", version = "0.11.0" }
+pounce-linalg = { path = "crates/pounce-linalg", version = "0.11.0" }
+pounce-linsol = { path = "crates/pounce-linsol", version = "0.11.0" }
+pounce-nlp = { path = "crates/pounce-nlp", version = "0.11.0" }
+pounce-nl = { path = "crates/pounce-nl", version = "0.11.0" }
+pounce-hsl = { path = "crates/pounce-hsl", version = "0.11.0" }
+pounce-feral = { path = "crates/pounce-feral", version = "0.11.0" }
+pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.11.0" }
+pounce-restoration = { path = "crates/pounce-restoration", version = "0.11.0" }
+pounce-presolve = { path = "crates/pounce-presolve", version = "0.11.0" }
+pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.11.0" }
+pounce-qp = { path = "crates/pounce-qp", version = "0.11.0" }
+pounce-convex = { path = "crates/pounce-convex", version = "0.11.0" }
+pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.11.0" }
+pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.11.0" }
+pounce-studio-core = { path = "crates/pounce-studio-core", version = "0.11.0" }
+pounce-observability = { path = "crates/pounce-observability", version = "0.11.0" }
 # feral: pinned to the published crates.io release so the pounce crates stay
 # publishable — a git rev would block the crates.io publish and is rejected by
 # scripts/check-release-consistency.sh ("git dependency … needs a crates.io

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Most HPC sites run Apptainer/Singularity rather than Docker; it pulls the
 same image and runs it as your own user:
 
 ```sh
-apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.10.0
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.11.0
 apptainer run pounce.sif problem.nl
 ```
 

--- a/dev-notes/cargo-release.md
+++ b/dev-notes/cargo-release.md
@@ -115,9 +115,39 @@ note they all share the `pounce-` prefix under account `jkitchin`.
 4. Bump `CITATION.cff` to match: set `version:` to the new release version and
    `date-released:` to the release date. GitHub's "Cite this repository"
    widget reads these. (The `doi:` is the Zenodo *concept* DOI and stays put.)
-5. Run `scripts/publish-crates.sh --dry-run` to catch missing metadata, broken
-   links, or dirty-tree errors. This dry-runs every crate end-to-end, so any
-   breakage appears here, not three crates into the real release.
+5. Run `cargo package --workspace --exclude pounce-py --exclude
+   pounce-studio-pyo3 --exclude iter-diff --exclude pounce-wasm` to catch
+   missing metadata, broken links, or dirty-tree errors. It packages and then
+   compiles every publishable crate, so breakage appears here rather than
+   three crates into the real release.
+
+   **Do not use `scripts/publish-crates.sh --dry-run` for this**, even though
+   it exists and reads like the obvious choice. It stops at the *second*
+   crate, always, on a release commit:
+
+   ```
+   [2/20] cargo publish -p pounce-linalg --dry-run
+   error: failed to select a version for the requirement `pounce-common = "^0.11.0"`
+     candidate versions found which didn't match: 0.10.0, 0.9.0, 0.8.0, ...
+   ```
+
+   That is not a defect in the tree — it is what step 2 just did. `cargo
+   publish --dry-run` resolves each crate's dependencies against the **live**
+   crates.io index, and the whole point of a release commit is that the new
+   version is not there yet. Only the leaves (`pounce-common`,
+   `pounce-studio-core`) can ever pass. The failure is therefore expected and
+   carries no information, which is worse than useless: it trains you to skip
+   the step.
+
+   `cargo package --workspace` is the one that works, because it resolves
+   intra-workspace dependencies against the versions it is packaging locally
+   instead of against the index. Drop `--no-verify` — that flag skips the
+   compile, which is most of the value.
+
+   The same limitation applies to `release-crates.yml`'s `workflow_dispatch`
+   dry-run mode, which runs this same script: it will fail at crate 2 on a
+   release commit for the same reason. Its dry run is meaningful only when
+   run against a tree whose version is *already* published.
 
 ### Real release
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -8,8 +8,8 @@
 # The build context is irrelevant here (nothing is COPYed in), so it can be
 # built from anywhere — including straight off GitHub without a clone:
 #
-#   docker build -f docker/Dockerfile.release -t pounce:0.10.0 \
-#     --build-arg POUNCE_VERSION=0.10.0 .
+#   docker build -f docker/Dockerfile.release -t pounce:0.11.0 \
+#     --build-arg POUNCE_VERSION=0.11.0 .
 #
 # or `make docker-release`, which reads the version out of Cargo.toml.
 #
@@ -38,8 +38,9 @@ ARG PYTHON_VERSION=3.12
 # on bookworm, on both amd64 and arm64. #456 fixed it by building the CLI in
 # the container, and `scripts/check-cli-portability.sh` in CI keeps it fixed.
 #
-# The fix reached PyPI in 0.10.0, which is what this image installs. Measured
-# on the published artifact rather than inferred from the build:
+# The fix reached PyPI in 0.10.0. Measured on that published artifact rather
+# than inferred from the build — 0.10.0 is the most recent release the floor
+# was measured on, and `scripts/check-cli-portability.sh` guards it in CI:
 #
 #   pounce_solver-0.10.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 #   objdump -T pounce/bin/pounce | grep GLIBC | sort -uV | tail -1
@@ -58,7 +59,7 @@ FROM python:${PYTHON_VERSION}-slim-${DEBIAN_RELEASE}
 # single arg pins both wheels. Pinned rather than floating on purpose: an
 # image tagged 0.9.0 should contain 0.9.0 forever, not whatever was newest
 # the day it was rebuilt.
-ARG POUNCE_VERSION=0.10.0
+ARG POUNCE_VERSION=0.11.0
 
 LABEL org.opencontainers.image.title="POUNCE" \
       org.opencontainers.image.description="Interior-point optimization solver (CLI + Python + Pyomo), released build from PyPI" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,8 +38,8 @@ The equivalents by hand:
 docker build -f docker/Dockerfile -t pounce:dev \
   --build-arg POUNCE_BUILD_GIT="$(git rev-parse --short=8 HEAD)" .
 
-docker build -f docker/Dockerfile.release -t pounce:0.10.0 \
-  --build-arg POUNCE_VERSION=0.9.0 .
+docker build -f docker/Dockerfile.release -t pounce:0.11.0 \
+  --build-arg POUNCE_VERSION=0.11.0 .
 ```
 
 Each image runs its own smoke test as the final build step — CLI solve,

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -80,9 +80,9 @@ The optional extras are *not* installed — no JAX, no PyTorch, no `plotly`,
 no GAMS bindings. Add what you need in a derived image:
 
 ```dockerfile
-FROM ghcr.io/jkitchin/pounce:0.10.0
+FROM ghcr.io/jkitchin/pounce:0.11.0
 USER root
-RUN pip install --no-cache-dir "pounce-solver[jax]==0.10.0"
+RUN pip install --no-cache-dir "pounce-solver[jax]==0.11.0"
 USER pounce
 ```
 
@@ -92,7 +92,7 @@ Most HPC sites run Apptainer (formerly Singularity) rather than Docker,
 because it needs no daemon and no root. It pulls Docker images directly:
 
 ```sh
-apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.10.0
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.11.0
 apptainer run pounce.sif problem.nl
 ```
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -67,7 +67,7 @@ No toolchain and nothing installed on the host:
 
 ```sh
 docker run --rm -v "$PWD:/work" ghcr.io/jkitchin/pounce:latest problem.nl
-apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.10.0
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.11.0
 ```
 
 Both images carry the CLI, the Python API, and the Pyomo plugin. See

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyomo-pounce"
-version = "0.10.0"
+version = "0.11.0"
 description = "Pyomo solver plugin for the POUNCE interior-point NLP solver"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 # because maturin's `module-name = "pounce._pounce"` and
 # `python-source = "."` keep the package folder named `pounce`.
 name = "pounce-solver"
-version = "0.10.0"
+version = "0.11.0"
 description = "Python interface to POUNCE — a pure-Rust interior-point optimization solver for nonlinear, conic (LP/QP/SOCP/SDP/exp/power), and global problems (NLP core ported from Ipopt). cyipopt-style Problem class, scipy-style minimize() facade, solve_qp/solve_socp/sos_minimize, and JAX-friendly autodiff / implicit differentiation."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -9,7 +9,14 @@
 #
 # Usage:
 #   scripts/publish-crates.sh                 # publish all, real upload
-#   scripts/publish-crates.sh --dry-run       # cargo publish --dry-run on each
+#   scripts/publish-crates.sh --dry-run       # cargo publish --dry-run on each.
+#                                             # NOT a release pre-flight: on a
+#                                             # release commit this always fails at
+#                                             # crate 2, because --dry-run resolves
+#                                             # deps against the live index and the
+#                                             # new version is not published yet.
+#                                             # Use `cargo package --workspace`.
+#                                             # See dev-notes/cargo-release.md step 5.
 #   scripts/publish-crates.sh --start-from pounce-algorithm
 #                                             # resume after a mid-batch failure
 #   SLEEP=600 scripts/publish-crates.sh       # override per-crate sleep (default 0)


### PR DESCRIPTION
**Preparation only — this does not cut 0.11.0.** Bug fixes and a full
benchmark run still have to land first. This PR gets the mechanical surfaces
and the release procedure in order so that when the release is actually cut,
the only outstanding work is the release itself.

Nothing here touches `crates/*/src`. No functional change to the solver, and
no trajectory change, so no fixture sweep applies.

Part of #840.

## Blocking the release, not this PR

- [ ] outstanding bug fixes
- [ ] full benchmark run
- [ ] re-date before tagging (see below)

## Two dates that will be wrong by the time we tag

`CHANGELOG.md` says `## [0.11.0] - 2026-08-31` and `CITATION.cff` says
`date-released: 2026-08-31`, because that is when the bump was prepared.
Since the release is now gated on the work above, **both must be reset to the
actual release date before the `v0.11.0` tag is pushed.**

`scripts/check-release-consistency.sh` does *not* check either one — it
verifies version agreement across the surfaces, not dates — so nothing will
catch this automatically. It is on the checklist above and in the "before
tagging" list at the end.

## The version bump

All six surfaces `dev-notes/cargo-release.md` lists, plus the docs pins
`check-release-consistency.sh` reports as advisory:

| surface | file |
|---|---|
| workspace + 17 dep self-pins | root `Cargo.toml` (18 sites) + `Cargo.lock` |
| PyPI `pounce-solver` | `python/pyproject.toml` |
| PyPI `pyomo-pounce` | `pyomo-pounce/pyproject.toml` |
| release image | `docker/Dockerfile.release` `ARG POUNCE_VERSION` |
| citation | `CITATION.cff` (`version`, `date-released`; concept `doi:` stays) |
| CHANGELOG | `[Unreleased]` → `[0.11.0]`, fresh `[Unreleased]`, link refs |

`check-release-consistency.sh` passes with **no advisory lines**.

Historical prose is deliberately untouched. `docs/src/` carries a lot of "up
to and including 0.10.0", plus pinned 0.10.0 fixture tables in
`initialization.md` and `troubleshooting.md`. Those are claims *about that
release* and stay at 0.10.0; only install and pull pins moved. One of them,
`docker/README.md`, was already internally inconsistent before this PR —
`-t pounce:0.10.0` built with `--build-arg POUNCE_VERSION=0.9.0`.

Note that promoting `[Unreleased]` now means any PR merged between this one
and the release adds its entry under the *new* `[Unreleased]` heading, not
under `[0.11.0]`. The bug fixes still to land will need their entries moved
into the `[0.11.0]` section before tagging, or they will silently document
themselves as post-0.11.0.

## CHANGELOG coverage was verified, not assumed

The `[0.11.0]` section is 200 bullets over ~8 900 lines. I mapped all **149
PRs merged since `v0.10.0`** to their closing issues and cross-checked both
numbers against the section. Everything user-facing is represented. The one
apparent gap, #784 (degenerate-start diagnosis), is covered under different
wording. The remaining uncited PRs are CI, test, and dev-note changes that
correctly get no entry.

## Two corrections that are not version bumps

**1. Pre-flight step 5 described a check that cannot pass.** It said to run
`scripts/publish-crates.sh --dry-run` and claimed it "dry-runs every crate
end-to-end, so any breakage appears here, not three crates into the real
release." It cannot, and it fails in the only situation it is ever run in:

```
[2/20] cargo publish -p pounce-linalg --dry-run
error: failed to select a version for the requirement `pounce-common = "^0.11.0"`
  candidate versions found which didn't match: 0.10.0, 0.9.0, 0.8.0, ...
```

`cargo publish --dry-run` resolves against the **live** index, and step 2 of
the same pre-flight just bumped the version. Only the two leaves can pass.
`cargo package --no-verify` hits the identical wall — it is the resolution
that fails, not the build. A step that always fails and carries no
information is worse than no step: it trains you to skip it on the one run
where a real packaging defect would surface.

Step 5 now runs `cargo package --workspace` (four `publish = false` crates
excluded, and *without* `--no-verify`, since dropping the compile drops most
of the value), which resolves intra-workspace deps against the versions it is
packaging locally. Verified against this tree: **exit 0, 20 packaged, 20
verified**. The caveat is also annotated at the `--dry-run` flag in the
script's own usage block, and the doc records that `release-crates.yml`'s
`workflow_dispatch` dry-run mode inherits the same limitation — it shells out
to this same script.

**2. A base-image comment that the bump falsified.**
`docker/Dockerfile.release` justified its bookworm base with "the fix reached
PyPI in 0.10.0, **which is what this image installs**" — true while the ARG
said 0.10.0, false the moment it says 0.11.0. The glibc floor (`GLIBC_2.16`)
was measured on the published 0.10.0 wheel, and 0.11.0 is not on PyPI, so the
comment now says 0.10.0 is the most recent release the floor was measured on
and points at `scripts/check-cli-portability.sh`, rather than implying a
measurement nobody has made.

## What the green docker check does and does not prove

`build release` passes here, but the plan job logs why:

> PR rot guard: building the release image against the newest published
> version (0.10.0), not the workspace version (0.11.0).

The release image pip-installs a pinned version from PyPI, so on a PR it can
only build against something actually published. The check proves
`Dockerfile.release` still builds; it does **not** validate the 0.11.0 image,
which is first built at tag time. Verifying the published image stays a real
post-release step.

## Before tagging (not in this PR)

- Reset the CHANGELOG `[0.11.0]` date and `CITATION.cff` `date-released` to
  the real release date.
- Move any post-merge CHANGELOG entries from `[Unreleased]` into `[0.11.0]`.
- Tag in order — `python-v0.11.0` and `pyomo-pounce-v0.11.0` **at or before**
  `v0.11.0`, since the release image pip-installs from PyPI but fires on `v*`.
- `gh release create v0.11.0 --notes-file` — by hand, no workflow makes it.
- `docker run --rm ghcr.io/jkitchin/pounce:0.11.0 --version` to verify the
  published image rather than assuming.
- Re-measure the CLI glibc floor on the published 0.11.0 wheel and update the
  `Dockerfile.release` comment to cite it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVXWp9fLta3pQTYF2aaxEB
