### PR TITLE
fix(797): find the negative-curvature witness on axis-aligned saddles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ changes.
 
 ## [Unreleased]
 
+- **The negative-curvature escape now finds the witness it is asked for, on
+  saddles whose curvature lies along a coordinate axis (gh #797 follow-up).**
+  gh #797 added the second-order question and `neg_curv_escapes` to answer it;
+  the gate worked, but the *search* behind it declined often enough that the
+  defect it was written to fix stayed reachable. At default options
+  `min ½(x₀² − 1.05·x₁²)` on `[-2, 2]²` from the origin reported
+  `Optimal Solution Found` at the saddle, objective `0`, against a true minimum
+  of `-2.1` — and the same model with its two variables *renamed* answered
+  `-2.1`, because what actually decided the outcome was the overlap between the
+  negative-curvature eigenvector and the probe's fixed seed. Measured over
+  diagonal indefinite models with one negative eigenvalue, 114 of 300 (28–45%
+  per dimension, n = 2..6) certified the saddle.
+
+  Two compounding causes, both now fixed in
+  `PdFullSpaceSolver::negative_curvature_direction`:
+
+  - The shift ladder climbs by ×10 and stopped at the first rung that factored,
+    so it could overshoot `|λ_min|` by a decade. On the model above it rejects
+    `δ = 1` and takes `δ = 10`, leaving eigenvalues `(11, 8.95)` — a ratio of
+    0.81, at which inverse iteration separates almost nothing. The ladder now
+    keeps its bracket and bisects it geometrically
+    (`NEG_CURV_SHIFT_REFINEMENTS`, 8 rungs, a decade down to ~2%), then
+    re-factors at the tightened shift.
+  - Only three inverse iterations ran, amplifying the negative direction by
+    `1.9×` on that spectrum. `NEG_CURV_INVERSE_ITERS` is now 20, matching the
+    QP arm's `neg_curv_probe_iters`.
+
+  Both are individually sufficient on the regression fixture and are kept
+  together deliberately — a wider spectrum starves 20 iterations too, and an
+  exact shift still needs iterations to converge. The declining branch also no
+  longer returns in silence: it logs that a shift *was* required, so "the
+  reduced Hessian is positive definite here" is no longer indistinguishable
+  from "no witness was found".
+
+  `crates/pounce-qp/src/negcurv.rs` (gh #848) had already been given both
+  treatments for the same reason on the QP arm; this brings the NLP arm level.
+  Found by the adversary agent while probing the PRs merged 2026-08-24..31.
+  The full CLI fixture corpus is **unmoved on both legs** (79 fixtures × exact
+  and limited-memory), so this is not a trajectory change on anything the
+  corpus covers — no fixture reaches the declining branch, which is why nothing
+  saw it. `neg_curv_escapes=0` still reports the first-order certificate.
+
 - **Added FBBT support to `pounce-rs`.** `presolve_fbbt=yes` now runs
   feasibility-based bound tightening when an `ExpressionProvider` is
   available; `Solution::fbbt_report` exposes diagnostics and

--- a/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
@@ -403,6 +403,88 @@ impl PdFullSpaceSolver {
             return None;
         }
 
+        // Step 2b: tighten the shift by bisecting the bracket the ladder just
+        // produced. `delta_x` factored and `delta_x / NEG_CURV_DELTA_FACTOR`
+        // did not, so `|λ_min|` lies between them — but the ladder climbs by
+        // a factor of ten, so the rung it lands on can overshoot `|λ_min|` by
+        // up to that much, and the shifted spectrum the inverse iteration
+        // below runs against is then barely separated.
+        //
+        // On `min ½(x₀² − 1.05·x₁²)` over `[−2, 2]²` from the origin the ladder
+        // rejects `δ = 1` and takes `δ = 10`, giving eigenvalues `(11, 8.95)`;
+        // three back-solves amplify the negative direction by `(11/8.95)³ ≈ 1.9`,
+        // which does not make the Rayleigh quotient negative from a seed whose
+        // component along it is small. The probe then declines and the solve
+        // certifies a saddle as `Solve_Succeeded`. That is gh#797's own defect,
+        // and it reached 28–45% of diagonal indefinite models — with the answer
+        // depending on *which coordinate* carried the negative curvature, since
+        // that is what decides the fixed seed's overlap with the eigenvector.
+        //
+        // `crates/pounce-qp/src/negcurv.rs` (gh#848) already brackets and
+        // bisects for exactly this reason; this is the same treatment on the
+        // NLP arm's own ladder.
+        if delta_x > NEG_CURV_DELTA_MIN {
+            let mut lo = delta_x / NEG_CURV_DELTA_FACTOR;
+            let mut hi = delta_x;
+            for _ in 0..NEG_CURV_SHIFT_REFINEMENTS {
+                if deadline_exceeded(data) {
+                    break;
+                }
+                let mid = (lo * hi).sqrt();
+                if !(mid > lo && mid < hi) {
+                    break;
+                }
+                let coeffs = neg_curv_coeffs(&b, mid);
+                let rhs = AugSysRhs {
+                    rhs_x: &*seed.x,
+                    rhs_s: &*seed.s,
+                    rhs_c: &*zero_c,
+                    rhs_d: &*zero_d,
+                };
+                let mut aug_sol = AugSysSol {
+                    sol_x: &mut *sol.x,
+                    sol_s: &mut *sol.s,
+                    sol_c: &mut *sol.y_c,
+                    sol_d: &mut *sol.y_d,
+                };
+                match self
+                    .aug_solver
+                    .solve(&coeffs, &rhs, &mut aug_sol, true, num_neg_evals)
+                {
+                    ESymSolverStatus::Success => hi = mid,
+                    ESymSolverStatus::WrongInertia | ESymSolverStatus::Singular => lo = mid,
+                    _ => break,
+                }
+            }
+            // Land on the tightest shift known to factor, so the cached factor
+            // the inverse iteration re-solves against is that one and `sol`
+            // holds its first iterate.
+            if hi < delta_x {
+                delta_x = hi;
+                let coeffs = neg_curv_coeffs(&b, delta_x);
+                let rhs = AugSysRhs {
+                    rhs_x: &*seed.x,
+                    rhs_s: &*seed.s,
+                    rhs_c: &*zero_c,
+                    rhs_d: &*zero_d,
+                };
+                let mut aug_sol = AugSysSol {
+                    sol_x: &mut *sol.x,
+                    sol_s: &mut *sol.s,
+                    sol_c: &mut *sol.y_c,
+                    sol_d: &mut *sol.y_d,
+                };
+                if self
+                    .aug_solver
+                    .solve(&coeffs, &rhs, &mut aug_sol, true, num_neg_evals)
+                    != ESymSolverStatus::Success
+                {
+                    self.invalidate_aug_cache();
+                    return None;
+                }
+            }
+        }
+
         // Step 3: inverse iteration against that factor. Every candidate is
         // measured; the best Rayleigh quotient wins.
         // `make_new_zeroed` allocates but does not initialize (see the note on
@@ -467,6 +549,21 @@ impl PdFullSpaceSolver {
         self.invalidate_aug_cache();
 
         if !(best_curvature < 0.0) {
+            // Not the same statement as "the reduced Hessian is positive
+            // definite here", which is the `delta_x == 0.0` branch above and
+            // says so. Reaching this line means a shift WAS needed — the
+            // reduced Hessian is indefinite, singular, or the constraint block
+            // is rank deficient — and the iteration simply did not produce a
+            // witness. The caller cannot tell those apart, and until gh#797's
+            // follow-up this declined without a word, so a solve that
+            // certified a saddle left no trace of having tried.
+            tracing::debug!(target: "pounce::kkt",
+                "negative-curvature probe: a shift of {:.3e} was needed, so the \
+                 reduced Hessian is NOT positive definite here, but {} inverse \
+                 iterations produced no direction of negative curvature \
+                 (best Rayleigh quotient {:.3e}); declining the escape and \
+                 reporting the stationary point uncertified (gh#797)",
+                delta_x, NEG_CURV_INVERSE_ITERS, best_quotient);
             return None;
         }
         // Rescale to unit inf-norm so the caller's step length is expressed in
@@ -1937,11 +2034,28 @@ const NEG_CURV_DELTA_FACTOR: Number = 10.0;
 /// gh #797 shape — pays exactly one factorization and stops.
 const NEG_CURV_MAX_FACTORIZATIONS: usize = 30;
 /// Inverse-iteration steps (the first is the factorization's own solve, the
-/// rest are back-solves against the cached factor). Three is enough to
-/// separate `λ_min` from `λ_2` at the ladder's resolution, and every
-/// candidate is measured anyway, so an extra step can only improve the
-/// answer, never invalidate it.
-const NEG_CURV_INVERSE_ITERS: usize = 3;
+/// rest are back-solves against the cached factor). Every candidate is
+/// measured, so an extra step can only improve the answer, never invalidate
+/// it.
+///
+/// This was three, on the reasoning that three "is enough to separate `λ_min`
+/// from `λ_2` at the ladder's resolution". That is only true when the shift is
+/// close to `|λ_min|`, and the bare ×10 ladder does not deliver that: landing a
+/// decade high leaves a spectral ratio near one, where each back-solve buys
+/// almost no separation. Measured on `min ½(x₀² − 1.05·x₁²)` over `[−2, 2]²`,
+/// three steps amplify the negative direction by 1.9× and the probe declines;
+/// the solve then reports `Solve_Succeeded` at the saddle. The bracket
+/// bisection in [`PdFullSpaceSolver::negative_curvature_direction`] fixes the
+/// shift, and this raises the iteration budget so a merely *awkward* spectrum
+/// is not fatal either. `crates/pounce-qp/src/negcurv.rs` uses 20 for the same
+/// search, and the cost is one back-solve per step against a factor that has
+/// already been computed.
+const NEG_CURV_INVERSE_ITERS: usize = 20;
+/// Geometric bisections of the `[δ/factor, δ]` bracket the ladder leaves, to
+/// stop a decade-wide overshoot from starving the inverse iteration above.
+/// Mirrors `neg_curv_shift_refinements` on the QP arm (gh#848); each costs one
+/// factorization, and eight takes a decade-wide bracket to about 2%.
+const NEG_CURV_SHIFT_REFINEMENTS: usize = 8;
 
 /// Write a deterministic, index-dependent seed into `v`, returning `false`
 /// when the vector is not dense (the restoration inner IPM's compound

--- a/crates/pounce-cli/tests/fixtures/saddle_axis_first.nl
+++ b/crates/pounce-cli/tests/fixtures/saddle_axis_first.nl
@@ -1,0 +1,34 @@
+g3 1 1 0	# problem unknown
+ 2 0 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 0 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+O0 0
+o2
+n0.5
+o0
+o2
+n-1.05
+o5
+v0
+n2
+o5
+v1
+n2
+x2
+0 0.0
+1 0.0
+r
+b
+0 -2 2
+0 -2 2
+k1
+0
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/fixtures/saddle_axis_second.nl
+++ b/crates/pounce-cli/tests/fixtures/saddle_axis_second.nl
@@ -1,0 +1,34 @@
+g3 1 1 0	# problem unknown
+ 2 0 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 0 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+O0 0
+o2
+n0.5
+o0
+o5
+v0
+n2
+o2
+n-1.05
+o5
+v1
+n2
+x2
+0 0.0
+1 0.0
+r
+b
+0 -2 2
+0 -2 2
+k1
+0
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/issue_797_probe_finds_axis_aligned_curvature.rs
+++ b/crates/pounce-cli/tests/issue_797_probe_finds_axis_aligned_curvature.rs
@@ -1,0 +1,160 @@
+//! gh #797 follow-up — the negative-curvature *probe* must find the witness,
+//! not just be asked for one.
+//!
+//! `issue_797_neg_curvature_escape.rs` pins that the escape fires on
+//! `nonconvex_qp.nl`. It cannot see the failure this file pins, because that
+//! model's negative-curvature direction happens to overlap the probe's fixed
+//! seed well. When it does not, the probe declines and the solve reports
+//! `Solve_Succeeded` at the saddle — gh#797's own defect, reached through the
+//! search rather than through the gate.
+//!
+//! The fixtures are `min ½(a·x₀² + b·x₁²)` on `[-2, 2]²` from the origin, which
+//! is a strict saddle with every KKT residual zero. The minimum is `-2.1`, at
+//! the bound of whichever coordinate carries the negative curvature. The two
+//! differ ONLY by which coordinate that is:
+//!
+//! * `saddle_axis_second.nl` — `a = 1, b = -1.05`
+//! * `saddle_axis_first.nl`  — `a = -1.05, b = 1`
+//!
+//! They are the same model with the variables renamed, so any answer that
+//! differs between them is reporting a property of the solver's seed rather
+//! than of the problem. Before the fix `saddle_axis_second` returned `0` and
+//! `saddle_axis_first` returned `-2.1`.
+//!
+//! Two things caused it, and both are pinned below.
+//!
+//! 1. The shift ladder climbs by ×10 and stops at the first rung that factors,
+//!    so it can overshoot `|λ_min|` by a decade. Here it rejects `δ = 1` and
+//!    takes `δ = 10`, leaving eigenvalues `(11, 8.95)` — a ratio of 0.81, at
+//!    which inverse iteration barely separates anything.
+//! 2. Only three inverse iterations ran, amplifying the negative direction by
+//!    `1.9×`, which is not enough from a seed with a small component along it.
+//!
+//! The fix bisects the bracket the ladder leaves and raises the iteration
+//! budget, mirroring `crates/pounce-qp/src/negcurv.rs` (gh#848), which had
+//! already been given both on the QP arm.
+//!
+//! MUTATION TABLE — measured, not assumed. **The two halves of the fix are
+//! individually sufficient on this fixture**, so reverting either one alone
+//! leaves the suite green; only reverting both reproduces the defect. That is
+//! recorded here rather than tidied away, because a table claiming each
+//! constant is separately load-bearing would be false, and the next reader
+//! deleting "the redundant one" needs to know it is redundant *on this
+//! fixture* and not in general — a wider spectrum starves 20 iterations too,
+//! and a shift landing exactly on `|λ_min|` still needs iterations to converge.
+//!
+//! | change                                             | result                                    |
+//! |----------------------------------------------------|-------------------------------------------|
+//! | `NEG_CURV_SHIFT_REFINEMENTS = 0` alone             | green — 20 iterations carry it            |
+//! | `NEG_CURV_INVERSE_ITERS = 3` alone                 | green — the tightened shift carries it    |
+//! | **both** reverted (`0` and `3`)                    | `both_axis_orientations_leave_the_saddle` and `the_answer_does_not_depend_on_which_coordinate_is_concave` fail, `saddle_axis_second.nl` reporting `0` |
+//! | make the escape unconditional (ignore the option)  | `the_kill_switch_still_reports_the_saddle` fails |
+
+use pounce_solve_report::SolveReport;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The saddle's objective, and the value a declining probe reports.
+const SADDLE_OBJ: f64 = 0.0;
+/// The true minimum of both fixtures: `-2 * 1.05`.
+const TRUE_MIN: f64 = -2.1;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture_named(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn solve_named(fixture: &str, tag: &str, opts: &[&str]) -> SolveReport {
+    let json = std::env::temp_dir().join(format!("pounce_797_probe_{tag}.json"));
+    let _ = std::fs::remove_file(&json);
+    let out = Command::new(pounce_exe())
+        .arg(fixture_named(fixture))
+        .arg("--no-sol")
+        .arg("--json-output")
+        .arg(&json)
+        .args(opts)
+        .output()
+        .expect("spawn pounce");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(out.status.code(), Some(0), "must solve:\n{combined}");
+    let text = std::fs::read_to_string(&json).expect("JSON report should be written");
+    let _ = std::fs::remove_file(&json);
+    serde_json::from_str(&text).expect("deserialize report")
+}
+
+const ORIENTATIONS: [&str; 2] = ["saddle_axis_second.nl", "saddle_axis_first.nl"];
+
+/// The defect, stated as the property it violated: renaming the variables must
+/// not change the answer.
+#[test]
+fn both_axis_orientations_leave_the_saddle() {
+    for fixture in ORIENTATIONS {
+        let tag = fixture.trim_end_matches(".nl");
+        let r = solve_named(fixture, tag, &[]);
+        let obj = r.solution.objective;
+        assert!(
+            (obj - TRUE_MIN).abs() < 1e-4,
+            "{fixture}: expected the minimum {TRUE_MIN}, got {obj}. \
+             {SADDLE_OBJ} is the saddle the probe is supposed to leave — a value \
+             there means the negative-curvature search declined, which is the \
+             gh#797 defect reached through the search instead of the gate."
+        );
+    }
+}
+
+/// The two fixtures are one model under a permutation, so they must agree to
+/// the solver's own tolerance — not merely both be "close to the minimum".
+#[test]
+fn the_answer_does_not_depend_on_which_coordinate_is_concave() {
+    let a = solve_named(ORIENTATIONS[0], "perm_a", &[])
+        .solution
+        .objective;
+    let b = solve_named(ORIENTATIONS[1], "perm_b", &[])
+        .solution
+        .objective;
+    assert!(
+        (a - b).abs() < 1e-6,
+        "the same model with its variables renamed gave {a} and {b}; the probe's \
+         fixed seed is leaking into the answer"
+    );
+}
+
+/// The escape stays opt-out, and turning it off restores the pre-gh#797
+/// behaviour on exactly these models. Without this, a change that made the
+/// escape unconditional would pass everything above.
+#[test]
+fn the_kill_switch_still_reports_the_saddle() {
+    for (i, fixture) in ORIENTATIONS.iter().enumerate() {
+        let r = solve_named(fixture, &format!("off_{i}"), &["neg_curv_escapes=0"]);
+        let obj = r.solution.objective;
+        assert!(
+            (obj - SADDLE_OBJ).abs() < 1e-6,
+            "{fixture}: with neg_curv_escapes=0 the first-order certificate at \
+             the saddle is what should be reported, got {obj}"
+        );
+    }
+}
+
+/// The bisection must not cost the model the original gh#797 test covers: the
+/// escape still fires on `nonconvex_qp.nl`, whose minimum on the feasible
+/// segment is `0` against the constrained maximum `1`.
+#[test]
+fn the_original_797_model_still_escapes() {
+    let r = solve_named("nonconvex_qp.nl", "orig", &[]);
+    let obj = r.solution.objective;
+    assert!(
+        obj.abs() < 1e-4,
+        "nonconvex_qp.nl should still reach the minimum 0, got {obj}"
+    );
+}


### PR DESCRIPTION
## What

gh#797 added the second-order question and `neg_curv_escapes` to answer it. The
gate works; the **search behind it** declined often enough that the defect it was
written to fix stayed reachable at default options.

At stock settings, `min ½(x₀² − 1.05·x₁²)` on `[-2, 2]²` from the origin reported
`Optimal Solution Found` with objective **0**, against a true minimum of **−2.1**
at `(0, ±2)`. The origin is a strict saddle with every KKT residual zero.

The sharpest statement of the bug: **the same model with its two variables renamed
answered −2.1.**

```
f = 0.5( x0^2 - 1.05 x1^2)  ->  obj +0.000000  status Solve_Succeeded   x = [0, 0]
f = 0.5(-1.05 x0^2 +  x1^2) ->  obj -2.100000  status Solve_Succeeded   x = [2, 0]
```

What actually decided the outcome was the overlap between the negative-curvature
eigenvector and the probe's fixed seed. Over diagonal indefinite models with one
negative eigenvalue, **114 of 300** certified the saddle — 35% / 28% / 45% / 42% /
40% at n = 2..6. Reproduced on the bare CLI `.nl` path, so it is not a Python
wrapper artifact. `neg_curv_escapes` at 2, 5 or 20 does not help; perturbing the
start by `1e-8` does.

## Why

Two compounding causes in `PdFullSpaceSolver::negative_curvature_direction`:

1. **The shift overshoots.** The ladder climbs by ×10 and stopped at the first
   rung that factored, so it could land a decade above `|λ_min|`. Here it rejects
   `δ = 1` and takes `δ = 10`, leaving eigenvalues `(11, 8.95)` — a ratio of 0.81,
   at which inverse iteration separates almost nothing.
2. **Three iterations is not enough at that ratio.** They amplify the negative
   direction by `1.9×`, which does not make the Rayleigh quotient negative from a
   seed with a small component along it. The routine then hit
   `if !(best_curvature < 0.0) { return None; }` and declined **silently** — there
   is a debug line for "positive definite here" but none for "no witness found",
   and no status distinguishes *certified second-order* from *could not check*.

The old doc comment asserted three "is enough to separate `λ_min` from `λ_2` at
the ladder's resolution". That holds only when the shift is near `|λ_min|`, which
the bare ladder does not deliver; the comment is corrected rather than deleted.

## Fix

`crates/pounce-qp/src/negcurv.rs` (#860, gh#848) already had both treatments for
exactly this reason on the QP arm. This brings the NLP arm level:

- keep the ladder's bracket and **bisect it geometrically**
  (`NEG_CURV_SHIFT_REFINEMENTS = 8`, taking a decade-wide bracket to ~2%), then
  re-factor at the tightened shift so the cached factor is the one the iteration
  back-solves against;
- `NEG_CURV_INVERSE_ITERS` 3 → **20**, matching the QP arm's
  `neg_curv_probe_iters`;
- the declining branch logs that a shift **was** required, so "positive definite
  here" is no longer indistinguishable from "no witness was found".

Result: **114/300 → 0/300**. An independent rotation scan over the eigenbasis went
21/73 → 0/73.

## Evidence this is real, and internal

The same binary already got **both** variable orderings right through
`solver_selection=qp-active-set` and wrong through the default NLP arm — an
internal contradiction that needs no external oracle. Independently:

- multistart SLSQP and the closed form both give −2.1;
- `pounce verify` returns **VERIFIED** on the saddle, correctly — it checks
  feasibility and first-order KKT, and a saddle satisfies both. That is precisely
  why no existing guard saw this;
- an independent reimplementation of the ladder + `fill_probe_seed` + 3-step
  inverse iteration predicts fire/decline on **10 of 10** models of the randomized
  corpus that surfaced it.

## Trajectory

Per CLAUDE.md this reroutes which correction the solver reaches for, so the sweep
was run against a baseline binary built from `main`:

**79 fixtures × both legs (exact and limited-memory) = 158 lines, zero diff.**

No fixture in the corpus reaches the declining branch — which is the reason
nothing saw this, and the reason the sweep is evidence of *no collateral damage*
rather than evidence the fix works. The new test and the adversary probe are that
evidence.

## Tests

`crates/pounce-cli/tests/issue_797_probe_finds_axis_aligned_curvature.rs`, over two
fixtures that differ only by which coordinate is concave:

- `both_axis_orientations_leave_the_saddle`
- `the_answer_does_not_depend_on_which_coordinate_is_concave`
- `the_kill_switch_still_reports_the_saddle` — `neg_curv_escapes=0` must still
  report the first-order certificate, so a change making the escape unconditional
  cannot pass
- `the_original_797_model_still_escapes` — `nonconvex_qp.nl` unaffected

**The mutation table is measured, not assumed.** The two halves of the fix are
*individually sufficient* on this fixture, so reverting either alone leaves the
suite green; only reverting both reproduces the defect, with `saddle_axis_second.nl`
back at `0`. That is recorded in the file rather than tidied away — a table
claiming each constant is separately load-bearing would be false, and the next
reader deleting "the redundant one" needs to know it is redundant *on this fixture*
and not in general.

Suites: `pounce-cli` 114 suites / 0 failures; `pounce-algorithm`,
`pounce-sensitivity` (274), `pounce-qp` + `pounce-convex` (659) all green. Clippy
warning count unchanged from `main` (295).

## Provenance

Found by the adversary agent while probing the PRs merged 2026-08-24..31. That run
also cleared #865, #790, #796, the sensitivity cluster (#859, #842, #832,
#829/#830/#837) against a warm re-solve oracle, the convex σ path (#835, #781) to
scale 1e14, and six of eight new option kill switches. Reports are on the
`adversary-runs` branch (`586c65f0`).

Context: gh#797, gh#805, gh#848. No open issue is being closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXuHz55zzpfSMGN6wSzHCk
