### PR TITLE
feat(sens): sens_jacobian(of=<Objective>) gives the total derivative df/dp (#878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,58 @@ changes.
 
 ## [Unreleased]
 
+- **`sens_jacobian(of=<Objective>)` now returns the total derivative `df/dp`
+  (gh#878).** `of=` a Var gave `dx/dp` and `of=` an equality Constraint gave
+  `dlambda/dp`, but the objective was rejected — `ValueError: obj: not a
+  variable of the solved model` — so there was no route to the derivative of
+  the objective with respect to a declared parameter at all. That is one of the
+  most commonly wanted sensitivity quantities: outer-loop optimization,
+  design-of-experiments scoring, "which parameter is my objective most exposed
+  to".
+
+  ```python
+  sens_jacobian(m.obj, wrt=m.p1)   # df/dp1
+  ```
+
+  Both halves of
+
+      df/dp = df/dp|_x + sum_i (df/dx_i)(dx_i/dp)
+
+  are included, and they fall out of a single contraction rather than being
+  assembled from separate blocks. `declare_sens_param` has already rewritten a
+  declared parameter into a variable pinned by a defining equality, so `p` is an
+  ordinary coordinate of the solve: the objective gradient carries `df/dp|_x` in
+  `p`'s own slot and the derivative column carries `dp/dp = 1` there. That
+  matters for correctness, not elegance — on `min (x - p)^2 + 3 p^2` subject to
+  `x + y == 5` the optimum sits at `x = p`, every `df/dx_i` is zero, and a
+  chain-rule-only reading returns `0` instead of `6p`. Nothing about that `0`
+  looks wrong.
+
+  Deliberately **not** added, per the issue: a flat-block `get_dfds_dcds`
+  equivalent, or raw `grad_p c` / `grad_p f` partials. POUNCE's convention —
+  pass the Pyomo object, get a number — cannot be misindexed by construction,
+  and the total derivative is the quantity with obvious demand and no new index
+  convention.
+
+  Only the **active** objective of the solved model is accepted; a deactivated
+  one left on the model from another formulation is refused by name rather than
+  answered with the solved objective's gradient.
+
+  The three dimensions `crates/pounce-sensitivity/tests/sens_invariance_legs.rs`
+  defends are covered for the new accessor in
+  `pyomo-pounce/tests/test_issue_878_objective_total_derivative.py`. Every
+  expected value there is computed **without a solver** — in closed form or by
+  hand — so none of it is a number POUNCE produced; a live Ipopt re-solve
+  confirms the closed forms on top of that, and is skipped where Ipopt is
+  absent rather than required. They are not rows in the Rust legs:
+  the accessor is in the Pyomo layer, because `pounce-sensitivity`'s `Solver`
+  exposes no objective gradient, and rows there would test a path that does not
+  exist. Leg 3's dimension is the one that bites here — `df/dp` is a scalar
+  contracted over the whole step, so contracting a full-x gradient with a var-x
+  step would pair every `df/dx_i` with a neighbouring variable's sensitivity
+  from the first fixed variable on (gh#450, gh#672 finding 1). The fixture
+  asserts the index spaces really do diverge before trusting the leg.
+
 - **A `mu_strategy_fallback` retry that loses now gives back the answer it
   displaced, not just the status (pounce#870).** The retry re-solves under the
   flipped barrier schedule and promotes only on `Solve_Succeeded`; otherwise the

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -169,11 +169,46 @@ pyo.SolverFactory("pounce").solve(m)    # ordinary solve
 
 sens_jacobian(m.x, wrt=m.p)                  # dx*/dp (float)
 sens_jacobian(m.con, wrt=m.p)                # d(multiplier of con)/dp
+sens_jacobian(m.obj, wrt=m.p)                # df/dp, the total derivative
 G = sens_jacobian(m.z, wrt=m.r)              # containers -> Jacobian object
 G[m.z[1], m.r[2]]; G.to_dataframe()     # element access / full Jacobian
 sens_solution(m, [(m.p, 2.5)])               # first-order solution estimate at
                                         # new values, clamped to bounds
 ```
+
+### The objective: `df/dp`
+
+`of=` the model's `Objective` gives the **total** derivative of the
+objective with respect to a declared parameter,
+
+```
+df/dp  =  df/dp|_x  +  sum_i (df/dx_i)(dx_i/dp)
+```
+
+which is the quantity an outer-loop optimization, a design-of-experiments
+score, or a "which parameter is my objective most exposed to" question
+actually wants. It is one number per parameter, on the same convention as
+the rest of the call: pass the Pyomo object, get a float.
+
+Both halves are included. A parameter that appears *in* the objective
+contributes its explicit partial as well as its effect through the
+solution — on `min (x - p)^2 + 3 p^2` subject to `x + y == 5`, where the
+optimum sits at `x = p`, the whole answer is the explicit partial and a
+chain-rule-only reading would return `0` instead of `6p`. Nothing about
+that `0` looks wrong, which is why
+`pyomo-pounce/tests/test_issue_878_objective_total_derivative.py` carries a
+fixture whose implicit half vanishes.
+
+This works because `declare_sens_param` has already rewritten the
+parameter into a variable pinned by a defining equality, so `p` is an
+ordinary coordinate of the solve: the objective gradient carries
+`df/dp|_x` in `p`'s own slot and the derivative column carries `dp/dp = 1`
+there. One contraction picks up both terms, with no second index
+convention to get wrong.
+
+Only the **active** objective of the solved model is accepted; a
+deactivated one left on the model from another formulation is refused by
+name rather than answered with the solved objective's gradient.
 
 `sens_jacobian` returns exact first-order derivatives (unit-perturbation
 backsolves, no finite differencing); `sens_solution` combines the stored

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -698,6 +698,10 @@ class _Session:
         self.pins = pins              # ComponentMap: param data -> pin row
         self.con_alias = con_alias    # original con name -> clone row name
         self.base_x = None
+        # Cached `grad_x f` at the solved point (gh#878). Evaluated at most
+        # once per session; `sens_jacobian(m.obj, wrt=...)` over an indexed
+        # parameter would otherwise re-evaluate it per column.
+        self._obj_grad = None
         # Objective value at the solve. NaN, not None, is the "never
         # computed" sentinel: that is the convention the engine itself
         # uses for info["obj_val"] (pounce-py's problem.rs seeds
@@ -808,6 +812,44 @@ class _Session:
             if row is not None:
                 out[full_idx] = dx_var[row]
         return out
+
+    def objective_gradient(self):
+        """`grad_x f` at the solved point, in full-x (`.col`) order."""
+        if self._obj_grad is None:
+            if self.base_x is None:
+                raise ValueError(
+                    "sens_jacobian(objective): the solve recorded no primal "
+                    "point, so the objective gradient cannot be evaluated")
+            self._obj_grad = np.asarray(self.nl.gradient(self.base_x),
+                                        dtype=float)
+        return self._obj_grad
+
+    def total_objective_derivative(self, col):
+        """`df/dp` for the KKT derivative column `col` (gh#878).
+
+        The chain rule is
+
+            df/dp  =  df/dp|_x  +  sum_i (df/dx_i)(dx_i/dp)
+
+        and both terms fall out of a single contraction here, because a
+        declared sensitivity parameter is not a `Param` by the time the
+        solve sees it. `declare_sens_param` rewrites every occurrence into
+        a variable pinned by a defining equality, so `p` is an ordinary
+        coordinate of full-x: `objective_gradient()` carries `df/dp|_x` in
+        `p`'s own slot, and the step carries `dp/dp = 1` there. Contracting
+        the two therefore picks up the explicit partial and the implicit
+        sum in one product, with no separate `grad_p f` term to assemble
+        and no second index convention to get wrong.
+
+        Written as a dot product over **full-x**, not the factor's var-x:
+        `scatter_x` is what reconciles them, and a model carrying one fixed
+        variable is where the two diverge. Contracting a full-x gradient
+        with a var-x step would silently pair `df/dx_i` with a NEIGHBOURING
+        variable's sensitivity from the first fixed variable on -- gh#450
+        and gh#672 finding 1, the same defect twice. `sens_invariance_legs`
+        leg 3 is the guard.
+        """
+        return float(self.objective_gradient() @ self.scatter_x(col))
 
     def column(self, pin_idx):
         """Full KKT-space derivative column for a unit perturbation."""
@@ -1462,8 +1504,9 @@ def _param_pin(session, param_data):
 
 class Jacobian:
     """Derivatives d(target*)/d(param) for one or more targets/parameters.
-    Targets are variables (primal sensitivities) or equality constraints
-    (multiplier sensitivities).
+    Targets are variables (primal sensitivities), equality constraints
+    (multiplier sensitivities), or the objective (the total derivative
+    df/dp).
 
     Access with g[target_data, param_data] (either order); when one side is
     a single component, g[data] works. to_dataframe() gives the full
@@ -1475,6 +1518,27 @@ class Jacobian:
         self._params = list(params)
         self._tset = set(id(t) for t in self._targets)
         self._pset = set(id(p) for p in self._params)
+
+    def _check_objective(self, td):
+        """The objective target must be the one this session solved.
+
+        Without this a second, deactivated objective left on the model --
+        the ordinary way a script switches between formulations -- reads
+        as a valid target and is answered with the gradient of the
+        objective that *was* solved, under the name of the one that was
+        not. Cheap to check, and the failure it prevents is silent.
+        """
+        active = [o for o in self._session.model.component_data_objects(
+            pyo.Objective, active=True, descend_into=True)]
+        if not any(o is td for o in active):
+            raise ValueError(
+                f"{td.name}: not the active objective of the solved model. "
+                "sens_jacobian(of=<Objective>) differentiates the objective "
+                "the solve minimized; " + (
+                    f"this model's is {active[0].name}."
+                    if len(active) == 1 else
+                    f"this model has {len(active)} active objectives "
+                    f"({[o.name for o in active]})."))
 
     def _entry(self, td):
         if td.ctype is Constraint:
@@ -1505,6 +1569,12 @@ class Jacobian:
 
     def _value(self, td, pd):
         col = self._session.column(_param_pin(self._session, pd))
+        if td.ctype is pyo.Objective:
+            # Not a row of the factor at all: `df/dp` is a scalar contracted
+            # over the whole step, so it has no `_entry` and no convention
+            # sign to apply (gh#878).
+            self._check_objective(td)
+            return self._session.total_objective_derivative(col)
         return self._convention_sign(td) * float(col[self._entry(td)])
 
     def __getitem__(self, key):
@@ -1562,10 +1632,21 @@ def sens_jacobian(of=None, *, wrt, max_pdpert=None):
     """d(of*)/d(wrt).
 
     of: what the derivative is about (the target rows) -- a Var
-    (primal sensitivity) or an equality Constraint (its multiplier's
-    sensitivity); data object or container; omit for all model
+    (primal sensitivity), an equality Constraint (its multiplier's
+    sensitivity), or the model's Objective (the TOTAL derivative
+    df/dp, gh#878); data object or container; omit for all model
     variables. wrt: the differentiation variable, a declared Param
     (data or container).
+
+    The objective target answers
+
+        df/dp = df/dp|_x + sum_i (df/dx_i)(dx_i/dp)
+
+    -- the quantity an outer loop, a design-of-experiments score or a
+    "which parameter is my objective most exposed to" question wants.
+    Both halves are included: a parameter that appears in the objective
+    contributes its explicit partial as well as its effect through the
+    solution. Only the active objective of the solved model is accepted.
 
     Scalar of and scalar wrt -> float. Anything else -> a Jacobian
     object: g[target, param], or g.to_dataframe() for the full

--- a/pyomo-pounce/tests/test_issue_878_objective_total_derivative.py
+++ b/pyomo-pounce/tests/test_issue_878_objective_total_derivative.py
@@ -1,0 +1,390 @@
+"""gh#878 — ``sens_jacobian(of=<Objective>)`` returns the total derivative df/dp.
+
+``of=`` a Var gives ``dx/dp`` and ``of=`` an equality Constraint gives
+``dlambda/dp``; the objective used to be rejected outright, so there was no
+route to ``df/dp`` at all.
+
+    df/dp  =  df/dp|_x  +  sum_i (df/dx_i)(dx_i/dp)
+
+Both halves fall out of one contraction, because ``declare_sens_param``
+rewrites a declared parameter into a variable pinned by a defining equality.
+``p`` is therefore an ordinary coordinate of full-x: the objective gradient
+carries ``df/dp|_x`` in ``p``'s slot and the step carries ``dp/dp = 1`` there.
+
+WHY THESE TESTS LIVE HERE AND NOT IN ``sens_invariance_legs.rs``.  gh#878's
+test note asks for a row in each of the three Rust invariance legs.  The
+accessor did not land in the Rust crate: ``pounce-sensitivity``'s ``Solver``
+exposes no objective gradient, and the issue scopes the proposal to
+``sens_jacobian``'s ``of=``, which is the Pyomo layer.  Putting the rows in the
+Rust legs would test a code path that does not exist.  So the three
+*dimensions* those legs defend are covered here instead, against the code that
+actually runs, and each test below names the leg it stands in for.  If a Rust
+``df/dp`` accessor is ever added, it needs its own rows there — these do not
+cover it.
+
+ORACLES.  Every expected value here is computed **without a solver** — in
+closed form, or by hand — so none of it is a number POUNCE produced.  A step
+that is self-consistently wrong is the class with the worst blast radius, and
+checking POUNCE against POUNCE cannot see it.  Each fixture below carries the
+derivation of its own answer.
+
+A live central-difference re-solve through **Ipopt** runs on top of that where
+Ipopt is installed, as an independent confirmation that the closed forms
+describe the model POUNCE actually solved.  It is skipped, not required: the
+`wheel smoke (pyomo-pounce)` CI job has no Ipopt, and a test that can only run
+where a third-party binary happens to exist is not a regression guard.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+pyo = pytest.importorskip("pyomo.environ")
+
+np = pytest.importorskip("numpy")
+
+from pyomo_pounce import declare_sens_param, sens_jacobian  # noqa: E402
+from pyomo_pounce import sens as _sens  # noqa: E402
+
+TOL = 1e-7
+
+
+def _have_ipopt():
+    try:
+        return bool(pyo.SolverFactory("ipopt").available(False))
+    except Exception:
+        return False
+
+
+requires_ipopt = pytest.mark.skipif(
+    not _have_ipopt(), reason="the live re-solve cross-check needs Ipopt"
+)
+
+
+def _solve(m, tol=1e-10):
+    pyo.SolverFactory("pounce").solve(m, options={"tol": tol})
+    return m
+
+
+def _fd(build, pname, p0, h=1e-6):
+    """Central difference of a re-solve, through Ipopt. Gated by
+    `requires_ipopt` at every call site."""
+
+    def f(v):
+        m = build(**{pname: v})
+        pyo.SolverFactory("ipopt").solve(m, options={"tol": 1e-12})
+        return pyo.value(m.obj)
+
+    return (f(p0 + h) - f(p0 - h)) / (2 * h)
+
+
+def _fd_closed(f, i, args, h=1e-6):
+    """Central difference of a CLOSED-FORM objective. No solver involved."""
+    a, b = list(args), list(args)
+    a[i] += h
+    b[i] -= h
+    return (f(*a) - f(*b)) / (2 * h)
+
+
+def f_implicit_closed(p1, p2):
+    """`implicit_only`'s optimal objective in closed form.
+
+    It is a least-norm problem, `min |x|^2` subject to `A(p2) x = b(p1)`, so
+    `x* = A'(AA')^-1 b` and `f* = b'(AA')^-1 b` — no solver, and it agrees
+    with a solved value to 1e-16.
+    """
+    A = np.array([[6.0, 3.0, 2.0], [p2, 1.0, -1.0]])
+    b = np.array([p1, 1.0])
+    return float(b @ np.linalg.solve(A @ A.T, b))
+
+
+def f_fixed_ahead_closed(p):
+    """`fixed_ahead`'s optimal objective in closed form.
+
+    With `u = x1/s`, `v = x2/s` and `x0` pinned at 0.75 the model is
+    `min (u-p)^2 + 2(v-1)^2 + 2.25 p` subject to `u + v = 4.25`, whose
+    multiplier is `lam = (4/3)(p - 3.25)`, giving `u - p = -lam/2` and
+    `v - 1 = -lam/4`. Substituting collapses it to
+
+        f*(p) = (2/3)(p - 3.25)^2 + 2.25 p      =>   df/dp = (4/3)(p - 3.25) + 2.25
+
+    which is 7/12 at p = 2, and independent of `s` — the scaling leg's point.
+    """
+    return (2.0 / 3.0) * (p - 3.25) ** 2 + 2.25 * p
+
+
+# --------------------------------------------------------------------------
+# Fixtures, chosen to reach DIFFERENT branches of the chain rule.
+# --------------------------------------------------------------------------
+def implicit_only(p1=4.5, p2=1.0):
+    """The parameter reaches the objective only through the solution.
+
+    ``df/dp|_x`` is identically zero here, so this fixture exercises the
+    ``sum_i (df/dx_i)(dx_i/dp)`` half and says nothing about the other one.
+    Pyomo's own ``sensitivity_toolbox`` example.
+    """
+    m = pyo.ConcreteModel()
+    m.x1 = pyo.Var(initialize=0.15)
+    m.x2 = pyo.Var(initialize=0.15)
+    m.x3 = pyo.Var(initialize=0.0)
+    m.p1 = pyo.Param(initialize=p1, mutable=True)
+    m.p2 = pyo.Param(initialize=p2, mutable=True)
+    m.obj = pyo.Objective(expr=m.x1**2 + m.x2**2 + m.x3**2)
+    m.c1 = pyo.Constraint(expr=6 * m.x1 + 3 * m.x2 + 2 * m.x3 - m.p1 == 0)
+    m.c2 = pyo.Constraint(expr=m.p2 * m.x1 + m.x2 - m.x3 - 1 == 0)
+    return m
+
+
+def explicit_partial(p=2.0):
+    """The parameter is in the objective, and the implicit half vanishes.
+
+    ``min (x1 - p)^2 + 3 p^2`` subject to ``x1 + x2 == 5`` puts ``x1`` at
+    ``p``, so ``df/dx1 = 2(x1 - p) = 0`` and the entire answer is the explicit
+    partial: ``f* = 3 p^2``, ``df/dp = 6 p = 12``.
+
+    This is the discriminator for the half `implicit_only` cannot see. An
+    implementation that summed only ``(df/dx_i)(dx_i/dp)`` returns **0** here
+    — the right shape, the wrong number, and nothing about it looks wrong.
+    """
+    m = pyo.ConcreteModel()
+    m.x1 = pyo.Var(initialize=0.3)
+    m.x2 = pyo.Var(initialize=0.3)
+    m.p = pyo.Param(initialize=p, mutable=True)
+    m.obj = pyo.Objective(expr=(m.x1 - m.p) ** 2 + 3 * m.p**2)
+    m.c = pyo.Constraint(expr=m.x1 + m.x2 == 5)
+    return m
+
+
+def fixed_ahead(p=2.0, s=1.0):
+    """A FIXED variable declared ahead of everything else (leg 3's shape).
+
+    ``x0`` has ``lb == ub``, so the default ``fixed_variable_treatment =
+    make_parameter`` drops it from the solve and full-x and var-x stop
+    agreeing from that column on. ``df/dp`` is a scalar contracted over the
+    whole step, so reading a full-x gradient against a var-x step pairs every
+    ``df/dx_i`` with a NEIGHBOURING variable's sensitivity — gh#450 and gh#672
+    finding 1, the same defect twice.
+
+    ``s`` rescales the free variables for the scaling leg below.
+    """
+    m = pyo.ConcreteModel()
+    m.x0 = pyo.Var(bounds=(0.75, 0.75), initialize=0.75)
+    m.x1 = pyo.Var(initialize=0.3)
+    m.x2 = pyo.Var(initialize=0.3)
+    m.p = pyo.Param(initialize=p, mutable=True)
+    m.obj = pyo.Objective(
+        expr=(m.x1 / s - m.p) ** 2 + 2 * (m.x2 / s - 1.0) ** 2 + 3 * m.x0 * m.p
+    )
+    m.c = pyo.Constraint(expr=m.x1 / s + m.x2 / s + m.x0 == 5)
+    return m
+
+
+# --------------------------------------------------------------------------
+# The accessor itself, on both branches of the chain rule.
+# --------------------------------------------------------------------------
+def test_the_implicit_half_matches_a_finite_difference_resolve():
+    m = implicit_only()
+    declare_sens_param(m.p1, m.p2)
+    _solve(m)
+    for pd, name, i in ((m.p1, "p1", 0), (m.p2, "p2", 1)):
+        got = sens_jacobian(m.obj, wrt=pd)
+        want = _fd_closed(f_implicit_closed, i, (4.5, 1.0))
+        assert abs(got - want) < TOL, f"df/d{name}: {got} vs closed form {want}"
+
+
+def test_the_explicit_partial_is_not_dropped():
+    """The half `implicit_only` cannot see. Answer is 12; dropping the
+    explicit partial gives 0."""
+    m = explicit_partial()
+    declare_sens_param(m.p)
+    _solve(m)
+    assert pyo.value(m.x1) == pytest.approx(2.0, abs=1e-7), "x1 sits at p"
+    got = sens_jacobian(m.obj, wrt=m.p)
+    assert got == pytest.approx(12.0, abs=1e-6), (
+        f"df/dp = 6p = 12 here, got {got}. 0.0 is the answer an "
+        "implementation that summed only (df/dx_i)(dx_i/dp) returns."
+    )
+    # and the implicit half really is zero, so the test above is not passing
+    # for the wrong reason
+    dx1 = sens_jacobian(m.x1, wrt=m.p)
+    implicit = 2.0 * (pyo.value(m.x1) - 2.0) * dx1
+    assert abs(implicit) < 1e-6, f"the implicit half should vanish, got {implicit}"
+
+
+# --------------------------------------------------------------------------
+# Leg 1 (scaling): df/dp is a physical quantity and must not move under a
+# change of variables. `variable_scaling_sensitivity.rs` makes the same point
+# about the classifier.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("s", [1.0, 1e3, 1e-3])
+def test_leg_scaling_the_total_derivative_is_unmoved_by_a_change_of_variables(s):
+    m = fixed_ahead(s=s)
+    declare_sens_param(m.p)
+    _solve(m)
+    got = sens_jacobian(m.obj, wrt=m.p)
+    want = _fd_closed(f_fixed_ahead_closed, 0, (2.0,))
+    assert abs(got - want) < 1e-6, (
+        f"scale s={s:g}: df/dp = {got} against the closed form's {want}. "
+        "Rescaling the variables rewrites the same problem; the derivative "
+        "of the objective with respect to a parameter is not a scaled "
+        "quantity and must not move."
+    )
+
+
+# --------------------------------------------------------------------------
+# Leg 2 (perturbation magnitude): `sens_jacobian` takes no step, so the
+# analogue is that the derivative agrees with the re-solve across the range of
+# differencing widths where the difference is meaningful. gh#672 finding 4 put
+# an absolute tolerance on a quantity that scales with the perturbation.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("h", [1e-2, 1e-3, 1e-4, 1e-5, 1e-6])
+def test_leg_magnitude_the_derivative_is_the_limit_of_the_difference_quotient(h):
+    m = explicit_partial()
+    declare_sens_param(m.p)
+    _solve(m)
+    got = sens_jacobian(m.obj, wrt=m.p)
+    want = _fd_closed(lambda p: 3.0 * p * p, 0, (2.0,), h=h)
+    assert abs(got - want) < 1e-5, f"h={h:g}: {got} vs {want}"
+
+
+# --------------------------------------------------------------------------
+# Leg 3 (a fixed variable ahead of the parameter). The one gh#878 called out
+# as most likely to catch an error here.
+# --------------------------------------------------------------------------
+def test_leg_fixed_the_index_spaces_actually_diverge():
+    """Without this the leg below could pass on a model where full-x and
+    var-x coincide, which is every model that has no fixed variable."""
+    m = fixed_ahead()
+    declare_sens_param(m.p)
+    _solve(m)
+    session = _sens._session_for(m.p)
+    rows = session._primal_row_map()
+    assert any(r is None for r in rows), (
+        "no variable was removed from the solve, so full-x and var-x agree "
+        f"and this fixture cannot detect a mis-indexed contraction: {rows}"
+    )
+
+
+def test_leg_fixed_the_total_derivative_survives_a_fixed_variable_ahead_of_it():
+    m = fixed_ahead()
+    declare_sens_param(m.p)
+    _solve(m)
+    got = sens_jacobian(m.obj, wrt=m.p)
+    want = _fd_closed(f_fixed_ahead_closed, 0, (2.0,))
+    assert abs(got - want) < 1e-6, (
+        f"df/dp = {got} against the closed form's {want}. A fixed variable ahead "
+        "of the parameter shifts every later var-x column, so contracting a "
+        "full-x gradient with a var-x step returns a neighbouring variable's "
+        "sensitivity — plausible and wrong (gh#450, gh#672 finding 1)."
+    )
+
+
+# --------------------------------------------------------------------------
+# Shape and refusal.
+# --------------------------------------------------------------------------
+def test_indexed_parameters_give_a_jacobian_with_an_objective_row():
+    m = pyo.ConcreteModel()
+    m.I = pyo.RangeSet(1, 2)
+    m.q = pyo.Param(m.I, initialize={1: 1.0, 2: 2.0}, mutable=True)
+    m.y = pyo.Var(m.I, initialize=0.5)
+    m.obj = pyo.Objective(
+        expr=sum((m.y[i] - m.q[i]) ** 2 for i in m.I) + m.q[1] * m.q[2]
+    )
+    m.c = pyo.Constraint(expr=m.y[1] + m.y[2] == 2.0)
+    declare_sens_param(m.q)
+    _solve(m)
+    g = sens_jacobian(m.obj, wrt=m.q)
+    # Worked by hand: y = (0.5, 1.5), so df/dq1 = -2(y1-q1) + q2 = 3 and
+    # df/dq2 = -2(y2-q2) + q1 = 2, the implicit halves cancelling in both.
+    assert g[m.obj, m.q[1]] == pytest.approx(3.0, abs=1e-7)
+    assert g[m.obj, m.q[2]] == pytest.approx(2.0, abs=1e-7)
+    df = g.to_dataframe()
+    assert list(df.index) == ["obj"]
+    assert df.loc["obj", "q[1]"] == pytest.approx(3.0, abs=1e-7)
+
+
+def test_a_deactivated_objective_is_refused_by_name():
+    """A script that switches formulations leaves the unused objective on the
+    model. Answering for it with the solved objective's gradient, under the
+    unused one's name, is the silent failure this refuses."""
+    m = explicit_partial()
+    m.unused = pyo.Objective(expr=m.x1)
+    m.unused.deactivate()
+    declare_sens_param(m.p)
+    _solve(m)
+    with pytest.raises(ValueError, match="not the active objective"):
+        sens_jacobian(m.unused, wrt=m.p)
+
+
+def test_an_undeclared_parameter_is_still_refused():
+    """The objective route must not bypass the declaration check."""
+    m = explicit_partial()
+    m.q = pyo.Param(initialize=1.0, mutable=True)
+    declare_sens_param(m.p)
+    _solve(m)
+    with pytest.raises(ValueError, match="declare_sens_param"):
+        sens_jacobian(m.obj, wrt=m.q)
+
+
+def test_the_gradient_is_evaluated_once_per_session():
+    """`sens_jacobian(m.obj, wrt=<indexed param>)` asks for one column per
+    member; the gradient does not depend on the column."""
+    m = explicit_partial()
+    declare_sens_param(m.p)
+    _solve(m)
+    session = _sens._session_for(m.p)
+    assert session._obj_grad is None
+    sens_jacobian(m.obj, wrt=m.p)
+    first = session._obj_grad
+    assert first is not None
+    sens_jacobian(m.obj, wrt=m.p)
+    assert session._obj_grad is first, "the gradient was re-evaluated"
+
+
+def test_the_kink_warning_still_fires_for_an_objective_target():
+    """A degenerate base point makes `df/dp` one-sided too, and the caller
+    has to hear about it on this route as much as on the variable one."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=0.0, mutable=True)
+    m.x = pyo.Var(bounds=(0.0, 10.0), initialize=0.5)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2)
+    declare_sens_param(m.p)
+    _solve(m)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sens_jacobian(m.obj, wrt=m.p)
+    assert any("degenerate" in str(w.message) for w in caught), (
+        f"expected the kink warning, got {[str(w.message) for w in caught]}"
+    )
+
+
+# --------------------------------------------------------------------------
+# The independent confirmation, where a third-party solver is available.
+# --------------------------------------------------------------------------
+@requires_ipopt
+@pytest.mark.parametrize(
+    "build, pname, p0",
+    [
+        (implicit_only, "p1", 4.5),
+        (implicit_only, "p2", 1.0),
+        (explicit_partial, "p", 2.0),
+        (fixed_ahead, "p", 2.0),
+    ],
+)
+def test_the_closed_forms_describe_the_model_pounce_actually_solved(build, pname, p0):
+    """Confirms the hand-derived answers above against a live central
+    difference of an **Ipopt** re-solve.
+
+    This is what stops the closed forms from being a second opinion on my own
+    algebra: if a fixture's model and its derivation ever drift apart, every
+    assertion above would agree with the derivation and be wrong about the
+    model. Skipped where Ipopt is absent, and nothing above depends on it.
+    """
+    m = build()
+    declare_sens_param(getattr(m, pname))
+    _solve(m)
+    got = sens_jacobian(m.obj, wrt=getattr(m, pname))
+    want = _fd(build, pname, p0)
+    assert abs(got - want) < 1e-6, f"{build.__name__}/{pname}: {got} vs {want}"


### PR DESCRIPTION
## What

`sens_jacobian`'s `of=` accepted variables and constraint rows but rejected the
objective, so there was no route to `df/dp`:

```python
sens_jacobian(m.c1,  wrt=m.p1)   # dlambda_1/dp_1
sens_jacobian(m.x1,  wrt=m.p1)   # dx_1/dp_1
sens_jacobian(m.obj, wrt=m.p1)   # ValueError: obj: not a variable of the solved model
```

Now:

```python
sens_jacobian(m.obj, wrt=m.p1)   # 0.132653061224  — df/dp1
```

## How, and why it is one contraction rather than two terms

```
df/dp = df/dp|_x + sum_i (df/dx_i)(dx_i/dp)
```

Both halves fall out of a single dot product. `declare_sens_param` has already
rewritten a declared parameter into a variable pinned by a defining equality,
so `p` is an ordinary coordinate of full-x — the objective gradient carries
`df/dp|_x` in `p`'s own slot, and the derivative column carries `dp/dp = 1`
there. No separate `grad_p f` block to assemble, and no second index convention
to get wrong, which is the property the issue asked to preserve.

That is correctness rather than elegance. On `min (x - p)^2 + 3 p^2` subject to
`x + y == 5` the optimum sits at `x = p`, so every `df/dx_i` is zero and a
chain-rule-only reading returns **0** instead of `6p`. Nothing about that `0`
looks wrong.

## Verified against three independent oracles

On the Pyomo `sensitivity_toolbox` model, `df/dp1`:

| source | value |
|---|---|
| central finite difference of an **Ipopt** re-solve | 0.132653061224 |
| analytic chain rule, `∇f · dx/dp` | 0.132653061253 |
| **k_aug** predicted solution, as the perturbation shrinks | 0.132683… → 0.13265 |
| **POUNCE** `sens_jacobian(m.obj, wrt=m.p1)` | 0.132653061224 |

(I installed k_aug/dot_sens via `idaes get-extensions` to get the third; sIPOPT
is also present but returned the unperturbed point through the toolbox call, so
k_aug is the third-party number that discriminates.)

## Scope

Deliberately **not** added, following the issue: a flat-block `get_dfds_dcds`
equivalent, or raw `grad_p c` / `grad_p f` partials.

Only the **active** objective of the solved model is accepted. A deactivated
objective left on the model from another formulation — the ordinary way a
script switches formulations — would otherwise read as a valid target and be
answered with the solved objective's gradient, under the unused one's name.

## Tests, and one place I departed from the issue

The issue asks for a row in each of the three legs in
`crates/pounce-sensitivity/tests/sens_invariance_legs.rs`. **The rows are not
there, and the test file says why.** The accessor landed in the Pyomo layer,
because `pounce-sensitivity`'s `Solver` exposes no objective gradient and the
issue scopes the proposal to `sens_jacobian`'s `of=`. Rows in the Rust legs
would test a code path that does not exist. So the three *dimensions* those
legs defend are covered against the code that actually runs, in
`pyomo-pounce/tests/test_issue_878_objective_total_derivative.py`, each test
naming the leg it stands in for. If a Rust `df/dp` accessor is ever added it
needs its own rows — these do not cover it.

**Oracles are solver-free.** Every expected value is computed in closed form or
by hand, so none of it is a number POUNCE produced:

- `implicit_only` is a least-norm problem, so `f* = b'(AA')^-1 b` in numpy —
  agrees with a solved value to 1e-16;
- `explicit_partial` collapses to `f* = 3p^2`, `df/dp = 6p`;
- `fixed_ahead` collapses to `f* = (2/3)(p-3.25)^2 + 2.25p`, `df/dp = 7/12` at
  `p = 2` and independent of the scale `s` — which is the scaling leg's point.

A live central-difference re-solve through **Ipopt** confirms those closed forms
describe the model POUNCE actually solved, so the derivations cannot quietly
drift from the fixtures. It is skipped where Ipopt is absent rather than
required — the first push failed `wheel smoke (pyomo-pounce)` for exactly that
reason, and a test that only runs where a third-party binary happens to exist is
not a regression guard. Without Ipopt: 17 pass, 4 skip, and both mutations below
are still caught.

Two fixtures, reaching **different branches** of the chain rule, per the
CLAUDE.md rule that a leg is only evidence about the branch its fixture takes:

- `implicit_only` — `df/dp|_x` is identically zero; exercises the sum only.
- `explicit_partial` — the implicit half vanishes and the whole answer is the
  explicit partial. This is the discriminator the first fixture cannot be.

Leg 3's dimension is the one that bites here, as the issue predicted: `df/dp`
is a scalar contracted over the whole step, so contracting a full-x gradient
with a var-x step pairs every `df/dx_i` with a **neighbouring** variable's
sensitivity from the first fixed variable on — gh#450 and gh#672 finding 1, the
same defect twice. `test_leg_fixed_the_index_spaces_actually_diverge` asserts
the spaces really do diverge before the leg beside it is trusted.

**Mutation table — measured:**

| change | result |
|---|---|
| zero the gradient at the pinned params (drop `df/dp\|_x`) | 11 tests fail, led by `test_the_explicit_partial_is_not_dropped` |
| contract against var-x instead of full-x | the scaling leg and `test_leg_fixed_the_total_derivative_survives_a_fixed_variable_ahead_of_it` fail |

Suites: `pyomo-pounce` 516 passed, 5 skipped, 0 failed. `ruff` clean.
`check-docs-consistency.sh` and `check-release-consistency.sh` both OK. No Rust
code changed, so the fixture sweep is not in play.

Fixes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXuHz55zzpfSMGN6wSzHCk
