### PR TITLE
fix(882): give the sigma-path census an exact reference, and take back the conclusion it produced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,35 +94,35 @@ changes.
   for stiffness (`Σ`) and never for complementarity.
 
   Measured on a 72-instance census (`cond` `1e2 ‥ 1e12` × magnitude
-  `1e-3 ‥ 1e3` × `n ∈ {2, 5}` × rotated or not),
-  claimed-optimal-but-wrong falls **17/72 → 9/72** against the census's fixed
-  `1e-6` threshold:
+  `1e-3 ‥ 1e3` × `n ∈ {2, 5}` × rotated or not), scored against the **exact**
+  optimum of each realised problem (gh #882), claimed-optimal-but-wrong falls
+  **17/72 → 9/72** at a `1e-6` relative-error threshold:
 
-  | `cond` | before | after | worst relative error after | census can resolve |
+  | `cond` | before | after | worst relative error after | `ε·cond` |
   |---|---|---|---|---|
   | `1e2`  | 0/12 | 0/12 | 6.4e-08 | 2.2e-14 |
   | `1e4`  | 0/12 | 0/12 | 6.3e-08 | 2.2e-12 |
   | `1e6`  | 2/12 | 0/12 | 3.8e-09 | 2.2e-10 |
-  | `1e8`  | 3/12 | 0/12 | 1.1e-08 | 2.2e-08 |
+  | `1e8`  | 3/12 | 0/12 | 1.4e-08 | 2.2e-08 |
   | `1e10` | 6/12 | 3/12 | 2.0e-06 (was 3.2e-01) | 2.2e-06 |
-  | `1e12` | 6/12 | 6/12 | 4.5e-04 (was 7.1e-01) | 2.2e-04 |
+  | `1e12` | 6/12 | 6/12 | 4.9e-04 (was 7.1e-01) | 2.2e-04 |
 
-  **Read the error column, not the count.** The last column is the census's own
-  resolution: `x* = t` is exact by construction but `P = Q diag(e) Qᵀ` is formed
-  in floating point, so the realised optimum sits `ε·cond·‖t‖` from `t`. At the
-  bottom two rows the `1e-6` threshold is *below* that, so the count there
-  reports the reference's error as the solver's. Per instance, eight of the nine
-  survivors are at or under their own floor (`err/floor` `0.02 ‥ 1.05`) and only
-  one is outside it, by 2×. The signature the issue actually described is gone
-  outright: every failing coupled row in gh #880's table reported `Optimal` in
-  **one** iteration — an inert certificate — and after this change all 72 take
-  3–13. So this is evidence of a fix through `cond = 1e8` and evidence of no
-  regression above it; sharpening the reference so the top of the range means
-  something is gh #882.
+  **The nine survivors are real, and they begin where double precision ends.**
+  `‖Δ‖` is accumulated in `f64`, so this guard cannot resolve a relative error
+  below `ε·cond` — the last column — and cannot reject what it cannot see. A
+  `1e-6` verdict therefore means something only while `ε·cond < 1e-6`, i.e.
+  `cond ≲ 4.5e9`; every conditioning below that boundary is now clean and every
+  survivor is above it, eight of the nine *smaller* than their own floor
+  (`err/(ε·cond)` `0.01 ‥ 0.91`) and one at 2.2×. Closing the residue needs a
+  differently-conditioned estimator, not a tighter cut; it stays open as
+  gh #880.
 
-  Two limits, stated rather than papered over. The estimator computes `‖Δ‖` in
-  double precision, so its own arithmetic floor is `ε·cond` too and at `1e12` it
-  cannot distinguish a small error from zero. And under an equality row the
+  The signature the issue actually described is gone outright, and that one is
+  not a matter of resolution: every failing coupled row in gh #880's table
+  reported `Optimal` in **one** iteration — a certificate accepted without being
+  tested — and after this change the survivors take 5–13.
+
+  One further limit, stated rather than papered over: under an equality row the
   operator above is the wrong one (`A` has no barrier diagonal; the honest form
   is the full saddle system), so the arm declines rather than guessing.
 

--- a/adversary/runs/2026-08-31_convex_sigma-census.org
+++ b/adversary/runs/2026-08-31_convex_sigma-census.org
@@ -1,0 +1,143 @@
+#+TITLE: Adversary Run: The sigma-Path Census Could Not Resolve Its Own Top Two Rows (gh#882)
+#+DATE: <2026-08-31>
+
+* Problem
+:PROPERTIES:
+:FAMILY: convex
+:CLASS: unconstrained ill-conditioned QP, cond x magnitude x n x rotated-or-not
+:SOURCE: no published instance; the randomized family gh#875 and gh#880 were both measured on, regenerated from SEED=875
+:KNOWN_OPTIMAL: yes, and that is the whole subject of this run
+:N_VARIABLES: 2 and 5
+:N_CONSTRAINTS: 0
+:SELECTED_BY: a measurement defect found while writing up gh#880
+:COVERAGE_TARGET: the measurement itself, not the solver -- crates/pounce-convex/src/ipm.rs's sigma path is what it measures
+:END:
+
+The census generates
+
+\[ \min \tfrac12 x^\top P x + c^\top x, \quad P = Q\,\mathrm{diag}(e)\,Q^\top,
+   \quad c = -P t \]
+
+and scores a solver's answer against $x^* = t$, on the stated grounds that
+this is exact "by construction, with no solver in the loop and no reliance on
+an oracle."
+
+It is not. $t$ is the optimum in *exact* arithmetic. The problem actually
+handed to the solver is the one whose coefficients are the float64 values $P$
+and $c$ hold, and $c = -Pt$ is rounded on the way in. Its optimum is a
+different point, and the gap grows with the conditioning -- which is precisely
+the axis the census exists to sweep.
+
+* Method
+
+Not higher precision: *exact* arithmetic. Every float64 is a rational, so the
+realised problem $(P_{fl}, c_{fl})$ is an exactly-specified rational linear
+system and $x^* = -P_{fl}^{-1} c_{fl}$ can be computed with =fractions.Fraction=
+Gaussian elimination with partial pivoting, rounding nowhere. Errors are then
+compared in =Fraction= as well, so the printed number is the solver's error and
+nothing else.
+
+Two things make that the *solver's* problem and not a neighbouring one, and
+both are checked rather than assumed:
+
+- =assert_nl_roundtrip= re-reads each =.nl= after writing it and requires the
+  objective literals (as a multiset) and the =G0= gradient block to be exactly
+  the float64 values the generator intended. Pyomo emits shortest-round-trip
+  =repr= today; if that ever becomes a fixed =%g= the census fails loudly here
+  instead of quietly reacquiring this bug.
+- Pyomo drops coefficients equal to =0.0= and =1.0= from the expression tree,
+  so the comparison is against written values, not all $n^2$. Both exclusions
+  were confirmed to be expression-tree simplification, not precision loss.
+
+Three independent confirmations that the reference is right: the exact residual
+$P x^* + c$ is identically zero on all 72 instances; the =.sol= files carry 18
+significant digits, so the solver's answer round-trips in full; and a numpy
+cross-check at =cond=1e2= agrees to ~1e-15.
+
+* Result
+
+How far the old reference sat from the realised optimum, in the census's own
+relative-error units, against its fixed =1e-6= threshold:
+
+| cond | 1e2 | 1e4 | 1e6 | 1e8 | 1e10 | 1e12 |
+| drift | 2.6e-15 | 4.0e-13 | 4.2e-11 | 2.6e-09 | 2.8e-07 | 4.3e-05 |
+
+At =1e12= the reference is wrong by more than the threshold outright. At
+=1e10= it is within a factor of a few of the errors being judged.
+
+Rescoring the two gh#880 binaries against the exact reference:
+
+| cond | wrong before | wrong after | worst rel err before | after |
+|------+--------------+-------------+----------------------+-------|
+| 1e2  | 0/12 | 0/12 | 6.405e-08 | 6.405e-08 |
+| 1e4  | 0/12 | 0/12 | 6.275e-08 | 6.275e-08 |
+| 1e6  | 2/12 | 0/12 | 2.287e-04 | 3.828e-09 |
+| 1e8  | 3/12 | 0/12 | 1.091e-02 | 1.405e-08 |
+| 1e10 | 6/12 | 3/12 | 3.208e-01 | 2.026e-06 |
+| 1e12 | 6/12 | 6/12 | 7.050e-01 | 4.908e-04 |
+
+17/72 -> 9/72, and every survivor is =rot=True=.
+
+* What it overturned
+
+This run reversed a conclusion that was already written down. Read against
+$t$, eight of the nine survivors looked like they sat at or under the
+measurement floor, so "9/72" read as mostly ruler and gh#880 read as closed.
+Read against the exact optimum, all nine are real solver errors above the
+threshold. The =err/drift= column in the score script is that correction as a
+number, per instance: several 1e12 rows come in at 0.5, meaning the old
+reference contributed more than the solver did.
+
+The right explanation for the residue turned out to be a *different* floor, and
+one that belongs to the guard rather than to the census. =sigma_forward_error_is_small=
+accumulates $\lVert\Delta\rVert$ in float64, so it cannot resolve a relative
+error below $\varepsilon\cdot\mathrm{cond}$ and cannot reject what it cannot
+see. A =1e-6= verdict is meaningful only while $\varepsilon\cdot\mathrm{cond} < 10^{-6}$,
+i.e. $\mathrm{cond} \lesssim 4.5\times10^9$ -- and every conditioning below
+that boundary is now clean while every survivor is above it:
+
+|    k |  cond | rel err | err/eps.cond | iters |
+|------+-------+---------+--------------+-------|
+|   49 |  1e10 | 1.288e-06 | 0.58 |  5 |
+|   51 |  1e10 | 1.122e-06 | 0.51 |  7 |
+|   57 |  1e10 | 2.026e-06 | 0.91 | 11 |
+|   61 |  1e12 | 3.277e-05 | 0.15 |  8 |
+|   63 |  1e12 | 6.631e-06 | 0.03 |  7 |
+|   65 |  1e12 | 4.908e-04 | 2.21 | 10 |
+|   67 |  1e12 | 1.781e-05 | 0.08 | 11 |
+|   69 |  1e12 | 2.523e-05 | 0.11 | 13 |
+|   71 |  1e12 | 1.631e-06 | 0.01 | 13 |
+
+Eight of nine below the guard's own arithmetic floor, one at 2.2x. The
+boundary is soft rather than sharp -- of the two instances gh#880's fix
+repaired at =cond <= 1e8=, one sat at 17.2x of its floor and the other at
+0.63x -- so the claim that survives is the weaker one: the guard works over
+the range a double-precision forward-error test can act on at all, and closing
+the residue needs a differently-conditioned estimator, not a tighter cut.
+
+The unrelated signature is gone outright and is not a matter of resolution:
+every failing coupled row in gh#880's table reported =Optimal Solution Found=
+in *one* iteration, which is what a certificate accepted without being tested
+looks like. The survivors take 5-13.
+
+* Lesson
+
+A reference that is exact in the model is not exact in the problem the solver
+receives. Wherever an oracle is constructed by *inverting* a generator --
+"pick $x^*$, then derive the data that makes it optimal" -- the derivation
+itself rounds, and the resulting error scales with exactly the quantity the
+sweep is varying. The census swept conditioning; the reference degraded with
+conditioning; the two were indistinguishable in the region that mattered.
+
+The tell was available before this run and was misread: gh#880's own table
+carried a =ref acc= column. It was read as a caveat on the top rows rather
+than as a statement that the top rows could not be read at all.
+
+* Reproduce
+
+: python3 2026-08-31_convex_sigma-census_gen.py
+: python3 2026-08-31_convex_sigma-census_score.py <path-to-pounce>
+
+Instances land in the ignored sibling =2026-08-31_convex_sigma-census/= and are
+regenerable from =SEED = 875= by construction, so they are not published here --
+the rule =adversary/.gitignore= already applies to =fuzz/instances.jsonl=.

--- a/adversary/runs/2026-08-31_convex_sigma-census_gen.py
+++ b/adversary/runs/2026-08-31_convex_sigma-census_gen.py
@@ -1,0 +1,189 @@
+"""The sigma-path census, with a reference the census can actually resolve.
+
+gh#875 and gh#880 both used this family: unconstrained ill-conditioned QPs,
+`cond` x magnitude x `n` x rotated-or-not, where
+
+    min 1/2 x'Px + c'x,   P = Q diag(eig) Q',   c = -P t
+
+is built so that `x* = t` "exactly, by construction, with no solver in the loop
+and no reliance on an oracle".
+
+That claim is false at the top of the range, and gh#882 is the consequence. `t`
+is the optimum of the problem in *exact* arithmetic, but the problem handed to
+the solver is the one whose coefficients are the float64 values `P` and `c`
+actually hold, and `c = -P @ t` is itself rounded. The realised optimum
+therefore sits away from `t` by, measured here,
+
+    cond   1e2      1e4      1e6      1e8      1e10     1e12
+    drift  2.6e-15  4.0e-13  4.2e-11  2.6e-09  2.8e-07  4.3e-05
+
+against a fixed 1e-6 threshold. At `1e12` the reference is wrong by more than
+the threshold outright; at `1e10` it is within a factor of a few of the errors
+being judged. So in exactly the regime the defect lives in, the census was
+mixing its own reference error into the solver's.
+
+That mattered in practice, not in principle: read with the `t` reference, eight
+of the nine instances that survive the gh#880 fix looked like they were at or
+under the measurement floor, and the residue looked like mostly ruler. Read
+against the exact optimum, all nine are real solver errors. The conclusion
+reversed.
+
+The fix here is not higher precision, it is **exact** arithmetic. Every float64
+is a rational, so the realised problem `(P_fl, c_fl)` is an exactly-specified
+rational linear system, and `x* = -P_fl^-1 c_fl` is computed with
+`fractions.Fraction` and no rounding anywhere. The reference is then exact to
+the last bit and the census resolves down to the float64 representation of `x*`
+itself, ~1e-16 relative, at every conditioning.
+
+Two things make that reference the *solver's* problem and not a neighbouring
+one, and both are checked rather than assumed:
+
+  * `assert_nl_roundtrip` re-reads the `.nl` that was just written and requires
+    every numeric literal in it to be exactly a float64 the generator intended.
+    Pyomo's writer emits shortest-round-trip `repr`, so this passes today; if it
+    ever switches to a fixed `%g`, the census fails loudly here rather than
+    quietly reacquiring the bug this file exists to remove.
+  * the tree Pyomo writes omits coefficients equal to `0.0` and `1.0`, so the
+    check compares against the multiset of *written* values, not all n^2.
+
+Run `gen.py` to write the instances and `run.py <binary>` to score one.
+"""
+
+import itertools
+import json
+import os
+import re
+from fractions import Fraction
+
+import numpy as np
+import pyomo.environ as pyo
+
+# Instances are regenerable from SEED by construction, so they live in an
+# ignored sibling directory (`runs/*/`) rather than in the published history --
+# the same rule adversary/.gitignore applies to fuzz/instances.jsonl.
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "2026-08-31_convex_sigma-census")
+
+# Unchanged from the gh#875 census, so instance k here is instance k there.
+SEED = 875
+CONDS = [1e2, 1e4, 1e6, 1e8, 1e10, 1e12]
+MAGS = [1e-3, 1.0, 1e3]
+NS = [2, 5]
+ROTS = [False, True]
+
+
+def exact_solve(P, c):
+    """`x` solving `P x = -c` in exact rational arithmetic.
+
+    Gaussian elimination with partial pivoting over `Fraction`. Every float64 is
+    exactly a rational, so nothing here rounds: the result is *the* optimum of
+    the realised problem, not an estimate of it. `P` is symmetric positive
+    definite, so a pivot can only vanish on a singular matrix.
+    """
+    n = len(c)
+    a = [[Fraction(P[i][j]) for j in range(n)] + [Fraction(-c[i])] for i in range(n)]
+    for col in range(n):
+        piv = max(range(col, n), key=lambda r: abs(a[r][col]))
+        if a[piv][col] == 0:
+            raise ZeroDivisionError(f"singular at column {col}")
+        a[col], a[piv] = a[piv], a[col]
+        inv = a[col][col]
+        for r in range(col + 1, n):
+            f = a[r][col] / inv
+            if f:
+                for j in range(col, n + 1):
+                    a[r][j] -= f * a[col][j]
+    x = [Fraction(0)] * n
+    for i in range(n - 1, -1, -1):
+        s = a[i][n] - sum(a[i][j] * x[j] for j in range(i + 1, n))
+        x[i] = s / a[i][i]
+    return x
+
+
+def assert_nl_roundtrip(path, P, c, n):
+    """The `.nl` must carry `P` and `c` bit-for-bit, or the reference is wrong.
+
+    Pyomo drops coefficients of `0.0` and `1.0` from the expression tree, so the
+    objective literals are compared as a multiset against the values that are
+    actually written. The gradient block carries every entry of `c`.
+    """
+    txt = open(path).read()
+    lits = [float(v) for v in re.findall(r"^n(-?[\d.eE+-]+)$", txt, re.M)]
+    assert lits and lits[0] == 0.5, f"{path}: expected a leading 0.5 factor"
+    want = sorted(P[i][j] for i in range(n) for j in range(n) if P[i][j] not in (0.0, 1.0))
+    got = sorted(v for v in lits[1:] if v not in (0.0, 1.0))
+    assert got == want, f"{path}: objective coefficients did not round-trip"
+    block = txt.split(f"G0 {n}\n")[1].strip().splitlines()
+    grad = [float(line.split()[1]) for line in block]
+    assert grad == list(c), f"{path}: gradient coefficients did not round-trip"
+
+
+def build():
+    rng = np.random.default_rng(SEED)
+    cases = []
+    for cond, mag, n, rot in itertools.product(CONDS, MAGS, NS, ROTS):
+        eig = np.logspace(0, np.log10(cond), n) * mag
+        Q = np.linalg.qr(rng.standard_normal((n, n)))[0] if rot else np.eye(n)
+        P = Q @ np.diag(eig) @ Q.T
+        P = 0.5 * (P + P.T)
+        t = rng.uniform(-3.0, 3.0, n)
+        cases.append(dict(cond=cond, mag=mag, n=n, rot=rot, P=P, t=t))
+    return cases
+
+
+def main():
+    os.makedirs(OUT, exist_ok=True)
+    meta = []
+    for k, cs in enumerate(build()):
+        P, t, n = cs["P"], cs["t"], cs["n"]
+        c = -P @ t
+
+        m = pyo.ConcreteModel()
+        m.I = pyo.RangeSet(0, n - 1)
+        m.x = pyo.Var(m.I, initialize=0.0)
+        m.obj = pyo.Objective(
+            expr=0.5 * sum(P[i, j] * m.x[i] * m.x[j] for i in range(n) for j in range(n))
+            + sum(c[i] * m.x[i] for i in range(n))
+        )
+        path = os.path.join(OUT, f"c{k:03d}.nl")
+        m.write(path, io_options={"symbolic_solver_labels": False})
+
+        Pl = P.tolist()
+        cl = c.tolist()
+        assert_nl_roundtrip(path, Pl, cl, n)
+        xstar = exact_solve(Pl, cl)
+
+        # How far the old reference was from the true one, in the census's own
+        # relative-error units. This is the bug of gh#882 as a number, per
+        # instance, and `run.py` prints it beside each result.
+        scale = max(1, max(abs(v) for v in xstar))
+        drift = float(max(abs(xstar[i] - Fraction(t[i])) for i in range(n)) / scale)
+
+        meta.append(
+            dict(
+                k=k,
+                cond=cs["cond"],
+                mag=cs["mag"],
+                n=n,
+                rot=cs["rot"],
+                # exact, as num/den strings -- float64 would reintroduce the
+                # very rounding this file exists to remove.
+                xstar=[[str(v.numerator), str(v.denominator)] for v in xstar],
+                xstar_float=[float(v) for v in xstar],
+                t=list(map(float, t)),
+                old_reference_drift=drift,
+            )
+        )
+
+    with open(os.path.join(OUT, "meta.json"), "w") as fh:
+        json.dump(meta, fh, indent=1)
+    print(f"wrote {len(meta)} instances with exact references")
+    worst = {}
+    for e in meta:
+        worst[e["cond"]] = max(worst.get(e["cond"], 0.0), e["old_reference_drift"])
+    print("\nhow far `x* = t` was from the realised optimum (the gh#882 bug):")
+    for cond in sorted(worst):
+        print(f"  cond {cond:8.0e}   up to {worst[cond]:.2e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/adversary/runs/2026-08-31_convex_sigma-census_score.py
+++ b/adversary/runs/2026-08-31_convex_sigma-census_score.py
@@ -1,0 +1,92 @@
+"""Score one pounce binary against the census. See the `_gen.py` companion.
+
+    python3 2026-08-31_convex_sigma-census_score.py <path-to-pounce> [--threshold 1e-6]
+
+Relative error is computed in exact rational arithmetic against the exact
+optimum of the realised problem, so the number printed is the solver's error and
+nothing else. The `drift` column is how far the old `x* = t` reference sat from
+that optimum -- any row whose error is at or below its own drift is a row the
+pre-gh#882 census could not have resolved.
+
+The `err/eps.cond` column is the other floor, and the one that turned out to
+matter: `sigma_forward_error_is_small` accumulates `||delta||` in float64, so it
+cannot resolve a relative error below `eps * cond` and cannot reject what it
+cannot see. A flagged row below 1.0 there is a genuine error that no
+double-precision forward-error guard can be asked to catch.
+"""
+
+import collections
+import json
+import os
+import subprocess
+import sys
+from fractions import Fraction
+
+EPS = 2.220446049250313e-16
+
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "2026-08-31_convex_sigma-census")
+
+
+def read_sol(path, n):
+    lines = open(path).read().splitlines()
+    i = next(j for j, ln in enumerate(lines) if ln.strip() == "Options")
+    j = i + 1
+    j += 1 + int(lines[j])
+    vals = []
+    for ln in lines[j:]:
+        try:
+            vals.append(float(ln.strip()))
+        except ValueError:
+            break
+    return vals[-n:]
+
+
+def main():
+    binary = sys.argv[1]
+    threshold = float(sys.argv[sys.argv.index("--threshold") + 1]) if "--threshold" in sys.argv else 1e-6
+    meta = json.load(open(os.path.join(OUT, "meta.json")))
+
+    bad = 0
+    by_cond = collections.defaultdict(lambda: [0, 0, 0.0])
+    rows = []
+    for e in meta:
+        nl = os.path.join(OUT, f"c{e['k']:03d}.nl")
+        sol = nl[:-3] + ".sol"
+        if os.path.exists(sol):
+            os.remove(sol)
+        r = subprocess.run([binary, nl], capture_output=True, text=True, timeout=120)
+        ok = "Optimal Solution Found" in r.stdout
+        iters = next(
+            (ln.split(":")[-1].strip() for ln in r.stdout.splitlines() if "Number of Iterations" in ln),
+            "-",
+        )
+        xstar = [Fraction(int(a), int(b)) for a, b in e["xstar"]]
+        x = [Fraction(v) for v in read_sol(sol, e["n"])]
+        scale = max(1, max(abs(v) for v in xstar))
+        rel = float(max(abs(x[i] - xstar[i]) for i in range(e["n"])) / scale)
+        wrong = ok and rel > threshold
+        bad += wrong
+        s = by_cond[e["cond"]]
+        s[0] += wrong
+        s[1] += 1
+        s[2] = max(s[2], rel)
+        rows.append((e["k"], e["cond"], e["mag"], e["n"], e["rot"], rel, e["old_reference_drift"], iters, wrong))
+
+    print(binary)
+    print(f"claimed-optimal-but-wrong (rel > {threshold:g}): {bad} / {len(meta)}")
+    print(f"{'cond':>9} {'wrong':>7} {'max rel err':>12}")
+    for cond in sorted(by_cond):
+        w, t, worst = by_cond[cond]
+        print(f"{cond:>9.0e} {w:>3d}/{t:<3d} {worst:>12.3e}")
+
+    flagged = [r for r in rows if r[8]]
+    if flagged:
+        print(f"\n{'k':>4} {'cond':>8} {'mag':>7} {'n':>2} {'rot':>5} {'rel err':>11} {'old drift':>11} {'err/drift':>9} {'err/eps.cond':>13} {'it':>4}")
+        for k, cond, mag, n, rot, rel, drift, iters, _ in flagged:
+            ratio = rel / drift if drift else float("inf")
+            floor = rel / (EPS * cond)
+            print(f"{k:>4} {cond:>8.0e} {mag:>7.0e} {n:>2} {str(rot):>5} {rel:>11.3e} {drift:>11.3e} {ratio:>9.2f} {floor:>13.2f} {iters:>4}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/pounce-convex/tests/issue875_unconstrained_sigma_stationarity.rs
+++ b/crates/pounce-convex/tests/issue875_unconstrained_sigma_stationarity.rs
@@ -59,11 +59,14 @@
 //! quantity: `sigma_forward_error_is_small` measures the affine-scaling Newton
 //! step `‖Δ‖∞` — a norm of a vector, so basis-free, where any per-row ratio
 //! (this file's included) is not. Over the same 72-instance census the two
-//! fixes together take claimed-optimal-but-wrong from **32/72 → 17/72 → 9/72**,
-//! and the remaining 9 all sit at `cond ≥ 1e10`, where the census's own
-//! reference is only good to `ε·cond·‖t‖` — eight of the nine are at or under
-//! that floor, so the count there is mostly the ruler and not the solver
-//! (gh #882).
+//! fixes together take claimed-optimal-but-wrong from **32/72 → 17/72 → 9/72**
+//! (the first arrow is against the census's original `x* = t` reference; the
+//! second is against the exact rational one gh #882 replaced it with, under
+//! which this file's own result still reads 17/72). The remaining 9 are all at
+//! `cond ≥ 1e10` and all real — but eight of them are smaller than `ε·cond`,
+//! the arithmetic floor of the `f64` estimator that would have to reject them,
+//! so what is left is out of reach of a double-precision guard rather than
+//! out of reach of a tighter threshold.
 //!
 //! So a green run of *this* file still does not cover the coupled arm, for the
 //! same reason it never did — every fixture below is separable, and the

--- a/crates/pounce-convex/tests/issue880_coupled_sigma_forward_error.rs
+++ b/crates/pounce-convex/tests/issue880_coupled_sigma_forward_error.rs
@@ -73,59 +73,64 @@
 //!
 //! # Measured
 //!
-//! Over the same 72-instance unconstrained census gh #875 used (`cond`
-//! `1e2 ‥ 1e12` × magnitude `1e-3 ‥ 1e3` × `n` ∈ {2, 5} × rotated or not),
-//! claimed-optimal-but-wrong goes **17/72 → 9/72** against the census's fixed
-//! `1e-6` threshold:
+//! Over the 72-instance unconstrained census gh #875 used (`cond` `1e2 ‥ 1e12`
+//! × magnitude `1e-3 ‥ 1e3` × `n` ∈ {2, 5} × rotated or not), rebuilt under
+//! gh #882 so its reference is the **exact** optimum of the realised problem —
+//! `x* = −P⁻¹c` computed in `fractions.Fraction`, verified by an exactly-zero
+//! residual on all 72 — rather than the `t` each instance was designed around.
+//! That distinction is not pedantry: `c = −Pt` is rounded, so `t` sits up to
+//! `2.8e-07` (`cond = 1e10`) and `4.3e-05` (`1e12`) away from the optimum the
+//! solver is actually handed, which is the same order as the errors being
+//! judged. Claimed-optimal-but-wrong (relative error `> 1e-6`) goes
+//! **17/72 → 9/72**:
 //!
 //! | `cond` | wrong before | wrong after | worst rel. err before | after |
 //! |---|---|---|---|---|
-//! | `1e6`  | 2 | 0 | — | — |
-//! | `1e8`  | 3 | 0 | — | — |
-//! | `1e10` | 6 | 3 | 3.208e-01 | 1.969e-06 |
-//! | `1e12` | 6 | 6 | 7.051e-01 | 4.479e-04 |
+//! | `1e2`  | 0 | 0 | 6.405e-08 | 6.405e-08 |
+//! | `1e4`  | 0 | 0 | 6.275e-08 | 6.275e-08 |
+//! | `1e6`  | 2 | 0 | 2.287e-04 | 3.828e-09 |
+//! | `1e8`  | 3 | 0 | 1.091e-02 | 1.405e-08 |
+//! | `1e10` | 6 | 3 | 3.208e-01 | 2.026e-06 |
+//! | `1e12` | 6 | 6 | 7.050e-01 | 4.908e-04 |
 //!
-//! **That fixed `1e-6` threshold is below the measurement's own noise floor at
-//! the bottom two rows, so read the last column, not the count.** `x* = t` is
-//! exact by construction but `P = Q diag(e) Qᵀ` is formed in floating point, so
-//! the census can only resolve an error down to `ε·cond·‖t‖` — `1.3e-6 ‥ 2.2e-6`
-//! at `cond = 1e10` and `1.9e-4 ‥ 2.2e-4` at `1e12`. gh #880 says so itself,
-//! in the `ref acc` column of its table; the rows it reported were three or
-//! more orders above their floor, and these are not. Per instance, `err/floor`
-//! for the nine survivors is
+//! **The nine survivors are real, and they begin exactly where double
+//! precision ends.** `‖Δ‖` is accumulated in `f64`, so this guard cannot
+//! resolve a relative error below `ε·cond`, and cannot reject what it cannot
+//! see. A `1e-6` verdict is therefore meaningful only while `ε·cond < 1e-6`,
+//! i.e. `cond < 1e-6/ε ≈ 4.5e9` — every conditioning below that boundary is
+//! now clean, and every survivor is above it. Per instance, `err/(ε·cond)`:
 //!
 //! ```text
-//!   k=49 1.05   k=51 0.63   k=57 0.89     (cond 1e10)
-//!   k=61 0.21   k=63 0.09   k=65 2.02
-//!   k=67 0.05   k=69 0.13   k=71 0.02     (cond 1e12)
+//!   k=49 0.58   k=51 0.51   k=57 0.91              (cond 1e10)
+//!   k=61 0.15   k=63 0.03   k=65 2.21
+//!   k=67 0.08   k=69 0.11   k=71 0.01              (cond 1e12)
 //! ```
 //!
-//! so **eight of the nine are at or under the floor** and only `k=65` is
-//! outside it, by 2×. The other signature is gone outright: every failing
-//! coupled row in gh #880's table reported `Optimal Solution Found` in **one**
-//! iteration, which is what an inert guard looks like. After this change all 72
-//! take 3–13, i.e. the arm fires everywhere and the residue is the destination's
-//! accuracy, not a certificate that was never checked.
+//! — eight of the nine *below* the estimator's own arithmetic floor, one at
+//! 2.2×. The boundary is soft rather than sharp: of the two instances this
+//! change fixed at `cond ≤ 1e8`, one sat at 17.2× of its floor and the other
+//! at 0.63×, so the arm can reject just under the line but not dependably. The
+//! statement that survives is the weaker one — this guard works over the range
+//! a double-precision forward-error test can act on at all, and closing the
+//! residue needs a differently-conditioned estimator rather than a tighter cut.
+//! That residue is gh #880, still open; this file does not claim it.
 //!
-//! What that buys is a bound on the claim, not a stronger claim: the census can
-//! no longer tell a correct answer from a wrong one above `cond = 1e10`, so it
-//! is evidence of a fix through `1e8` and evidence of *nothing* above it in
-//! either direction. Resolving that needs a reference built in extended
-//! precision rather than a tighter guard — gh #882.
+//! The other signature is gone outright, and that one is not a matter of
+//! resolution: every failing coupled row in gh #880's table reported `Optimal
+//! Solution Found` in **one** iteration, which is what a certificate accepted
+//! without being tested looks like. After this change the survivors take 5–13.
+//! The arm fires everywhere; what is left is accuracy, not an unchecked claim.
 //!
 //! # What this file is NOT evidence about
 //!
-//! **`cond ≥ 1e10`, in either direction.** Three things are simultaneously
-//! true up there and none of them is "six instances stay wrong". The estimator
-//! `‖Δ‖` is itself computed in double precision, so its own arithmetic floor is
-//! `ε·cond ≈ 1e-4` at `1e12` and it can under-report by ~30×. The census
-//! reference is no better, per the section above. And `qp_hsde=no` — the
-//! destination a `σ` reject routes to — was *itself* wrong at that conditioning
-//! in gh #880's table (`1.39` and `1.04` relative), so rejecting harder had
-//! nowhere correct to route to; after this change those two rows read `2.96e-05`
-//! and `4.68e-06`, but that improvement is measured with the same blunt ruler.
-//! The honest statement is that this file demonstrates the fix through
-//! `cond = 1e8` and demonstrates no regression above it.
+//! **`cond ≳ 4.5e9`.** Nine instances stay wrong, this file does not fix
+//! them, and the section above says why a `f64` estimator cannot. One further
+//! thing is true up there and is not addressed here either: `qp_hsde=no` — the
+//! destination a `σ` reject routes to — was *itself* wrong at that
+//! conditioning in gh #880's table (`1.39` and `1.04` relative), so rejecting
+//! harder had nowhere correct to route to. The honest statement is that this
+//! file demonstrates the fix through `cond = 1e8`, and above it demonstrates a
+//! large improvement in magnitude with no regression.
 //! `the_cond_1e12_floor_is_a_carve_out`
 //! pins the improvement as a number so the carve-out cannot quietly widen.
 //!
@@ -677,13 +682,13 @@ fn a_large_magnitude_coupled_answer_survives_sigma() {
 // ---------------------------------------------------------------------------
 
 /// **`cond = 1e12` is improved, not repaired, and this is where that is
-/// written down.** The estimator's own arithmetic floor is `ε·cond ≈ 1e-4`, so
-/// at this conditioning it under-reports `‖Δ‖` by ~30× and cannot be relied on
-/// to reject; and independently, `qp_hsde=no` — where a reject routes — is
-/// itself wrong here, so rejecting harder has nowhere correct to go. That is
-/// sub-problem 2 of gh #880.
+/// written down.** `‖Δ‖` is accumulated in `f64`, so the estimator's own
+/// arithmetic floor is `ε·cond ≈ 2e-4` here — larger than every error it is
+/// being asked to reject — and independently, `qp_hsde=no`, where a reject
+/// routes, is itself wrong at this conditioning, so rejecting harder has
+/// nowhere correct to go. That is sub-problem 2 of gh #880.
 ///
-/// The census worst case moves `7.051e-01 → 4.479e-04`, ~1500×. The bar below
+/// The census worst case moves `7.050e-01 → 4.908e-04`, ~1400×. The bar below
 /// is that measured number with headroom, not a target: it exists so the
 /// carve-out cannot quietly widen back toward `O(1)` without a test going red,
 /// and it is deliberately *far* looser than every other bar in this file.
@@ -696,7 +701,7 @@ fn the_cond_1e12_floor_is_a_carve_out() {
     assert!(
         err < 1e-2,
         "cond 1e12: x off by {err:.3e} relative — the census worst case is \
-         4.479e-04 after this fix and 7.051e-01 before it, so anything near \
+         4.908e-04 after this fix and 7.050e-01 before it, so anything near \
          O(1) means the arm stopped firing here"
     );
 }


### PR DESCRIPTION
The census that measured #875 and #880 could not resolve its own top two rows,
and reading it wrong changed a conclusion. This gives it an exact reference and
corrects the write-up that #881 merged.

`Fixes #882` / `Refs #880`.

## The defect

Both issues were measured on the same family — unconstrained ill-conditioned
QPs, `cond` x magnitude x `n` x rotated-or-not —

```
min 1/2 x'Px + c'x,   P = Q diag(e) Q',   c = -P t
```

scored against `x* = t`, on the stated grounds that this is exact "by
construction, with no solver in the loop and no reliance on an oracle."

It is not. `t` is the optimum in *exact* arithmetic. The problem handed to the
solver is the one whose coefficients are the float64 values `P` and `c` hold,
and `c = -P @ t` rounds on the way in. The realised optimum is a different
point, and the gap grows with conditioning — the one axis the census exists to
sweep:

| `cond` | 1e2 | 1e4 | 1e6 | 1e8 | 1e10 | 1e12 |
|---|---|---|---|---|---|---|
| drift of `t` from the realised optimum | 2.6e-15 | 4.0e-13 | 4.2e-11 | 2.6e-09 | 2.8e-07 | 4.3e-05 |

against a fixed `1e-6` threshold. At `1e12` the reference is wrong by more than
the threshold outright; at `1e10` it is within a factor of a few of the errors
being judged.

## The fix

Not higher precision — **exact** arithmetic. Every float64 is a rational, so
`(P_fl, c_fl)` is an exactly-specified rational linear system and
`x* = -P_fl^-1 c_fl` falls out of `fractions.Fraction` Gaussian elimination
with partial pivoting, rounding nowhere. Errors are compared in `Fraction` too,
so the number printed is the solver's error and nothing else.

Two things make that the *solver's* problem and not a neighbouring one, and
both are checked rather than assumed:

- `assert_nl_roundtrip` re-reads each `.nl` after writing it and requires the
  objective literals (as a multiset) and the `G0` gradient block to be exactly
  the float64s the generator intended. Pyomo emits shortest-round-trip `repr`
  today; if that ever becomes a fixed `%g`, the census fails loudly here rather
  than quietly reacquiring this bug.
- Pyomo drops coefficients equal to `0.0` and `1.0` from the expression tree,
  so the comparison is against written values, not all `n^2`. Both exclusions
  were confirmed to be expression-tree simplification, not precision loss.

Three independent confirmations that the reference is right: the exact residual
`P x* + c` is identically zero on all 72 instances; the `.sol` files carry 18
significant digits, so the solver's answer round-trips in full; and numpy
agrees to ~1e-15 at `cond=1e2`.

## What it overturned

This reverses a conclusion `4005ca8d` already wrote down, and #881 merged.

Read against `t`, eight of the nine instances surviving #880's fix looked like
they sat at or under the measurement floor, so `9/72` read as mostly ruler and
#880 read as closed. The bound used there, `eps*cond*||t||`, is an **upper**
bound, and the real drift is 10-40x smaller than it. Read against the exact
optimum, all nine are genuine solver errors above the threshold — several `1e12`
rows come in at `err/drift ~ 0.5`, meaning the old reference contributed more
than the solver did, but the errors clear the threshold either way.

Rescoring the two #880 binaries:

| `cond` | wrong before | wrong after | worst rel. err before | after |
|---|---|---|---|---|
| `1e2`  | 0/12 | 0/12 | 6.405e-08 | 6.405e-08 |
| `1e4`  | 0/12 | 0/12 | 6.275e-08 | 6.275e-08 |
| `1e6`  | 2/12 | 0/12 | 2.287e-04 | 3.828e-09 |
| `1e8`  | 3/12 | 0/12 | 1.091e-02 | 1.405e-08 |
| `1e10` | 6/12 | 3/12 | 3.208e-01 | 2.026e-06 |
| `1e12` | 6/12 | 6/12 | 7.050e-01 | 4.908e-04 |

17/72 -> 9/72, and every survivor is `rot=True`.

## The residue has a different floor, and it belongs to the guard

`sigma_forward_error_is_small` accumulates `||delta||` in `f64`, so it cannot
resolve a relative error below `eps*cond` and cannot reject what it cannot see.
A `1e-6` verdict means something only while `eps*cond < 1e-6`, i.e.
`cond <~ 4.5e9` — and that is exactly where the results split:

| k | cond | rel err | err/(eps*cond) | iters |
|---|---|---|---|---|
| 49 | 1e10 | 1.288e-06 | 0.58 | 5 |
| 51 | 1e10 | 1.122e-06 | 0.51 | 7 |
| 57 | 1e10 | 2.026e-06 | 0.91 | 11 |
| 61 | 1e12 | 3.277e-05 | 0.15 | 8 |
| 63 | 1e12 | 6.631e-06 | 0.03 | 7 |
| 65 | 1e12 | 4.908e-04 | 2.21 | 10 |
| 67 | 1e12 | 1.781e-05 | 0.08 | 11 |
| 69 | 1e12 | 2.523e-05 | 0.11 | 13 |
| 71 | 1e12 | 1.631e-06 | 0.01 | 13 |

Every conditioning below the boundary is clean; every survivor is above it,
eight of nine below the guard's own arithmetic floor and one at 2.2x. The
boundary is soft rather than sharp — of the two instances #880's fix repaired
at `cond <= 1e8`, one sat at 17.2x of its floor and the other at 0.63x — so the
claim that survives is the weaker one: the guard works over the range a
double-precision forward-error test can act on at all, and closing the residue
needs a differently-conditioned estimator, not a tighter cut.

**#880 therefore stays open for that residue.** It was merged as `Fixes` in
#881 on the strength of the reading this PR retracts; it has been reopened, with
the per-instance table in
https://github.com/jkitchin/pounce/issues/880#issuecomment-5493841456.

One thing is fixed unambiguously and is not a matter of resolution: every
failing coupled row in #880's table reported `Optimal Solution Found` in **one**
iteration, which is what a certificate accepted without being tested looks like.
The survivors take 5-13.

## Changed

- `adversary/runs/2026-08-31_convex_sigma-census_gen.py` — the exact reference,
  the round-trip assertion, and the per-instance drift of the old one.
- `adversary/runs/2026-08-31_convex_sigma-census_score.py` — scores a binary in
  exact `Fraction`, with `err/drift` and `err/(eps*cond)` columns.
- `adversary/runs/2026-08-31_convex_sigma-census.org` — the run report.
  Instances are regenerable from `SEED = 875` by construction, so they stay
  unpublished, per the rule `adversary/.gitignore` already applies to
  `fuzz/instances.jsonl`.
- `CHANGELOG.md`, `issue880_coupled_sigma_forward_error.rs`,
  `issue875_unconstrained_sigma_stationarity.rs` — the superseded framing from
  `4005ca8d`, corrected. No assertion changes; two doc-comment numbers in
  `the_cond_1e12_floor_is_a_carve_out` move to the exact-reference values
  (`7.050e-01 -> 4.908e-04`), and its `1e-2` bar is untouched.

No solver code changes, so the fixture sweep is not implicated.
`cargo fmt --check` clean and the `pounce-convex` suite green on this branch.

## Lesson

A reference that is exact in the model is not exact in the problem the solver
receives. Wherever an oracle is built by *inverting* a generator — pick `x*`,
derive the data that makes it optimal — the derivation itself rounds, and the
resulting error scales with exactly the quantity the sweep is varying. The
census swept conditioning; the reference degraded with conditioning; the two
were indistinguishable in the region that mattered.

The tell was available beforehand and was misread: #880's own table carried a
`ref acc` column. It was read as a caveat on the top rows rather than as a
statement that the top rows could not be read at all.
