### PR TITLE
refactor(sens): the sensitivity core is pounce's, pyomo-pounce is a caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,26 @@ changes.
   from the first fixed variable on (gh#450, gh#672 finding 1). The fixture
   asserts the index spaces really do diverge before trusting the leg.
 
+### Documentation
+
+- **The comparison against `pyomo.contrib.sensitivity_toolbox` is now in one
+  place.** `docs/src/sensitivity.md` said three separate things about the Pyomo
+  toolbox — a divergence note under "Declared Params in variable bounds", the
+  sIPOPT-driven verification table, and nothing at all about the capability
+  gap — so a reader deciding between the two had to assemble the answer
+  themselves. A new "Compared with the Pyomo sensitivity toolbox" section
+  collects it: what the toolbox's four entry points are and which binaries each
+  needs, a feature-by-feature table, the three cases where the toolbox is the
+  right tool (any Ipopt build, `pynumero.get_dsdp_dfdp`'s solver-free square
+  path, and `parmest` / `contrib.doe` incumbency), what POUNCE reuses from it
+  (`setup_sensitivity` on the call-time `sens_params=` route only), and three
+  defects measured against Pyomo 6.10.0 — a filtered name list indexed against
+  an unfiltered array in `get_dsdp` and `get_dfds_dcds`, the acknowledged
+  `DeltaP` sign inversion, and an options mapping assigned to a single option
+  name. None of the three is reachable from POUNCE, and the section says why
+  for each. The two older passages now cross-reference it instead of
+  half-answering the question.
+
 ### Fixed
 - **The cost-normalization (`σ`) path no longer certifies a wrong answer on a
   coupled Hessian (gh #880).** When `hsde_cost_scale` rescales the objective,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,77 @@ changes.
   from the first fixed variable on (gh#450, gh#672 finding 1). The fixture
   asserts the index spaces really do diverge before trusting the leg.
 
+- **`pounce.sensitivity`: the sensitivity analysis layer is now pounce's, and
+  `pyomo_pounce` is one of its callers.** Every numeric behind
+  `sens_solution()`, `sens_solution_report()`, `sens_active_set_changes()`,
+  `sens_covariance()` and `sens_information()` lived in
+  `pyomo-pounce/pyomo_pounce/sens.py` and was reachable only with Pyomo
+  installed and a Pyomo model in hand — so a `.nl`, CLI or CasADi user had the
+  linear step and the reduced Hessian and nothing else: no fix-relax, no path
+  mode, no corrector, no activity classification, no covariance,
+  no identifiability.
+
+  None of that code was Pyomo-shaped. Measured before the move, 82 of its 100
+  functions contained no Pyomo reference in executable code at all, the
+  headline five (`sens_covariance` at 454 lines, `sens_solution` at 312,
+  `_classify_fitted_block` at 240, `sens_information` at 231,
+  `sens_active_set_changes` at 96) contained **zero**, and
+  `sens_solution_report`'s only two were the `ComponentMap()` it built its
+  answer in. It already worked in row indices and numpy; it was packaged
+  Pyomo-first, not written that way.
+
+  2 400 lines moved to `pounce/sensitivity/`, addressed by row:
+
+  ```python
+  import pounce
+  from pounce.sensitivity import solve_for_sensitivity, solution, covariance
+
+  nl   = pounce.read_nl("model.nl")
+  sess = solve_for_sensitivity(nl, pins={"p": 4})
+  solution(sess, [4], [0.05], mode="fix_relax")
+  ```
+
+  `SensSession` is the seam: a solved NL plus its held factor, keyed by
+  whatever the caller keys it with. `pyomo_pounce._Session` subclasses it and
+  supplies three hooks — `var_key`, `user_row_data`, `new_keymap` — so a Pyomo
+  caller still gets `ComponentMap`s of component data back and a bare-NL caller
+  gets `.col` names. `who=` keeps each wrapper's own function name in the
+  messages its users see, and a `hints` mapping keeps the declarations those
+  messages point at spelled the caller's way (`declare_sens_residual()` for
+  Pyomo, `res_rows=` for everyone else), so no diagnostic now names an API the
+  reader is not using.
+
+  The Pyomo API is unchanged — same functions, same arguments, same result
+  types (`Covariance`, `Information`, `SolutionReport`, `ActiveSetChange` are
+  re-exported from the core), same messages. Its 500 tests pass untouched
+  apart from five imports of internals that moved.
+
+  `python/tests/test_sensitivity_core.py` is the point of the exercise: twelve
+  tests, no Pyomo, checked against closed forms rather than against a previous
+  run — the parametric step against `dx/dp = 1`, `df/dp` against `6p` on the
+  gh#878 model where a chain-rule-only reading returns 0, the covariance
+  against the linear least-squares formula, and the information matrix against
+  `2 sum(t^2)`. Two of them exist because this refactor created a package
+  boundary exactly where full-x meets var-x: a fixture with an equal-bounds
+  variable placed AHEAD of the parameter makes the two spaces genuinely
+  diverge (`primal_row_map() == [0, 1, None, 2]`) and pins the step across it,
+  since reading one space as the other returns a neighbouring variable's
+  answer — plausible, wrong, and gh#450 twice already.
+
+  Two duplications are gone with it. `_NlBridge` is now
+  `pounce.sensitivity.NlBridge`, used by both. And `_curve_fit.py` and the
+  covariance code each carried their own SVD nullspace basis, same formula and
+  same rank tolerance written twice; both now call
+  `pounce._stats_util.nullspace`. Their *covariance* routines are deliberately
+  NOT merged: `curve_fit` reads `inv(H_S)` straight off the factor because its
+  parameters are the decision variables and `K = H_S`, while
+  `pounce.sensitivity` recovers a tangent map because its fitted block sits
+  inside a larger model with equalities. Same word, different computation.
+
+  `pyomo-pounce` now requires `pounce-solver>=0.11.0`, the release this lands
+  in. An older wheel imports but every sensitivity entry point raises
+  `ImportError`, so the floor is a hard requirement.
+
 ### Documentation
 
 - **The comparison against `pyomo.contrib.sensitivity_toolbox` is now in one

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -131,6 +131,60 @@ eigendecomposition; `sens_bound_eps=…` tunes the bound refinement. See
 [`python/notebooks/04_sensitivity.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/04_sensitivity.ipynb)
 for a walkthrough.
 
+### The analysis layer: `pounce.sensitivity`
+
+`solve_with_sens` answers one perturbation. The `pounce.sensitivity`
+subpackage is the whole analysis surface — the step in every mode, what
+the step did about the bounds, the active-set events along a path, and
+the estimation statistics — over a session that is *a solved NL plus the
+factorization it left behind*:
+
+```python
+import pounce
+from pounce.sensitivity import solve_for_sensitivity, solution, covariance
+
+nl = pounce.read_nl("model.nl")
+sess = solve_for_sensitivity(nl, pins={"p": 4})     # 4 is p's pin row
+
+solution(sess, [4], [0.05])                         # the moved solution
+solution(sess, [4], [0.05], mode="fix_relax")       # bounds respected
+solution_report(sess, [4], [0.05])                  # what it did about them
+active_set_changes(sess, [4], [0.05])               # the events, in order
+```
+
+Estimation statistics need the fitted parameters' `.col` columns and the
+residual variables' columns, which is what `declare_sens_fitted` and
+`declare_sens_residual` resolve to on the Pyomo side:
+
+```python
+sess = solve_for_sensitivity(nl, fit_rows={"a": 0}, res_rows={None: [1, 2, 3]})
+cov = covariance(sess)          # cov["a"], cov.std_err["a"], cov.eigen()
+inf = information(sess)         # the reduced Hessian it inverts
+```
+
+A parameter is addressed by the **full-g row** of the defining equality
+it is pinned by; a fitted parameter or residual by its **full-x
+column**. Keys are opaque — they order the result and label it — so
+results come back keyed by whatever the caller keyed the session with
+(names here, Pyomo component data under `pyomo_pounce`).
+
+Two index-space warnings that a caller working in raw rows owns, and
+that a modelling layer would otherwise hide:
+
+- `.col` order is **full-x**; the factor's `x` block is **var-x**, which
+  drops every variable the solve removed as fixed (`lb == ub` under the
+  default `fixed_variable_treatment=make_parameter`). Route every factor
+  index through `session.primal_row()`, which raises rather than
+  returning a neighbouring variable's answer (gh#450).
+- `fit_rows` and `res_rows` hold **variable columns**, not constraint
+  rows, including for the residuals.
+
+`pyomo_pounce` is a caller of this package, not a reimplementation of
+it: `sens_solution`, `sens_solution_report`, `sens_active_set_changes`,
+`sens_covariance` and `sens_information` resolve Pyomo components to
+rows and hand the same session to the same functions. A fix here reaches
+both.
+
 ## Pyomo
 
 `pyomo_pounce` wraps the same machinery in a declare-then-query

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -753,9 +753,11 @@ alone: **fixed** Vars, whose bounds the solver never enforces, and Vars
 on **deactivated** Blocks.
 
 This is a deliberate divergence from
-`pyomo.contrib.sensitivity_toolbox`'s `sensitivity_calculation`, which
-substitutes declared Params in constraint expressions only and still
-reports zero for the same model. Four things follow from it:
+`pyomo.contrib.sensitivity_toolbox`, which substitutes declared Params
+in constraint and objective expressions only and so still reports zero
+for the same model; see [Compared with the Pyomo sensitivity
+toolbox](#compared-with-the-pyomo-sensitivity-toolbox). Four things
+follow from the divergence:
 
 - **The bound is dropped from the Var.** `m.x.ub` reads `None` after
   the declaration and the NL row carries the reader's no-bound
@@ -1540,12 +1542,173 @@ against sIPOPT 3.14.19 itself, driven through
 | the barrier correction, at `tol = 1e-3` | 2.4e-7 |
 | the barrier correction, at `tol = 1e-8` | 4e-10 |
 
-Each case is one the other two do not reach. The release case returns
+Each case is one the other two do not reach. For how the two
+interfaces compare feature by feature, rather than number by number,
+see [Compared with the Pyomo sensitivity
+toolbox](#compared-with-the-pyomo-sensitivity-toolbox). The release case returns
 `x = 0` without it where the answer is `1.667`, since the linear step
 preserves complementarity and holds the variable on its bound. The
 barrier case differs by 9e-6 without the correction at `tol = 1e-3`,
 and by 2e-9 at `tol = 1e-8`, which is why it is only visible where the
 solve leaves `mu` loose.
+
+## Compared with the Pyomo sensitivity toolbox
+
+Pyomo ships its own parametric sensitivity interface,
+`pyomo.contrib.sensitivity_toolbox`. It computes the same
+Pirnay–Biegler quantity POUNCE does; the differences are in how the
+computation is reached and in what is built on top of it. Everything
+below is measured against Pyomo 6.10.0.
+
+### What the toolbox is
+
+Four entry points over three backends:
+
+| Entry point | Backend | Returns |
+|---|---|---|
+| `sensitivity_calculation("sipopt"\|"k_aug", m, paramList, perturbList)` | the `ipopt_sens`, or `ipopt` + `k_aug` + `dot_sens`, binaries | a **mutated model** whose `Var` values are the perturbed-solution estimate |
+| `get_dsdp(m, theta_names, theta)` | the `k_aug` binary | `ds/dp` as a SciPy sparse matrix, plus a list of column names |
+| `get_dfds_dcds(m, theta_names)` | `ipopt` + `k_aug --print_kkt` | raw `∇f` and `∇c` at the solution — a building block, not a sensitivity |
+| `pynumero.get_dsdp_dfdp(m, theta)` | PyNumero, no solver | `ds/dp` and `df/dp` for a **square** system by the implicit function theorem |
+| `sipopt()`, `kaug()` | — | deprecated shims for `sensitivity_calculation` |
+
+The first two work by model surgery: clone the model, replace each
+declared `Param` with a `Var`, walk every objective and constraint
+substituting occurrences, deactivate **all** original constraints and
+rebuild them on a new block, add one `paramConst` equality per
+parameter, stamp eight `Suffix` objects, write `.nl`/`.row`/`.col` into
+a temporary directory, shell out to the solver binary, and parse the
+answer back out of files on disk. The rebuild is unconditional — the
+upstream source notes it: *"Unfortunate that this deactivates and
+replaces constraints even if they don't contain the parameters."*
+
+### Capability comparison
+
+| | Pyomo toolbox | `pyomo_pounce` |
+|---|---|---|
+| External binaries | `ipopt_sens` / `k_aug` / `dot_sens` — none on PyPI, all must be built from source | none; in-process through `pounce.read_nl` |
+| Cost per query | model clone + full constraint rebuild + subprocess + file parse | declare once; the KKT factor is retained and each query is one backsolve |
+| Perturbation values | required **before** the solve | not required; ask for any `Δp` afterwards |
+| `dx*/dp` | ✅ `get_dsdp`, whole matrix | ✅ `sens_jacobian(of, wrt=…)`, scalar or `Jacobian` / DataFrame |
+| `dλ/dp`, multiplier sensitivity | ❌ | ✅ pass an equality `Constraint` as `of=` |
+| Total `df/dp` | ❌ | ✅ `sens_jacobian(m.obj, wrt=p)`, explicit partial plus the path through `x*` |
+| Declared `Param` in a variable **bound** | ❌ substitution walks constraints and the objective only, so the derivative reads exactly `0.0` | ✅ rewritten to a row at declaration — see [Declared Params in variable bounds](#declared-params-in-variable-bounds) |
+| Bound crossing (fix-relax) | sIPOPT implements `sens_boundcheck`, but the toolbox never sets it — only `run_sens=yes` | ✅ `mode="fix_relax"`, both the pin and the release half |
+| Stepwise application | ❌ | ✅ `mode="path"`, plus `sens_active_set_changes()` |
+| Barrier corrector | ❌ | ✅ `corrector_iter=` |
+| Degenerate base point | ❌ returns one side silently | ✅ directional derivatives, `degeneracy=`, activity classification, `reduced_activity` / `reduced_row_activity` |
+| What the step did about the bounds | ❌ | ✅ `sens_solution_report()`, clamp warnings |
+| Covariance, standard errors, correlations | ❌ — `parmest` builds its own from `get_dfds_dcds` | ✅ `sens_covariance()` off one solve |
+| Information matrix, identifiability | ❌ | ✅ `sens_information()`, rank and conditioning diagnostics |
+| Reduced Hessian, eigendecomposition | ❌ | ✅ |
+| Refusal on an inertia-corrected factor | ❌ | ✅ `max_pdpert=` |
+| NLP scaling | ❌ | ✅ `user-scaling` respected end to end |
+| Continuation, path following | ❌ | ✅ `continuation()`, `PathFollower`, pseudo-arclength, `inverse_map_rhs` |
+
+### Where the toolbox is the right tool
+
+Three cases, and they are real:
+
+- **Any Ipopt build.** The toolbox is solver-agnostic; `pyomo_pounce`'s
+  sensitivity requires POUNCE to be the solver. If you are committed to
+  a particular Ipopt/HSL configuration, that decides it.
+- **No solver at all.** `pynumero.get_dsdp_dfdp` is a pure
+  equality-Jacobian solve for a square system with as many parameters
+  as degrees of freedom. It ignores inequalities, bounds and
+  multipliers entirely — a limitation for an NLP, and the point for a
+  flowsheet you only want to differentiate.
+- **Incumbency.** `pyomo.contrib.parmest` and `pyomo.contrib.doe` both
+  call `get_dsdp` directly.
+
+### What POUNCE reuses from it
+
+The call-time route — `sens_solve(m, sens_params=[…])` — still runs the
+toolbox's `SensitivityInterface.setup_sensitivity()` on a clone built
+for that one solve and thrown away, so it inherits the unconditional
+constraint rebuild. It does not inherit the bound gap:
+`_reformulate_param_bounds()` runs on the clone immediately afterwards,
+so a `Param` in a variable bound gets a real derivative on that path
+too.
+
+The declared route — `declare_sens_param` — does not touch the toolbox
+at all. No clone, no surgery, the model solves as written.
+
+### Known defects in the toolbox, as of Pyomo 6.10.0
+
+Recorded here because POUNCE reuses part of this module, and because a
+reader comparing numbers across the two needs to know which paths are
+affected.
+
+**A filtered name list indexed against an unfiltered array.**
+`get_dsdp` drops the surgery block's own columns from the name list and
+then indexes the *unfiltered* matrix with the filtered position
+(`sens.py:322–327`):
+
+```python
+col = [i for i in col if sens.get_default_block_name() not in i]
+dsdp_out = np.zeros((len(theta_names), len(col)))
+for j in range(len(col)):
+    dsdp_out[i, j] = -dsdp[i, j]      # dsdp columns are still in NL order
+```
+
+That is only sound if the substituted variables occupy the last
+columns. They do not — the NL writer interleaves them:
+
+```
+0 _SENSITIVITY_TOOLBOX_DATA.p1
+1 x1
+2 _SENSITIVITY_TOOLBOX_DATA.p2
+3 x2
+4 x3
+```
+
+so the row labelled `x1` carries `p1`'s column. `get_dfds_dcds` repeats
+the shape at `sens.py:455`: `gradient_c` is built with unfiltered
+column indices but the filtered width, and `gradient_f` is returned at
+full NL length beside a filtered `col`.
+
+Both sites are reachable only when the declared parameters are
+`Param`s. A declared fixed `Var` takes the other branch of
+`_add_sensitivity_data` — a `Param` is added to the block, which
+creates no column — so the filter removes nothing and the arithmetic
+happens to line up. `parmest` and `contrib.doe` both pass fixed `Var`s,
+and both `test_get_dsdp` cases use `Var`s, so the `Param` path has no
+in-tree caller and no test.
+
+**An acknowledged sign inversion.** `perturb_parameters` carries its own
+note (`sens.py:811`):
+
+> `# FIXME: ^ This is incorrect. DeltaP should be (ptb - current).`
+> `# But at least one test doesn't pass unless I use (current - ptb).`
+
+**An options dict assigned to one option.**
+`sensitivity_calculation` passes the caller's whole `solver_options`
+mapping as the value of a single option (`sens.py:223`):
+
+```python
+ipopt_sens.options['linear_solver'] = solver_options
+```
+
+### None of the three is reachable from POUNCE
+
+- POUNCE never calls `get_dsdp`, never runs `k_aug`, and never parses a
+  `dsdp_in_.in` file. Its own name-to-position mapping is a dict
+  (`_row_index`, `sens.py:603`) and every lookup raises on a miss, so
+  the filter-then-index shape cannot occur. The one place two index
+  spaces genuinely differ — the user's full-x `.col` order against the
+  factor's var-x block, which drops variables removed as fixed — is
+  routed through a single raising accessor, `primal_row()`, and on the
+  Rust side through the `VarX` / `FullX` newtypes in
+  `crates/pounce-sensitivity/src/index.rs`, with leg 3 of
+  `sens_invariance_legs.rs` covering what the newtypes do not.
+- POUNCE calls `setup_sensitivity()` and nothing else. `DeltaP`,
+  `perturb_parameters()` and `sens_state_value_1` are k_aug and sIPOPT
+  wire-format concerns and appear nowhere in `pyomo_pounce`. The
+  right-hand-side shifts are computed in `_perturbation_deltas()`,
+  measured from each pin row's stored right-hand side rather than the
+  `Param`'s current value, and the sign is pinned by the
+  `parametric_cpp` golden comparison above.
+- Solver options are applied one key at a time.
 
 ## Beyond one perturbation
 

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -147,6 +147,16 @@ fact.refactor(&new_values)?;       // pattern preserved; numeric reuse
 fact.solve_one(&mut another_rhs)?;
 ```
 
+## The analysis layer above these calls
+
+`Solver` is the primitive; `pounce.sensitivity` is the analysis built on
+it — the parametric step in every mode, what the step did about the
+bounds, the active-set events along a path, parameter covariance and the
+information matrix — over a session that bundles a solved NL with its
+held factor. It has no modelling-layer dependency; `pyomo_pounce` is one
+of its callers. See
+[Sensitivity Analysis](sensitivity.md#the-analysis-layer-pouncesensitivity).
+
 ## What's preserved across operations
 
 * **Symbolic factor / AMD ordering.** Owned by the linear-solver

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -64,7 +64,6 @@ import tempfile
 import threading
 import time
 import warnings
-from collections import namedtuple
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -76,6 +75,28 @@ from pyomo.core.base.constraint import Constraint
 from pyomo.core.expr import identify_mutable_parameters, identify_variables
 from pyomo.core.expr.visitor import replace_expressions
 from pyomo.opt import SolverResults, SolverStatus, TerminationCondition
+
+from pounce.sensitivity import (
+    # re-exported unchanged for `from pyomo_pounce import Covariance` and
+    # friends: the result types are the core's, and a Pyomo caller gets
+    # the same objects a bare-NL one does
+    ActiveSetChange,          # noqa: F401
+    Covariance,               # noqa: F401
+    Information,              # noqa: F401
+    NlBridge as _NlBridge,
+    SensSession,
+    SolutionReport,           # noqa: F401
+    active_set_changes as _core_active_set_changes,
+    check_margins as _check_margins,
+    covariance as _core_covariance,
+    information as _core_information,
+    refuse_on_pdpert as _refuse_on_pdpert,
+    row_index as _row_index,
+    solution as _core_solution,
+    solution_report as _core_solution_report,
+    user_row_names as _user_row_names,
+    weakly_active as _weakly_active,
+)
 
 from pyomo_pounce.scaling import (
     problem_scaling,
@@ -570,44 +591,7 @@ def has_declarations(model):
 
 # ── the read_nl -> callback-Problem bridge ────────────────────────────────────
 
-class _NlBridge:
-    """cyipopt-style callback object backed by pounce.read_nl evaluators."""
-
-    def __init__(self, nl):
-        self._nl = nl
-
-    def objective(self, x):
-        return self._nl.objective(x)
-
-    def gradient(self, x):
-        return self._nl.gradient(x)
-
-    def constraints(self, x):
-        return self._nl.constraints(x)
-
-    def jacobianstructure(self):
-        return self._nl.jacobian_structure()
-
-    def jacobian(self, x):
-        return self._nl.jacobian(x)
-
-    def hessianstructure(self):
-        return self._nl.hessian_structure()
-
-    def hessian(self, x, lam, obj_factor):
-        return self._nl.hessian(x, lam, obj_factor)
-
-
 # ── session ───────────────────────────────────────────────────────────────────
-
-def _row_index(names):
-    """{name: position} for a .col/.row name list.
-
-    The NL writer emits unique symbolic labels, so first-wins and last-wins
-    agree; enumerate order matches `list.index` either way.
-    """
-    return {nm: i for i, nm in enumerate(names)}
-
 
 class SolutionMap(Mapping):
     """What `sens_solution()` returns: a read-only mapping {original var
@@ -678,52 +662,30 @@ class SolutionMap(Mapping):
         return f"SolutionMap({len(self._keys)} variables)"
 
 
-class _Session:
+class _Session(SensSession):
+    """`SensSession` in Pyomo's terms.
+
+    The core session addresses everything by row and keys its results by
+    whatever the caller handed it. This adds the modelling half: the
+    model itself, the variable data behind each `.col` column, and the
+    `ComponentMap` containers a Pyomo user expects back -- Pyomo
+    components are unhashable, so a plain dict cannot hold them.
+    """
+
     def __init__(self, model, nl, solver, var_names, con_names, pins,
                  con_alias, var_row=None, con_row=None):
+        super().__init__(nl, solver, var_names, con_names, pins=pins,
+                         con_alias=con_alias, var_row=var_row,
+                         con_row=con_row)
         self.model = model            # original model
-        self.nl = nl
-        self.solver = solver
-        self.var_names = var_names    # .col order = x-vector order
-        self.con_names = con_names    # .row order = g-vector order
-        # Reverse maps for the two orders above. Every query resolves a
-        # component name to its row, and a list scan makes that O(n) per
-        # lookup -- quadratic for sens_jacobian(of=None).to_dataframe(),
-        # which asks for every variable (gh #365). Built once here, or
-        # reused from the caller when it has already built them.
-        # `is None`, not truthiness: an unconstrained model's con_row is a
-        # legitimately empty dict, which `or` would discard and rebuild.
-        self._var_row = _row_index(var_names) if var_row is None else var_row
-        self._con_row = _row_index(con_names) if con_row is None else con_row
-        self.pins = pins              # ComponentMap: param data -> pin row
-        self.con_alias = con_alias    # original con name -> clone row name
-        self.base_x = None
-        # Cached `grad_x f` at the solved point (gh#878). Evaluated at most
-        # once per session; `sens_jacobian(m.obj, wrt=...)` over an indexed
-        # parameter would otherwise re-evaluate it per column.
-        self._obj_grad = None
-        # Objective value at the solve. NaN, not None, is the "never
-        # computed" sentinel: that is the convention the engine itself
-        # uses for info["obj_val"] (pounce-py's problem.rs seeds
-        # final_obj with NaN precisely because 0.0 is an ordinary
-        # objective value and cannot signal it), so one isfinite check
-        # covers both an unset session and a solve that evaluated
-        # nothing.
-        self.base_obj = float("nan")
-        # var name -> (lb, ub): the numeric values a moved bound had
-        # when it was moved, which is declaration time for declared
-        # params and this solve for a call-time clone. NOT refreshed
-        # when the bound's param later moves: a reader that needs the
-        # current bound must evaluate the moved row, not this record.
-        self.moved_bounds = {}
         # d(row)/d(param) and the param's solve-time value, per declared
         # param pinned through its own defining equality. Empty for the
         # clone-and-surgery paths, whose rows carry the param value as
-        # the row's right-hand side.
+        # the row's right-hand side. ComponentMap, not the base's dict,
+        # because these are keyed by param data.
         self.pin_coefs = ComponentMap()
         self.pin_bases = ComponentMap()
-        self._columns = {}            # pin row -> full KKT-space column
-        self._primal_rows = None      # full-x -> KKT row, lazily fetched
+        self.fit_rows = ComponentMap()
         # The original model's variable data, in .col order, captured
         # when the solve loads its solution back. A column the
         # declared-parameter surgery created has no model counterpart
@@ -737,8 +699,22 @@ class _Session:
         # and rebuilds model components after the solve invalidates
         # this session like any other of its caches.
         self.var_data = None
-        self._row_data = None         # user row name -> data, on demand
         self._solution_keys = None    # (keys, id -> column), on demand
+
+    # ── the three hooks the core reports results through ─────────────
+
+    @staticmethod
+    def new_keymap():
+        return ComponentMap()
+
+    def var_key(self, full_idx):
+        """The variable data behind `.col` column `full_idx`.
+
+        None for a column the declared-parameter surgery created, which
+        has no counterpart on the user's model: the core skips those
+        rather than reporting a name the user never wrote.
+        """
+        return self.var_data[full_idx]
 
     def user_row_data(self):
         """The original model's constraint data per solve row, in .row
@@ -748,6 +724,8 @@ class _Session:
             self._row_data = [self.model.find_component(nm)
                               for nm in _user_row_names(self)]
         return self._row_data
+
+    # ── Pyomo-only ───────────────────────────────────────────────────
 
     def solution_keys(self):
         """The columns a solution map exposes: the captured variable
@@ -766,122 +744,6 @@ class _Session:
                     keys.append(vd)
             self._solution_keys = (keys, index_of)
         return self._solution_keys
-
-    def _primal_row_map(self):
-        if self._primal_rows is None:
-            self._primal_rows = self.solver.primal_rows(
-                list(range(len(self.var_names))))
-        return self._primal_rows
-
-    def primal_row(self, full_idx, what):
-        """The KKT-factor row of a user-space (`.col`) variable index.
-
-        `.col` order -- what `var_entry`, `fit_rows` and `res_rows` all
-        hold -- is the user's FULL-x space. The factor's `x` block is
-        the algorithm's var-x space, which drops every variable the
-        solve removed as fixed (`lb == ub` under the default
-        `fixed_variable_treatment=make_parameter`). The two spaces
-        coincide exactly when the model has no fixed variable, which is
-        every model in the test suite and most models anywhere, so
-        indexing the factor with a full-x row is invisible until it is
-        not: one fixed variable shifts every later column and the
-        back-solve quietly returns a NEIGHBOURING variable's
-        sensitivity, a plausible number with nothing wrong-looking
-        about it. Route every factor index through here.
-        """
-        row = self._primal_row_map()[full_idx]
-        if row is None:
-            raise ValueError(
-                f"{what}: {self.var_names[full_idx]} was removed from the "
-                "solve as a fixed variable (its bounds are equal), so it "
-                "has no row in the KKT factor and no sensitivity "
-                "sens_information. Give it distinct bounds to keep it in the "
-                "solve.")
-        return row
-
-    def scatter_x(self, dx_var):
-        """Full-x vector from an algorithm-space (var-x) one.
-
-        `parametric_step` truncates its result to the factor's `x`
-        block, so it is var-x while `base_x`, `nl.x_l/x_u` and
-        `var_names` are all full-x. Variables the solve removed as
-        fixed get 0: a fixed variable does not move.
-        """
-        out = np.zeros(len(self.var_names))
-        for full_idx, row in enumerate(self._primal_row_map()):
-            if row is not None:
-                out[full_idx] = dx_var[row]
-        return out
-
-    def objective_gradient(self):
-        """`grad_x f` at the solved point, in full-x (`.col`) order."""
-        if self._obj_grad is None:
-            if self.base_x is None:
-                raise ValueError(
-                    "sens_jacobian(objective): the solve recorded no primal "
-                    "point, so the objective gradient cannot be evaluated")
-            self._obj_grad = np.asarray(self.nl.gradient(self.base_x),
-                                        dtype=float)
-        return self._obj_grad
-
-    def total_objective_derivative(self, col):
-        """`df/dp` for the KKT derivative column `col` (gh#878).
-
-        The chain rule is
-
-            df/dp  =  df/dp|_x  +  sum_i (df/dx_i)(dx_i/dp)
-
-        and both terms fall out of a single contraction here, because a
-        declared sensitivity parameter is not a `Param` by the time the
-        solve sees it. `declare_sens_param` rewrites every occurrence into
-        a variable pinned by a defining equality, so `p` is an ordinary
-        coordinate of full-x: `objective_gradient()` carries `df/dp|_x` in
-        `p`'s own slot, and the step carries `dp/dp = 1` there. Contracting
-        the two therefore picks up the explicit partial and the implicit
-        sum in one product, with no separate `grad_p f` term to assemble
-        and no second index convention to get wrong.
-
-        Written as a dot product over **full-x**, not the factor's var-x:
-        `scatter_x` is what reconciles them, and a model carrying one fixed
-        variable is where the two diverge. Contracting a full-x gradient
-        with a var-x step would silently pair `df/dx_i` with a NEIGHBOURING
-        variable's sensitivity from the first fixed variable on -- gh#450
-        and gh#672 finding 1, the same defect twice. `sens_invariance_legs`
-        leg 3 is the guard.
-        """
-        return float(self.objective_gradient() @ self.scatter_x(col))
-
-    def column(self, pin_idx):
-        """Full KKT-space derivative column for a unit perturbation."""
-        if pin_idx not in self._columns:
-            self._columns[pin_idx] = np.asarray(
-                self.solver.parametric_step_full([pin_idx], [1.0]))
-        return self._columns[pin_idx]
-
-    def var_entry(self, name):
-        # ValueError, not the dict's KeyError: this used to be a list scan
-        # and callers (and the message a user sees) expect ValueError.
-        try:
-            return self._var_row[name]
-        except KeyError:
-            raise ValueError(
-                f"{name}: not a variable of the solved model") from None
-
-    def mult_entry(self, con_name):
-        # the sensitivity surgery replaces user constraints with copies on
-        # its data block; translate the original name to the clone's row
-        con_name = self.con_alias.get(con_name, con_name)
-        try:
-            g = self._con_row[con_name]
-        except KeyError:
-            raise ValueError(
-                f"{con_name}: not a constraint of the solved model") from None
-        row = self.solver.multiplier_rows([g])[0]
-        if row is None:
-            raise ValueError(
-                f"{con_name}: multiplier sensitivities are only available "
-                "for equality constraints")
-        return row
 
 
 def _iter_data(comp):
@@ -1601,31 +1463,6 @@ class Jacobian:
             columns=[p.name for p in self._params])
 
 
-def _weakly_active(session):
-    """The degenerate bounds at the held solve, cached per session.
-
-    `(variable name, "lower" or "upper")` for every bound the
-    classifier could call neither active nor inactive. Empty when the
-    solve relaxed its bounds, since the classifier cannot read shifted
-    slacks. Cached because the factor is fixed per solve and
-    `sens_jacobian()` runs in tight loops.
-    """
-    cached = getattr(session, "_weakly_active_cache", None)
-    if cached is None:
-        if session.solver.bound_relax_factor:
-            cached = []
-        else:
-            full_of = {row: full
-                       for full, row in enumerate(session._primal_row_map())
-                       if row is not None}
-            cached = [
-                (session.var_names[full_of[vr]],
-                 "lower" if low else "upper")
-                for vr, low in session.solver.weakly_active_bounds()
-                if vr in full_of
-            ]
-        session._weakly_active_cache = cached
-    return cached
 
 
 def sens_jacobian(of=None, *, wrt, max_pdpert=None):
@@ -1713,1605 +1550,65 @@ def _perturbation_deltas(session, perturb):
     return pin_idx, deltas
 
 
-def _check_margins(bound_eps, max_pdpert, who):
-    """Reject the values the CLI's option surface rejects.
-
-    `sens_bound_eps` and `sens_max_pdpert` are both registered with
-    `add_lower_bounded_number_option(..., 0.0, strict)`, so a value the
-    CLI turns down is turned down here too. A `bound_eps` of zero
-    reinstates the roundoff pinning the floor exists to prevent, a NaN
-    makes every "outside a bound" comparison false so the refinement
-    pins nothing and still reports settled, and a negative `max_pdpert`
-    always refuses with a message that reads as though the factor were
-    bad.
-    """
-    for name, value in (("bound_eps", bound_eps), ("max_pdpert", max_pdpert)):
-        if value is None:
-            continue
-        if not float(value) > 0.0:
-            raise ValueError(
-                f"{who}: {name} must be a positive number, got {value!r}")
 
 
-def _bound_margin(session, bound_eps):
-    """How far outside a bound a coordinate has to end to count as
-    having left it.
-
-The refinement pins against this margin and `sens_solution()` clamps
-    against it. `sens_solution_report()` measures `crossed` against the same
-    number whenever the caller sets one, since deciding it twice is
-    what let `refine_stop == "settled"` come back beside a coordinate
-    reported 2.0 outside its bound.
-
-    Unset it is how far outside the solve itself was willing to settle,
-    floored so an unrelaxed solve does not pin on roundoff. The report
-    keeps the floor there instead, because a coordinate the SOLVE left
-    outside its bound is one of the things `crossed` exists to name,
-    and the relaxation is exactly how far out it is.
-    """
-    if bound_eps is not None:
-        return float(bound_eps)
-    return max(abs(session.solver.bound_relax_factor or 0.0), 1e-9)
 
 
-def _refuse_on_pdpert(session, max_pdpert, who):
-    """Refuse when the converged factor carries more inertia correction
-    than the caller will accept.
-
-    A non-zero entry means the factorization every sensitivity output
-    inverts is not this problem's KKT matrix but a nearby one's, and how
-    nearby is what the entries measure. `SolutionReport.perturbations`
-    reports them either way, and this is the caller choosing to stop
-    rather than to read them.
-
-    The comparison comes from `pounce_sensitivity::pdpert_verdict`,
-    which `sens_max_pdpert` reads too, so the two surfaces cannot drift
-    apart on what counts as too perturbed. The message is written here
-    rather than taken from there, since that one names a CLI option and
-    says the sensitivity was skipped, and neither is true of a call
-    that raises.
-    """
-    if max_pdpert is None:
-        return
-    refuse, worst = session.solver.pdpert_verdict(float(max_pdpert))
-    if refuse:
-        pert = [abs(float(v)) for v in session.solver.kkt_perturbations]
-        raise ValueError(
-            f"{who}: the converged KKT factor carries a perturbation of "
-            f"{worst:.3e} (dx={pert[0]:.3e}, ds={pert[1]:.3e}, "
-            f"dc={pert[2]:.3e}, dd={pert[3]:.3e}), above the requested "
-            f"max_pdpert={max_pdpert:.3e}. The factor the step would "
-            f"invert is not this problem's KKT matrix. Raise max_pdpert "
-            f"to accept it anyway.")
 
 
-def _degeneracy_iter(degeneracy_iter, degeneracy, who):
-    """Resolve the budget's default and warn when it is inert: only
-    the "directional" decision spends back-solves, so a budget passed
-    under another option changes nothing, the same shape as bound_eps
-    under a mode that runs no refinement."""
-    if degeneracy_iter is None:
-        return 16
-    if degeneracy != "directional":
-        warnings.warn(
-            f"{who}: degeneracy_iter budgets the directional decision's "
-            f"back-solves and degeneracy={degeneracy!r} makes no "
-            "decision, so it changes nothing here.")
-    return degeneracy_iter
 
 
-def _correct(session, pin_idx, deltas, step, corrector_iter):
-    """Refine a step by Newton iterations on the barrier system.
-
-    Returns the refined primal step and what the iterations did.
-
-    The corrector starts from a point, so it needs the multipliers as
-    well as the primal step, and only the plain parametric step reports
-    both. Every mode refines the same underlying step, so the start is
-    the mode's own primal block carrying the plain step's multipliers.
-    The iterations correct the multipliers from there, which is what
-    they are for.
-
-    Two consequences worth naming. This spends a second solve even under
-    mode="linear" with degeneracy="one_sided", where the primal block it
-    then overwrites is the one it just computed. And under
-    degeneracy="directional" the multipliers come from the one-sided
-    step rather than the directional one that produced `step`, since
-    there is no directional full step to ask. Under
-    degeneracy="release_all" the mismatch is sharper still: the held
-    factorization supplies bound multipliers at exactly the bounds the
-    step just released to zero, over the maximal weak set rather than
-    a decided subset.
-    """
-    full = np.asarray(session.solver.parametric_step_full(pin_idx, deltas))
-    n_x = len(step)
-    full[:n_x] = np.asarray(step)
-    out, info = session.solver.correct_step(
-        pin_idx, deltas, list(full), corrector_iter)
-    return np.asarray(out)[:n_x], dict(info)
 
 
-def sens_solution(model, perturb, clamp=True, mode="linear",
-             predictor_iter=16, degeneracy="directional", degeneracy_iter=None,
-             corrector_iter=0, bound_eps=None, max_pdpert=None):
-    """First-order estimate of the solution at perturbed parameter values.
-
-    perturb: pairs of (declared Param, new value) -- a list of tuples or a
-    ComponentMap (plain dicts don't work: Pyomo components are unhashable).
-    Returns a read-only `SolutionMap` {original var data: estimated
-    value}, keyed by the component data objects themselves. Values are
-    clamped to variable bounds (with a warning) unless clamp=False.
-
-    mode selects what happens when the step leaves a variable bound.
-    "linear" (the default) takes the step and clamps, which truncates the
-    crossing variable and leaves every other one at its predictor value.
-    "fix_relax" instead pins the crossing variable at its bound and
-    re-solves, so the others move to stay consistent under the pin, which
-    is what `sens_solution_report`'s step fraction says the step needs. It
-    costs a dense solve and a backsolve per crossing and tracks a full
-    re-solve far more closely. Where nothing crosses the two agree
-    exactly.
-
-    "path" applies the perturbation a little at a time, stopping at
-    each fraction where the active set changes and continuing under
-    the changed set, so a variable can reach a bound partway through
-    the change and leave it again further along. Where the two settle
-    the same active set it agrees with "fix_relax". At a change large
-    enough that they disagree, "fix_relax" decides every change from
-    a single step taken at the base point while "path" applies each
-    change at the fraction where it happens. `sens_active_set_changes()`
-    returns the record of those changes.
-
-    predictor_iter bounds that work. Under "fix_relax" it caps the
-    passes, each of which pins every crossing it can see and costs a
-    dense solve whose size grows with the number of pins. It is a
-    safety limit there rather than a budget, since the loop ends when
-    nothing is left outside a bound. Under "path" it caps the number of
-    active-set changes applied, and past the cap the rest of the
-    perturbation is taken in one step under the active set reached.
-
-    degeneracy selects what happens when the base point itself sits at
-    an active-set kink: a bound the classifier can call neither active
-    nor inactive, on the bound with a multiplier of the same order as
-    the slack. The solution has two one-sided derivatives there.
-    "directional" (the default) decides the weakly active bounds by the
-    directional-derivative QP for the perturbation's own direction, in
-    every mode, at the cost of a few extra backsolves paid only at a
-    kink. degeneracy_iter budgets those backsolves: the all-released
-    solve and one basis column per engaged bound count against it, and
-    a budget the engagement cannot fit falls back to the one-sided
-    step with a warning naming the counts. Only
-    degeneracy="directional" reads it, and passing it under another
-    option warns and changes nothing. "one_sided" takes the
-    single-sided value today's thresholds produce, bit-identical to
-    the release before this option existed. "release_all" releases
-    every weakly active bound undecided, at one back-solve and no QP:
-    the step is the all-released direction, and the bounds this
-    perturbation actually holds come back as bound crossings for the
-    mode or a correction to handle. It trades the decision's cost for
-    downstream repair: under mode="fix_relax" or "path" the crossings
-    are pinned or walked by the mode's own machinery, while
-    mode="linear" clamps each crossing coordinate and leaves its
-    neighbors carrying the released coupling.
-
-    corrector_iter runs Newton iterations on the barrier system after
-    the step, against an operator assembled at the predicted point:
-    one derivative evaluation and one factorization there, every
-    block including the barrier diagonal, then a back-solve per
-    iteration. It aims at the barrier solution at the mu the solve
-    finished on rather than at a re-solve, so the accuracy it reaches
-    is bounded by that offset, and it stops as soon as an iteration
-    fails to improve the residual, warning when the whole correction
-    failed to improve it. Where the perturbation needs a bound to
-    leave the active set and the step's endpoint does not show the
-    release, no released row is applied: the iterations can move the
-    variable partway off the bound on the weak diagonal entry the
-    step's clamped multiplier builds, and the estimate is not the
-    re-solve. mode="fix_relax" and mode="path" decide such releases
-    themselves, and the corrector applies the rows they decided. It
-    applies under every mode, refining whatever step that mode
-    produced.
-
-    bound_eps sets how far outside a variable bound a step has to end
-    to count as having left it, which decides what mode="fix_relax"
-    pins, what `sens_solution_report()` reports in `crossed`, and what the
-    clamp below acts on. It is absolute, as the refinement's own test
-    is. Unset, it is how far outside the solve itself was willing to
-    settle, floored so an unrelaxed solve does not pin on roundoff. A
-    constraint row keeps its own floor, and a bound is released when the
-    step drives its multiplier negative past the solve's own margin,
-    whatever bound_eps is. Only mode="fix_relax" reads it, and passing
-    it under another mode warns and changes nothing. It must be
-    positive, as the CLI's sens_bound_eps is.
-
-    max_pdpert refuses rather than answering when the converged KKT
-    factor carries an inertia correction larger than the value given.
-    Every sensitivity output inverts that factor, so a perturbed one
-    answers for a nearby problem rather than this one.
-    `sens_solution_report().perturbations` reports the same numbers for a
-    caller who would rather read them than stop. It must be positive,
-    as the CLI's sens_max_pdpert is, and the same argument is on
-    sens_jacobian(), sens_solution(), sens_solution_report(),
-    sens_active_set_changes(),
-    sens_covariance() and sens_information().
-
-    clamp keeps its meaning in both modes: it clamps whatever is still
-    outside a bound at the end. Under "fix_relax" the pins usually
-    leave nothing to clamp, and when they do not, the warning says
-    which of the refinement's stopping conditions was reached.
-
-    The perturbation is measured from the SOLVE point (the pin
-    constraint's stored right-hand side, which is the value the Param
-    had at the solve), not from the Param's current value on the model.
-    Writing a new value into the Param first (the receding-horizon
-    pattern: solve at a prediction, record the measurement, then ask)
-    does not change the answer.
-
-    A bound written in terms of a declared Param is a constraint by the
-    time the model is solved, so it is not clamped against here and no
-    clamp warning is raised for it. That is deliberate: the bound moves
-    with the perturbation, so the linear step already respects it to
-    first order.
-    """
-    reg = model.__dict__.get(_REG)
-    session = reg.session if reg else None
-    if session is None:
-        raise RuntimeError(
-            "no sensitivity session: declare_sens_param() then solve with "
-            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
-            "contrib SolverFactory('pounce') first")
-
-    if mode not in ("linear", "fix_relax", "path"):
-        raise ValueError(
-            "sens_solution: mode must be 'linear', 'fix_relax' or 'path', got "
-            f"{mode!r}")
-    if degeneracy not in ("directional", "one_sided", "release_all"):
-        raise ValueError(
-            "sens_solution: degeneracy must be 'directional', 'one_sided' or "
-            f"'release_all', got {degeneracy!r}")
-    degeneracy_iter = _degeneracy_iter(
-        degeneracy_iter, degeneracy, "sens_solution")
-    _check_margins(bound_eps, max_pdpert, "sens_solution")
-    if bound_eps is not None and mode != "fix_relax":
-        warnings.warn(
-            "sens_solution: bound_eps is the margin the fix_relax refinement "
-            f"pins against and mode={mode!r} runs no refinement, so it "
-            "changes nothing here.")
-    _refuse_on_pdpert(session, max_pdpert, "sens_solution")
-
-    pin_idx, deltas = _perturbation_deltas(session, perturb)
-
-    # parametric_step returns the factor's x block (var-x); base_x and
-    # everything below it (nl.x_l/x_u, var_names) are full-x
-    segments = []
-    fell_back = False
-    if degeneracy == "directional":
-        # At a degenerate base point the weakly active bounds are
-        # decided by the directional-derivative QP for this
-        # perturbation's own direction; at a clean base point these are
-        # the plain calls at no extra solve cost. A failed decision
-        # (budget exhausted, no sign-consistent working set) falls back
-        # to the one-sided step and says so.
-        try:
-            step, held_rows, _ = (
-                session.solver.parametric_step_directional(
-                    pin_idx, deltas, degeneracy_iter))
-            if mode == "fix_relax":
-                step, pinned, stop = (
-                    session.solver.parametric_step_bounded_decided(
-                        pin_idx, deltas, held_rows, predictor_iter,
-                        bound_eps))
-            elif mode == "path":
-                step, segments = (
-                    session.solver.parametric_step_path_decided(
-                        pin_idx, deltas, held_rows, predictor_iter))
-        except RuntimeError as e:
-            if "directional derivative" not in str(e):
-                raise
-            warnings.warn(
-                f"sens_solution: {e}. Falling back to the one-sided step, "
-                "the degeneracy='one_sided' behavior.")
-            fell_back = True
-    if degeneracy == "release_all":
-        # Every weakly active bound is released undecided, at one
-        # back-solve and no QP: the bounds this perturbation actually
-        # holds come back as crossings for the mode or a correction to
-        # handle. fix_relax and path run their own machinery under the
-        # all-released treatment, the decided variants' empty held set.
-        if mode == "fix_relax":
-            step, pinned, stop = (
-                session.solver.parametric_step_bounded_decided(
-                    pin_idx, deltas, [], predictor_iter, bound_eps))
-        elif mode == "path":
-            step, segments = (
-                session.solver.parametric_step_path_decided(
-                    pin_idx, deltas, [], predictor_iter))
-        else:
-            step, _released = session.solver.parametric_step_release_all(
-                pin_idx, deltas)
-    if degeneracy == "one_sided" or fell_back:
-        if mode == "fix_relax":
-            step, pinned, stop = session.solver.parametric_step_bounded(
-                pin_idx, deltas, predictor_iter, bound_eps)
-        elif mode == "path":
-            step, segments = session.solver.parametric_step_path(
-                pin_idx, deltas, predictor_iter)
-        else:
-            step = session.solver.parametric_step(pin_idx, deltas)
-    corrector = None
-    if corrector_iter:
-        step, corrector = _correct(
-            session, pin_idx, deltas, step, corrector_iter)
-        # A correction that works drives the residual down by orders;
-        # one whose Newton direction finds nothing to reduce shaves a
-        # few percent off and leaves the estimate where it was.
-        # Halving is a low bar that separates them cleanly, and saying
-        # nothing would let the second case pass for the first.
-        # Written as `not (<=)` rather than `>`, so a non-finite
-        # residual warns instead of comparing false and passing in
-        # silence. gh#845 was exactly that: the corrector normed an
-        # all-NaN residual to 0.0, `0.0 > 0.5 * 6.09` was false, and
-        # `sens_solution()` returned {x: nan} with nothing said. The Rust
-        # side no longer produces that number, and this side no longer
-        # depends on it not doing so.
-        if corrector is not None and not (
-                corrector["residual"] <= 0.5 * corrector[
-                    "initial_residual"]):
-            warnings.warn(
-                "sens_solution: the corrector spent "
-                f"{corrector['iterations']} back-solve(s) and moved the "
-                f"residual from {corrector['initial_residual']:.2e} to "
-                f"{corrector['residual']:.2e}, measured from the point the "
-                "iterations start at rather than from the step handed in, "
-                "so the estimate is close to the uncorrected step. One "
-                "cause is a bound that must leave the active set with "
-                "nothing else for the iterations to reduce; "
-                "mode=\"fix_relax\" and mode=\"path\" decide such releases "
-                "where the step shows them.")
-
-    dx = session.scatter_x(np.asarray(step))
-    x_new = session.base_x + dx
-
-    lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
-    if mode in ("fix_relax", "path"):
-        # The refinement holds each pinned coordinate AT its bound and
-        # lets the others move, so a coordinate can still be left
-        # outside one, either because the pass budget ran out or because
-        # the pins have exhausted the problem's degrees of freedom.
-        # `clamp` decides what happens then, exactly as it does under
-        # `linear`, and the warning says which of the two stopped it.
-        #
-        # One tolerance for "outside its bound", taken from the solve
-        # rather than chosen here: it was willing to leave a converged
-        # point `bound_relax_factor` outside, so anything within that is
-        # on the bound. The refinement pins against the same number.
-        # The comparison is absolute, as the refinement's own is, so the
-        # clamp and the pins agree on a coordinate of any magnitude.
-        eps = _bound_margin(
-            session, bound_eps if mode == "fix_relax" else None)
-        out = np.where((x_new < lo - eps) | (x_new > hi + eps))[0]
-        if out.size:
-            names = [session.var_names[i] for i in out]
-            if mode == "fix_relax":
-                did = f"pinned {len(pinned)} variable(s)"
-                # The refinement says why it stopped rather than the
-                # count being read as a proxy for it: a pass pins every
-                # crossing it sees, so the number of pins says nothing
-                # about whether predictor_iter bound the work (gh#732).
-                why = {
-                    "iteration_limit":
-                        "the safety limit of %d pass(es) was reached, so "
-                        "raising predictor_iter may finish it" % predictor_iter,
-                    "degrees_of_freedom":
-                        "holding them all would need more pins than the "
-                        "problem has degrees of freedom, so no step does",
-                    "worse_than_plain":
-                        "the refinement ended further outside the bounds "
-                        "than the plain step, which was returned instead",
-                }.get(stop, "the refinement settled here")
-            else:
-                n_changes = len(segments)
-                did = f"applied {n_changes} active-set change(s)"
-                why = ("the limit of %d was reached, so raising "
-                       "predictor_iter may finish it" % predictor_iter
-                       if n_changes >= predictor_iter else
-                       "the path settled the active set here")
-            warnings.warn(
-                f"sens_solution: {mode} {did} and "
-                f"still leaves the bounds for {names}, because {why}."
-                + (" The values were clamped, which breaks the constraints "
-                   "the pins were solved against." if clamp else
-                   " The values are returned unclamped."))
-            if clamp:
-                x_new = np.clip(x_new, lo, hi)
-    elif clamp:
-        # `linear` takes the step as the predictor gives it, so a
-        # crossing shows up as a value outside its bound and clamping is
-        # all this mode can do about it. The active set changed and the
-        # step does not know, which is what `fix_relax` addresses.
-        # The comparison is absolute, as the refinement's own is.
-        eps = _bound_margin(session, None)
-        clamped = (x_new < lo - eps) | (x_new > hi + eps)
-        if clamped.any():
-            names = [session.var_names[i] for i in np.where(clamped)[0]]
-            warnings.warn(
-                "sens_solution: linear step leaves the variable bounds for "
-                f"{names}; values were clamped and the active set likely "
-                "changed, so the estimate is unreliable there. mode="
-                "'fix_relax' pins them and re-solves instead.")
-        x_new = np.clip(x_new, lo, hi)
-
-    keys, index_of = session.solution_keys()
-    return SolutionMap(keys, index_of, x_new)
 
 
 # ── step diagnostics ──────────────────────────────────────────────────────────
 
-class SolutionReport:
-    """What the linear step behind `sens_solution()` does about the bounds.
-
-    Attributes
-    ----------
-    alpha : float
-        The fraction of the requested perturbation that can be taken
-        before the first bound is reached, from the ratio test along
-        the step. On a solve that kept its bounds, at least 1.0 means
-        the full step stays inside every one of them. That does not
-        follow when `bounds_relaxed` is true, since the solve can leave
-        a coordinate outside a bound before the step starts. Infinity
-        means no bound lies in the step direction.
-    first : str or None
-        Name of the variable or constraint reaching its bound at
-        `alpha`, None when `alpha` is infinite.
-    first_kind : str or None
-        Either "variable" or "constraint", naming what `first` is.
-    crossed : ComponentMap
-        Variable data to the distance by which the full step leaves
-        that variable's bound. These are the variables `sens_solution()`
-        clamps. Measured at the predicted point against both bounds, so
-        on a relaxed solve an entry can be a coordinate the SOLVE left
-        outside its bound rather than one the step carried past. The
-        step fraction looks only along the step direction, so the two
-        answer different questions there and `alpha` can be at or above
-        one while this is non-empty.
-    crossed_rows : ComponentMap
-        Constraint data to the same distance, for inequality
-        constraints.
-
-    Those two are keyed by model components, because every coordinate
-    that crosses has one. The two classifications below are keyed by
-    solve-space name instead, because they cover every coordinate of
-    the solve, including the ones the declared-parameter surgery
-    created, which have no counterpart on the model.
-    violation : float
-        Largest constraint violation at the predicted point, measured
-        against the perturbed right-hand sides. This is the primal
-        half of the residual. The dual half needs the multipliers at
-        the perturbed point, so it is computed by the corrector, which
-        holds them, rather than assembled here.
-    mu : float
-        Barrier parameter of the held factorization.
-    activity, row_activity : dict
-        Name to activity classification from the core classifier, over
-        variables and over constraints. Both are empty when
-        `bounds_relaxed` is true.
-    perturbations : list
-        The held factor's inertia-correction perturbations. Any
-        non-zero entry means the factor is regularized, so the step is
-        taken against a modified matrix and differs from the exact
-        active-set answer by that much.
-    corrector : dict or None
-        What `corrector_iter` iterations did, None when none were run.
-        Holds the back-solves spent under `iterations`, the residual
-        before and after under `initial_residual` and `residual`
-        (`initial_residual` is measured at the point the iterations
-        start from, after the active-set decision and the clamp, not at
-        the step handed in), and
-        that residual split into `stationarity`, `feasibility` and
-        `complementarity`. `released` counts the bounds the step took
-        out of the active set and `pinned` the ones it brought in, with
-        `active_set_changes` their total. `converged` says the loop
-        stopped because an iteration failed to improve rather than
-        because it ran out of budget. This is the dual half `violation`
-        refers to: it needs the multipliers at the perturbed point,
-        which the corrector holds.
-    refine_stop : str or None
-        Why the `mode="fix_relax"` refinement stopped, one of
-        "settled", "iteration_limit", "degrees_of_freedom" or
-        "worse_than_plain". None under the other two modes, which run
-        no refinement. A pass pins every crossing it sees, so the
-        number of pins says nothing about which limit was reached and
-        this is the only thing that does. "worse_than_plain" means the
-        step reported here is the unrefined one.
-    bounds_relaxed : bool
-        True when the solve ran with a non-zero `bound_relax_factor`,
-        which lets a variable settle outside the bound the model
-        declares. The classifier raises for such a solve, since relaxed
-        bounds shift the slacks it reads, and the ratio test measures
-        distances to bounds the solve did not hold to.
-
-    The last three, with `mu`, are what separate this predictor from
-    the exact value at the perturbed active set. A caller comparing the
-    estimate against a re-solve reads them to tell which one explains
-    the difference.
-    """
-
-    def __init__(self, alpha, first, first_kind, crossed, crossed_rows,
-                 violation, mu, activity, row_activity, perturbations,
-                 bounds_relaxed, corrector=None, refine_stop=None):
-        self.alpha = alpha
-        self.first = first
-        self.first_kind = first_kind
-        self.crossed = crossed
-        self.crossed_rows = crossed_rows
-        self.violation = violation
-        self.mu = mu
-        self.activity = activity
-        self.row_activity = row_activity
-        self.perturbations = perturbations
-        self.bounds_relaxed = bounds_relaxed
-        self.corrector = corrector
-        self.refine_stop = refine_stop
-
-    def __repr__(self):
-        n = len(self.crossed) + len(self.crossed_rows)
-        where = f", first {self.first_kind} {self.first}" if self.first else ""
-        flags = "".join([
-            ", regularized" if any(self.perturbations) else "",
-            ", bounds relaxed" if self.bounds_relaxed else "",
-        ])
-        return (f"SolutionReport(alpha={self.alpha:.6g}{where}, "
-                f"crossed={n}, violation={self.violation:.3e}, "
-                f"mu={self.mu:.3e}{flags})")
 
 
-def _row_step(session, dx):
-    """Jacobian at the base point times the step, in row order."""
-    rows, cols = session.nl.jacobian_structure()
-    vals = np.asarray(session.nl.jacobian(session.base_x))
-    return np.bincount(np.asarray(rows),
-                       weights=vals * dx[np.asarray(cols)],
-                       minlength=len(session.con_names))
 
 
-#: No bound at all reaches here as the reader's sentinel rather than an
-#: infinity: `read_nl` seeds every bound vector with +-1e19, so an
-#: `isfinite` test passes on it and scores a crossing at 1e18 times the
-#: perturbation. The magnitude test is the convention the rest of the
-#: package already uses (`preflight`, `block_init`, gh #401 / #403).
-_NO_BOUND = 1e19
 
 
-def _ratio_test(base, step, lo, hi, names, live=None, on_bound=None,
-                mu=float("nan"), tol=None):
-    """Smallest fraction of `step` that reaches a bound, and where.
-
-    Only coordinates strictly inside their bounds take part, because a
-    coordinate already on a bound is not one the step can cross. That
-    exclusion is what makes the answer mean anything: at an active
-    bound the remaining gap is the small slack the barrier leaves, the
-    step component is the same size, and their quotient can take any
-    value. It would then become the minimum on any model carrying an
-    active bound. Activity is reported through the classification
-    instead.
-
-    A coordinate the full step carries past a bound is always scored,
-    whatever the exclusion would otherwise say. That case IS a crossing,
-    at a fraction below one by construction, and the caller reads it in
-    `crossed` off the same predicate and the same tolerance. Deciding it
-    twice is what let the two disagree, reporting that 998 times the
-    perturbation fits while naming a coordinate the single step leaves
-    its bound by 0.25.
-
-    So the exclusion below only ever applies to coordinates that do not
-    cross, and cannot cost a crossing. Two things drive it. `on_bound`
-    carries the classification, which is exact where the classifier
-    commits, applied per SIDE rather than per coordinate, since a
-    coordinate held at one bound can still be carried across its other
-    one.
-
-    The distance test covers the coordinates the classifier declines to
-    rule on, where the label cannot answer the question because
-    `ambiguous` spans both a coordinate near its bound with room left
-    and one already on it. What separates those is the size of the
-    remaining gap, which is O(mu) at a strongly active bound and
-    O(sqrt(mu)) at a weakly active one, against O(1) room in the
-    interior. So the threshold scales with sqrt(mu), measured four
-    orders of magnitude clear of the interior case. It is capped
-    because it is applied relative to the coordinate's own magnitude,
-    and a loose `mu` at termination would otherwise widen it without
-    limit. Without a classification there is no `mu` either, and it
-    falls back to a fixed threshold.
-
-    Coordinates whose step is below the roundoff of their own magnitude
-    also take no part, since dividing by one puts the crossing at an
-    enormous multiple of the perturbation, which is not a finding.
-    """
-    scale = np.maximum(1.0, np.abs(base))
-    toward_hi = step > 0
-    bound = np.where(toward_hi, hi, lo)
-    distance = bound - base
-    present = np.abs(bound) < _NO_BOUND
-    moving = np.abs(step) > 1e-12 * scale
-
-    # The same predicate, and the same tolerance, that fills `crossed`
-    # or `crossed_rows`. The caller passes the tolerance it fills with,
-    # and the default is the rows' own.
-    reached = base + step
-    if tol is None:
-        tol = 1e-9 * np.maximum(1.0, np.abs(reached))
-    crosses = present & moving & np.where(
-        toward_hi, reached > bound + tol, reached < bound - tol)
-
-    floor = 1e-9 if not np.isfinite(mu) else min(
-        1e-2, max(1e-9, 10.0 * mu ** 0.5))
-    interior = np.abs(distance) > floor * scale
-    if on_bound is not None:
-        # the nearer bound is the one the coordinate is held at, and it
-        # is only that side the classification rules out
-        at_hi = (hi - base) <= (base - lo)
-        interior &= ~(on_bound & (toward_hi == at_hi))
-
-    ok = present & moving & (crosses | interior)
-    if live is not None:
-        ok &= live
-    if not ok.any():
-        return float("inf"), None
-    fraction = np.full(base.shape, np.inf)
-    # a relaxed solve can settle outside a bound, which leaves no room
-    # to move rather than a negative amount of it
-    fraction[ok] = np.maximum(distance[ok] / step[ok], 0.0)
-    i = int(np.argmin(fraction))
-    return float(fraction[i]), names[i]
 
 
-#: Classifications that put a coordinate ON its bound. Both have the
-#: slack going to zero, so neither can be crossed by a step. Strongly
-#: active leaves an O(mu) gap and weakly active an O(sqrt(mu)) one, and
-#: neither gap is room the step can move through. `ambiguous` and
-#: `unidentified` are absent on purpose: the first spans coordinates on
-#: their bound AND coordinates near it with room left, and the second
-#: says only that the curvature is below scale, so neither label
-#: answers the question. `_ratio_test`'s distance test rules on those.
-_AT_BOUND = ("strongly_active", "weakly_active")
 
 
-def _on_bound(statuses):
-    return np.array([s in _AT_BOUND for s in statuses])
 
 
-def _user_row_names(session):
-    """Row names as the user wrote them.
-
-    The declared-parameter surgery moves every constraint onto its own
-    block, so the solve's constraint names are clone names. `con_alias`
-    records the move in the other direction. A constraint with no entry
-    keeps the clone name, which is what the pin constraints have and
-    what marks them as the solve's own.
-    """
-    back = {clone: orig for orig, clone in session.con_alias.items()}
-    return [back.get(nm, nm) for nm in session.con_names]
 
 
-def sens_solution_report(model, perturb, max_iter=None,
-                    degeneracy="directional", degeneracy_iter=None,
-                    corrector_iter=0, mode="linear", predictor_iter=16,
-                    bound_eps=None, max_pdpert=None):
-    """Report what `sens_solution()`'s step does about the bounds.
 
-    degeneracy and degeneracy_iter match `sens_solution()`'s arguments of
-    the same names, so the step measured here is the step `sens_solution()`
-    takes for the same arguments, including the directional-derivative
-    correction at a degenerate base point. degeneracy_iter budgets that
-    correction's back-solves.
-
-    max_iter is accepted for positional compatibility and does nothing.
-    It used to budget the directional decision here, so passing it, in
-    particular `max_iter=0` to force the one-sided fallback, changed the
-    reported step. `degeneracy_iter` is that knob now. Passing it raises
-    a DeprecationWarning rather than being ignored in silence, since the
-    two readings differ and nothing else would say so.
-
-    mode and predictor_iter match `sens_solution()`'s arguments of the same
-    names, so the step measured here is the step `sens_solution()` takes for
-    the same arguments. `violation` and `corrector` are properties of
-    that step and move with the mode. Reporting the linear step's
-    violation for a `fix_relax` estimate would describe a step the
-    caller did not take.
-
-    `alpha`, `first`, `crossed` and `crossed_rows` measure where the
-    step leaves a bound. Under "fix_relax" and "path" it does not,
-    since both stop at the bound by construction, so `alpha` is 1.0 and
-    `crossed` is empty for every model. That is the correct answer for
-    such a step rather than a missing one. A `bound_eps` wide enough to
-    cover the crossing is the exception: the refinement then pins
-    nothing, so the step reaches a bound at a fraction below one. It is
-    not quite the linear step either, since the release test keeps the
-    solve's own margin whatever `bound_eps` is, so a bound the step
-    drives negative is released and the step moves by that multiplier's
-    size. The reason to run those modes is what "linear" reports at the
-    same perturbation.
-
-    `activity`, `row_activity` and `mu` come from the converged base
-    point and `perturbations` and `bounds_relaxed` from the solve, so
-    none of the five depends on the mode.
-
-    bound_eps sets how far outside a variable bound a step has to end
-    to count as having left it, which decides what mode="fix_relax"
-    pins and what `crossed` and `alpha` measure against. It is absolute,
-    as the refinement's own test is. Unset, it is how far outside the
-    solve itself was willing to settle, floored so an unrelaxed solve
-    does not pin on roundoff, and `crossed` keeps that floor so a
-    coordinate the solve itself left outside a relaxed bound is still
-    named. A constraint row keeps its own floor, and a bound is released
-    when the step drives its multiplier negative past the solve's own
-    margin, whatever bound_eps is. Only mode="fix_relax" reads it, and
-    passing it under another mode warns. It must be positive, as the
-    CLI's sens_bound_eps is.
-
-    max_pdpert refuses rather than answering when the converged KKT
-    factor carries an inertia correction larger than the value given.
-    Every sensitivity output inverts that factor, so a perturbed one
-    answers for a nearby problem rather than this one.
-    `sens_solution_report().perturbations` reports the same numbers for a
-    caller who would rather read them than stop. It must be positive,
-    as the CLI's sens_max_pdpert is, and the same argument is on
-    sens_jacobian(), sens_solution(), sens_solution_report(),
-    sens_active_set_changes(),
-    sens_covariance() and sens_information().
-
-    corrector_iter runs the same Newton iterations `sens_solution()` runs and
-    reports what they did on the `corrector` attribute, without changing
-    anything the rest of the report measures. Those describe the step
-    handed to the corrector, which is what a caller comparing the two
-    wants.
-
-    Takes the same perturbation argument `sens_solution()` takes and returns
-    a SolutionReport. Nothing about the estimate changes: this runs
-    the same step and measures it.
-
-    The ratio test divides each bounded coordinate's distance to the
-    bound it moves toward by the size of its step component and keeps
-    the smallest value, over variables and over inequality constraint
-    constraints. Equality constraints do not take part, since the step
-    holds them to first order and they admit no activity change. The
-    constraints pinning the declared Params are excluded on the same
-    grounds, because the perturbation moves their right-hand sides by
-    construction.
-    """
-    reg = model.__dict__.get(_REG)
-    session = reg.session if reg else None
-    if session is None:
-        raise RuntimeError(
-            "no sensitivity session: declare_sens_param() then solve with "
-            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
-            "contrib SolverFactory('pounce') first")
-
-    if mode not in ("linear", "fix_relax", "path"):
-        raise ValueError(
-            "sens_solution_report: mode must be 'linear', 'fix_relax' or "
-            f"'path', got {mode!r}")
-    if degeneracy not in ("directional", "one_sided", "release_all"):
-        raise ValueError(
-            "sens_solution_report: degeneracy must be 'directional', "
-            f"'one_sided' or 'release_all', got {degeneracy!r}")
-    degeneracy_iter = _degeneracy_iter(
-        degeneracy_iter, degeneracy, "sens_solution_report")
-    _check_margins(bound_eps, max_pdpert, "sens_solution_report")
-    if bound_eps is not None and mode != "fix_relax":
-        warnings.warn(
-            "sens_solution_report: bound_eps is the margin the fix_relax "
-            f"refinement pins against and mode={mode!r} runs no "
-            "refinement, so it changes nothing here.")
-    _refuse_on_pdpert(session, max_pdpert, "sens_solution_report")
-    if max_iter is not None:
-        warnings.warn(
-            "sens_solution_report: max_iter no longer does anything "
-            "here and is "
-            "ignored; it used to budget the directional decision, which "
-            "degeneracy_iter budgets now. Pass degeneracy_iter instead.",
-            DeprecationWarning, stacklevel=2)
-    pin_idx, deltas = _perturbation_deltas(session, perturb)
-    # the same dispatch `sens_solution()` runs, so the step measured here is
-    # the step it takes for these arguments
-    fell_back = False
-    refine_stop = None
-    if degeneracy == "directional":
-        try:
-            step, held_rows, _ = session.solver.parametric_step_directional(
-                pin_idx, deltas, degeneracy_iter)
-            if mode == "fix_relax":
-                step, _, refine_stop = (
-                    session.solver.parametric_step_bounded_decided(
-                        pin_idx, deltas, held_rows, predictor_iter,
-                        bound_eps))
-            elif mode == "path":
-                step, _ = session.solver.parametric_step_path_decided(
-                    pin_idx, deltas, held_rows, predictor_iter)
-        except RuntimeError as e:
-            if "directional derivative" not in str(e):
-                raise
-            warnings.warn(
-                f"sens_solution_report: {e}. Falling back to the one-sided "
-                "step, the degeneracy='one_sided' behavior.")
-            fell_back = True
-    if degeneracy == "release_all":
-        if mode == "fix_relax":
-            step, _, refine_stop = (
-                session.solver.parametric_step_bounded_decided(
-                    pin_idx, deltas, [], predictor_iter, bound_eps))
-        elif mode == "path":
-            step, _ = session.solver.parametric_step_path_decided(
-                pin_idx, deltas, [], predictor_iter)
-        else:
-            step, _released = session.solver.parametric_step_release_all(
-                pin_idx, deltas)
-    if degeneracy == "one_sided" or fell_back:
-        if mode == "fix_relax":
-            step, _, refine_stop = session.solver.parametric_step_bounded(
-                pin_idx, deltas, predictor_iter, bound_eps)
-        elif mode == "path":
-            step, _ = session.solver.parametric_step_path(
-                pin_idx, deltas, predictor_iter)
-        else:
-            step = session.solver.parametric_step(pin_idx, deltas)
-    dx = session.scatter_x(np.asarray(step))
-    base = np.asarray(session.base_x)
-    x_new = base + dx
-
-    lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
-    g_l, g_u = np.asarray(session.nl.g_l), np.asarray(session.nl.g_u)
-
-    # The margin the refinement pinned against, so `alpha` and `crossed`
-    # answer with the number that decided the step. It is absolute, as
-    # the refinement's own test is, so a coordinate of order 1e4 does not
-    # get a tolerance the refinement never gave it. Unset keeps the
-    # fixed floor rather than the solve's relaxation: `crossed` reports
-    # a coordinate the SOLVE left outside its bound, and the relaxation
-    # is exactly how far out that is, so taking it as the margin would
-    # hide the case this report exists to name.
-    eps = (1e-9 if bound_eps is None or mode != "fix_relax"
-           else float(bound_eps))
-    # The refinement pins variable bounds only, so a constraint row
-    # keeps its floor whatever margin the caller set: a wide margin has
-    # no say over a row the step carries past its limit. Its tolerance
-    # is set beside the row ratio test below.
-
-    row_names = _user_row_names(session)
-
-    # The classifier raises for a solve that relaxed its bounds, since
-    # relaxed bounds shift the slacks it reads. Ask the solve what it
-    # ran under instead of provoking that and reading the message, and
-    # report it as the fact it is. The rest of the report is still
-    # measured, where a diagnostic that raised would give the caller
-    # nothing exactly when they are trying to find out why the estimate
-    # disagrees with a re-solve. `mu` comes from the classifier, so it
-    # is unavailable on that path too.
-    mu, activity, row_status = float("nan"), {}, {}
-    var_on_bound = row_on_bound = None
-    bounds_relaxed = bool(session.solver.bound_relax_factor)
-    if not bounds_relaxed:
-        act = session.solver.classify_activity()
-        mu = float(act["mu"])
-        activity = dict(zip(session.var_names, act["var_status"]))
-        row_status = dict(zip(row_names, act["row_status"]))
-        var_on_bound = _on_bound(act["var_status"])
-        row_on_bound = _on_bound(act["row_status"])
-
-    alpha, first = _ratio_test(base, dx, lo, hi, session.var_names, tol=eps,
-                               on_bound=var_on_bound, mu=mu)
-    first_kind = None if first is None else "variable"
-    dg = _row_step(session, dx)
-    g_base = np.asarray(session.nl.constraints(base))
-    # an equality constraint is held to first order and cannot change
-    # activity, and a pin constraint moves by construction
-    live = g_l < g_u
-    live[list(pin_idx)] = False
-    g_pred = g_base + dg
-    gtol = 1e-9 * np.maximum(1.0, np.abs(g_pred))
-    a_row, f_row = _ratio_test(g_base, dg, g_l, g_u, row_names, live=live,
-                               on_bound=row_on_bound, mu=mu, tol=gtol)
-    if a_row < alpha:
-        alpha, first, first_kind = a_row, f_row, "constraint"
-
-    crossed = ComponentMap()
-    for i in np.where((x_new < lo - eps) | (x_new > hi + eps))[0]:
-        ov = session.var_data[i]
-        if ov is not None:
-            crossed[ov] = float(max(lo[i] - x_new[i], x_new[i] - hi[i]))
-    crossed_rows = ComponentMap()
-    out_of_bounds = (g_pred < g_l - gtol) | (g_pred > g_u + gtol)
-    rows_out = np.where(live & out_of_bounds)[0]
-    # resolved only when a row actually crossed: the resolution is
-    # once per session, but the common case has nothing to resolve for
-    row_data = session.user_row_data() if rows_out.size else ()
-    for j in rows_out:
-        oc = row_data[j]
-        if oc is not None:
-            crossed_rows[oc] = float(
-                max(g_l[j] - g_pred[j], g_pred[j] - g_u[j]))
-
-    # the perturbation IS the shift of the pin constraints' right-hand
-    # sides, so the violation is measured against the shifted ones
-    gl_p, gu_p = g_l.copy(), g_u.copy()
-    for pin, d in zip(pin_idx, deltas):
-        gl_p[pin] += d
-        gu_p[pin] += d
-    g_at = np.asarray(session.nl.constraints(x_new))
-    violation = float(np.max(np.maximum.reduce(
-        [gl_p - g_at, g_at - gu_p, np.zeros_like(g_at)])))
-
-    corrector = None
-    if corrector_iter:
-        _, corrector = _correct(
-            session, pin_idx, deltas, np.asarray(step), corrector_iter)
-
-    return SolutionReport(
-        alpha=alpha, first=first, first_kind=first_kind,
-        crossed=crossed, crossed_rows=crossed_rows, violation=violation,
-        mu=mu, activity=activity, row_activity=row_status,
-        perturbations=np.asarray(session.solver.kkt_perturbations).tolist(),
-        bounds_relaxed=bounds_relaxed, corrector=corrector,
-        refine_stop=refine_stop,
-    )
-
-
-#: One active-set change along `sens_solution(mode="path")`'s path.
-#: `fraction` is how far along the perturbation the change happens,
-#: `var` is the variable (its solve-space name when the solve created
-#: it without a model counterpart), `bound` is "lower" or "upper", and
-#: `action` is "reaches" when the variable arrives at the bound and is
-#: held there, "leaves" when it comes off it.
-#:
-#: A weakly active bound can be recorded as "reaches" at a fraction of
-#: essentially zero, which does not contradict the variable having been
-#: on that bound at the base point: what the working set gained there
-#: is the *hold*. Undecided, such a bound sits in the factorization as
-#: an order-one penalty that bends the step without enforcing anything,
-#: so a perturbation pressing into it is a breakpoint like any other
-#: (gh#852).
-ActiveSetChange = namedtuple(
-    "ActiveSetChange", ["fraction", "var", "bound", "action"])
-
-
-def sens_active_set_changes(model, perturb, predictor_iter=16,
-                       degeneracy="directional", degeneracy_iter=None,
-                       max_pdpert=None):
-    """The active-set changes `sens_solution(mode="path")` applies, in order.
-
-    Takes the same perturbation argument `sens_solution()` takes and returns
-    a list of `ActiveSetChange` entries, one per change, in the order
-    the path applies them. Nothing about the estimate changes: this
-    runs the same path and returns its record.
-
-    The record is what `mode="path"` produces that no other mode does.
-    The first entry's fraction is how much of the measurement
-    discrepancy the held solve's active set survives unchanged, and the
-    list as a whole says which bounds the re-optimized solution enters
-    and leaves between the predicted state and the measured one.
-
-    A list of length `predictor_iter` means the cap stopped the path before
-    the target, the same condition `sens_solution()` warns about.
-
-    degeneracy and degeneracy_iter match `sens_solution()`'s arguments of the
-    same names. Under "directional" (the default), a weakly active bound
-    the perturbation releases appears in the record as a departure at
-    the fraction where its multiplier reaches zero: essentially zero at
-    an exact kink, and partway along the step when the held solve sits
-    inside the ambiguous band, where the bound is genuinely active for
-    the first stretch. degeneracy_iter budgets that decision's
-    back-solves, and a budget it cannot fit falls back to the one-sided
-    record with a warning, and predictor_iter above still caps the path
-    itself. Under "release_all" every weakly active bound starts the
-    path released undecided, so a bound the perturbation holds appears
-    as a return to its bound along the path rather than a decision at
-    the base point.
-
-    max_pdpert refuses rather than answering when the converged KKT
-    factor carries an inertia correction larger than the value given.
-    This runs the same predictor `sens_solution(mode="path")` runs and
-    inverts the same factor, so it takes the same cap. There is no
-    bound_eps here, since the path decides its changes from where a
-    multiplier reaches zero and reads no margin.
-    """
-    reg = model.__dict__.get(_REG)
-    session = reg.session if reg else None
-    if session is None:
-        raise RuntimeError(
-            "no sensitivity session: declare_sens_param() then solve with "
-            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
-            "contrib SolverFactory('pounce') first")
-
-    if degeneracy not in ("directional", "one_sided", "release_all"):
-        raise ValueError(
-            "sens_active_set_changes: degeneracy must be 'directional', "
-            f"'one_sided' or 'release_all', got {degeneracy!r}")
-    degeneracy_iter = _degeneracy_iter(
-        degeneracy_iter, degeneracy, "sens_active_set_changes")
-    _check_margins(None, max_pdpert, "sens_active_set_changes")
-    _refuse_on_pdpert(session, max_pdpert, "sens_active_set_changes")
-    pin_idx, deltas = _perturbation_deltas(session, perturb)
-    if degeneracy == "directional":
-        try:
-            _, held_rows, _ = (
-                session.solver.parametric_step_directional(
-                    pin_idx, deltas, degeneracy_iter))
-            _, segments = session.solver.parametric_step_path_decided(
-                pin_idx, deltas, held_rows, predictor_iter)
-        except RuntimeError as e:
-            if "directional derivative" not in str(e):
-                raise
-            warnings.warn(
-                f"sens_active_set_changes: {e}. Falling back to the "
-                "one-sided record, the degeneracy='one_sided' behavior.")
-            _, segments = session.solver.parametric_step_path(
-                pin_idx, deltas, predictor_iter)
-    elif degeneracy == "release_all":
-        _, segments = session.solver.parametric_step_path_decided(
-            pin_idx, deltas, [], predictor_iter)
-    else:
-        _, segments = session.solver.parametric_step_path(
-            pin_idx, deltas, predictor_iter)
-
-    # segments carry var-x rows (the factor's x block); var_names is
-    # full-x, so invert the same map scatter_x applies
-    full_of = {row: full
-               for full, row in enumerate(session._primal_row_map())
-               if row is not None}
-    out = []
-    for frac, var_row, lower, pinned in segments:
-        full = full_of[var_row]
-        name = session.var_names[full]
-        comp = session.var_data[full]
-        out.append(ActiveSetChange(
-            fraction=float(frac),
-            var=comp if comp is not None else name,
-            bound="lower" if lower else "upper",
-            action="reaches" if pinned else "leaves",
-        ))
-    return out
 
 
 # ── parameter covariance ──────────────────────────────────────────────────────
 
-class _ParamKeyed:
-    """Lookup from a declared Param's data object to its row index.
-    Keyed by id() because Pyomo components are unhashable."""
-
-    _who = "sens_covariance"          # accessor name used in diagnostics
-
-    def __init__(self, params):
-        self._params = list(params)
-        self._pos = {id(p): i for i, p in enumerate(self._params)}
-
-    def _loc(self, pd):
-        i = self._pos.get(id(pd))
-        if i is None:
-            raise KeyError(f"{getattr(pd, 'name', pd)}: not one of the "
-                           f"{self._who} parameters")
-        return i
 
 
-class _ParamVector(_ParamKeyed):
-    """Vector keyed by param data: v[m.k1] -> float."""
-
-    def __init__(self, params, values):
-        super().__init__(params)
-        self.values = np.asarray(values, dtype=float)
-
-    def __getitem__(self, pd):
-        return float(self.values[self._loc(pd)])
 
 
-class _ParamMatrix(_ParamKeyed):
-    """Symmetric matrix keyed by param data: M[m.k1, m.k2] (either
-    order) or M[m.k1] for a diagonal entry."""
-
-    def __init__(self, params, matrix):
-        super().__init__(params)
-        self.matrix = np.asarray(matrix, dtype=float)
-
-    def __getitem__(self, key):
-        if isinstance(key, tuple):
-            i, j = (self._loc(k) for k in key)
-        else:
-            i = j = self._loc(key)
-        return float(self.matrix[i, j])
 
 
-def _pin_eigenvector_signs(vecs):
-    """Fix the arbitrary sign LAPACK gives each eigenvector column, so
-    the direction an eigen() call reports is reproducible.
-
-    `v` and `-v` are equally valid eigenvectors, and which one `eigh`
-    returns is a convention of the LAPACK build, not a property of the
-    matrix: the same model and data can report opposite directions on
-    two machines. The convention here is the largest-magnitude
-    component positive, ties broken by the earliest `params` position
-    (argmax takes the first maximum). It is scale-invariant and
-    independent of parameter ordering except through that tie-break.
-
-    This pins the sign only. A repeated eigenvalue leaves the basis
-    WITHIN its eigenspace arbitrary — any rotation of those columns
-    diagonalizes just as well — so the individual eigenvectors of a
-    degenerate block are still not reproducible; only the subspace
-    they span is."""
-    vecs = np.asarray(vecs, dtype=float)
-    if vecs.size == 0:
-        return vecs
-    lead = np.abs(vecs).argmax(axis=0)
-    signs = np.sign(vecs[lead, np.arange(vecs.shape[1])])
-    signs[signs == 0.0] = 1.0        # an all-zero column, if one ever
-    return vecs * signs              # reaches here, is left alone
 
 
-class Covariance(_ParamMatrix):
-    """Asymptotic parameter covariance, from sens_covariance().
-
-    Keyed by the fitted variables' data objects (the free `Var`s
-    flagged with `declare_sens_fitted`, not Pyomo `Param`s) in `params`
-    (declaration) order: cov[m.k1, m.k2] (either order),
-    cov[m.k1] for a variance, cov.std_err[m.k1],
-    cov.correlation[m.k1, m.k2]. `matrix` is the dense numpy array
-    ordered like `params`; `sigma_sq` is the residual variance that was
-    used. eigen() supports identifiability diagnosis."""
-
-    def __init__(self, params, matrix, sigma_sq, conditioned_on=()):
-        super().__init__(params, matrix)
-        self.params = self._params
-        self.sigma_sq = sigma_sq          # float, or {group: float}
-        self._conditioned = conditioned_on
-        with np.errstate(invalid="ignore", divide="ignore"):
-            se = np.sqrt(np.diag(self.matrix))
-            corr = self.matrix / np.outer(se, se)
-        # entries whose scale is undefined (a projected bound-active
-        # parameter has exactly zero variance) are reported as 0
-        corr[~np.isfinite(corr)] = 0.0
-        self.std_err = _ParamVector(self.params, se)
-        self.correlation = _ParamMatrix(self.params, corr)
-
-    @property
-    def conditioned_on(self):
-        """Strongly active variables OUTSIDE the block: the matrix is
-        conditional on those bounds (roadmap item 3); empty when none.
-        Computed on first access (one backsolve per near-bound
-        candidate) and cached, so calls that never read it pay
-        nothing. Until first access the pending computation keeps the
-        sensitivity session, and so the held KKT factor, alive; read
-        it (or discard the result) to release them."""
-        if callable(self._conditioned):
-            self._conditioned = self._conditioned()
-        return self._conditioned
-
-    def eigen(self):
-        """(eigenvalues, eigenvectors) of the covariance matrix,
-        eigenvalues ascending, eigenvectors[:, i] in `params` order.
-        An eigenvalue much larger than the rest flags a poorly
-        identified direction: its eigenvector gives the parameter
-        combination the data cannot pin down.
-
-        Each eigenvector's sign is pinned so the direction it names
-        reproduces across machines: its largest-magnitude component
-        is positive (see _pin_eigenvector_signs)."""
-        w, v = np.linalg.eigh(self.matrix)
-        return w, _pin_eigenvector_signs(v)
 
 
-def _indefinite(block):
-    """A symmetric block with a genuinely negative eigenvalue, at a
-    tolerance relative to the block's own scale. At a strict local
-    minimum with LICQ the reduced Hessian is PSD, so this fires only
-    on non-minimum stationary points or regularized (inertia-
-    corrected) convergence: exactly the finding worth returning
-    rather than refusing."""
-    if block.size == 0:
-        return False
-    ev_min = float(np.linalg.eigvalsh(block).min())
-    scale = float(np.abs(block).max())
-    return ev_min < -1e-10 * max(1.0, scale)
 
 
-def _estimation_counts(session):
-    """(#factor variables, #equality rows). The tangent recovery is
-    the constrained tangent map only when n_var - n_eq equals the
-    number of fitted parameters: the equalities then determine the
-    non-fitted variables given the fitted block. Callers guard on
-    this, because outside it T = Zx inv(M) is quietly not the tangent
-    map and R would be silently wrong."""
-    n_var = sum(1 for r in session._primal_row_map() if r is not None)
-    g_l = np.asarray(session.nl.g_l)
-    g_u = np.asarray(session.nl.g_u)
-    return n_var, int(np.count_nonzero(g_l == g_u))
 
 
-def _tangent_reduced_hessian(session, M, zcols, who="sens_covariance"):
-    """The reduced Hessian over the fitted block, by tangent recovery:
-    the x-blocks of the K-inverse columns are T*M (each satisfies the
-    equalities and has the fitted block as its own coordinates), so
-    T = Zx inv(M) exactly, with the factor's barrier weight cancelling
-    multiplicatively rather than by subtraction. Then R = T^T H T with
-    the exact Lagrangian Hessian (covariance roadmap item 2).
-
-    Machine-exact for equality and variable-bound activity (everything
-    in W cancels multiplicatively, pinned variables included), verified
-    against analytic ground truth where the subtraction route loses
-    log10(Sigma/q) digits. A binding INEQUALITY row instead couples
-    through its slack barrier with large-but-finite weight, tilting
-    the recovered tangent along that row's normal: measured ~1e-6
-    relative at practical mu, degrading as mu tightens (the pinned
-    combination drives M toward singularity), still ~6 digits beyond
-    the subtraction it replaces. Requires the square estimation
-    structure of _estimation_counts(); callers guard."""
-    # the factor's x block is var-x (a fixed variable's column is
-    # removed under make_parameter, gh #450), so slice that block and
-    # scatter each tangent back to full-x for hessian_vec, whose
-    # contract is user-space with zeros on the removed columns
-    n_var = sum(1 for r in session._primal_row_map() if r is not None)
-    Zx = np.column_stack([z[:n_var] for z in zcols])
-    T = np.column_stack(
-        [session.scatter_x(col) for col in (Zx @ _minv(M, who)).T])
-    HT = np.column_stack([
-        np.asarray(session.solver.hessian_vec(T[:, j]))
-        for j in range(T.shape[1])
-    ])
-    R = T.T @ HT
-    return 0.5 * (R + R.T)
 
 
-_WORDING = {
-    # the default block IS the fitted set, and saying so is strictly
-    # more informative there; an arbitrary of= block gets the
-    # block-relative nouns (review of gh #466)
-    "fitted": {"member": "fitted parameter",
-               "outside": "non-fitted variables",
-               "reach": "the fitted parameters",
-               "combo": "fitted combination",
-               "scale": "the fitted block's"},
-    "block": {"member": "block member",
-              "outside": "variables outside the block",
-              "reach": "the block",
-              "combo": "block combination",
-              "scale": "the block's"},
-}
 
 
-def _classify_fitted_block(session, params, rows, M, zcols,
-                           who="sens_covariance", wording="fitted"):
-    """Membership and row handling shared by sens_covariance() and
-    sens_information(): item 1's classification at the reduced fitted
-    block, the value-correction bookkeeping, and the binding-row
-    normals, with the warnings both accessors owe their callers.
-    Returns a namespace consumed by each accessor's own assembly."""
-    from types import SimpleNamespace
-
-    W = _WORDING[wording]
-    n_params = len(params)
-    # ── membership from the barrier activity classification ──────────────
-    # (covariance roadmap item 1). The classifier's per-coordinate rule
-    # scales Sigma by the coordinate's own Lagrangian curvature, which is
-    # zero for a fitted parameter in the residual-variable idiom (the
-    # curvature lives on the residuals), so the same rule runs HERE on
-    # the reduced fitted block, where the parameter's curvature actually
-    # is: q = the reduced Hessian diagonal with the parameter's own
-    # barrier term removed, Sigma retained by the solve. A weakly active
-    # parameter is KEPT and warned rather than silently pinned; no slack
-    # threshold can make that distinction, because slack and multiplier
-    # are both O(sqrt(mu)) at weak activity.
-    R_exact = None
-    act = session.solver.classify_activity()
-    mu = float(act["mu"])
-    R_W = _minv(M, who)                # reduced Hessian off the factor, W-based
-    # M (and so R_W) is natural-units by the kkt_solve contract
-    # (pounce#128), and so are the report's sigmas and row_normal
-    # (unscaled at the classifier boundary per the same contract), so
-    # everything here composes without scale factors.
-    sig_fit = np.array([float(act["var_sigma"][r]) for r in rows])
-    q_red = np.abs(np.diag(R_W) - sig_fit)
-    floor = np.sqrt(np.finfo(float).eps) * max(
-        1.0, float(np.abs(np.diag(R_W)).max()))
-    active = []
-    for i, p in enumerate(params):
-        st = act["var_status"][rows[i]]
-        if st in ("unbounded", "fixed"):
-            continue                       # no variable bound to classify
-        ri = float(sig_fit[i]) / max(float(q_red[i]), floor)
-        if q_red[i] < floor and ri <= 1e1:
-            # curvature AND barrier weight both below scale: the bound
-            # question does not arise, but the direction is poorly
-            # identified (a dominant Sigma cancelling inside q_red
-            # instead lands ri astronomically high and classifies
-            # strongly active)
-            status = "unidentified"
-        else:
-            status = _classify_ratio(ri, mu)
-        if status == "strongly_active":
-            active.append(i)
-            warnings.warn(
-                f"{who}: {W['member']} {p.name} is held by its "
-                "bound at the optimum (strongly active); its direction is "
-                "projected out (zero variance, conditional on the active "
-                "bound) and the boundary asymptotics are nonstandard.")
-        elif status == "weakly_active":
-            warnings.warn(
-                f"{who}: {W['member']} {p.name} sits exactly on "
-                "its bound with a vanishing multiplier (weakly active). "
-                "It is kept in the free block with finite variance; "
-                "boundary asymptotics are nonstandard.")
-        elif status == "ambiguous":
-            warnings.warn(
-                f"{who}: {W['member']} {p.name} has ambiguous "
-                "bound activity at the solve's final barrier parameter; "
-                "re-solve with a tighter tol to settle it. It is kept in "
-                "the free block.")
-        elif status == "unidentified":
-            warnings.warn(
-                f"{who}: {W['member']} {p.name} has curvature "
-                "below the model's own noise scale (unidentified); its "
-                "variance is large rather than small. It is kept in the "
-                "free block.")
-
-    # ── binding general rows on the fitted block ──────────────────────────
-    # (item 1 row projection, jkitchin/pounce#362). A strongly active
-    # inequality row whose normal touches the fitted parameters pins a
-    # DIRECTION of the fitted block: no per-parameter disposition can
-    # state that, so the free block is reduced on the null space of the
-    # binding normals and pushed back, singular by the number of binding
-    # rows. Rows classify at the reduced level exactly as the variable
-    # bounds above: the row's barrier weight against the curvature along
-    # its own normal. A bound moved onto a row by declared-parameter
-    # reformulation (jkitchin/pounce#357) is the single-coordinate case
-    # and reproduces the variable disposition exactly.
-    R_corr = R_W - np.diag(sig_fit)
-    # columns held constant by the declared-parameter pins: a row's
-    # support there contributes nothing through elimination (the pin
-    # variable cannot move), so it does not make the row "mixed". The
-    # pin constraint's normal is e_{pin var}, so its support IS the
-    # pin column.
-    pin_cols = set()
-    for _pr in session.pins.values():
-        _pn = np.asarray(session.solver.row_normal(int(_pr)), dtype=float)
-        pin_cols.update(int(i) for i in np.nonzero(_pn)[0])
-    fit_cols = set(int(r) for r in rows)
-    bind_normals = []                  # unit normals over the fitted block
-    row_corrections = []               # (weight, unit normal), applied after
-    for j, rst in enumerate(act["row_status"]):
-        if rst in ("equality", "unbounded", "inactive"):
-            # inactive rows carry O(mu) geometric weight (the invariant
-            # form), the same order as every other accepted O(mu) term;
-            # skipping them also avoids fetching every row normal on
-            # wide models (an O(m*n) sweep). The bound and row
-            # spellings of an INACTIVE limit therefore agree to O(mu)
-            # rather than exactly, tested at that tolerance.
-            continue
-        a_full = np.asarray(session.solver.row_normal(j), dtype=float)
-        a = a_full[rows]
-        na = float(np.linalg.norm(a))
-        # A row whose normal also touches NON-fitted variables pins a
-        # combination that reaches the fitted block through the
-        # eliminated variables, not along the restricted normal: e.g.
-        # a + r_1 <= cap with r_1 = y_1 - a - b*x_1 actually pins a
-        # b-direction, while the restricted normal reads e_a. The
-        # restricted projection would delete the wrong direction, so a
-        # mixed binding row is kept unprojected with an explicit
-        # warning instead. The general treatment needs the row's
-        # reduced normal through the elimination (roadmap item 2's
-        # machinery).
-        nf = float(np.linalg.norm(a_full))
-        outside = [i for i in np.nonzero(a_full)[0]
-                   if int(i) not in fit_cols and int(i) not in pin_cols]
-        mixed = bool(outside) and (
-            float(np.linalg.norm(a_full[outside])) > 1e-8 * max(1.0, nf))
-        if na <= 1e-12 * max(1.0, nf):
-            # entirely outside the fitted block: the extreme mixed case
-            # (relative tolerance, matching the mixed test above)
-            mixed = True
-        cname = (session.con_names[j] if j < len(session.con_names)
-                 else f"row {j}")
-        if mixed:
-            # the reduced-level rule is also unreliable here: the row's
-            # barrier weight lands through elimination on a direction
-            # the restricted normal cannot see, so re-classifying
-            # against it manufactures a wrong ratio. Item 0's raw
-            # classification (scale-invariant along the full normal) is
-            # the honest status for a mixed row.
-            if rst == "strongly_active":
-                warnings.warn(
-                    f"{who}: constraint {cname} is strongly active "
-                    f"and involves {W['outside']}; the "
-                    f"direction it pins reaches {W['reach']} through the "
-                    "eliminated variables and cannot be represented by "
-                    "a restricted normal, so it is NOT projected. Treat "
-                    "the returned variances as not conditioned on this "
-                    "constraint.")
-            elif rst in ("weakly_active", "ambiguous", "unidentified"):
-                warnings.warn(
-                    f"{who}: constraint {cname} is {rst} and "
-                    f"involves {W['outside']}; it is kept "
-                    "unprojected and its barrier weight is not "
-                    "corrected for (the restricted direction would be "
-                    "the wrong one). Boundary asymptotics are "
-                    "nonstandard.")
-            continue
-        a = a / na
-        # the row's slack elimination contributes Sigma_j * (raw normal
-        # outer product) to the reduced block; in the unit-normal basis
-        # that coefficient is Sigma_j * ||raw normal||^2 (all natural
-        # units: the report unscales at the classifier boundary)
-        sig_row = float(act["row_sigma"][j]) * na * na
-        q_w = float(a @ R_corr @ a)
-        # |q|, matching the Rust classifier: indefinite curvature
-        # classifies on magnitude, and indefiniteness still surfaces
-        # through the negative-variance warning downstream
-        q_row = abs(q_w - sig_row)
-        ri = sig_row / max(q_row, floor)
-        if q_row < floor and ri <= 1e1:
-            status = "unidentified"
-        else:
-            status = _classify_ratio(ri, mu)
-        combo = " + ".join(
-            f"{a[k]:.3g}*{params[k].name}" for k in range(n_params)
-            if abs(a[k]) > 1e-12)
-        if status == "strongly_active":
-            bind_normals.append(a)
-            # conditional information along the pinned combination via
-            # the tangent-recovered reduced Hessian (item 2 machinery;
-            # lazy, only solves with a binding row pay the Hessian
-            # products). Accurate to ~1e-6 at practical mu, the residue
-            # being this row's own finite slack-barrier weight in the
-            # recovery, where the factor subtraction lost ten digits.
-            # Outside the square estimation structure the recovery is
-            # undefined, so the subtraction value is kept there.
-            if R_exact is None:
-                n_var, n_eq = _estimation_counts(session)
-                if n_var - n_eq == n_params:
-                    R_exact = _tangent_reduced_hessian(
-                        session, M, zcols, who)
-            if R_exact is not None:
-                s_a = float(a @ R_exact @ a)
-            else:
-                s_a = max(q_w - sig_row, 0.0)
-            warnings.warn(
-                f"{who}: constraint {cname} is strongly active and "
-                f"pins the {W['combo']} {combo}; variance along it "
-                "is projected to zero (conditional on the constraint). "
-                f"Conditional information along the combination: {s_a:.6g}.")
-        elif status == "weakly_active":
-            warnings.warn(
-                f"{who}: constraint {cname} is weakly active on the "
-                f"{W['combo']} {combo} (multiplier and slack vanish "
-                "together). It is kept unprojected with finite variance; "
-                "boundary asymptotics are nonstandard.")
-        elif status == "ambiguous":
-            warnings.warn(
-                f"{who}: constraint {cname} has ambiguous activity "
-                f"on the {W['combo']} {combo} at the solve's final "
-                "barrier parameter; re-solve with a tighter tol to "
-                "settle it. It is kept unprojected.")
-        elif status == "unidentified":
-            warnings.warn(
-                f"{who}: constraint {cname} has curvature below "
-                f"{W['scale']} noise scale on {combo} "
-                "(unidentified); it is kept unprojected and its "
-                "variance is large rather than small.")
-        if status in ("weakly_active", "ambiguous"):
-            # collected, applied after the loop: every row classifies
-            # against the same snapshot, so results do not depend on
-            # the order rows happen to be visited in
-            row_corrections.append((sig_row, a))
-    for _w, _a in row_corrections:
-        # the row analog of the variable value correction: remove a
-        # kept row's own barrier weight from the reduced block
-        R_corr = R_corr - _w * np.outer(_a, _a)
-    ns = SimpleNamespace()
-    ns.act = act
-    ns.mu = mu
-    ns.R_W = R_W
-    ns.sig_fit = sig_fit
-    ns.floor = floor
-    ns.active = active
-    ns.free = [i for i in range(n_params) if i not in active]
-    ns.R_corr = R_corr
-    ns.bind_normals = bind_normals
-    ns.row_corrections = row_corrections
-    ns.R_exact = R_exact
-    return ns
 
 
-class Information(_ParamMatrix):
-    """Observed or expected information over the fitted block, from
-    sens_information(). Keyed like Covariance: info[m.k1, m.k2] (either
-    order), info[m.k1] for a diagonal entry; `matrix` is the dense
-    numpy array in `params` (declaration) order. Natural units, no
-    sigma^2 anywhere: for the homoscedastic Lagrangian case,
-    sens_covariance() equals 2*sigma^2 * inv(sens_information()) on the free
-    block. eigen() supports identifiability diagnosis directly: a
-    near-zero eigenvalue is a direction the data does not inform, and
-    its eigenvector names the parameter combination."""
-
-    _who = "sens_information"
-
-    def __init__(self, params, matrix, conditioned_on=()):
-        super().__init__(params, matrix)
-        self.params = self._params
-        self._conditioned = conditioned_on
-
-    @property
-    def conditioned_on(self):
-        """Strongly active variables OUTSIDE the block: the matrix is
-        conditional on those bounds (roadmap item 3); empty when none.
-        Computed on first access (one backsolve per near-bound
-        candidate) and cached, so calls that never read it pay
-        nothing. Until first access the pending computation keeps the
-        sensitivity session, and so the held KKT factor, alive; read
-        it (or discard the result) to release them."""
-        if callable(self._conditioned):
-            self._conditioned = self._conditioned()
-        return self._conditioned
-
-    def eigen(self):
-        """(eigenvalues, eigenvectors) of the information matrix,
-        eigenvalues ascending, eigenvectors[:, i] in `params` order.
-        Small eigenvalues flag poorly informed directions; a negative
-        one means the point is not a least-squares minimum along that
-        direction (Lagrangian form only; Gauss-Newton is PSD by
-        construction).
-
-        Each eigenvector's sign is pinned so the direction it names
-        reproduces across machines: its largest-magnitude component
-        is positive (see _pin_eigenvector_signs)."""
-        w, v = np.linalg.eigh(self.matrix)
-        return w, _pin_eigenvector_signs(v)
 
 
-def _classify_ratio(r, mu):
-    """The activity rule of covariance roadmap item 0, applied at the
-    reduced fitted block. Mirrors pounce_sensitivity::activity with one
-    deliberate divergence: the Rust classifier maps q below the floor
-    to `unidentified` unconditionally, while the caller here first
-    checks the ratio, because at the reduced level a huge Sigma
-    cancelling inside q_red would otherwise misfile a strongly active
-    entry as unidentified. Exposing the rule from pounce-py so one
-    implementation serves both is item-2 follow-up."""
-    if mu > 1e-4:
-        if r < 1e-1:
-            return "inactive"
-        if r > 1e1:
-            return "strongly_active"
-        return "ambiguous"
-    if r < np.sqrt(mu):
-        return "inactive"
-    if r > 1.0 / np.sqrt(mu):
-        return "strongly_active"
-    if 1e-1 <= r <= 1e1:
-        return "weakly_active"
-    return "ambiguous"
 
 
-def _free_nullspace(bind_normals, free):
-    """Projection basis over the free fitted coordinates: the null
-    space of the binding row normals restricted to `free`. A normal
-    that vanished with the pinned coordinates is dropped (its content
-    is already excluded by the free restriction)."""
-    nf = len(free)
-    rows_ = []
-    for a in bind_normals:
-        af = np.asarray(a)[free]
-        nn = float(np.linalg.norm(af))
-        if nn > 1e-12:
-            rows_.append(af / nn)
-    A = np.array(rows_) if rows_ else np.zeros((0, nf))
-    return _nullspace(A)
 
 
-def _nullspace(A):
-    """Orthonormal basis of the null space of A's rows (columns of the
-    returned matrix); the projection basis Z of item 1's row handling."""
-    if A.shape[0] == 0:
-        return np.eye(A.shape[1])
-    _, sv, vh = np.linalg.svd(A, full_matrices=True)
-    tol = max(A.shape) * np.finfo(float).eps * (sv[0] if sv.size else 1.0)
-    rank = int(np.sum(sv > tol))
-    return vh[rank:].T
 
 
 def _resolve_of(session, of, who):
@@ -3398,177 +1695,123 @@ def _resolve_of(session, of, who):
     return params, rows
 
 
-def _subblock_information(session, rows, dof, who):
-    """Marginal information of a proper sub-block of the fitted set,
-    by Schur complement of the EXACT tangent R over the fitted block:
-    never inverts a covariance, so a pinned member costs no digits.
-    Pinned fitted variables OUTSIDE the block are conditioned on
-    (their rows and columns are dropped: they are pinned, not
-    profiled); free ones are profiled out (the Schur step). The
-    matrix identity behind it: the inverse of a submatrix of an
-    inverse IS the Schur complement, so away from barrier
-    contamination this equals inv(M_B) exactly; the point is the
-    construction, not the value. Returns None when not applicable
-    (the block is not inside a square fitted set, or the fitted level
-    carries binding rows, whose projection does not compose simply
-    with marginalization) and the caller falls back to the corrected
-    reduction off the factor."""
-    fit_params = list(session.fit_rows.keys())
-    if len(fit_params) != dof:
-        return None
-    fit_rows_ = [session.fit_rows[fp] for fp in fit_params]
-    pos = {r: i for i, r in enumerate(fit_rows_)}
-    if any(r not in pos for r in rows):
-        return None
-    dim = session.solver.kkt_dim
-    fkrows = [session.primal_row(r, f"{who}(fitted)") for r in fit_rows_]
-    zcols_f = []
-    for kr in fkrows:
-        e = np.zeros(dim)
-        e[kr] = 1.0
-        zcols_f.append(np.asarray(session.solver.kkt_solve(e)))
-    M_f = np.array([[zcols_f[j][fkrows[i]] for j in range(dof)]
-                    for i in range(dof)])
-    M_f = 0.5 * (M_f + M_f.T)
-    with warnings.catch_warnings():
-        # the fitted-level classification is scaffolding here; its
-        # warnings belong to the block-level pass the caller runs
-        warnings.simplefilter("ignore")
-        cb_f = _classify_fitted_block(session, fit_params, fit_rows_,
-                                      M_f, zcols_f,
-                                      who=f"{who}(fitted)",
-                                      wording="fitted")
-    if cb_f.bind_normals:
-        return None
-    R_f = cb_f.R_exact
-    if R_f is None:
-        R_f = _tangent_reduced_hessian(session, M_f, zcols_f, who)
-    keep = [pos[r] for r in rows]
-    kept = set(keep)
-    pinned_f = set(cb_f.active)
-    o_free = [i for i in range(dof)
-              if i not in kept and i not in pinned_f]
-    sel = keep + o_free
-    Rs = R_f[np.ix_(sel, sel)]
-    nb = len(keep)
-    if o_free:
-        A_ = Rs[:nb, :nb]
-        B_ = Rs[:nb, nb:]
-        D_ = Rs[nb:, nb:]
-        try:
-            R_B = A_ - B_ @ np.linalg.solve(D_, B_.T)
-        except np.linalg.LinAlgError:
-            warnings.warn(
-                f"{who}: the free fitted coordinates outside the block "
-                "are singular, so the exact Schur route is unavailable; "
-                "falling back to the corrected reduction off the "
-                "factor, which loses digits at tight mu on pinned "
-                "members.")
-            return None
-    else:
-        R_B = Rs[:nb, :nb]
-    return 0.5 * (R_B + R_B.T)
 
 
-def _conditioned_on(session, act, rows, who):
-    """Strongly active variables outside the block. Their Sigma stays
-    in the held factor and drives the coupling through them to zero as
-    mu falls, so the block's numbers are the values conditional on
-    those bounds, not the marginal over them. Returned with the matrix
-    rather than warned: it is a property of the answer, not a defect.
-
-    Identification is item 1's reduced-level rule applied to each
-    candidate as a singleton block: one backsolve gives (K^-1)_ii, the
-    effective reduced curvature is |1/(K^-1)_ii - Sigma_i| (a pinned
-    variable in the residual idiom has zero RAW curvature, which is
-    why the raw report calls it unidentified), and the shipped ratio
-    edges make the call. Scale-invariant, same theory as the block
-    members. Candidates pass a cheap Sigma > sqrt(mu) prefilter first,
-    so only near-bound variables pay the backsolve; below the
-    cancellation floor q_red is clamped to it, exactly as the
-    block-level rule does."""
-    inside = set(int(r) for r in rows)
-    mu = float(act["mu"])
-    pre = np.sqrt(mu) if mu > 0 else 0.0
-    dim = session.solver.kkt_dim
-    out = []
-    for idx, st in enumerate(act["var_status"]):
-        if idx in inside or st in ("unbounded", "fixed", "equality",
-                                   "inactive"):
-            continue
-        sig = float(act["var_sigma"][idx])
-        if st == "strongly_active":
-            pinned = True
-        elif sig <= pre:
-            continue
-        else:
-            krow = session.primal_row(idx, f"{who} conditioned_on")
-            e = np.zeros(dim)
-            e[krow] = 1.0
-            kii = float(np.asarray(session.solver.kkt_solve(e))[krow])
-            if kii == 0.0:
-                continue
-            q_red = abs(1.0 / kii - sig)
-            # clamp to the floor rather than refuse, exactly as the
-            # block-level rule does: a huge Sigma cancelling inside
-            # q_red would otherwise misfile a strongly active variable
-            floor = np.sqrt(np.finfo(float).eps) * max(1.0, abs(1.0 / kii))
-            pinned = (_classify_ratio(sig / max(q_red, floor), mu)
-                      == "strongly_active")
-        if pinned:
-            v = session.var_data[idx]
-            out.append(v if v is not None else session.var_names[idx])
-    return tuple(out)
 
 
-def _rank_deficient(A):
-    """True when the symmetric block `A` is rank-deficient, tested on
-    its diagonally scaled form so the verdict is a statement about
-    COLLINEARITY and not about units.
-
-    `np.linalg.matrix_rank` thresholds the singular values at
-    `sigma_max * n * eps`, which is relative to the largest singular
-    value and so is not invariant under rescaling the coordinates
-    against each other: a covariance block carries the SQUARE of any
-    unit spread between its members, so two perfectly well-determined
-    parameters ~1e8 apart in magnitude (a rate prefactor against a
-    reaction order) push `cond(M)` past the default tolerance and read
-    as dependent on unit spread alone. Scaling by `sqrt(|diag|)` first
-    — the correlation form — makes the test the same kind of
-    scale-invariant ratio as the block-membership rule (roadmap item 1)
-    and the conditioned_on rule, rather than a threshold that tracks
-    the user's choice of units. Second review of gh #466.
-
-    A zero diagonal leaves its own row and column unscaled: there is no
-    scale to divide by, and a genuinely zero row is rank-deficient
-    either way."""
-    n = A.shape[0]
-    if n == 0:
-        return False
-    d = np.sqrt(np.abs(np.diag(A)))
-    d = np.where(d > 0.0, d, 1.0)
-    return int(np.linalg.matrix_rank(A / np.outer(d, d))) < n
 
 
-class _SingularBlock(RuntimeError):
-    """The requested block of the inverse KKT matrix is singular.
-    A dedicated type so callers that rescue this case (the of=
-    dependent-block paths) do not do control flow on message text
-    (review of gh #466)."""
 
 
-def _minv(M, who="sens_covariance"):
-    try:
-        return np.linalg.inv(M)
-    except np.linalg.LinAlgError as e:
-        raise _SingularBlock(
-            f"{who}: the requested block of the inverse KKT matrix "
-            "is singular; the block members are linearly "
-            "dependent (structurally unidentifiable)") from e
 
 
-def sens_covariance(model, sigma_sq=None, n_data=None,
-                    hessian="lagrangian", of=None, max_pdpert=None):
+
+
+
+
+# ── the Pyomo API over pounce.sensitivity ─────────────────────────────────────
+#
+# Everything below resolves Pyomo components to rows, calls the core, and
+# keys the answer back by component. The numerics live in
+# `pounce.sensitivity`, so a bare-NL or CasADi caller reaches the same
+# code without Pyomo installed; `who=` keeps these function names in the
+# messages a Pyomo user sees, and `_HINTS` keeps the declarations those
+# messages point at spelled the Pyomo way.
+
+#: How this layer spells the declarations the core's diagnostics name.
+_HINTS = {
+    "fitted": "declare_sens_fitted()",
+    "residual": "declare_sens_residual()",
+    "residual_group": "declare_sens_residual(..., group=...)",
+}
+
+_NO_SESSION_PARAM = (
+    "no sensitivity session: declare_sens_param() then solve with "
+    "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
+    "contrib SolverFactory('pounce') first")
+
+_NO_SESSION_FIT = (
+    "no sensitivity session: declare_sens_fitted() (and optionally "
+    "declare_sens_residual()), or sens_retain_kkt() for "
+    "of= queries with nothing declared, then solve with "
+    "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
+    "contrib SolverFactory('pounce') first")
+
+
+def _model_session(model, message):
+    reg = model.__dict__.get(_REG)
+    session = reg.session if reg else None
+    if session is None:
+        raise RuntimeError(message)
+    return session
+
+
+def sens_solution(model, perturb, clamp=True, mode="linear",
+                  predictor_iter=16, degeneracy="directional",
+                  degeneracy_iter=None, corrector_iter=0, bound_eps=None,
+                  max_pdpert=None):
+    """First-order estimate of the solution at perturbed parameter values.
+
+    perturb: pairs of (declared Param, new value) -- a list of tuples or a
+    ComponentMap (plain dicts don't work: Pyomo components are unhashable).
+    Returns a read-only `SolutionMap` {original var data: estimated
+    value}, keyed by the component data objects themselves. Values are
+    clamped to variable bounds (with a warning) unless clamp=False.
+
+    See `pounce.sensitivity.solution` for what every other argument does;
+    this resolves the perturbation to pin rows and shifts and hands it
+    the same session.
+    """
+    session = _model_session(model, _NO_SESSION_PARAM)
+    pin_idx, deltas = _perturbation_deltas(session, perturb)
+    x_new = _core_solution(
+        session, pin_idx, deltas, clamp=clamp, mode=mode,
+        predictor_iter=predictor_iter, degeneracy=degeneracy,
+        degeneracy_iter=degeneracy_iter, corrector_iter=corrector_iter,
+        bound_eps=bound_eps, max_pdpert=max_pdpert, who="sens_solution")
+    keys, index_of = session.solution_keys()
+    return SolutionMap(keys, index_of, x_new)
+
+
+def sens_solution_report(model, perturb, max_iter=None,
+                         degeneracy="directional", degeneracy_iter=None,
+                         corrector_iter=0, mode="linear", predictor_iter=16,
+                         bound_eps=None, max_pdpert=None):
+    """Report what `sens_solution()`'s step does about the bounds.
+
+    Takes the same perturbation argument `sens_solution()` takes and
+    returns a `SolutionReport`; see `pounce.sensitivity.solution_report`.
+    `crossed` and `crossed_rows` come back as `ComponentMap`s keyed by
+    the original model's data objects.
+    """
+    session = _model_session(model, _NO_SESSION_PARAM)
+    pin_idx, deltas = _perturbation_deltas(session, perturb)
+    return _core_solution_report(
+        session, pin_idx, deltas, max_iter=max_iter, degeneracy=degeneracy,
+        degeneracy_iter=degeneracy_iter, corrector_iter=corrector_iter,
+        mode=mode, predictor_iter=predictor_iter, bound_eps=bound_eps,
+        max_pdpert=max_pdpert, who="sens_solution_report")
+
+
+def sens_active_set_changes(model, perturb, predictor_iter=16,
+                            degeneracy="directional", degeneracy_iter=None,
+                            max_pdpert=None):
+    """The active-set changes `sens_solution(mode="path")` applies, in order.
+
+    Takes the same perturbation argument `sens_solution()` takes and
+    returns a tuple of `ActiveSetChange`; see
+    `pounce.sensitivity.active_set_changes`.
+    """
+    session = _model_session(model, _NO_SESSION_PARAM)
+    pin_idx, deltas = _perturbation_deltas(session, perturb)
+    return _core_active_set_changes(
+        session, pin_idx, deltas, predictor_iter=predictor_iter,
+        degeneracy=degeneracy, degeneracy_iter=degeneracy_iter,
+        max_pdpert=max_pdpert, who="sens_active_set_changes")
+
+
+def sens_covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian",
+                    of=None, max_pdpert=None):
     """Asymptotic covariance of the fitted parameters of a
     least-squares problem, from ONE ordinary solve.
 
@@ -3577,680 +1820,30 @@ def sens_covariance(model, sigma_sq=None, n_data=None,
     declare_sens_residual, solve with SolverFactory('pounce'), then call
     sens_covariance(model) with no further information.
 
-    ASSUMES the model objective is the plain sum of squared residuals.
-    The parameter block of the inverse KKT matrix, obtained by one
-    backsolve per parameter against the held factorization, equals the
-    inverse reduced Hessian of the eliminated problem, inv(d2f*/dp2);
-    for f = SSR the asymptotic covariance is then
-
-        cov = 2 * sigma_sq * (K^-1)_pp
-
-    The factor 2 belongs to the unscaled sum of squares; it is verified
-    against the analytical linear-regression covariance
-    sigma^2 * inv(X^T X) in tests/test_covariance.py.
-
-    The noise variance sigma_sq comes from, in order of precedence:
-    sigma_sq= (known measurement variance; scalar, or {group: value}
-    when residual groups are declared); declared residuals (estimated
-    per pooled or labeled group as SSR_g / (n_g - n_params)); or the
-    n_data= fallback (count of data points, with SSR taken from the
-    SOLVE-TIME objective value on trust -- writing into the model
-    first, the receding-horizon pattern of sens_solution(), does not change
-    the answer). With multiple labeled groups the heteroscedastic
-    sandwich covariance is reported.
-
-    hessian= selects the information matrix. "lagrangian" (the default)
-    inverts the exact reduced Hessian of the Lagrangian from the held
-    factorization: the observed-information form, the same object
-    sIPOPT or k_aug would factor. "gauss-newton" rebuilds
-    the expected-information form from the residual Jacobian, recovered
-    from the same backsolves at no extra solve (requires declared
-    residuals). They agree for linear models; for nonlinear fits
-    Gauss-Newton drops the residual-curvature term, matches the scipy /
-    ``pounce.curve_fit`` convention, and is structurally positive
-    semidefinite, which makes it the safe choice when the covariance
-    must stay PSD, e.g. feeding an arrival-cost update in moving
-    horizon estimation.
-
-    of= selects the block (covariance roadmap item 3): any of the
-    solve's variables, not only the declared fitted ones, given as a
-    Var (scalar or indexed), an indexed slice (m.x[2, :]), a
-    (Var, iterable) pair, data objects, or a list mixing these; None
-    (default) is the declared fitted block, exactly the prior
-    behavior. Each call re-reduces onto its own argument, so one solve
-    serves as many blocks as are asked about, each getting that
-    block's MARGINAL (everything else profiled out). Sigma estimation
-    always divides by the fit's own degrees of freedom, a property of
-    the solve, not the block. A rank-deficient block (more
-    coordinates than the fit has degrees of freedom, e.g. a predicted
-    trajectory: the prediction-band case) gets the homoscedastic
-    Lagrangian marginal, with membership handling bypassed. Strongly
-    active variables OUTSIDE the block come back on the result as
-    .conditioned_on: the matrix is conditional on those bounds, not
-    marginal over them.
-
-    Returns a Covariance object keyed by the declared variables'
-    data objects: cov[m.A, m.k], cov.std_err[m.A],
-    cov.correlation[m.A, m.k], cov.matrix, cov.sigma_sq (float or
-    per-group dict), cov.eigen().
-
-    Same scale-and-invert-the-reduced-Hessian recipe as
-    ``pounce.curve_fit``, with one difference for NONLINEAR models: this
-    feeds the exact Lagrangian Hessian (via the .nl bridge) and so reports
-    the OBSERVED-information covariance (the full reduced Hessian),
-    whereas ``curve_fit`` factors the Gauss-Newton Hessian and reports
-    ``2 sigma^2 (J^T J)^-1`` (the expected-information / scipy convention,
-    always positive semidefinite). The two agree for linear models and in
-    the small-residual limit and differ by O(residual x curvature)
-    otherwise. Gauss-Newton cannot produce a negative variance; the full
-    Hessian can go indefinite, which is what the negative-diagonal warning
-    below signals -- pass hessian="gauss-newton" then, or whenever
-    scipy-matching numbers are wanted. Use ``curve_fit`` for the
-    callable-model-plus-data surface
-    (starting point, robust losses, confidence intervals, prediction
-    bands, active-bound projection); use this for a model already written
-    in Pyomo.
-
-    Bound and constraint activity is classified from the solve's own
-    barrier geometry (the ratio of each direction's barrier weight to
-    its curvature; pounce's covariance roadmap item 1), not from a
-    slack threshold. A STRONGLY ACTIVE bound pins its parameter: zero
-    variance, correlation entries 0, conditional on the bound, with a
-    warning. A WEAKLY ACTIVE bound (slack and multiplier vanish
-    together) is KEPT: the parameter keeps its full finite variance,
-    corrected for the barrier weight the held factor carries, and a
-    warning notes the nonstandard boundary asymptotics. AMBIGUOUS
-    (loosely converged) and UNIDENTIFIED (curvature below the model's
-    own noise scale) parameters stay in the free block with warnings.
-    A strongly active inequality CONSTRAINT involving fitted
-    parameters pins a combination rather than a coordinate: the matrix
-    is projected on the constraint's null space, going singular by one
-    per binding row, and the surviving correlations say what the data
-    still determines (for a + b <= cap binding, corr(a, b) = -1: only
-    the difference is determined). The same limit written as a bound
-    or as a row returns the same matrix (jkitchin/pounce#362).
-
-    max_pdpert refuses rather than answering when the converged KKT
-    factor carries an inertia correction larger than the value given.
-    This inverts that factor, so a perturbed one answers for a nearby
-    problem rather than this one. It warns either way, and the cap is
-    the caller choosing to stop instead of to read the warning.
+    of= selects the block explicitly instead: a Var, a slice, a
+    (Var, iterable) pair, a VarData, or an iterable mixing them. See
+    `pounce.sensitivity.covariance` for the statistics and for what
+    sigma_sq=, n_data=, hessian= and max_pdpert= do.
     """
-    if hessian not in ("lagrangian", "gauss-newton"):
-        raise ValueError(
-            "sens_covariance: hessian must be 'lagrangian' or 'gauss-newton', "
-            f"got {hessian!r}")
-    reg = model.__dict__.get(_REG)
-    session = reg.session if reg else None
-    if session is None:
-        raise RuntimeError(
-            "no sensitivity session: declare_sens_fitted() (and optionally "
-            "declare_sens_residual()), or sens_retain_kkt() for "
-            "of= queries with nothing declared, then solve with "
-            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
-            "contrib SolverFactory('pounce') first")
-    # the block: the declared fitted parameters by default, or any
-    # block of the solve's variables via of= (each call re-reduces
-    # onto its own argument, so one solve serves as many blocks as are
-    # asked about, each getting that block's marginal)
-    params, rows = _resolve_of(session, of, "sens_covariance")
-    n_params = len(params)
-    wording = "fitted" if of is None else "block"
-    # sigma estimation divides by the FIT's degrees of freedom, a
-    # property of the solve, not of the block being asked about
-    n_fit = len(session.fit_rows)
-
-    # ── guardrails ────────────────────────────────────────────────────────
-    _check_margins(None, max_pdpert, "sens_covariance")
-    _refuse_on_pdpert(session, max_pdpert, "sens_covariance")
-    pert = np.asarray(session.solver.kkt_perturbations)
-    if pert.any():
-        warnings.warn(
-            "sens_covariance: the held KKT factor carries inertia-correction "
-            f"perturbations {pert.tolist()}, so the covariance is "
-            "regularized rather than exact. Linearly dependent (structurally"
-            " unidentifiable) parameters are the usual cause.")
-    # ── parameter block of the inverse KKT matrix ─────────────────────────
-    # `rows` is full-x (the space of the activity report and of
-    # row_normal, both read below); `krows` is the same variables as
-    # factor rows. Keep the two apart -- they differ exactly when the
-    # model has a fixed variable, and agree everywhere else.
-    dim = session.solver.kkt_dim
-    krows = [session.primal_row(r, f"sens_covariance({p.name})")
-             for r, p in zip(rows, params)]
-    zcols = []
-    for r in krows:
-        e = np.zeros(dim)
-        e[r] = 1.0
-        zcols.append(np.asarray(session.solver.kkt_solve(e)))
-    M = np.array([[zcols[j][krows[i]] for j in range(n_params)]
-                  for i in range(n_params)])
-    M = 0.5 * (M + M.T)
-
-    # a rank-deficient EXPLICIT block (more coordinates than the fit
-    # has degrees of freedom, e.g. a predicted trajectory) has a
-    # perfectly well-defined marginal covariance, 2 sigma^2 M; what it
-    # does not have is inv(M), which the membership classification
-    # needs. Gate on the count: LAPACK does not reliably raise on a
-    # structurally singular M (tiny nonzero pivots slip through and
-    # give garbage, not an error).
-    n_var, n_eq = _estimation_counts(session)
-    deficient = None
-    if of is not None:
-        if n_params > n_var - n_eq:
-            deficient = "count"
-        elif _rank_deficient(M):
-            # the count gate's own justification, one step to its
-            # left: LAPACK does not reliably raise on a structurally
-            # singular M, so a within-count dependent block needs its
-            # own gate (fp-detectable dependence; anything softer is
-            # caught by _SingularBlock below as a last resort).
-            # Diagonally scaled, so a badly-scaled but well-determined
-            # block is not refused for its units (second review)
-            deficient = "dependent"
-    if deficient is not None:
-        cb = None
-    else:
-        try:
-            cb = _classify_fitted_block(session, params, rows, M, zcols,
-                                        wording=wording)
-        except _SingularBlock:
-            if of is None:
-                raise
-            deficient = "dependent"
-            cb = None
-    if cb is not None:
-        sig_fit = cb.sig_fit
-        floor = cb.floor
-        R_corr = cb.R_corr
-        bind_normals = cb.bind_normals
-        row_corrections = cb.row_corrections
-
-    # ── noise variance per group ──────────────────────────────────────────
-    groups = dict(session.res_rows)
-    if hessian == "gauss-newton" and not groups:
-        raise ValueError(
-            "sens_covariance: hessian='gauss-newton' needs declared residuals "
-            "(declare_sens_residual()); the residual Jacobian is "
-            "recovered from "
-            "their rows. Without residual variables only the "
-            "hessian='lagrangian' default is available.")
-    if n_data is not None and (sigma_sq is not None or groups):
-        warnings.warn(
-            "sens_covariance: n_data is ignored because a "
-            "higher-precedence noise "
-            "source was given (sigma_sq, or the declared residuals).")
-    if sigma_sq is not None:
-        if isinstance(sigma_sq, dict):
-            named = [g for g in groups if g is not None]
-            if not named:
-                raise ValueError(
-                    "sens_covariance: sigma_sq was given as a "
-                    "per-group dict but "
-                    "no named residual groups were declared; pass a scalar "
-                    "sigma_sq, or declare grouped residuals with "
-                    "declare_sens_residual(..., group=...)")
-            missing = [g for g in groups if g not in sigma_sq]
-            if missing:
-                raise ValueError(
-                    "sens_covariance: sigma_sq is missing an entry "
-                    "for residual "
-                    f"group(s) {sorted(map(repr, missing))}")
-            group_sigma = {g: float(sigma_sq[g]) for g in groups}
-        else:
-            group_sigma = {g: float(sigma_sq) for g in (groups or {None: []})}
-    elif groups:
-        if n_fit == 0:
-            raise ValueError(
-                "sens_covariance: the noise variance must be estimated from "
-                "the declared residuals, but no fitted parameters were "
-                "declared, so the degrees of freedom for the estimate "
-                "are unknown; pass sigma_sq= (known variance) or flag "
-                "the fitted parameters with declare_sens_fitted()")
-        group_sigma = {}
-        for g, rws in groups.items():
-            n_g = len(rws)
-            if n_g <= n_fit:
-                raise ValueError(
-                    f"sens_covariance: residual group {g!r} has "
-                    f"{n_g} members, "
-                    f"not more than the {n_fit} fitted parameters; "
-                    "cannot estimate its noise variance")
-            ssr_g = float(np.sum(session.base_x[rws] ** 2))
-            group_sigma[g] = ssr_g / (n_g - n_fit)
-    elif n_data is not None:
-        if n_fit == 0:
-            raise ValueError(
-                "sens_covariance: n_data= estimates the noise variance, but "
-                "no fitted parameters were declared, so the degrees of "
-                "freedom for the estimate are unknown; pass sigma_sq= "
-                "(known variance) or flag the fitted parameters with "
-                "declare_sens_fitted()")
-        if n_data <= n_fit:
-            raise ValueError(
-                f"sens_covariance: n_data ({n_data}) must exceed the "
-                "number of "
-                f"fitted parameters ({n_fit})")
-        # the objective value AT THE SOLVE, not evaluated on the live
-        # model: pyo.value(objective) reads the model's current variable
-        # and Param values, so anything written after the solve (a
-        # measurement, a warm start for the next horizon) would silently
-        # rescale the covariance (gh #426)
-        if not np.isfinite(session.base_obj):
-            raise RuntimeError(
-                "sens_covariance: the solve reported no usable "
-                "objective value "
-                f"({session.base_obj}), so n_data= cannot estimate the "
-                "noise variance. Pass sigma_sq= (known variance), or "
-                "declare the residual container with declare_sens_residual().")
-        ssr = session.base_obj
-        group_sigma = {None: ssr / (n_data - n_fit)}
-    else:
-        raise ValueError(
-            "sens_covariance: the noise variance is unknown; declare the "
-            "residual container(s) with declare_sens_residual(), or pass "
-            "sigma_sq= (known variance), or pass n_data= (data count, "
-            "with the SSR taken from the solve-time objective value)")
-
-    # ── assemble ──────────────────────────────────────────────────────────
-    # Pooled covariance when there is one group or all group variances are
-    # equal to relative tolerance; otherwise the heteroscedastic sandwich.
-    sig_vals = list(group_sigma.values())
-    homoscedastic = len(sig_vals) <= 1 or (
-        max(sig_vals) - min(sig_vals)
-        <= 1e-12 * max(abs(v) for v in sig_vals)
-    )
-
-    def minv():
-        return _minv(M)
-
-    def group_jacobians():
-        # The Jacobian rows are recovered from the same backsolves: the
-        # residual rows of the z-columns equal J * inv(d2f/dp2), so
-        # J = Z_r * inv(M).
-        # No Sigma correction is needed on this path, by an exact
-        # identity: the residual rows of the K-inverse columns are J
-        # times the W-based parameter sensitivities, Z_r = J @ M, so
-        # Z_r @ inv(M) = J exactly and the factor's barrier weight
-        # cancels regardless of Sigma. The Lagrangian branch corrects
-        # R_W because it USES the W-based reduced Hessian; Gauss-Newton
-        # rebuilds from the exact J instead. Pinned empirically by the
-        # GN counterpart of the weakly-active analytic test.
-        Mi = minv()
-        out = {}
-        for g, rws in groups.items():
-            # res_rows is full-x like fit_rows; zcols are factor rows
-            Zr = np.array([[zcols[j][session.primal_row(r, "sens_covariance")]
-                            for j in range(n_params)]
-                           for r in rws])
-            out[g] = Zr @ Mi                  # d r_g / d p
-        return out
-
-    if cb is None:
-        # marginal-only path for a rank-deficient explicit block. The
-        # Gauss-Newton and heteroscedastic routes profile Jacobians
-        # through inv(M), so only the homoscedastic Lagrangian marginal
-        # exists here.
-        reason = ("more coordinates than the fit has degrees of "
-                  "freedom" if deficient == "count"
-                  else "linearly dependent coordinates")
-        if hessian == "gauss-newton" or not homoscedastic:
-            raise RuntimeError(
-                f"sens_covariance: the of= block is rank-deficient "
-                f"({reason}), so the profiled Jacobians behind "
-                "hessian='gauss-newton' and per-group noise are not "
-                "defined; only the homoscedastic hessian='lagrangian' "
-                "marginal is available for this block")
-        act = session.solver.classify_activity()
-        flagged = [p.name for i, p in enumerate(params)
-                   if act["var_status"][rows[i]] not in
-                   ("inactive", "unbounded", "fixed", "equality")]
-        if flagged:
-            warnings.warn(
-                f"sens_covariance: block members {flagged} have bound "
-                f"activity, but the block is rank-deficient ({reason}), "
-                "so the "
-                "membership handling (pinned parameters, binding rows) "
-                "is unavailable; the marginal is returned without it.")
-        cov = 2.0 * sig_vals[0] * M
-        cov = 0.5 * (cov + cov.T)
-        sig_out = (next(iter(group_sigma.values()))
-                   if len(group_sigma) == 1 and None in group_sigma
-                   else group_sigma)
-        return Covariance(
-            params, cov, sig_out,
-            lambda: _conditioned_on(session, act, rows, "sens_covariance"))
-
-    # Active-bound projection: the covariance is computed in the free
-    # (off-bound) directions and embedded with zero rows/cols for the
-    # pinned parameters, i.e. the covariance conditional on the active
-    # set. Restricting the INFORMATION matrix to the free block and
-    # inverting (not restricting the inverse) is the curve_fit
-    # _projected_covariance construction.
-    free = cb.free
-
-    def embed(cov_ff):
-        if len(free) == n_params:
-            return cov_ff
-        full = np.zeros((n_params, n_params))
-        if free:
-            full[np.ix_(free, free)] = cov_ff
-        return full
-
-    if not free:
-        cov = np.zeros((n_params, n_params))
-    elif hessian == "gauss-newton":
-        # Expected information: H_GN = 2 J^T J in place of the exact
-        # reduced Hessian. Pooled: cov = 2 s^2 inv(H_GN) = s^2 inv(J^T J).
-        # Grouped: cov = inv(J^T J) (sum_g s_g^2 Jg^T Jg) inv(J^T J).
-        Js = {g: Jg[:, free] for g, Jg in group_jacobians().items()}
-        G = sum(Jg.T @ Jg for Jg in Js.values())
-        Zb = _free_nullspace(bind_normals, free)
-        try:
-            if Zb.shape[1] == 0:
-                Ginv = np.zeros((len(free), len(free)))
-            else:
-                Ginv = Zb @ np.linalg.inv(Zb.T @ G @ Zb) @ Zb.T
-        except np.linalg.LinAlgError as e:
-            raise RuntimeError(
-                "sens_covariance: the Gauss-Newton matrix J^T J is singular; "
-                "the block members are linearly dependent in the "
-                "residual Jacobian") from e
-        if homoscedastic:
-            cov = embed(sig_vals[0] * Ginv)
-        else:
-            B = np.zeros((len(free), len(free)))
-            for g, Jg in Js.items():
-                B += group_sigma[g] * (Jg.T @ Jg)
-            cov = embed(Ginv @ B @ Ginv)
-    else:
-        if (not bind_normals and not row_corrections
-                and len(free) == n_params
-                and float(np.abs(sig_fit).max()) <= floor):
-            # nothing active, nothing to correct above noise scale: M
-            # is already the answer, and skipping inv(inv(M)) spares
-            # the conditioning round-trip on the common all-free path
-            Mc = M
-        else:
-            # R_corr is the reduced Hessian with the item-1 value
-            # corrections applied: the fitted rows' own barrier
-            # diagonal subtracted (a weakly active kept parameter
-            # reports its true curvature q, not the factor's 2q) and
-            # kept rows' barrier weight removed. Active rows and
-            # binding normals never enter: coordinates are excluded by
-            # the free restriction, directions are annihilated by the
-            # projection basis Z (which also annihilates the binding
-            # rows' huge barrier weight, exactly).
-            Rff = R_corr[np.ix_(free, free)]
-            Zb = _free_nullspace(bind_normals, free)
-            try:
-                if Zb.shape[1] == 0:
-                    Mc = np.zeros((len(free), len(free)))
-                else:
-                    Mc = Zb @ np.linalg.inv(Zb.T @ Rff @ Zb) @ Zb.T
-            except np.linalg.LinAlgError as e:
-                raise RuntimeError(
-                    "sens_covariance: the reduced Hessian restricted to the "
-                    "free (off-bound, off-constraint) members is "
-                    "singular; the remaining free block members are "
-                    "linearly dependent"
-                ) from e
-        if homoscedastic:
-            s2 = sig_vals[0]
-            cov = embed(2.0 * s2 * Mc)
-        else:
-            # heteroscedastic sandwich: cov = A^-1 B A^-1 with A = d2f/dp2
-            # and B built from per-group residual Jacobians.
-            B = np.zeros((len(free), len(free)))
-            for g, Jg in group_jacobians().items():
-                Jf = Jg[:, free]
-                B += group_sigma[g] * (Jf.T @ Jf)
-            # dtheta = -A^-1 * 2 J^T eps with A = d2f/dp2 = inv(M), so
-            # cov = 4 M (sum_g sigma_g^2 Jg^T Jg) M; the single-group case
-            # reduces to 2 sigma^2 M since J^T J = A/2.
-            cov = embed(4.0 * Mc @ B @ Mc)
-
-    cov = 0.5 * (cov + cov.T)
-    if np.diag(cov).min() < 0:
-        warnings.warn(
-            "sens_covariance: negative variance on the diagonal; the point is "
-            "probably not a least-squares minimum.")
-    sig_out = (next(iter(group_sigma.values()))
-               if len(group_sigma) == 1 and None in group_sigma
-               else group_sigma)
-    return Covariance(
-        params, cov, sig_out,
-        lambda: _conditioned_on(session, cb.act, rows, "sens_covariance"))
+    session = _model_session(model, _NO_SESSION_FIT)
+    params, rows = (None, None) if of is None else _resolve_of(
+        session, of, "sens_covariance")
+    return _core_covariance(
+        session, params, rows, sigma_sq=sigma_sq, n_data=n_data,
+        hessian=hessian, max_pdpert=max_pdpert, who="sens_covariance",
+        hints=_HINTS)
 
 
 def sens_information(model, hessian="lagrangian", of=None, max_pdpert=None):
     """The information matrix of the fitted parameters: the reduced
-    Hessian over the declared block, the un-inverted sibling of
-    sens_covariance(), from the same single solve.
+    Hessian `sens_covariance()` inverts.
 
-    Natural units and no sigma^2 anywhere (the core's convention;
-    sens_covariance() carries the 2*sigma^2 on top): for a homoscedastic
-    Lagrangian fit, sens_covariance() equals 2*sigma^2*inv(sens_information())
-    on the free block. hessian= selects the form exactly as in
-    sens_covariance(): "lagrangian" (default) is the observed information,
-    built by tangent recovery against the held factorization (the
-    K-inverse columns' x-blocks are T*M, so T = Zx*inv(M) exactly and
-    R = T'HT with the exact Lagrangian Hessian: machine precision for
-    equality and bound activity, no subtraction against the
-    barrier-augmented factor; a binding inequality row leaves ~1e-6
-    relative residue through its slack barrier). "gauss-newton" is the expected information 2*J'J, with J
-    recovered over ALL fitted parameters and sliced afterwards, so the
-    pinned rows exist to build their disposition from (requires
-    declared residuals, as in sens_covariance()).
-
-    Membership and warnings follow sens_covariance() exactly (item 1's
-    table): a free parameter's row is the reduced Hessian; a strongly
-    active parameter's block is S, the reduction onto the pinned set,
-    NOT a zero row, because zero information is the opposite of what a
-    pinned parameter carries; cross blocks between free and pinned are
-    zero. Binding constraint rows project the free block on both sides
-    (the pseudo-inverse of the projected covariance). An indefinite
-    Lagrangian block is returned as computed with a warning naming
-    Gauss-Newton as the PSD alternative: refusing would withhold the
-    finding that the point is not a minimum or the model is
-    over-parameterized.
-
-    of= selects the block exactly as in sens_covariance() (roadmap item
-    3): the declared fitted block by default, or any block of the
-    solve's variables. A block that parameterizes the constraint
-    manifold (size equal to the fit's degrees of freedom, the square
-    structure above) gets the exact tangent construction; a smaller
-    block reduces off the held factor with the item-1 corrections
-    (that route's documented precision); a rank-deficient block
-    carries no information matrix and is refused toward sens_covariance().
-    Strongly active variables outside the block come back as
-    .conditioned_on.
-
-    Returns an Information object keyed by the declared variables'
-    data objects: info[m.A, m.k], info.matrix, info.eigen().
-
-    max_pdpert refuses rather than answering when the converged KKT
-    factor carries an inertia correction larger than the value given.
-    This inverts that factor, so a perturbed one answers for a nearby
-    problem rather than this one. It warns either way, and the cap is
-    the caller choosing to stop instead of to read the warning.
+    Same block selection as `sens_covariance()`; see
+    `pounce.sensitivity.information`.
     """
-    if hessian not in ("lagrangian", "gauss-newton"):
-        raise ValueError(
-            "sens_information: hessian must be 'lagrangian' or "
-            "'gauss-newton', "
-            f"got {hessian!r}")
-    reg = model.__dict__.get(_REG)
-    session = reg.session if reg else None
-    if session is None:
-        raise RuntimeError(
-            "no sensitivity session: declare_sens_fitted() (and optionally "
-            "declare_sens_residual()), or sens_retain_kkt() for "
-            "of= queries with nothing declared, then solve with "
-            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
-            "contrib SolverFactory('pounce') first")
-    params, rows = _resolve_of(session, of, "sens_information")
-    n_params = len(params)
-    wording = "fitted" if of is None else "block"
-
-    _check_margins(None, max_pdpert, "sens_information")
-    _refuse_on_pdpert(session, max_pdpert, "sens_information")
-    pert = np.asarray(session.solver.kkt_perturbations)
-    if pert.any():
-        warnings.warn(
-            "sens_information: the held KKT factor carries inertia-correction "
-            f"perturbations {pert.tolist()}, so the information is "
-            "regularized rather than exact; the isotropic delta_w lands on "
-            "the free block and survives the projection.")
-
-    # `rows` is full-x (the space _classify_fitted_block reads the
-    # activity report and row_normal in); `krows` is the same variables
-    # as factor rows (gh #450): they differ exactly when the model has
-    # a fixed variable, and agree everywhere else
-    dim = session.solver.kkt_dim
-    krows = [session.primal_row(r, f"sens_information({p.name})")
-             for r, p in zip(rows, params)]
-    zcols = []
-    for r in krows:
-        e = np.zeros(dim)
-        e[r] = 1.0
-        zcols.append(np.asarray(session.solver.kkt_solve(e)))
-    M = np.array([[zcols[j][krows[i]] for j in range(n_params)]
-                  for i in range(n_params)])
-    M = 0.5 * (M + M.T)
-
-    n_var, n_eq = _estimation_counts(session)
-    def _refuse_rank(reason):
-        raise RuntimeError(
-            f"sens_information: the of= block is rank-deficient ({reason}), "
-            "so it carries no information matrix; its covariance "
-            "(sens_covariance(model, of=...)) is the meaningful object "
-            "for such a block")
-    if of is not None:
-        if n_params > n_var - n_eq:
-            _refuse_rank("more coordinates than the fit has degrees "
-                         "of freedom")
-        if _rank_deficient(M):
-            # the count gate one step to its left: LAPACK does not
-            # reliably raise on a structurally singular M. Diagonally
-            # scaled, so the refusal tracks collinearity and not the
-            # user's units (second review)
-            _refuse_rank("linearly dependent coordinates")
-    try:
-        cb = _classify_fitted_block(session, params, rows, M, zcols,
-                                    who="sens_information", wording=wording)
-    except _SingularBlock:
-        if of is None:
-            raise
-        _refuse_rank("linearly dependent coordinates")
-    free, active = cb.free, cb.active
-
-    if hessian == "gauss-newton":
-        groups = dict(session.res_rows)
-        if not groups:
-            raise ValueError(
-                "sens_information: hessian='gauss-newton' needs declared "
-                "residuals (declare_sens_residual()); the residual "
-                "Jacobian is "
-                "recovered from their rows. Without residual variables "
-                "only the hessian='lagrangian' default is available.")
-        Mi = _minv(M, "sens_information")
-        R = np.zeros((n_params, n_params))
-        for g, rws in groups.items():
-            # slice LAST: J over the whole fitted block, so the pinned
-            # rows exist for S below; res_rows is full-x like fit_rows,
-            # zcols are factor rows (gh #450)
-            Zr = np.array([[zcols[j][session.primal_row(r, "sens_information")]
-                            for j in range(n_params)]
-                           for r in rws])
-            Jg = Zr @ Mi
-            R += 2.0 * (Jg.T @ Jg)
-    else:
-        R = cb.R_exact
-        if R is None:
-            if n_var - n_eq == n_params:
-                R = _tangent_reduced_hessian(session, M, zcols,
-                                             "sens_information")
-            elif of is not None:
-                # a sub-block of the fitted set gets its marginal by
-                # Schur complement of the exact tangent R over the
-                # fitted block (never inverts a covariance, exact even
-                # with pinned members); any other explicit block
-                # reduces off the held factor with the item-1
-                # corrections, which is benign for free coordinates
-                # (no barrier term in the slice)
-                R = _subblock_information(session, rows,
-                                          n_var - n_eq, "sens_information")
-                if R is None:
-                    R = cb.R_corr
-            else:
-                raise RuntimeError(
-                    "sens_information: hessian='lagrangian' requires the "
-                    "square estimation structure (the equality "
-                    "constraints determine the non-fitted variables "
-                    "given the fitted block); this model has "
-                    f"{n_var} factor variables, {n_eq} equalities and "
-                    f"{n_params} fitted parameters, so "
-                    f"{n_var} - {n_eq} != {n_params} and the tangent "
-                    "recovery is not defined. hessian='gauss-newton' "
-                    "does not need it.")
-
-    info_mat = np.zeros((n_params, n_params))
-    if free:
-        Rff = R[np.ix_(free, free)]
-        Zb = _free_nullspace(cb.bind_normals, free)
-        if Zb.shape[1] == Rff.shape[0]:
-            info_ff = Rff
-        else:
-            # projected on both sides: the pseudo-inverse of the
-            # projected covariance (item 1's rule, identical in both
-            # accessors)
-            info_ff = Zb @ (Zb.T @ Rff @ Zb) @ Zb.T
-        info_mat[np.ix_(free, free)] = info_ff
-        if hessian == "lagrangian" and _indefinite(info_ff):
-            warnings.warn(
-                "sens_information: the Lagrangian free block is indefinite "
-                "(returned as computed): the point is not a "
-                "least-squares minimum along some direction, or the "
-                "model is over-parameterized. "
-                "hessian='gauss-newton' is the PSD alternative.")
-    if active:
-        # the pinned set's disposition is S, the reduction onto the
-        # pinned block, not a zero row: zero information is the
-        # opposite of what a pinned parameter carries. Conditional on
-        # the rest of the pinned set (item 1's caveat).
-        if free:
-            # rank-gate the free block before the solve: whether LAPACK
-            # raises on a singular system is BLAS-dependent (the CI
-            # wheel job's fresh numpy returned garbage where the local
-            # build raised), the same non-determinism the of= gates
-            # exist for; the exception clause stays as the last resort.
-            # Applies on the DEFAULT path too, not only under of=: a
-            # numerically dependent free block now refuses where it
-            # could previously return a large-but-meaningless S
-            # (CHANGELOG "Changed"). Diagonally scaled like the of=
-            # gates, so an ill-scaled but well-determined free block
-            # keeps its answer (second review)
-            R_FF = R[np.ix_(free, free)]
-            singular = _rank_deficient(R_FF)
-            if not singular:
-                try:
-                    S = (R[np.ix_(active, active)]
-                         - R[np.ix_(active, free)]
-                         @ np.linalg.solve(R_FF,
-                                           R[np.ix_(free, active)]))
-                except np.linalg.LinAlgError:
-                    singular = True
-            if singular:
-                raise RuntimeError(
-                    "sens_information: the free block is singular, so the "
-                    "pinned parameters' conditional information S is not "
-                    "defined; the free block members are linearly "
-                    "dependent")
-        else:
-            S = R[np.ix_(active, active)]
-        info_mat[np.ix_(active, active)] = S
-
-    return Information(
-        params, info_mat,
-        lambda: _conditioned_on(session, cb.act, rows, "sens_information"))
+    session = _model_session(model, _NO_SESSION_FIT)
+    params, rows = (None, None) if of is None else _resolve_of(
+        session, of, "sens_information")
+    return _core_information(
+        session, params, rows, hessian=hessian, max_pdpert=max_pdpert,
+        who="sens_information", hints=_HINTS)

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -17,7 +17,11 @@ authors = [{name = "John Kitchin", email = "jkitchin@andrew.cmu.edu"}]
 # API changes.
 dependencies = [
     "pyomo>=6.0",
-    "pounce-solver>=0.9.0",
+    # 0.11.0 is the first release carrying `pounce.sensitivity`, which
+    # holds every numeric this package's sens_* functions call. An older
+    # wheel imports but every sensitivity entry point raises ImportError,
+    # so the floor is a hard requirement, not a preference.
+    "pounce-solver>=0.11.0",
     "numpy",
     "pandas",
 ]
@@ -31,10 +35,13 @@ classifiers = [
 
 [project.optional-dependencies]
 # The `pyomo.contrib.solver` (v2) interface registered by
-# `pyomo_pounce.v2`. Both floors here are strictly tighter than the base
-# dependencies, and neither applies to the legacy
+# `pyomo_pounce.v2`. Neither floor here applies to the legacy
 # SolverFactory('pounce') plugin -- which is why the base stays where it
-# is and this is an extra: `pip install pyomo-pounce[pyomo-v2]`.
+# is and this is an extra: `pip install pyomo-pounce[pyomo-v2]`. The
+# `pyomo` floor is strictly tighter than the base one; the
+# `pounce-solver` one is now subsumed by the base `>=0.11.0` and is kept
+# because it records WHY the v2 route needs it, which stays true and
+# would be needed again if the base floor ever moved back.
 #
 # NAME: this extra must NOT be called `v2`, and more generally must never
 # parse as a PEP 440 version. An extra emits `; extra == "<name>"` into the

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -100,7 +100,7 @@ def test_eigen_sign_convention_is_deterministic():
     directions on two machines (issue #471). eigen() pins it: the
     largest-magnitude component of each eigenvector is positive, ties
     broken by the earliest `params` position."""
-    from pyomo_pounce.sens import _pin_eigenvector_signs
+    from pounce.sensitivity._stats import _pin_eigenvector_signs
     rng = np.random.default_rng(7)
     A = rng.standard_normal((4, 4))
     A = A + A.T
@@ -639,7 +639,7 @@ def test_mixed_normal_binding_row_warns_not_projects():
 
 
 def test_classify_ratio_covers_all_branches():
-    from pyomo_pounce.sens import _classify_ratio
+    from pounce.sensitivity._stats import _classify_ratio
     assert _classify_ratio(1e-12, 1e-10) == "inactive"
     assert _classify_ratio(1.0, 1e-10) == "weakly_active"
     assert _classify_ratio(1e12, 1e-10) == "strongly_active"
@@ -822,7 +822,7 @@ def test_classify_ratio_agrees_with_the_rust_classifier():
     the Python rule -- which only ever sees a ratio -- neither can nor
     should reproduce it.
     """
-    from pyomo_pounce.sens import _classify_ratio
+    from pounce.sensitivity._stats import _classify_ratio
 
     seen = set()
     for p, expected in ((1.0, "inactive"), (0.0, "weakly_active"),

--- a/pyomo-pounce/tests/test_information.py
+++ b/pyomo-pounce/tests/test_information.py
@@ -368,7 +368,7 @@ def test_indefinite_detector():
     """At a genuine minimum the reduced Hessian is PSD, so the branch
     cannot be reached by a healthy fixture; the detector is pinned
     directly instead."""
-    from pyomo_pounce.sens import _indefinite
+    from pounce.sensitivity._stats import _indefinite
     assert not _indefinite(np.array([[2.0, 0.0], [0.0, 3.0]]))
     assert _indefinite(np.array([[2.0, 0.0], [0.0, -0.5]]))
     assert not _indefinite(np.array([[1.0, 0.0], [0.0, -1e-14]]))

--- a/pyomo-pounce/tests/test_of_block.py
+++ b/pyomo-pounce/tests/test_of_block.py
@@ -19,7 +19,7 @@ from pyomo_pounce import (
     sens_covariance,
     sens_information,
 )
-from pyomo_pounce.sens import _rank_deficient
+from pounce.sensitivity._stats import _rank_deficient
 
 N = 25
 SIGMA = 0.3

--- a/pyomo-pounce/tests/test_sens_solution_report.py
+++ b/pyomo-pounce/tests/test_sens_solution_report.py
@@ -8,8 +8,8 @@ import pyomo.environ as pyo
 import pyomo_pounce  # noqa: F401  (registers 'pounce')
 from pyomo_pounce import (sens_active_set_changes, declare_sens_param, sens_solution,
                           sens_solution_report)
-from pyomo_pounce.sens import (_NO_BOUND, _perturbation_deltas, _ratio_test,
-                               _session_for)
+from pounce.sensitivity._step import _NO_BOUND, _ratio_test
+from pyomo_pounce.sens import _perturbation_deltas, _session_for
 
 
 # ── the ratio test on its own ────────────────────────────────────────────────

--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -34,6 +34,8 @@ from typing import Any, Callable, Mapping, Sequence
 
 import numpy as np
 
+from ._stats_util import nullspace as _nullspace
+
 from ._pounce import Solver
 from ._minimize import (
     _DEFAULT_ACCEPTABLE_TOL,
@@ -1775,11 +1777,7 @@ def _projected_covariance(M, s2, active_mask, A_gen, n):
     if not rows:                                        # nothing binds
         return s2 * np.linalg.pinv(M)
     A = np.vstack(rows)
-    # orthonormal nullspace basis of A via SVD (rank-robust).
-    _, sv, Vt = np.linalg.svd(A)
-    tol = max(A.shape) * np.finfo(float).eps * (sv[0] if sv.size else 0.0)
-    rank = int((sv > tol).sum())
-    Z = Vt[rank:].T                                     # (n, n - rank)
+    Z = _nullspace(A)                                   # (n, n - rank)
     if Z.shape[1] == 0:                                 # active set pins x fully
         return np.zeros((n, n))
     return s2 * Z @ np.linalg.pinv(Z.T @ M @ Z) @ Z.T

--- a/python/pounce/_stats_util.py
+++ b/python/pounce/_stats_util.py
@@ -1,0 +1,32 @@
+"""Small numerical helpers shared by the statistics in this package.
+
+`pounce.sensitivity` and `pounce.curve_fit` both project a covariance
+onto the subspace an active set leaves free, and both used to compute
+the basis for that subspace with their own copy of the same SVD. One
+copy, so a change to the rank tolerance reaches both.
+
+They do NOT share a covariance routine, and should not: `curve_fit`
+reads `inv(H_S)` straight off the factor because its parameters ARE the
+decision variables and `K = H_S`, while `pounce.sensitivity` recovers a
+tangent map because its fitted block sits inside a larger model with
+equalities. Same word, different computation.
+"""
+import numpy as np
+
+
+def nullspace(A):
+    """Orthonormal basis of the null space of `A`'s rows, as columns.
+
+    The projection basis `Z`: with `A` the active constraint normals,
+    the covariance lives in `span(Z)` and is zero along everything else.
+    Rank is read off the singular values at the standard relative
+    tolerance, so a redundantly listed constraint costs a dimension
+    once rather than twice.
+    """
+    A = np.atleast_2d(A)
+    if A.shape[0] == 0:
+        return np.eye(A.shape[1])
+    _, sv, vh = np.linalg.svd(A, full_matrices=True)
+    tol = max(A.shape) * np.finfo(float).eps * (sv[0] if sv.size else 1.0)
+    rank = int(np.sum(sv > tol))
+    return vh[rank:].T

--- a/python/pounce/sensitivity/__init__.py
+++ b/python/pounce/sensitivity/__init__.py
@@ -1,0 +1,70 @@
+"""Post-optimal sensitivity analysis against a held KKT factorization.
+
+One converged solve, and every question below is a back-solve against
+the factorization it left behind -- no re-solve, no finite differences.
+
+    import pounce
+    from pounce.sensitivity import SensSession, solution, covariance
+
+    nl = pounce.read_nl("model.nl")
+    solver = pounce.Solver(problem)
+    solver.solve(x0)
+
+    sess = SensSession(nl, solver, nl.var_names, nl.con_names,
+                       pins={"p": 4})
+    x_new = solution(sess, [4], [0.05])          # the moved solution
+    rep   = solution_report(sess, [4], [0.05])   # what it did about bounds
+
+A parameter is addressed by the full-g row of the defining equality it
+is pinned by; a fitted parameter or a residual by its full-x column or
+full-g row. Nothing here knows about a modelling layer:
+:mod:`pyomo_pounce` is one caller, and builds the same session from
+Pyomo components.
+
+See `docs/src/sensitivity.md`.
+"""
+from ._session import (
+    NlBridge,
+    SensSession,
+    row_index,
+    solve_for_sensitivity,
+    user_row_names,
+)
+from ._stats import (
+    DEFAULT_HINTS,
+    Covariance,
+    Information,
+    covariance,
+    information,
+)
+from ._step import (
+    ActiveSetChange,
+    SolutionReport,
+    active_set_changes,
+    check_margins,
+    refuse_on_pdpert,
+    solution,
+    solution_report,
+    weakly_active,
+)
+
+__all__ = [
+    "SensSession",
+    "solve_for_sensitivity",
+    "NlBridge",
+    "row_index",
+    "user_row_names",
+    "solution",
+    "solution_report",
+    "active_set_changes",
+    "SolutionReport",
+    "ActiveSetChange",
+    "covariance",
+    "information",
+    "Covariance",
+    "Information",
+    "DEFAULT_HINTS",
+    "weakly_active",
+    "check_margins",
+    "refuse_on_pdpert",
+]

--- a/python/pounce/sensitivity/_session.py
+++ b/python/pounce/sensitivity/_session.py
@@ -1,0 +1,336 @@
+"""The held-factor session the sensitivity analyses run against.
+
+A :class:`SensSession` is *a solved NL problem plus the KKT factorization
+the solve left behind*, with enough row bookkeeping for the analyses in
+this package to address the model in the caller's own terms. It owns no
+modelling layer: rows are integers, labels are whatever the caller keyed
+them with, and nothing here knows what a Pyomo component is.
+
+`pyomo_pounce` subclasses this, adding the component-keyed containers and
+the model handle its own API needs; every analysis in this package works
+against either, because each reads only the attributes declared here.
+"""
+import numpy as np
+
+
+def row_index(names):
+    """{name: position} for a `.col` / `.row` name list.
+
+    The NL writer emits unique symbolic labels, so first-wins and
+    last-wins agree; enumerate order matches `list.index` either way.
+    """
+    return {nm: i for i, nm in enumerate(names)}
+
+
+class SensSession:
+    """A converged solve, its held KKT factor, and the rows that name things.
+
+    Parameters
+    ----------
+    nl :
+        The problem the solve ran on, as returned by :func:`pounce.read_nl`.
+        Used for bounds (`x_l`, `x_u`, `g_l`, `g_u`) and for evaluating
+        `constraints()` and `gradient()` at a perturbed point.
+    solver : pounce.Solver
+        A solver whose `solve()` has converged, so the factor is live.
+    var_names, con_names : list of str
+        `.col` and `.row` order — the user's FULL-x and full-g spaces.
+    pins : mapping, optional
+        Ordered mapping {key: pin row} for the declared parameters, one
+        row each. Keys are opaque: this package uses them only to
+        preserve order and to label results.
+    pin_coefs, pin_bases : mapping, optional
+        `d(row)/d(param)` and the param's solve-time value, keyed like
+        `pins`, for parameters pinned through a defining equality the
+        caller wrote rather than a plain `var == p` row.
+    fit_rows : mapping, optional
+        Ordered mapping {key: full-x column} for the fitted parameters of
+        an estimation model.
+    res_rows : dict, optional
+        {group: [full-g rows]} for the residual rows of an estimation
+        model. `group` may be None for the ungrouped case.
+    con_alias : dict, optional
+        Original constraint name -> the name the solved model carries,
+        for callers whose solve ran on a rewritten copy.
+    moved_bounds : dict, optional
+        Variable name -> (lb, ub) that a bound held when the caller moved
+        it into a row. NOT refreshed when the bound's parameter later
+        moves: a reader needing the current bound evaluates the moved row.
+    """
+
+    def __init__(self, nl, solver, var_names, con_names, *, pins=None,
+                 pin_coefs=None, pin_bases=None, fit_rows=None,
+                 res_rows=None, con_alias=None, moved_bounds=None,
+                 var_row=None, con_row=None):
+        self.nl = nl
+        self.solver = solver
+        self.var_names = list(var_names)
+        self.con_names = list(con_names)
+        # Reverse maps for the two orders above. Every query resolves a
+        # name to its row, and a list scan makes that O(n) per lookup --
+        # quadratic for a whole-model Jacobian, which asks for every
+        # variable (gh#365). Built once here, or reused from the caller
+        # when it has already built them. `is None`, not truthiness: an
+        # unconstrained model's con_row is a legitimately empty dict,
+        # which `or` would discard and rebuild.
+        self._var_row = row_index(self.var_names) if var_row is None else var_row
+        self._con_row = row_index(self.con_names) if con_row is None else con_row
+        self.pins = {} if pins is None else pins
+        self.pin_coefs = {} if pin_coefs is None else pin_coefs
+        self.pin_bases = {} if pin_bases is None else pin_bases
+        self.fit_rows = {} if fit_rows is None else fit_rows
+        self.res_rows = {} if res_rows is None else res_rows
+        self.con_alias = {} if con_alias is None else con_alias
+        self.moved_bounds = {} if moved_bounds is None else moved_bounds
+        self.base_x = None
+        # Objective value at the solve. NaN, not None, is the "never
+        # computed" sentinel: that is the convention the engine itself
+        # uses for info["obj_val"] (pounce-py seeds final_obj with NaN
+        # precisely because 0.0 is an ordinary objective value and cannot
+        # signal it), so one isfinite check covers both an unset session
+        # and a solve that evaluated nothing.
+        self.base_obj = float("nan")
+        # Cached `grad_x f` at the solved point (gh#878). Evaluated at
+        # most once per session; a total derivative over an indexed
+        # parameter would otherwise re-evaluate it per column.
+        self._obj_grad = None
+        self._columns = {}            # pin row -> full KKT-space column
+        self._primal_rows = None      # full-x -> KKT row, lazily fetched
+        self._row_data = None         # user row name -> data, on demand
+        self._weakly_active_cache = None
+
+    # ── keys and containers ──────────────────────────────────────────
+    #
+    # The analyses report which variable or row something happened to.
+    # A subclass that has richer objects than names -- Pyomo component
+    # data, say -- overrides these three, and every result container in
+    # this package is keyed with them instead. The names are the
+    # default because they are what a bare NL solve has.
+
+    def var_key(self, full_idx):
+        """What results are keyed by for full-x column `full_idx`."""
+        return self.var_names[full_idx]
+
+    def row_key(self, full_row):
+        """What results are keyed by for full-g row `full_row`."""
+        return self.user_row_data()[full_row]
+
+    @staticmethod
+    def new_keymap():
+        """An empty mapping that accepts whatever `var_key` returns.
+
+        A plain dict here; `pyomo_pounce` returns a `ComponentMap`,
+        because Pyomo components are unhashable.
+        """
+        return {}
+
+    def user_row_data(self):
+        """What each solve row is called, in `.row` order.
+
+        The base session has only names. A subclass with real row
+        objects returns those, and None for a row with no counterpart in
+        the caller's model -- a pin row, say -- which the analyses skip.
+        """
+        if self._row_data is None:
+            self._row_data = list(user_row_names(self))
+        return self._row_data
+
+    # ── index spaces ─────────────────────────────────────────────────
+
+    def _primal_row_map(self):
+        if self._primal_rows is None:
+            self._primal_rows = self.solver.primal_rows(
+                list(range(len(self.var_names))))
+        return self._primal_rows
+
+    def primal_row(self, full_idx, what):
+        """The KKT-factor row of a user-space (`.col`) variable index.
+
+        `.col` order -- what `var_entry`, `fit_rows` and `res_rows` all
+        hold -- is the user's FULL-x space. The factor's `x` block is
+        the algorithm's var-x space, which drops every variable the
+        solve removed as fixed (`lb == ub` under the default
+        `fixed_variable_treatment=make_parameter`). The two spaces
+        coincide exactly when the model has no fixed variable, which is
+        every model in the test suite and most models anywhere, so
+        indexing the factor with a full-x row is invisible until it is
+        not: one fixed variable shifts every later column and the
+        back-solve quietly returns a NEIGHBOURING variable's
+        sensitivity, a plausible number with nothing wrong-looking
+        about it. Route every factor index through here.
+        """
+        row = self._primal_row_map()[full_idx]
+        if row is None:
+            raise ValueError(
+                f"{what}: {self.var_names[full_idx]} was removed from the "
+                "solve as a fixed variable (its bounds are equal), so it "
+                "has no row in the KKT factor and no sensitivity. Give it "
+                "distinct bounds to keep it in the solve.")
+        return row
+
+    def scatter_x(self, dx_var):
+        """Full-x vector from an algorithm-space (var-x) one.
+
+        `parametric_step` truncates its result to the factor's `x`
+        block, so it is var-x while `base_x`, `nl.x_l/x_u` and
+        `var_names` are all full-x. Variables the solve removed as
+        fixed get 0: a fixed variable does not move.
+        """
+        out = np.zeros(len(self.var_names))
+        for full_idx, row in enumerate(self._primal_row_map()):
+            if row is not None:
+                out[full_idx] = dx_var[row]
+        return out
+
+    # ── derived quantities ───────────────────────────────────────────
+
+    def objective_gradient(self):
+        """`grad_x f` at the solved point, in full-x (`.col`) order."""
+        if self._obj_grad is None:
+            if self.base_x is None:
+                raise ValueError(
+                    "objective gradient: the solve recorded no primal "
+                    "point, so it cannot be evaluated")
+            self._obj_grad = np.asarray(self.nl.gradient(self.base_x),
+                                        dtype=float)
+        return self._obj_grad
+
+    def total_objective_derivative(self, col):
+        """`df/dp` for the KKT derivative column `col` (gh#878).
+
+        The chain rule is
+
+            df/dp  =  df/dp|_x  +  sum_i (df/dx_i)(dx_i/dp)
+
+        and both terms fall out of a single contraction here, because a
+        declared sensitivity parameter is an ordinary coordinate of the
+        solve: it has been rewritten into a variable pinned by a
+        defining equality, so `objective_gradient()` carries `df/dp|_x`
+        in `p`'s own slot and the step carries `dp/dp = 1` there.
+        Contracting the two therefore picks up the explicit partial and
+        the implicit sum in one product, with no separate `grad_p f`
+        term to assemble and no second index convention to get wrong.
+
+        Written as a dot product over **full-x**, not the factor's
+        var-x: `scatter_x` is what reconciles them, and a model carrying
+        one fixed variable is where the two diverge. Contracting a
+        full-x gradient with a var-x step would silently pair `df/dx_i`
+        with a NEIGHBOURING variable's sensitivity from the first fixed
+        variable on -- gh#450 and gh#672 finding 1, the same defect
+        twice. `sens_invariance_legs` leg 3 is the guard.
+        """
+        return float(self.objective_gradient() @ self.scatter_x(col))
+
+    def column(self, pin_idx):
+        """Full KKT-space derivative column for a unit perturbation."""
+        if pin_idx not in self._columns:
+            self._columns[pin_idx] = np.asarray(
+                self.solver.parametric_step_full([pin_idx], [1.0]))
+        return self._columns[pin_idx]
+
+    def var_entry(self, name):
+        """The full-x column of variable `name`."""
+        # ValueError, not the dict's KeyError: this used to be a list
+        # scan and callers (and the message a user sees) expect it.
+        try:
+            return self._var_row[name]
+        except KeyError:
+            raise ValueError(
+                f"{name}: not a variable of the solved model") from None
+
+    def mult_entry(self, con_name):
+        """The KKT row of constraint `con_name`'s multiplier."""
+        # a caller whose solve ran on a rewritten copy translates the
+        # original name to the copy's row
+        con_name = self.con_alias.get(con_name, con_name)
+        try:
+            g = self._con_row[con_name]
+        except KeyError:
+            raise ValueError(
+                f"{con_name}: not a constraint of the solved model") from None
+        row = self.solver.multiplier_rows([g])[0]
+        if row is None:
+            raise ValueError(
+                f"{con_name}: multiplier sensitivities are only available "
+                "for equality constraints")
+        return row
+
+
+def user_row_names(session):
+    """`con_names` in the caller's own naming, pin rows included."""
+    back = {clone: orig for orig, clone in session.con_alias.items()}
+    return [back.get(nm, nm) for nm in session.con_names]
+
+
+class NlBridge:
+    """cyipopt-style callback object backed by `read_nl` evaluators.
+
+    `pounce.Problem` wants an object with the cyipopt callback names;
+    an `NlProblem` from :func:`pounce.read_nl` or
+    :func:`pounce.build_nl_problem` spells two of them differently.
+    This is the adapter, and it is the same one `pyomo_pounce` uses.
+    """
+
+    def __init__(self, nl):
+        self._nl = nl
+
+    def objective(self, x):
+        return self._nl.objective(x)
+
+    def gradient(self, x):
+        return self._nl.gradient(x)
+
+    def constraints(self, x):
+        return self._nl.constraints(x)
+
+    def jacobianstructure(self):
+        return self._nl.jacobian_structure()
+
+    def jacobian(self, x):
+        return self._nl.jacobian(x)
+
+    def hessianstructure(self):
+        return self._nl.hessian_structure()
+
+    def hessian(self, x, lam, obj_factor):
+        return self._nl.hessian(x, lam, obj_factor)
+
+
+def solve_for_sensitivity(nl, x0=None, options=None, var_names=None,
+                          con_names=None, **session_kwargs):
+    """Solve `nl` and return a :class:`SensSession` over the held factor.
+
+    The one-call route for a caller who has a `.nl` file (or a problem
+    built with :func:`pounce.build_nl_problem`) and wants the
+    sensitivity surface over it::
+
+        nl = pounce.read_nl("model.nl")
+        sess = solve_for_sensitivity(nl, pins={"p": 4})
+        dx = solution(sess, [4], [0.05])
+
+    Returns the session; the solved point is `sess.base_x` and the
+    solver is `sess.solver`. Extra keyword arguments are passed to
+    :class:`SensSession`, which is how the pin, fitted and residual rows
+    are declared.
+
+    `bound_relax_factor` is set to 0 before the caller's options,
+    because the activity classification every statistic here leans on
+    reads slacks against the user's own bounds and the default
+    relaxation shifts every one of them. Pass it explicitly to override.
+    """
+    import pounce
+
+    prob = pounce.Problem(nl.n, nl.m, NlBridge(nl), lb=nl.x_l, ub=nl.x_u,
+                          cl=nl.g_l, cu=nl.g_u)
+    prob.add_option("bound_relax_factor", 0.0)
+    for key, val in (options or {}).items():
+        prob.add_option(key, val)
+    solver = pounce.Solver(prob)
+    x, info = solver.solve(np.asarray(nl.x0 if x0 is None else x0))
+
+    names = list(var_names if var_names is not None else nl.var_names)
+    rows = list(con_names if con_names is not None else nl.con_names)
+    session = SensSession(nl, solver, names, rows, **session_kwargs)
+    session.base_x = np.asarray(x, dtype=float)
+    session.base_obj = float(info.get("obj_val", float("nan")))
+    return session

--- a/python/pounce/sensitivity/_stats.py
+++ b/python/pounce/sensitivity/_stats.py
@@ -1,0 +1,1448 @@
+"""Parameter covariance, the information matrix, and identifiability.
+
+What one converged solve says about how well the data pinned the fitted
+parameters down. :func:`covariance` is the asymptotic covariance of a
+least-squares estimate; :func:`information` is the reduced Hessian it
+inverts, which is the object that stays finite when the block is
+rank-deficient and the covariance does not.
+
+Both take a :class:`~pounce.sensitivity.SensSession` and a *block*: the
+parameters the answer is about, as an ordered list of keys with their
+full-x rows. Omit it and the session's declared `fit_rows` block is
+used. Keys are opaque -- they order the result and label it -- so a
+caller with richer objects than names keys the result by those.
+"""
+import warnings
+
+import numpy as np
+
+from .._stats_util import nullspace as _nullspace
+from ._step import check_margins, refuse_on_pdpert
+
+#: How the caller spells the declarations these diagnostics point at.
+#: The core is told rather than assuming, because a bare-NL caller and
+#: `pyomo_pounce` declare fitted parameters and residual rows very
+#: differently, and a message naming the wrong declaration is worse
+#: than one naming none.
+DEFAULT_HINTS = {
+    "fitted": "fit_rows=",
+    "residual": "res_rows=",
+    "residual_group": "res_rows={group: rows}",
+}
+
+
+def _label(key):
+    """What to call a block member in a diagnostic.
+
+    A caller keying the block by rich objects gets their `.name`; one
+    keying it by the variable's own name gets the name back.
+    """
+    return getattr(key, "name", key)
+
+
+def _resolve_block(session, params, rows, who, hints):
+    """The block to answer about: the caller's, or the declared one.
+
+    `params` and `rows` come in already resolved -- normalizing a
+    modelling layer's way of naming a block is that layer's job, not
+    this one's.
+    """
+    if params is not None:
+        rows = list(rows)
+        params = list(params)
+        if len(params) != len(rows):
+            raise ValueError(
+                f"{who}: the block has {len(params)} keys but "
+                f"{len(rows)} rows")
+        if not params:
+            raise ValueError(f"{who}: the block is empty")
+        return params, rows
+    params = list(session.fit_rows.keys())
+    if not params:
+        raise RuntimeError(
+            f"{who}: no fitted parameters were declared; give the "
+            f"session a {hints['fitted']} block before the solve, or "
+            "pass one explicitly")
+    return params, [session.fit_rows[p] for p in params]
+
+class _ParamKeyed:
+    """Lookup from a block member's key to its position.
+
+    Keyed by id() rather than by value, so a caller whose keys are
+    unhashable objects -- Pyomo component data, say -- can use them
+    directly. The key list is held alongside, because an id is unique
+    only among live objects."""
+
+    _who = "covariance"          # accessor name used in diagnostics
+
+    def __init__(self, params):
+        self._params = list(params)
+        self._pos = {id(p): i for i, p in enumerate(self._params)}
+
+    def _loc(self, pd):
+        i = self._pos.get(id(pd))
+        if i is None:
+            raise KeyError(f"{getattr(pd, 'name', pd)}: not one of the "
+                           f"{self._who} parameters")
+        return i
+
+
+class _ParamVector(_ParamKeyed):
+    """Vector keyed by param data: v[m.k1] -> float."""
+
+    def __init__(self, params, values):
+        super().__init__(params)
+        self.values = np.asarray(values, dtype=float)
+
+    def __getitem__(self, pd):
+        return float(self.values[self._loc(pd)])
+
+
+class _ParamMatrix(_ParamKeyed):
+    """Symmetric matrix keyed by param data: M[m.k1, m.k2] (either
+    order) or M[m.k1] for a diagonal entry."""
+
+    def __init__(self, params, matrix):
+        super().__init__(params)
+        self.matrix = np.asarray(matrix, dtype=float)
+
+    def __getitem__(self, key):
+        if isinstance(key, tuple):
+            i, j = (self._loc(k) for k in key)
+        else:
+            i = j = self._loc(key)
+        return float(self.matrix[i, j])
+
+
+def _pin_eigenvector_signs(vecs):
+    """Fix the arbitrary sign LAPACK gives each eigenvector column, so
+    the direction an eigen() call reports is reproducible.
+
+    `v` and `-v` are equally valid eigenvectors, and which one `eigh`
+    returns is a convention of the LAPACK build, not a property of the
+    matrix: the same model and data can report opposite directions on
+    two machines. The convention here is the largest-magnitude
+    component positive, ties broken by the earliest `params` position
+    (argmax takes the first maximum). It is scale-invariant and
+    independent of parameter ordering except through that tie-break.
+
+    This pins the sign only. A repeated eigenvalue leaves the basis
+    WITHIN its eigenspace arbitrary — any rotation of those columns
+    diagonalizes just as well — so the individual eigenvectors of a
+    degenerate block are still not reproducible; only the subspace
+    they span is."""
+    vecs = np.asarray(vecs, dtype=float)
+    if vecs.size == 0:
+        return vecs
+    lead = np.abs(vecs).argmax(axis=0)
+    signs = np.sign(vecs[lead, np.arange(vecs.shape[1])])
+    signs[signs == 0.0] = 1.0        # an all-zero column, if one ever
+    return vecs * signs              # reaches here, is left alone
+
+
+class Covariance(_ParamMatrix):
+    """Asymptotic parameter covariance, from covariance().
+
+    Keyed by the block members' own keys -- the fitted variables, not
+    the model's parameters -- in `params` order: cov[m.k1, m.k2] (either order),
+    cov[m.k1] for a variance, cov.std_err[m.k1],
+    cov.correlation[m.k1, m.k2]. `matrix` is the dense numpy array
+    ordered like `params`; `sigma_sq` is the residual variance that was
+    used. eigen() supports identifiability diagnosis."""
+
+    def __init__(self, params, matrix, sigma_sq, conditioned_on=()):
+        super().__init__(params, matrix)
+        self.params = self._params
+        self.sigma_sq = sigma_sq          # float, or {group: float}
+        self._conditioned = conditioned_on
+        with np.errstate(invalid="ignore", divide="ignore"):
+            se = np.sqrt(np.diag(self.matrix))
+            corr = self.matrix / np.outer(se, se)
+        # entries whose scale is undefined (a projected bound-active
+        # parameter has exactly zero variance) are reported as 0
+        corr[~np.isfinite(corr)] = 0.0
+        self.std_err = _ParamVector(self.params, se)
+        self.correlation = _ParamMatrix(self.params, corr)
+
+    @property
+    def conditioned_on(self):
+        """Strongly active variables OUTSIDE the block: the matrix is
+        conditional on those bounds (roadmap item 3); empty when none.
+        Computed on first access (one backsolve per near-bound
+        candidate) and cached, so calls that never read it pay
+        nothing. Until first access the pending computation keeps the
+        sensitivity session, and so the held KKT factor, alive; read
+        it (or discard the result) to release them."""
+        if callable(self._conditioned):
+            self._conditioned = self._conditioned()
+        return self._conditioned
+
+    def eigen(self):
+        """(eigenvalues, eigenvectors) of the covariance matrix,
+        eigenvalues ascending, eigenvectors[:, i] in `params` order.
+        An eigenvalue much larger than the rest flags a poorly
+        identified direction: its eigenvector gives the parameter
+        combination the data cannot pin down.
+
+        Each eigenvector's sign is pinned so the direction it names
+        reproduces across machines: its largest-magnitude component
+        is positive (see _pin_eigenvector_signs)."""
+        w, v = np.linalg.eigh(self.matrix)
+        return w, _pin_eigenvector_signs(v)
+
+
+def _indefinite(block):
+    """A symmetric block with a genuinely negative eigenvalue, at a
+    tolerance relative to the block's own scale. At a strict local
+    minimum with LICQ the reduced Hessian is PSD, so this fires only
+    on non-minimum stationary points or regularized (inertia-
+    corrected) convergence: exactly the finding worth returning
+    rather than refusing."""
+    if block.size == 0:
+        return False
+    ev_min = float(np.linalg.eigvalsh(block).min())
+    scale = float(np.abs(block).max())
+    return ev_min < -1e-10 * max(1.0, scale)
+
+
+def _estimation_counts(session):
+    """(#factor variables, #equality rows). The tangent recovery is
+    the constrained tangent map only when n_var - n_eq equals the
+    number of fitted parameters: the equalities then determine the
+    non-fitted variables given the fitted block. Callers guard on
+    this, because outside it T = Zx inv(M) is quietly not the tangent
+    map and R would be silently wrong."""
+    n_var = sum(1 for r in session._primal_row_map() if r is not None)
+    g_l = np.asarray(session.nl.g_l)
+    g_u = np.asarray(session.nl.g_u)
+    return n_var, int(np.count_nonzero(g_l == g_u))
+
+
+def _tangent_reduced_hessian(session, M, zcols, who="covariance"):
+    """The reduced Hessian over the fitted block, by tangent recovery:
+    the x-blocks of the K-inverse columns are T*M (each satisfies the
+    equalities and has the fitted block as its own coordinates), so
+    T = Zx inv(M) exactly, with the factor's barrier weight cancelling
+    multiplicatively rather than by subtraction. Then R = T^T H T with
+    the exact Lagrangian Hessian (covariance roadmap item 2).
+
+    Machine-exact for equality and variable-bound activity (everything
+    in W cancels multiplicatively, pinned variables included), verified
+    against analytic ground truth where the subtraction route loses
+    log10(Sigma/q) digits. A binding INEQUALITY row instead couples
+    through its slack barrier with large-but-finite weight, tilting
+    the recovered tangent along that row's normal: measured ~1e-6
+    relative at practical mu, degrading as mu tightens (the pinned
+    combination drives M toward singularity), still ~6 digits beyond
+    the subtraction it replaces. Requires the square estimation
+    structure of _estimation_counts(); callers guard."""
+    # the factor's x block is var-x (a fixed variable's column is
+    # removed under make_parameter, gh #450), so slice that block and
+    # scatter each tangent back to full-x for hessian_vec, whose
+    # contract is user-space with zeros on the removed columns
+    n_var = sum(1 for r in session._primal_row_map() if r is not None)
+    Zx = np.column_stack([z[:n_var] for z in zcols])
+    T = np.column_stack(
+        [session.scatter_x(col) for col in (Zx @ _minv(M, who)).T])
+    HT = np.column_stack([
+        np.asarray(session.solver.hessian_vec(T[:, j]))
+        for j in range(T.shape[1])
+    ])
+    R = T.T @ HT
+    return 0.5 * (R + R.T)
+
+
+_WORDING = {
+    # the default block IS the fitted set, and saying so is strictly
+    # more informative there; an arbitrary of= block gets the
+    # block-relative nouns (review of gh #466)
+    "fitted": {"member": "fitted parameter",
+               "outside": "non-fitted variables",
+               "reach": "the fitted parameters",
+               "combo": "fitted combination",
+               "scale": "the fitted block's"},
+    "block": {"member": "block member",
+              "outside": "variables outside the block",
+              "reach": "the block",
+              "combo": "block combination",
+              "scale": "the block's"},
+}
+
+
+def _classify_fitted_block(session, params, rows, M, zcols,
+                           who="covariance", wording="fitted"):
+    """Membership and row handling shared by covariance() and
+    information(): item 1's classification at the reduced fitted
+    block, the value-correction bookkeeping, and the binding-row
+    normals, with the warnings both accessors owe their callers.
+    Returns a namespace consumed by each accessor's own assembly."""
+    from types import SimpleNamespace
+
+    W = _WORDING[wording]
+    n_params = len(params)
+    # ── membership from the barrier activity classification ──────────────
+    # (covariance roadmap item 1). The classifier's per-coordinate rule
+    # scales Sigma by the coordinate's own Lagrangian curvature, which is
+    # zero for a fitted parameter in the residual-variable idiom (the
+    # curvature lives on the residuals), so the same rule runs HERE on
+    # the reduced fitted block, where the parameter's curvature actually
+    # is: q = the reduced Hessian diagonal with the parameter's own
+    # barrier term removed, Sigma retained by the solve. A weakly active
+    # parameter is KEPT and warned rather than silently pinned; no slack
+    # threshold can make that distinction, because slack and multiplier
+    # are both O(sqrt(mu)) at weak activity.
+    R_exact = None
+    act = session.solver.classify_activity()
+    mu = float(act["mu"])
+    R_W = _minv(M, who)                # reduced Hessian off the factor, W-based
+    # M (and so R_W) is natural-units by the kkt_solve contract
+    # (pounce#128), and so are the report's sigmas and row_normal
+    # (unscaled at the classifier boundary per the same contract), so
+    # everything here composes without scale factors.
+    sig_fit = np.array([float(act["var_sigma"][r]) for r in rows])
+    q_red = np.abs(np.diag(R_W) - sig_fit)
+    floor = np.sqrt(np.finfo(float).eps) * max(
+        1.0, float(np.abs(np.diag(R_W)).max()))
+    active = []
+    for i, p in enumerate(params):
+        st = act["var_status"][rows[i]]
+        if st in ("unbounded", "fixed"):
+            continue                       # no variable bound to classify
+        ri = float(sig_fit[i]) / max(float(q_red[i]), floor)
+        if q_red[i] < floor and ri <= 1e1:
+            # curvature AND barrier weight both below scale: the bound
+            # question does not arise, but the direction is poorly
+            # identified (a dominant Sigma cancelling inside q_red
+            # instead lands ri astronomically high and classifies
+            # strongly active)
+            status = "unidentified"
+        else:
+            status = _classify_ratio(ri, mu)
+        if status == "strongly_active":
+            active.append(i)
+            warnings.warn(
+                f"{who}: {W['member']} {_label(p)} is held by its "
+                "bound at the optimum (strongly active); its direction is "
+                "projected out (zero variance, conditional on the active "
+                "bound) and the boundary asymptotics are nonstandard.")
+        elif status == "weakly_active":
+            warnings.warn(
+                f"{who}: {W['member']} {_label(p)} sits exactly on "
+                "its bound with a vanishing multiplier (weakly active). "
+                "It is kept in the free block with finite variance; "
+                "boundary asymptotics are nonstandard.")
+        elif status == "ambiguous":
+            warnings.warn(
+                f"{who}: {W['member']} {_label(p)} has ambiguous "
+                "bound activity at the solve's final barrier parameter; "
+                "re-solve with a tighter tol to settle it. It is kept in "
+                "the free block.")
+        elif status == "unidentified":
+            warnings.warn(
+                f"{who}: {W['member']} {_label(p)} has curvature "
+                "below the model's own noise scale (unidentified); its "
+                "variance is large rather than small. It is kept in the "
+                "free block.")
+
+    # ── binding general rows on the fitted block ──────────────────────────
+    # (item 1 row projection, jkitchin/pounce#362). A strongly active
+    # inequality row whose normal touches the fitted parameters pins a
+    # DIRECTION of the fitted block: no per-parameter disposition can
+    # state that, so the free block is reduced on the null space of the
+    # binding normals and pushed back, singular by the number of binding
+    # rows. Rows classify at the reduced level exactly as the variable
+    # bounds above: the row's barrier weight against the curvature along
+    # its own normal. A bound moved onto a row by declared-parameter
+    # reformulation (jkitchin/pounce#357) is the single-coordinate case
+    # and reproduces the variable disposition exactly.
+    R_corr = R_W - np.diag(sig_fit)
+    # columns held constant by the declared-parameter pins: a row's
+    # support there contributes nothing through elimination (the pin
+    # variable cannot move), so it does not make the row "mixed". The
+    # pin constraint's normal is e_{pin var}, so its support IS the
+    # pin column.
+    pin_cols = set()
+    for _pr in session.pins.values():
+        _pn = np.asarray(session.solver.row_normal(int(_pr)), dtype=float)
+        pin_cols.update(int(i) for i in np.nonzero(_pn)[0])
+    fit_cols = set(int(r) for r in rows)
+    bind_normals = []                  # unit normals over the fitted block
+    row_corrections = []               # (weight, unit normal), applied after
+    for j, rst in enumerate(act["row_status"]):
+        if rst in ("equality", "unbounded", "inactive"):
+            # inactive rows carry O(mu) geometric weight (the invariant
+            # form), the same order as every other accepted O(mu) term;
+            # skipping them also avoids fetching every row normal on
+            # wide models (an O(m*n) sweep). The bound and row
+            # spellings of an INACTIVE limit therefore agree to O(mu)
+            # rather than exactly, tested at that tolerance.
+            continue
+        a_full = np.asarray(session.solver.row_normal(j), dtype=float)
+        a = a_full[rows]
+        na = float(np.linalg.norm(a))
+        # A row whose normal also touches NON-fitted variables pins a
+        # combination that reaches the fitted block through the
+        # eliminated variables, not along the restricted normal: e.g.
+        # a + r_1 <= cap with r_1 = y_1 - a - b*x_1 actually pins a
+        # b-direction, while the restricted normal reads e_a. The
+        # restricted projection would delete the wrong direction, so a
+        # mixed binding row is kept unprojected with an explicit
+        # warning instead. The general treatment needs the row's
+        # reduced normal through the elimination (roadmap item 2's
+        # machinery).
+        nf = float(np.linalg.norm(a_full))
+        outside = [i for i in np.nonzero(a_full)[0]
+                   if int(i) not in fit_cols and int(i) not in pin_cols]
+        mixed = bool(outside) and (
+            float(np.linalg.norm(a_full[outside])) > 1e-8 * max(1.0, nf))
+        if na <= 1e-12 * max(1.0, nf):
+            # entirely outside the fitted block: the extreme mixed case
+            # (relative tolerance, matching the mixed test above)
+            mixed = True
+        cname = (session.con_names[j] if j < len(session.con_names)
+                 else f"row {j}")
+        if mixed:
+            # the reduced-level rule is also unreliable here: the row's
+            # barrier weight lands through elimination on a direction
+            # the restricted normal cannot see, so re-classifying
+            # against it manufactures a wrong ratio. Item 0's raw
+            # classification (scale-invariant along the full normal) is
+            # the honest status for a mixed row.
+            if rst == "strongly_active":
+                warnings.warn(
+                    f"{who}: constraint {cname} is strongly active "
+                    f"and involves {W['outside']}; the "
+                    f"direction it pins reaches {W['reach']} through the "
+                    "eliminated variables and cannot be represented by "
+                    "a restricted normal, so it is NOT projected. Treat "
+                    "the returned variances as not conditioned on this "
+                    "constraint.")
+            elif rst in ("weakly_active", "ambiguous", "unidentified"):
+                warnings.warn(
+                    f"{who}: constraint {cname} is {rst} and "
+                    f"involves {W['outside']}; it is kept "
+                    "unprojected and its barrier weight is not "
+                    "corrected for (the restricted direction would be "
+                    "the wrong one). Boundary asymptotics are "
+                    "nonstandard.")
+            continue
+        a = a / na
+        # the row's slack elimination contributes Sigma_j * (raw normal
+        # outer product) to the reduced block; in the unit-normal basis
+        # that coefficient is Sigma_j * ||raw normal||^2 (all natural
+        # units: the report unscales at the classifier boundary)
+        sig_row = float(act["row_sigma"][j]) * na * na
+        q_w = float(a @ R_corr @ a)
+        # |q|, matching the Rust classifier: indefinite curvature
+        # classifies on magnitude, and indefiniteness still surfaces
+        # through the negative-variance warning downstream
+        q_row = abs(q_w - sig_row)
+        ri = sig_row / max(q_row, floor)
+        if q_row < floor and ri <= 1e1:
+            status = "unidentified"
+        else:
+            status = _classify_ratio(ri, mu)
+        combo = " + ".join(
+            f"{a[k]:.3g}*{_label(params[k])}" for k in range(n_params)
+            if abs(a[k]) > 1e-12)
+        if status == "strongly_active":
+            bind_normals.append(a)
+            # conditional information along the pinned combination via
+            # the tangent-recovered reduced Hessian (item 2 machinery;
+            # lazy, only solves with a binding row pay the Hessian
+            # products). Accurate to ~1e-6 at practical mu, the residue
+            # being this row's own finite slack-barrier weight in the
+            # recovery, where the factor subtraction lost ten digits.
+            # Outside the square estimation structure the recovery is
+            # undefined, so the subtraction value is kept there.
+            if R_exact is None:
+                n_var, n_eq = _estimation_counts(session)
+                if n_var - n_eq == n_params:
+                    R_exact = _tangent_reduced_hessian(
+                        session, M, zcols, who)
+            if R_exact is not None:
+                s_a = float(a @ R_exact @ a)
+            else:
+                s_a = max(q_w - sig_row, 0.0)
+            warnings.warn(
+                f"{who}: constraint {cname} is strongly active and "
+                f"pins the {W['combo']} {combo}; variance along it "
+                "is projected to zero (conditional on the constraint). "
+                f"Conditional information along the combination: {s_a:.6g}.")
+        elif status == "weakly_active":
+            warnings.warn(
+                f"{who}: constraint {cname} is weakly active on the "
+                f"{W['combo']} {combo} (multiplier and slack vanish "
+                "together). It is kept unprojected with finite variance; "
+                "boundary asymptotics are nonstandard.")
+        elif status == "ambiguous":
+            warnings.warn(
+                f"{who}: constraint {cname} has ambiguous activity "
+                f"on the {W['combo']} {combo} at the solve's final "
+                "barrier parameter; re-solve with a tighter tol to "
+                "settle it. It is kept unprojected.")
+        elif status == "unidentified":
+            warnings.warn(
+                f"{who}: constraint {cname} has curvature below "
+                f"{W['scale']} noise scale on {combo} "
+                "(unidentified); it is kept unprojected and its "
+                "variance is large rather than small.")
+        if status in ("weakly_active", "ambiguous"):
+            # collected, applied after the loop: every row classifies
+            # against the same snapshot, so results do not depend on
+            # the order rows happen to be visited in
+            row_corrections.append((sig_row, a))
+    for _w, _a in row_corrections:
+        # the row analog of the variable value correction: remove a
+        # kept row's own barrier weight from the reduced block
+        R_corr = R_corr - _w * np.outer(_a, _a)
+    ns = SimpleNamespace()
+    ns.act = act
+    ns.mu = mu
+    ns.R_W = R_W
+    ns.sig_fit = sig_fit
+    ns.floor = floor
+    ns.active = active
+    ns.free = [i for i in range(n_params) if i not in active]
+    ns.R_corr = R_corr
+    ns.bind_normals = bind_normals
+    ns.row_corrections = row_corrections
+    ns.R_exact = R_exact
+    return ns
+
+
+class Information(_ParamMatrix):
+    """Observed or expected information over the fitted block, from
+    information(). Keyed like Covariance: info[m.k1, m.k2] (either
+    order), info[m.k1] for a diagonal entry; `matrix` is the dense
+    numpy array in `params` (declaration) order. Natural units, no
+    sigma^2 anywhere: for the homoscedastic Lagrangian case,
+    covariance() equals 2*sigma^2 * inv(information()) on the free
+    block. eigen() supports identifiability diagnosis directly: a
+    near-zero eigenvalue is a direction the data does not inform, and
+    its eigenvector names the parameter combination."""
+
+    _who = "information"
+
+    def __init__(self, params, matrix, conditioned_on=()):
+        super().__init__(params, matrix)
+        self.params = self._params
+        self._conditioned = conditioned_on
+
+    @property
+    def conditioned_on(self):
+        """Strongly active variables OUTSIDE the block: the matrix is
+        conditional on those bounds (roadmap item 3); empty when none.
+        Computed on first access (one backsolve per near-bound
+        candidate) and cached, so calls that never read it pay
+        nothing. Until first access the pending computation keeps the
+        sensitivity session, and so the held KKT factor, alive; read
+        it (or discard the result) to release them."""
+        if callable(self._conditioned):
+            self._conditioned = self._conditioned()
+        return self._conditioned
+
+    def eigen(self):
+        """(eigenvalues, eigenvectors) of the information matrix,
+        eigenvalues ascending, eigenvectors[:, i] in `params` order.
+        Small eigenvalues flag poorly informed directions; a negative
+        one means the point is not a least-squares minimum along that
+        direction (Lagrangian form only; Gauss-Newton is PSD by
+        construction).
+
+        Each eigenvector's sign is pinned so the direction it names
+        reproduces across machines: its largest-magnitude component
+        is positive (see _pin_eigenvector_signs)."""
+        w, v = np.linalg.eigh(self.matrix)
+        return w, _pin_eigenvector_signs(v)
+
+
+def _classify_ratio(r, mu):
+    """The activity rule of covariance roadmap item 0, applied at the
+    reduced fitted block. Mirrors pounce_sensitivity::activity with one
+    deliberate divergence: the Rust classifier maps q below the floor
+    to `unidentified` unconditionally, while the caller here first
+    checks the ratio, because at the reduced level a huge Sigma
+    cancelling inside q_red would otherwise misfile a strongly active
+    entry as unidentified. Exposing the rule from pounce-py so one
+    implementation serves both is item-2 follow-up."""
+    if mu > 1e-4:
+        if r < 1e-1:
+            return "inactive"
+        if r > 1e1:
+            return "strongly_active"
+        return "ambiguous"
+    if r < np.sqrt(mu):
+        return "inactive"
+    if r > 1.0 / np.sqrt(mu):
+        return "strongly_active"
+    if 1e-1 <= r <= 1e1:
+        return "weakly_active"
+    return "ambiguous"
+
+
+def _free_nullspace(bind_normals, free):
+    """Projection basis over the free fitted coordinates: the null
+    space of the binding row normals restricted to `free`. A normal
+    that vanished with the pinned coordinates is dropped (its content
+    is already excluded by the free restriction)."""
+    nf = len(free)
+    rows_ = []
+    for a in bind_normals:
+        af = np.asarray(a)[free]
+        nn = float(np.linalg.norm(af))
+        if nn > 1e-12:
+            rows_.append(af / nn)
+    A = np.array(rows_) if rows_ else np.zeros((0, nf))
+    return _nullspace(A)
+
+
+def _subblock_information(session, rows, dof, who):
+    """Marginal information of a proper sub-block of the fitted set,
+    by Schur complement of the EXACT tangent R over the fitted block:
+    never inverts a covariance, so a pinned member costs no digits.
+    Pinned fitted variables OUTSIDE the block are conditioned on
+    (their rows and columns are dropped: they are pinned, not
+    profiled); free ones are profiled out (the Schur step). The
+    matrix identity behind it: the inverse of a submatrix of an
+    inverse IS the Schur complement, so away from barrier
+    contamination this equals inv(M_B) exactly; the point is the
+    construction, not the value. Returns None when not applicable
+    (the block is not inside a square fitted set, or the fitted level
+    carries binding rows, whose projection does not compose simply
+    with marginalization) and the caller falls back to the corrected
+    reduction off the factor."""
+    fit_params = list(session.fit_rows.keys())
+    if len(fit_params) != dof:
+        return None
+    fit_rows_ = [session.fit_rows[fp] for fp in fit_params]
+    pos = {r: i for i, r in enumerate(fit_rows_)}
+    if any(r not in pos for r in rows):
+        return None
+    dim = session.solver.kkt_dim
+    fkrows = [session.primal_row(r, f"{who}(fitted)") for r in fit_rows_]
+    zcols_f = []
+    for kr in fkrows:
+        e = np.zeros(dim)
+        e[kr] = 1.0
+        zcols_f.append(np.asarray(session.solver.kkt_solve(e)))
+    M_f = np.array([[zcols_f[j][fkrows[i]] for j in range(dof)]
+                    for i in range(dof)])
+    M_f = 0.5 * (M_f + M_f.T)
+    with warnings.catch_warnings():
+        # the fitted-level classification is scaffolding here; its
+        # warnings belong to the block-level pass the caller runs
+        warnings.simplefilter("ignore")
+        cb_f = _classify_fitted_block(session, fit_params, fit_rows_,
+                                      M_f, zcols_f,
+                                      who=f"{who}(fitted)",
+                                      wording="fitted")
+    if cb_f.bind_normals:
+        return None
+    R_f = cb_f.R_exact
+    if R_f is None:
+        R_f = _tangent_reduced_hessian(session, M_f, zcols_f, who)
+    keep = [pos[r] for r in rows]
+    kept = set(keep)
+    pinned_f = set(cb_f.active)
+    o_free = [i for i in range(dof)
+              if i not in kept and i not in pinned_f]
+    sel = keep + o_free
+    Rs = R_f[np.ix_(sel, sel)]
+    nb = len(keep)
+    if o_free:
+        A_ = Rs[:nb, :nb]
+        B_ = Rs[:nb, nb:]
+        D_ = Rs[nb:, nb:]
+        try:
+            R_B = A_ - B_ @ np.linalg.solve(D_, B_.T)
+        except np.linalg.LinAlgError:
+            warnings.warn(
+                f"{who}: the free fitted coordinates outside the block "
+                "are singular, so the exact Schur route is unavailable; "
+                "falling back to the corrected reduction off the "
+                "factor, which loses digits at tight mu on pinned "
+                "members.")
+            return None
+    else:
+        R_B = Rs[:nb, :nb]
+    return 0.5 * (R_B + R_B.T)
+
+
+def _conditioned_on(session, act, rows, who):
+    """Strongly active variables outside the block. Their Sigma stays
+    in the held factor and drives the coupling through them to zero as
+    mu falls, so the block's numbers are the values conditional on
+    those bounds, not the marginal over them. Returned with the matrix
+    rather than warned: it is a property of the answer, not a defect.
+
+    Identification is item 1's reduced-level rule applied to each
+    candidate as a singleton block: one backsolve gives (K^-1)_ii, the
+    effective reduced curvature is |1/(K^-1)_ii - Sigma_i| (a pinned
+    variable in the residual idiom has zero RAW curvature, which is
+    why the raw report calls it unidentified), and the shipped ratio
+    edges make the call. Scale-invariant, same theory as the block
+    members. Candidates pass a cheap Sigma > sqrt(mu) prefilter first,
+    so only near-bound variables pay the backsolve; below the
+    cancellation floor q_red is clamped to it, exactly as the
+    block-level rule does."""
+    inside = set(int(r) for r in rows)
+    mu = float(act["mu"])
+    pre = np.sqrt(mu) if mu > 0 else 0.0
+    dim = session.solver.kkt_dim
+    out = []
+    for idx, st in enumerate(act["var_status"]):
+        if idx in inside or st in ("unbounded", "fixed", "equality",
+                                   "inactive"):
+            continue
+        sig = float(act["var_sigma"][idx])
+        if st == "strongly_active":
+            pinned = True
+        elif sig <= pre:
+            continue
+        else:
+            krow = session.primal_row(idx, f"{who} conditioned_on")
+            e = np.zeros(dim)
+            e[krow] = 1.0
+            kii = float(np.asarray(session.solver.kkt_solve(e))[krow])
+            if kii == 0.0:
+                continue
+            q_red = abs(1.0 / kii - sig)
+            # clamp to the floor rather than refuse, exactly as the
+            # block-level rule does: a huge Sigma cancelling inside
+            # q_red would otherwise misfile a strongly active variable
+            floor = np.sqrt(np.finfo(float).eps) * max(1.0, abs(1.0 / kii))
+            pinned = (_classify_ratio(sig / max(q_red, floor), mu)
+                      == "strongly_active")
+        if pinned:
+            v = session.var_key(idx)
+            out.append(v if v is not None else session.var_names[idx])
+    return tuple(out)
+
+
+def _rank_deficient(A):
+    """True when the symmetric block `A` is rank-deficient, tested on
+    its diagonally scaled form so the verdict is a statement about
+    COLLINEARITY and not about units.
+
+    `np.linalg.matrix_rank` thresholds the singular values at
+    `sigma_max * n * eps`, which is relative to the largest singular
+    value and so is not invariant under rescaling the coordinates
+    against each other: a covariance block carries the SQUARE of any
+    unit spread between its members, so two perfectly well-determined
+    parameters ~1e8 apart in magnitude (a rate prefactor against a
+    reaction order) push `cond(M)` past the default tolerance and read
+    as dependent on unit spread alone. Scaling by `sqrt(|diag|)` first
+    — the correlation form — makes the test the same kind of
+    scale-invariant ratio as the block-membership rule (roadmap item 1)
+    and the conditioned_on rule, rather than a threshold that tracks
+    the user's choice of units. Second review of gh #466.
+
+    A zero diagonal leaves its own row and column unscaled: there is no
+    scale to divide by, and a genuinely zero row is rank-deficient
+    either way."""
+    n = A.shape[0]
+    if n == 0:
+        return False
+    d = np.sqrt(np.abs(np.diag(A)))
+    d = np.where(d > 0.0, d, 1.0)
+    return int(np.linalg.matrix_rank(A / np.outer(d, d))) < n
+
+
+class _SingularBlock(RuntimeError):
+    """The requested block of the inverse KKT matrix is singular.
+    A dedicated type so callers that rescue this case (the of=
+    dependent-block paths) do not do control flow on message text
+    (review of gh #466)."""
+
+
+def _minv(M, who="covariance"):
+    try:
+        return np.linalg.inv(M)
+    except np.linalg.LinAlgError as e:
+        raise _SingularBlock(
+            f"{who}: the requested block of the inverse KKT matrix "
+            "is singular; the block members are linearly "
+            "dependent (structurally unidentifiable)") from e
+
+
+def covariance(session, params=None, rows=None, sigma_sq=None,
+               n_data=None, hessian="lagrangian", max_pdpert=None,
+               who="covariance", hints=None):
+    """Asymptotic covariance of the fitted parameters of a
+    least-squares problem, from ONE ordinary solve.
+
+    Workflow: give the session the fitted parameters' full-x columns as
+    `fit_rows` (they stay free variables) and, optionally, the residual
+    variables' columns as `res_rows`, solve once, then call this with no
+    further information. Pass `params`/`rows` instead to ask about any
+    other block of the solve's variables.
+
+    ASSUMES the model objective is the plain sum of squared residuals.
+    The parameter block of the inverse KKT matrix, obtained by one
+    backsolve per parameter against the held factorization, equals the
+    inverse reduced Hessian of the eliminated problem, inv(d2f*/dp2);
+    for f = SSR the asymptotic covariance is then
+
+        cov = 2 * sigma_sq * (K^-1)_pp
+
+    The factor 2 belongs to the unscaled sum of squares; it is verified
+    against the analytical linear-regression covariance
+    sigma^2 * inv(X^T X) in tests/test_covariance.py.
+
+    The noise variance sigma_sq comes from, in order of precedence:
+    sigma_sq= (known measurement variance; scalar, or {group: value}
+    when residual groups are declared); declared residuals (estimated
+    per pooled or labeled group as SSR_g / (n_g - n_params)); or the
+    n_data= fallback (count of data points, with SSR taken from the
+    SOLVE-TIME objective value on trust -- writing into the model
+    first, the receding-horizon pattern of solution(), does not change
+    the answer). With multiple labeled groups the heteroscedastic
+    sandwich covariance is reported.
+
+    hessian= selects the information matrix. "lagrangian" (the default)
+    inverts the exact reduced Hessian of the Lagrangian from the held
+    factorization: the observed-information form, the same object
+    sIPOPT or k_aug would factor. "gauss-newton" rebuilds
+    the expected-information form from the residual Jacobian, recovered
+    from the same backsolves at no extra solve (requires declared
+    residuals). They agree for linear models; for nonlinear fits
+    Gauss-Newton drops the residual-curvature term, matches the scipy /
+    ``pounce.curve_fit`` convention, and is structurally positive
+    semidefinite, which makes it the safe choice when the covariance
+    must stay PSD, e.g. feeding an arrival-cost update in moving
+    horizon estimation.
+
+    of= selects the block (covariance roadmap item 3): any of the
+    solve's variables, not only the declared fitted ones, given as a
+    Var (scalar or indexed), an indexed slice (m.x[2, :]), a
+    (Var, iterable) pair, data objects, or a list mixing these; None
+    (default) is the declared fitted block, exactly the prior
+    behavior. Each call re-reduces onto its own argument, so one solve
+    serves as many blocks as are asked about, each getting that
+    block's MARGINAL (everything else profiled out). Sigma estimation
+    always divides by the fit's own degrees of freedom, a property of
+    the solve, not the block. A rank-deficient block (more
+    coordinates than the fit has degrees of freedom, e.g. a predicted
+    trajectory: the prediction-band case) gets the homoscedastic
+    Lagrangian marginal, with membership handling bypassed. Strongly
+    active variables OUTSIDE the block come back on the result as
+    .conditioned_on: the matrix is conditional on those bounds, not
+    marginal over them.
+
+    Returns a Covariance object keyed by the declared variables'
+    data objects: cov[m.A, m.k], cov.std_err[m.A],
+    cov.correlation[m.A, m.k], cov.matrix, cov.sigma_sq (float or
+    per-group dict), cov.eigen().
+
+    Same scale-and-invert-the-reduced-Hessian recipe as
+    ``pounce.curve_fit``, with one difference for NONLINEAR models: this
+    feeds the exact Lagrangian Hessian (via the .nl bridge) and so reports
+    the OBSERVED-information covariance (the full reduced Hessian),
+    whereas ``curve_fit`` factors the Gauss-Newton Hessian and reports
+    ``2 sigma^2 (J^T J)^-1`` (the expected-information / scipy convention,
+    always positive semidefinite). The two agree for linear models and in
+    the small-residual limit and differ by O(residual x curvature)
+    otherwise. Gauss-Newton cannot produce a negative variance; the full
+    Hessian can go indefinite, which is what the negative-diagonal warning
+    below signals -- pass hessian="gauss-newton" then, or whenever
+    scipy-matching numbers are wanted. Use ``curve_fit`` for the
+    callable-model-plus-data surface
+    (starting point, robust losses, confidence intervals, prediction
+    bands, active-bound projection); use this when the fit is a block
+    inside a model you have already written and solved.
+
+    Bound and constraint activity is classified from the solve's own
+    barrier geometry (the ratio of each direction's barrier weight to
+    its curvature; pounce's covariance roadmap item 1), not from a
+    slack threshold. A STRONGLY ACTIVE bound pins its parameter: zero
+    variance, correlation entries 0, conditional on the bound, with a
+    warning. A WEAKLY ACTIVE bound (slack and multiplier vanish
+    together) is KEPT: the parameter keeps its full finite variance,
+    corrected for the barrier weight the held factor carries, and a
+    warning notes the nonstandard boundary asymptotics. AMBIGUOUS
+    (loosely converged) and UNIDENTIFIED (curvature below the model's
+    own noise scale) parameters stay in the free block with warnings.
+    A strongly active inequality CONSTRAINT involving fitted
+    parameters pins a combination rather than a coordinate: the matrix
+    is projected on the constraint's null space, going singular by one
+    per binding row, and the surviving correlations say what the data
+    still determines (for a + b <= cap binding, corr(a, b) = -1: only
+    the difference is determined). The same limit written as a bound
+    or as a row returns the same matrix (jkitchin/pounce#362).
+
+    max_pdpert refuses rather than answering when the converged KKT
+    factor carries an inertia correction larger than the value given.
+    This inverts that factor, so a perturbed one answers for a nearby
+    problem rather than this one. It warns either way, and the cap is
+    the caller choosing to stop instead of to read the warning.
+    """
+    if hessian not in ("lagrangian", "gauss-newton"):
+        raise ValueError(
+            f"{who}: hessian must be 'lagrangian' or 'gauss-newton', "
+            f"got {hessian!r}")
+    # the block: the declared fitted parameters by default, or any
+    # block of the solve's variables via of= (each call re-reduces
+    # onto its own argument, so one solve serves as many blocks as are
+    # asked about, each getting that block's marginal)
+    hints = DEFAULT_HINTS if hints is None else hints
+    # None here means "the session's own declared block", which is what
+    # the wording and the rank-deficiency advice below branch on
+    of = params
+    params, rows = _resolve_block(session, params, rows, who, hints)
+    n_params = len(params)
+    wording = "fitted" if of is None else "block"
+    # sigma estimation divides by the FIT's degrees of freedom, a
+    # property of the solve, not of the block being asked about
+    n_fit = len(session.fit_rows)
+
+    # ── guardrails ────────────────────────────────────────────────────────
+    check_margins(None, max_pdpert, who)
+    refuse_on_pdpert(session, max_pdpert, who)
+    pert = np.asarray(session.solver.kkt_perturbations)
+    if pert.any():
+        warnings.warn(
+            f"{who}: the held KKT factor carries inertia-correction "
+            f"perturbations {pert.tolist()}, so the covariance is "
+            "regularized rather than exact. Linearly dependent (structurally"
+            " unidentifiable) parameters are the usual cause.")
+    # ── parameter block of the inverse KKT matrix ─────────────────────────
+    # `rows` is full-x (the space of the activity report and of
+    # row_normal, both read below); `krows` is the same variables as
+    # factor rows. Keep the two apart -- they differ exactly when the
+    # model has a fixed variable, and agree everywhere else.
+    dim = session.solver.kkt_dim
+    krows = [session.primal_row(r, f"{who}({_label(p)})")
+             for r, p in zip(rows, params)]
+    zcols = []
+    for r in krows:
+        e = np.zeros(dim)
+        e[r] = 1.0
+        zcols.append(np.asarray(session.solver.kkt_solve(e)))
+    M = np.array([[zcols[j][krows[i]] for j in range(n_params)]
+                  for i in range(n_params)])
+    M = 0.5 * (M + M.T)
+
+    # a rank-deficient EXPLICIT block (more coordinates than the fit
+    # has degrees of freedom, e.g. a predicted trajectory) has a
+    # perfectly well-defined marginal covariance, 2 sigma^2 M; what it
+    # does not have is inv(M), which the membership classification
+    # needs. Gate on the count: LAPACK does not reliably raise on a
+    # structurally singular M (tiny nonzero pivots slip through and
+    # give garbage, not an error).
+    n_var, n_eq = _estimation_counts(session)
+    deficient = None
+    if of is not None:
+        if n_params > n_var - n_eq:
+            deficient = "count"
+        elif _rank_deficient(M):
+            # the count gate's own justification, one step to its
+            # left: LAPACK does not reliably raise on a structurally
+            # singular M, so a within-count dependent block needs its
+            # own gate (fp-detectable dependence; anything softer is
+            # caught by _SingularBlock below as a last resort).
+            # Diagonally scaled, so a badly-scaled but well-determined
+            # block is not refused for its units (second review)
+            deficient = "dependent"
+    if deficient is not None:
+        cb = None
+    else:
+        try:
+            cb = _classify_fitted_block(session, params, rows, M, zcols,
+                                        wording=wording)
+        except _SingularBlock:
+            if of is None:
+                raise
+            deficient = "dependent"
+            cb = None
+    if cb is not None:
+        sig_fit = cb.sig_fit
+        floor = cb.floor
+        R_corr = cb.R_corr
+        bind_normals = cb.bind_normals
+        row_corrections = cb.row_corrections
+
+    # ── noise variance per group ──────────────────────────────────────────
+    groups = dict(session.res_rows)
+    if hessian == "gauss-newton" and not groups:
+        raise ValueError(
+            f"{who}: hessian='gauss-newton' needs declared residuals "
+            f"({hints['residual']}); the residual Jacobian is "
+            "recovered from "
+            "their rows. Without residual variables only the "
+            "hessian='lagrangian' default is available.")
+    if n_data is not None and (sigma_sq is not None or groups):
+        warnings.warn(
+            f"{who}: n_data is ignored because a "
+            "higher-precedence noise "
+            "source was given (sigma_sq, or the declared residuals).")
+    if sigma_sq is not None:
+        if isinstance(sigma_sq, dict):
+            named = [g for g in groups if g is not None]
+            if not named:
+                raise ValueError(
+                    f"{who}: sigma_sq was given as a "
+                    "per-group dict but "
+                    "no named residual groups were declared; pass a scalar "
+                    "sigma_sq, or declare grouped residuals with "
+                    f"{hints['residual_group']}")
+            missing = [g for g in groups if g not in sigma_sq]
+            if missing:
+                raise ValueError(
+                    f"{who}: sigma_sq is missing an entry "
+                    "for residual "
+                    f"group(s) {sorted(map(repr, missing))}")
+            group_sigma = {g: float(sigma_sq[g]) for g in groups}
+        else:
+            group_sigma = {g: float(sigma_sq) for g in (groups or {None: []})}
+    elif groups:
+        if n_fit == 0:
+            raise ValueError(
+                f"{who}: the noise variance must be estimated from "
+                "the declared residuals, but no fitted parameters were "
+                "declared, so the degrees of freedom for the estimate "
+                "are unknown; pass sigma_sq= (known variance) or flag "
+                f"the fitted parameters with {hints['fitted']}")
+        group_sigma = {}
+        for g, rws in groups.items():
+            n_g = len(rws)
+            if n_g <= n_fit:
+                raise ValueError(
+                    f"{who}: residual group {g!r} has "
+                    f"{n_g} members, "
+                    f"not more than the {n_fit} fitted parameters; "
+                    "cannot estimate its noise variance")
+            ssr_g = float(np.sum(session.base_x[rws] ** 2))
+            group_sigma[g] = ssr_g / (n_g - n_fit)
+    elif n_data is not None:
+        if n_fit == 0:
+            raise ValueError(
+                f"{who}: n_data= estimates the noise variance, but "
+                "no fitted parameters were declared, so the degrees of "
+                "freedom for the estimate are unknown; pass sigma_sq= "
+                "(known variance) or flag the fitted parameters with "
+                f"{hints['fitted']}")
+        if n_data <= n_fit:
+            raise ValueError(
+                f"{who}: n_data ({n_data}) must exceed the "
+                "number of "
+                f"fitted parameters ({n_fit})")
+        # the objective value AT THE SOLVE, not re-evaluated: a
+        # modelling layer that evaluates the objective reads its
+        # CURRENT variable and parameter values, so anything written
+        # after the solve (a measurement, a warm start for the next
+        # horizon) would silently rescale the covariance (gh #426)
+        if not np.isfinite(session.base_obj):
+            raise RuntimeError(
+                f"{who}: the solve reported no usable "
+                "objective value "
+                f"({session.base_obj}), so n_data= cannot estimate the "
+                "noise variance. Pass sigma_sq= (known variance), or "
+                f"declare the residual container with {hints['residual']}.")
+        ssr = session.base_obj
+        group_sigma = {None: ssr / (n_data - n_fit)}
+    else:
+        raise ValueError(
+            f"{who}: the noise variance is unknown; declare the "
+            f"residual container(s) with {hints['residual']}, or pass "
+            "sigma_sq= (known variance), or pass n_data= (data count, "
+            "with the SSR taken from the solve-time objective value)")
+
+    # ── assemble ──────────────────────────────────────────────────────────
+    # Pooled covariance when there is one group or all group variances are
+    # equal to relative tolerance; otherwise the heteroscedastic sandwich.
+    sig_vals = list(group_sigma.values())
+    homoscedastic = len(sig_vals) <= 1 or (
+        max(sig_vals) - min(sig_vals)
+        <= 1e-12 * max(abs(v) for v in sig_vals)
+    )
+
+    def minv():
+        return _minv(M)
+
+    def group_jacobians():
+        # The Jacobian rows are recovered from the same backsolves: the
+        # residual rows of the z-columns equal J * inv(d2f/dp2), so
+        # J = Z_r * inv(M).
+        # No Sigma correction is needed on this path, by an exact
+        # identity: the residual rows of the K-inverse columns are J
+        # times the W-based parameter sensitivities, Z_r = J @ M, so
+        # Z_r @ inv(M) = J exactly and the factor's barrier weight
+        # cancels regardless of Sigma. The Lagrangian branch corrects
+        # R_W because it USES the W-based reduced Hessian; Gauss-Newton
+        # rebuilds from the exact J instead. Pinned empirically by the
+        # GN counterpart of the weakly-active analytic test.
+        Mi = minv()
+        out = {}
+        for g, rws in groups.items():
+            # res_rows is full-x like fit_rows; zcols are factor rows
+            Zr = np.array([[zcols[j][session.primal_row(r, who)]
+                            for j in range(n_params)]
+                           for r in rws])
+            out[g] = Zr @ Mi                  # d r_g / d p
+        return out
+
+    if cb is None:
+        # marginal-only path for a rank-deficient explicit block. The
+        # Gauss-Newton and heteroscedastic routes profile Jacobians
+        # through inv(M), so only the homoscedastic Lagrangian marginal
+        # exists here.
+        reason = ("more coordinates than the fit has degrees of "
+                  "freedom" if deficient == "count"
+                  else "linearly dependent coordinates")
+        if hessian == "gauss-newton" or not homoscedastic:
+            raise RuntimeError(
+                f"{who}: the of= block is rank-deficient "
+                f"({reason}), so the profiled Jacobians behind "
+                "hessian='gauss-newton' and per-group noise are not "
+                "defined; only the homoscedastic hessian='lagrangian' "
+                "marginal is available for this block")
+        act = session.solver.classify_activity()
+        flagged = [_label(p) for i, p in enumerate(params)
+                   if act["var_status"][rows[i]] not in
+                   ("inactive", "unbounded", "fixed", "equality")]
+        if flagged:
+            warnings.warn(
+                f"{who}: block members {flagged} have bound "
+                f"activity, but the block is rank-deficient ({reason}), "
+                "so the "
+                "membership handling (pinned parameters, binding rows) "
+                "is unavailable; the marginal is returned without it.")
+        cov = 2.0 * sig_vals[0] * M
+        cov = 0.5 * (cov + cov.T)
+        sig_out = (next(iter(group_sigma.values()))
+                   if len(group_sigma) == 1 and None in group_sigma
+                   else group_sigma)
+        return Covariance(
+            params, cov, sig_out,
+            lambda: _conditioned_on(session, act, rows, who))
+
+    # Active-bound projection: the covariance is computed in the free
+    # (off-bound) directions and embedded with zero rows/cols for the
+    # pinned parameters, i.e. the covariance conditional on the active
+    # set. Restricting the INFORMATION matrix to the free block and
+    # inverting (not restricting the inverse) is the curve_fit
+    # _projected_covariance construction.
+    free = cb.free
+
+    def embed(cov_ff):
+        if len(free) == n_params:
+            return cov_ff
+        full = np.zeros((n_params, n_params))
+        if free:
+            full[np.ix_(free, free)] = cov_ff
+        return full
+
+    if not free:
+        cov = np.zeros((n_params, n_params))
+    elif hessian == "gauss-newton":
+        # Expected information: H_GN = 2 J^T J in place of the exact
+        # reduced Hessian. Pooled: cov = 2 s^2 inv(H_GN) = s^2 inv(J^T J).
+        # Grouped: cov = inv(J^T J) (sum_g s_g^2 Jg^T Jg) inv(J^T J).
+        Js = {g: Jg[:, free] for g, Jg in group_jacobians().items()}
+        G = sum(Jg.T @ Jg for Jg in Js.values())
+        Zb = _free_nullspace(bind_normals, free)
+        try:
+            if Zb.shape[1] == 0:
+                Ginv = np.zeros((len(free), len(free)))
+            else:
+                Ginv = Zb @ np.linalg.inv(Zb.T @ G @ Zb) @ Zb.T
+        except np.linalg.LinAlgError as e:
+            raise RuntimeError(
+                f"{who}: the Gauss-Newton matrix J^T J is singular; "
+                "the block members are linearly dependent in the "
+                "residual Jacobian") from e
+        if homoscedastic:
+            cov = embed(sig_vals[0] * Ginv)
+        else:
+            B = np.zeros((len(free), len(free)))
+            for g, Jg in Js.items():
+                B += group_sigma[g] * (Jg.T @ Jg)
+            cov = embed(Ginv @ B @ Ginv)
+    else:
+        if (not bind_normals and not row_corrections
+                and len(free) == n_params
+                and float(np.abs(sig_fit).max()) <= floor):
+            # nothing active, nothing to correct above noise scale: M
+            # is already the answer, and skipping inv(inv(M)) spares
+            # the conditioning round-trip on the common all-free path
+            Mc = M
+        else:
+            # R_corr is the reduced Hessian with the item-1 value
+            # corrections applied: the fitted rows' own barrier
+            # diagonal subtracted (a weakly active kept parameter
+            # reports its true curvature q, not the factor's 2q) and
+            # kept rows' barrier weight removed. Active rows and
+            # binding normals never enter: coordinates are excluded by
+            # the free restriction, directions are annihilated by the
+            # projection basis Z (which also annihilates the binding
+            # rows' huge barrier weight, exactly).
+            Rff = R_corr[np.ix_(free, free)]
+            Zb = _free_nullspace(bind_normals, free)
+            try:
+                if Zb.shape[1] == 0:
+                    Mc = np.zeros((len(free), len(free)))
+                else:
+                    Mc = Zb @ np.linalg.inv(Zb.T @ Rff @ Zb) @ Zb.T
+            except np.linalg.LinAlgError as e:
+                raise RuntimeError(
+                    f"{who}: the reduced Hessian restricted to the "
+                    "free (off-bound, off-constraint) members is "
+                    "singular; the remaining free block members are "
+                    "linearly dependent"
+                ) from e
+        if homoscedastic:
+            s2 = sig_vals[0]
+            cov = embed(2.0 * s2 * Mc)
+        else:
+            # heteroscedastic sandwich: cov = A^-1 B A^-1 with A = d2f/dp2
+            # and B built from per-group residual Jacobians.
+            B = np.zeros((len(free), len(free)))
+            for g, Jg in group_jacobians().items():
+                Jf = Jg[:, free]
+                B += group_sigma[g] * (Jf.T @ Jf)
+            # dtheta = -A^-1 * 2 J^T eps with A = d2f/dp2 = inv(M), so
+            # cov = 4 M (sum_g sigma_g^2 Jg^T Jg) M; the single-group case
+            # reduces to 2 sigma^2 M since J^T J = A/2.
+            cov = embed(4.0 * Mc @ B @ Mc)
+
+    cov = 0.5 * (cov + cov.T)
+    if np.diag(cov).min() < 0:
+        warnings.warn(
+            f"{who}: negative variance on the diagonal; the point is "
+            "probably not a least-squares minimum.")
+    sig_out = (next(iter(group_sigma.values()))
+               if len(group_sigma) == 1 and None in group_sigma
+               else group_sigma)
+    return Covariance(
+        params, cov, sig_out,
+        lambda: _conditioned_on(session, cb.act, rows, who))
+
+
+def information(session, params=None, rows=None, hessian="lagrangian",
+                max_pdpert=None, who="information", hints=None):
+    """The information matrix of the fitted parameters: the reduced
+    Hessian over the declared block, the un-inverted sibling of
+    covariance(), from the same single solve.
+
+    Natural units and no sigma^2 anywhere (the core's convention;
+    covariance() carries the 2*sigma^2 on top): for a homoscedastic
+    Lagrangian fit, covariance() equals 2*sigma^2*inv(information())
+    on the free block. hessian= selects the form exactly as in
+    covariance(): "lagrangian" (default) is the observed information,
+    built by tangent recovery against the held factorization (the
+    K-inverse columns' x-blocks are T*M, so T = Zx*inv(M) exactly and
+    R = T'HT with the exact Lagrangian Hessian: machine precision for
+    equality and bound activity, no subtraction against the
+    barrier-augmented factor; a binding inequality row leaves ~1e-6
+    relative residue through its slack barrier). "gauss-newton" is the expected information 2*J'J, with J
+    recovered over ALL fitted parameters and sliced afterwards, so the
+    pinned rows exist to build their disposition from (requires
+    declared residuals, as in covariance()).
+
+    Membership and warnings follow covariance() exactly (item 1's
+    table): a free parameter's row is the reduced Hessian; a strongly
+    active parameter's block is S, the reduction onto the pinned set,
+    NOT a zero row, because zero information is the opposite of what a
+    pinned parameter carries; cross blocks between free and pinned are
+    zero. Binding constraint rows project the free block on both sides
+    (the pseudo-inverse of the projected covariance). An indefinite
+    Lagrangian block is returned as computed with a warning naming
+    Gauss-Newton as the PSD alternative: refusing would withhold the
+    finding that the point is not a minimum or the model is
+    over-parameterized.
+
+    of= selects the block exactly as in covariance() (roadmap item
+    3): the declared fitted block by default, or any block of the
+    solve's variables. A block that parameterizes the constraint
+    manifold (size equal to the fit's degrees of freedom, the square
+    structure above) gets the exact tangent construction; a smaller
+    block reduces off the held factor with the item-1 corrections
+    (that route's documented precision); a rank-deficient block
+    carries no information matrix and is refused toward covariance().
+    Strongly active variables outside the block come back as
+    .conditioned_on.
+
+    Returns an Information object keyed by the declared variables'
+    data objects: info[m.A, m.k], info.matrix, info.eigen().
+
+    max_pdpert refuses rather than answering when the converged KKT
+    factor carries an inertia correction larger than the value given.
+    This inverts that factor, so a perturbed one answers for a nearby
+    problem rather than this one. It warns either way, and the cap is
+    the caller choosing to stop instead of to read the warning.
+    """
+    if hessian not in ("lagrangian", "gauss-newton"):
+        raise ValueError(
+            f"{who}: hessian must be 'lagrangian' or "
+            "'gauss-newton', "
+            f"got {hessian!r}")
+    hints = DEFAULT_HINTS if hints is None else hints
+    # None here means "the session's own declared block", which is what
+    # the wording and the rank-deficiency advice below branch on
+    of = params
+    params, rows = _resolve_block(session, params, rows, who, hints)
+    n_params = len(params)
+    wording = "fitted" if of is None else "block"
+
+    check_margins(None, max_pdpert, who)
+    refuse_on_pdpert(session, max_pdpert, who)
+    pert = np.asarray(session.solver.kkt_perturbations)
+    if pert.any():
+        warnings.warn(
+            f"{who}: the held KKT factor carries inertia-correction "
+            f"perturbations {pert.tolist()}, so the information is "
+            "regularized rather than exact; the isotropic delta_w lands on "
+            "the free block and survives the projection.")
+
+    # `rows` is full-x (the space _classify_fitted_block reads the
+    # activity report and row_normal in); `krows` is the same variables
+    # as factor rows (gh #450): they differ exactly when the model has
+    # a fixed variable, and agree everywhere else
+    dim = session.solver.kkt_dim
+    krows = [session.primal_row(r, f"{who}({_label(p)})")
+             for r, p in zip(rows, params)]
+    zcols = []
+    for r in krows:
+        e = np.zeros(dim)
+        e[r] = 1.0
+        zcols.append(np.asarray(session.solver.kkt_solve(e)))
+    M = np.array([[zcols[j][krows[i]] for j in range(n_params)]
+                  for i in range(n_params)])
+    M = 0.5 * (M + M.T)
+
+    n_var, n_eq = _estimation_counts(session)
+    def _refuse_rank(reason):
+        raise RuntimeError(
+            f"{who}: the of= block is rank-deficient ({reason}), "
+            "so it carries no information matrix; its covariance "
+            "(covariance(model, of=...)) is the meaningful object "
+            "for such a block")
+    if of is not None:
+        if n_params > n_var - n_eq:
+            _refuse_rank("more coordinates than the fit has degrees "
+                         "of freedom")
+        if _rank_deficient(M):
+            # the count gate one step to its left: LAPACK does not
+            # reliably raise on a structurally singular M. Diagonally
+            # scaled, so the refusal tracks collinearity and not the
+            # user's units (second review)
+            _refuse_rank("linearly dependent coordinates")
+    try:
+        cb = _classify_fitted_block(session, params, rows, M, zcols,
+                                    who=who, wording=wording)
+    except _SingularBlock:
+        if of is None:
+            raise
+        _refuse_rank("linearly dependent coordinates")
+    free, active = cb.free, cb.active
+
+    if hessian == "gauss-newton":
+        groups = dict(session.res_rows)
+        if not groups:
+            raise ValueError(
+                f"{who}: hessian='gauss-newton' needs declared "
+                f"residuals ({hints['residual']}); the residual "
+                "Jacobian is "
+                "recovered from their rows. Without residual variables "
+                "only the hessian='lagrangian' default is available.")
+        Mi = _minv(M, who)
+        R = np.zeros((n_params, n_params))
+        for g, rws in groups.items():
+            # slice LAST: J over the whole fitted block, so the pinned
+            # rows exist for S below; res_rows is full-x like fit_rows,
+            # zcols are factor rows (gh #450)
+            Zr = np.array([[zcols[j][session.primal_row(r, who)]
+                            for j in range(n_params)]
+                           for r in rws])
+            Jg = Zr @ Mi
+            R += 2.0 * (Jg.T @ Jg)
+    else:
+        R = cb.R_exact
+        if R is None:
+            if n_var - n_eq == n_params:
+                R = _tangent_reduced_hessian(session, M, zcols,
+                                             who)
+            elif of is not None:
+                # a sub-block of the fitted set gets its marginal by
+                # Schur complement of the exact tangent R over the
+                # fitted block (never inverts a covariance, exact even
+                # with pinned members); any other explicit block
+                # reduces off the held factor with the item-1
+                # corrections, which is benign for free coordinates
+                # (no barrier term in the slice)
+                R = _subblock_information(session, rows,
+                                          n_var - n_eq, who)
+                if R is None:
+                    R = cb.R_corr
+            else:
+                raise RuntimeError(
+                    f"{who}: hessian='lagrangian' requires the "
+                    "square estimation structure (the equality "
+                    "constraints determine the non-fitted variables "
+                    "given the fitted block); this model has "
+                    f"{n_var} factor variables, {n_eq} equalities and "
+                    f"{n_params} fitted parameters, so "
+                    f"{n_var} - {n_eq} != {n_params} and the tangent "
+                    "recovery is not defined. hessian='gauss-newton' "
+                    "does not need it.")
+
+    info_mat = np.zeros((n_params, n_params))
+    if free:
+        Rff = R[np.ix_(free, free)]
+        Zb = _free_nullspace(cb.bind_normals, free)
+        if Zb.shape[1] == Rff.shape[0]:
+            info_ff = Rff
+        else:
+            # projected on both sides: the pseudo-inverse of the
+            # projected covariance (item 1's rule, identical in both
+            # accessors)
+            info_ff = Zb @ (Zb.T @ Rff @ Zb) @ Zb.T
+        info_mat[np.ix_(free, free)] = info_ff
+        if hessian == "lagrangian" and _indefinite(info_ff):
+            warnings.warn(
+                f"{who}: the Lagrangian free block is indefinite "
+                "(returned as computed): the point is not a "
+                "least-squares minimum along some direction, or the "
+                "model is over-parameterized. "
+                "hessian='gauss-newton' is the PSD alternative.")
+    if active:
+        # the pinned set's disposition is S, the reduction onto the
+        # pinned block, not a zero row: zero information is the
+        # opposite of what a pinned parameter carries. Conditional on
+        # the rest of the pinned set (item 1's caveat).
+        if free:
+            # rank-gate the free block before the solve: whether LAPACK
+            # raises on a singular system is BLAS-dependent (the CI
+            # wheel job's fresh numpy returned garbage where the local
+            # build raised), the same non-determinism the of= gates
+            # exist for; the exception clause stays as the last resort.
+            # Applies on the DEFAULT path too, not only under of=: a
+            # numerically dependent free block now refuses where it
+            # could previously return a large-but-meaningless S
+            # (CHANGELOG "Changed"). Diagonally scaled like the of=
+            # gates, so an ill-scaled but well-determined free block
+            # keeps its answer (second review)
+            R_FF = R[np.ix_(free, free)]
+            singular = _rank_deficient(R_FF)
+            if not singular:
+                try:
+                    S = (R[np.ix_(active, active)]
+                         - R[np.ix_(active, free)]
+                         @ np.linalg.solve(R_FF,
+                                           R[np.ix_(free, active)]))
+                except np.linalg.LinAlgError:
+                    singular = True
+            if singular:
+                raise RuntimeError(
+                    f"{who}: the free block is singular, so the "
+                    "pinned parameters' conditional information S is not "
+                    "defined; the free block members are linearly "
+                    "dependent")
+        else:
+            S = R[np.ix_(active, active)]
+        info_mat[np.ix_(active, active)] = S
+
+    return Information(
+        params, info_mat,
+        lambda: _conditioned_on(session, cb.act, rows, who))

--- a/python/pounce/sensitivity/_step.py
+++ b/python/pounce/sensitivity/_step.py
@@ -1,0 +1,1068 @@
+"""Parametric steps, and what they do about the bounds.
+
+The step is `dx ~ (dx*/dp) dp` against the held factor: how the solution
+moves when the parameters do. :func:`solution` returns the moved point,
+:func:`solution_report` says what the step did about the bounds on the
+way, and :func:`active_set_changes` lists the active-set events a path
+step applies.
+
+Everything here takes a :class:`~pounce.sensitivity.SensSession` and
+addresses parameters by the full-g row of the defining equality each is
+pinned by. `who` names the caller in diagnostics, so a wrapper can keep
+its own function name in the messages its users see.
+"""
+import warnings
+from collections import namedtuple
+
+import numpy as np
+
+from ._session import user_row_names
+
+def weakly_active(session):
+    """The degenerate bounds at the held solve, cached per session.
+
+    `(variable name, "lower" or "upper")` for every bound the
+    classifier could call neither active nor inactive. Empty when the
+    solve relaxed its bounds, since the classifier cannot read shifted
+    slacks. Cached because the factor is fixed per solve and
+    `sens_jacobian()` runs in tight loops.
+    """
+    cached = getattr(session, "_weakly_active_cache", None)
+    if cached is None:
+        if session.solver.bound_relax_factor:
+            cached = []
+        else:
+            full_of = {row: full
+                       for full, row in enumerate(session._primal_row_map())
+                       if row is not None}
+            cached = [
+                (session.var_names[full_of[vr]],
+                 "lower" if low else "upper")
+                for vr, low in session.solver.weakly_active_bounds()
+                if vr in full_of
+            ]
+        session._weakly_active_cache = cached
+    return cached
+
+
+def check_margins(bound_eps, max_pdpert, who):
+    """Reject the values the CLI's option surface rejects.
+
+    `sens_bound_eps` and `sens_max_pdpert` are both registered with
+    `add_lower_bounded_number_option(..., 0.0, strict)`, so a value the
+    CLI turns down is turned down here too. A `bound_eps` of zero
+    reinstates the roundoff pinning the floor exists to prevent, a NaN
+    makes every "outside a bound" comparison false so the refinement
+    pins nothing and still reports settled, and a negative `max_pdpert`
+    always refuses with a message that reads as though the factor were
+    bad.
+    """
+    for name, value in (("bound_eps", bound_eps), ("max_pdpert", max_pdpert)):
+        if value is None:
+            continue
+        if not float(value) > 0.0:
+            raise ValueError(
+                f"{who}: {name} must be a positive number, got {value!r}")
+
+
+def _bound_margin(session, bound_eps):
+    """How far outside a bound a coordinate has to end to count as
+    having left it.
+
+The refinement pins against this margin and `solution()` clamps
+    against it. `solution_report()` measures `crossed` against the same
+    number whenever the caller sets one, since deciding it twice is
+    what let `refine_stop == "settled"` come back beside a coordinate
+    reported 2.0 outside its bound.
+
+    Unset it is how far outside the solve itself was willing to settle,
+    floored so an unrelaxed solve does not pin on roundoff. The report
+    keeps the floor there instead, because a coordinate the SOLVE left
+    outside its bound is one of the things `crossed` exists to name,
+    and the relaxation is exactly how far out it is.
+    """
+    if bound_eps is not None:
+        return float(bound_eps)
+    return max(abs(session.solver.bound_relax_factor or 0.0), 1e-9)
+
+
+def refuse_on_pdpert(session, max_pdpert, who):
+    """Refuse when the converged factor carries more inertia correction
+    than the caller will accept.
+
+    A non-zero entry means the factorization every sensitivity output
+    inverts is not this problem's KKT matrix but a nearby one's, and how
+    nearby is what the entries measure. `SolutionReport.perturbations`
+    reports them either way, and this is the caller choosing to stop
+    rather than to read them.
+
+    The comparison comes from `pounce_sensitivity::pdpert_verdict`,
+    which `sens_max_pdpert` reads too, so the two surfaces cannot drift
+    apart on what counts as too perturbed. The message is written here
+    rather than taken from there, since that one names a CLI option and
+    says the sensitivity was skipped, and neither is true of a call
+    that raises.
+    """
+    if max_pdpert is None:
+        return
+    refuse, worst = session.solver.pdpert_verdict(float(max_pdpert))
+    if refuse:
+        pert = [abs(float(v)) for v in session.solver.kkt_perturbations]
+        raise ValueError(
+            f"{who}: the converged KKT factor carries a perturbation of "
+            f"{worst:.3e} (dx={pert[0]:.3e}, ds={pert[1]:.3e}, "
+            f"dc={pert[2]:.3e}, dd={pert[3]:.3e}), above the requested "
+            f"max_pdpert={max_pdpert:.3e}. The factor the step would "
+            f"invert is not this problem's KKT matrix. Raise max_pdpert "
+            f"to accept it anyway.")
+
+
+def _degeneracy_iter(degeneracy_iter, degeneracy, who):
+    """Resolve the budget's default and warn when it is inert: only
+    the "directional" decision spends back-solves, so a budget passed
+    under another option changes nothing, the same shape as bound_eps
+    under a mode that runs no refinement."""
+    if degeneracy_iter is None:
+        return 16
+    if degeneracy != "directional":
+        warnings.warn(
+            f"{who}: degeneracy_iter budgets the directional decision's "
+            f"back-solves and degeneracy={degeneracy!r} makes no "
+            "decision, so it changes nothing here.")
+    return degeneracy_iter
+
+
+def _correct(session, pin_idx, deltas, step, corrector_iter):
+    """Refine a step by Newton iterations on the barrier system.
+
+    Returns the refined primal step and what the iterations did.
+
+    The corrector starts from a point, so it needs the multipliers as
+    well as the primal step, and only the plain parametric step reports
+    both. Every mode refines the same underlying step, so the start is
+    the mode's own primal block carrying the plain step's multipliers.
+    The iterations correct the multipliers from there, which is what
+    they are for.
+
+    Two consequences worth naming. This spends a second solve even under
+    mode="linear" with degeneracy="one_sided", where the primal block it
+    then overwrites is the one it just computed. And under
+    degeneracy="directional" the multipliers come from the one-sided
+    step rather than the directional one that produced `step`, since
+    there is no directional full step to ask. Under
+    degeneracy="release_all" the mismatch is sharper still: the held
+    factorization supplies bound multipliers at exactly the bounds the
+    step just released to zero, over the maximal weak set rather than
+    a decided subset.
+    """
+    full = np.asarray(session.solver.parametric_step_full(pin_idx, deltas))
+    n_x = len(step)
+    full[:n_x] = np.asarray(step)
+    out, info = session.solver.correct_step(
+        pin_idx, deltas, list(full), corrector_iter)
+    return np.asarray(out)[:n_x], dict(info)
+
+
+def solution(session, pin_rows, deltas, clamp=True, mode="linear",
+             predictor_iter=16, degeneracy="directional", degeneracy_iter=None,
+             corrector_iter=0, bound_eps=None, max_pdpert=None,
+             who="solution"):
+    """First-order estimate of the solution at perturbed parameter values.
+
+    pin_rows: the full-g rows of the defining equalities the parameters
+    are pinned by. deltas: how far each one's right-hand side moves.
+    Returns the estimated point as a full-x array, ordered like
+    `session.var_names`. Values are clamped to variable bounds (with a
+    warning) unless clamp=False.
+
+    mode selects what happens when the step leaves a variable bound.
+    "linear" (the default) takes the step and clamps, which truncates the
+    crossing variable and leaves every other one at its predictor value.
+    "fix_relax" instead pins the crossing variable at its bound and
+    re-solves, so the others move to stay consistent under the pin, which
+    is what `solution_report`'s step fraction says the step needs. It
+    costs a dense solve and a backsolve per crossing and tracks a full
+    re-solve far more closely. Where nothing crosses the two agree
+    exactly.
+
+    "path" applies the perturbation a little at a time, stopping at
+    each fraction where the active set changes and continuing under
+    the changed set, so a variable can reach a bound partway through
+    the change and leave it again further along. Where the two settle
+    the same active set it agrees with "fix_relax". At a change large
+    enough that they disagree, "fix_relax" decides every change from
+    a single step taken at the base point while "path" applies each
+    change at the fraction where it happens. `active_set_changes()`
+    returns the record of those changes.
+
+    predictor_iter bounds that work. Under "fix_relax" it caps the
+    passes, each of which pins every crossing it can see and costs a
+    dense solve whose size grows with the number of pins. It is a
+    safety limit there rather than a budget, since the loop ends when
+    nothing is left outside a bound. Under "path" it caps the number of
+    active-set changes applied, and past the cap the rest of the
+    perturbation is taken in one step under the active set reached.
+
+    degeneracy selects what happens when the base point itself sits at
+    an active-set kink: a bound the classifier can call neither active
+    nor inactive, on the bound with a multiplier of the same order as
+    the slack. The solution has two one-sided derivatives there.
+    "directional" (the default) decides the weakly active bounds by the
+    directional-derivative QP for the perturbation's own direction, in
+    every mode, at the cost of a few extra backsolves paid only at a
+    kink. degeneracy_iter budgets those backsolves: the all-released
+    solve and one basis column per engaged bound count against it, and
+    a budget the engagement cannot fit falls back to the one-sided
+    step with a warning naming the counts. Only
+    degeneracy="directional" reads it, and passing it under another
+    option warns and changes nothing. "one_sided" takes the
+    single-sided value today's thresholds produce, bit-identical to
+    the release before this option existed. "release_all" releases
+    every weakly active bound undecided, at one back-solve and no QP:
+    the step is the all-released direction, and the bounds this
+    perturbation actually holds come back as bound crossings for the
+    mode or a correction to handle. It trades the decision's cost for
+    downstream repair: under mode="fix_relax" or "path" the crossings
+    are pinned or walked by the mode's own machinery, while
+    mode="linear" clamps each crossing coordinate and leaves its
+    neighbors carrying the released coupling.
+
+    corrector_iter runs Newton iterations on the barrier system after
+    the step, against an operator assembled at the predicted point:
+    one derivative evaluation and one factorization there, every
+    block including the barrier diagonal, then a back-solve per
+    iteration. It aims at the barrier solution at the mu the solve
+    finished on rather than at a re-solve, so the accuracy it reaches
+    is bounded by that offset, and it stops as soon as an iteration
+    fails to improve the residual, warning when the whole correction
+    failed to improve it. Where the perturbation needs a bound to
+    leave the active set and the step's endpoint does not show the
+    release, no released row is applied: the iterations can move the
+    variable partway off the bound on the weak diagonal entry the
+    step's clamped multiplier builds, and the estimate is not the
+    re-solve. mode="fix_relax" and mode="path" decide such releases
+    themselves, and the corrector applies the rows they decided. It
+    applies under every mode, refining whatever step that mode
+    produced.
+
+    bound_eps sets how far outside a variable bound a step has to end
+    to count as having left it, which decides what mode="fix_relax"
+    pins, what `solution_report()` reports in `crossed`, and what the
+    clamp below acts on. It is absolute, as the refinement's own test
+    is. Unset, it is how far outside the solve itself was willing to
+    settle, floored so an unrelaxed solve does not pin on roundoff. A
+    constraint row keeps its own floor, and a bound is released when the
+    step drives its multiplier negative past the solve's own margin,
+    whatever bound_eps is. Only mode="fix_relax" reads it, and passing
+    it under another mode warns and changes nothing. It must be
+    positive, as the CLI's sens_bound_eps is.
+
+    max_pdpert refuses rather than answering when the converged KKT
+    factor carries an inertia correction larger than the value given.
+    Every sensitivity output inverts that factor, so a perturbed one
+    answers for a nearby problem rather than this one.
+    `solution_report().perturbations` reports the same numbers for a
+    caller who would rather read them than stop. It must be positive,
+    as the CLI's sens_max_pdpert is, and the same argument is on
+    sens_jacobian(), solution(), solution_report(),
+    active_set_changes(),
+    covariance() and information().
+
+    clamp keeps its meaning in both modes: it clamps whatever is still
+    outside a bound at the end. Under "fix_relax" the pins usually
+    leave nothing to clamp, and when they do not, the warning says
+    which of the refinement's stopping conditions was reached.
+
+    `deltas` are measured from the SOLVE point -- each is how far that
+    pin row's right-hand side moves from the value it carried when the
+    factor was taken -- so a caller that has already written the new
+    parameter values somewhere else gets the same answer. This is what
+    makes the receding-horizon pattern (solve at a prediction, record
+    the measurement, then ask) come out right.
+
+    A limit the caller expressed as a CONSTRAINT rather than a variable
+    bound moves with the perturbation, so it is not clamped against
+    here and raises no clamp warning; the step already respects it to
+    first order.
+    """
+    if mode not in ("linear", "fix_relax", "path"):
+        raise ValueError(
+            f"{who}: mode must be 'linear', 'fix_relax' or 'path', got "
+            f"{mode!r}")
+    if degeneracy not in ("directional", "one_sided", "release_all"):
+        raise ValueError(
+            f"{who}: degeneracy must be 'directional', 'one_sided' or "
+            f"'release_all', got {degeneracy!r}")
+    degeneracy_iter = _degeneracy_iter(
+        degeneracy_iter, degeneracy, who)
+    check_margins(bound_eps, max_pdpert, who)
+    if bound_eps is not None and mode != "fix_relax":
+        warnings.warn(
+            f"{who}: bound_eps is the margin the fix_relax refinement "
+            f"pins against and mode={mode!r} runs no refinement, so it "
+            "changes nothing here.")
+    refuse_on_pdpert(session, max_pdpert, who)
+
+    pin_idx, deltas = list(pin_rows), list(deltas)
+
+    # parametric_step returns the factor's x block (var-x); base_x and
+    # everything below it (nl.x_l/x_u, var_names) are full-x
+    segments = []
+    fell_back = False
+    if degeneracy == "directional":
+        # At a degenerate base point the weakly active bounds are
+        # decided by the directional-derivative QP for this
+        # perturbation's own direction; at a clean base point these are
+        # the plain calls at no extra solve cost. A failed decision
+        # (budget exhausted, no sign-consistent working set) falls back
+        # to the one-sided step and says so.
+        try:
+            step, held_rows, _ = (
+                session.solver.parametric_step_directional(
+                    pin_idx, deltas, degeneracy_iter))
+            if mode == "fix_relax":
+                step, pinned, stop = (
+                    session.solver.parametric_step_bounded_decided(
+                        pin_idx, deltas, held_rows, predictor_iter,
+                        bound_eps))
+            elif mode == "path":
+                step, segments = (
+                    session.solver.parametric_step_path_decided(
+                        pin_idx, deltas, held_rows, predictor_iter))
+        except RuntimeError as e:
+            if "directional derivative" not in str(e):
+                raise
+            warnings.warn(
+                f"{who}: {e}. Falling back to the one-sided step, "
+                "the degeneracy='one_sided' behavior.")
+            fell_back = True
+    if degeneracy == "release_all":
+        # Every weakly active bound is released undecided, at one
+        # back-solve and no QP: the bounds this perturbation actually
+        # holds come back as crossings for the mode or a correction to
+        # handle. fix_relax and path run their own machinery under the
+        # all-released treatment, the decided variants' empty held set.
+        if mode == "fix_relax":
+            step, pinned, stop = (
+                session.solver.parametric_step_bounded_decided(
+                    pin_idx, deltas, [], predictor_iter, bound_eps))
+        elif mode == "path":
+            step, segments = (
+                session.solver.parametric_step_path_decided(
+                    pin_idx, deltas, [], predictor_iter))
+        else:
+            step, _released = session.solver.parametric_step_release_all(
+                pin_idx, deltas)
+    if degeneracy == "one_sided" or fell_back:
+        if mode == "fix_relax":
+            step, pinned, stop = session.solver.parametric_step_bounded(
+                pin_idx, deltas, predictor_iter, bound_eps)
+        elif mode == "path":
+            step, segments = session.solver.parametric_step_path(
+                pin_idx, deltas, predictor_iter)
+        else:
+            step = session.solver.parametric_step(pin_idx, deltas)
+    corrector = None
+    if corrector_iter:
+        step, corrector = _correct(
+            session, pin_idx, deltas, step, corrector_iter)
+        # A correction that works drives the residual down by orders;
+        # one whose Newton direction finds nothing to reduce shaves a
+        # few percent off and leaves the estimate where it was.
+        # Halving is a low bar that separates them cleanly, and saying
+        # nothing would let the second case pass for the first.
+        # Written as `not (<=)` rather than `>`, so a non-finite
+        # residual warns instead of comparing false and passing in
+        # silence. gh#845 was exactly that: the corrector normed an
+        # all-NaN residual to 0.0, `0.0 > 0.5 * 6.09` was false, and
+        # `solution()` returned {x: nan} with nothing said. The Rust
+        # side no longer produces that number, and this side no longer
+        # depends on it not doing so.
+        if corrector is not None and not (
+                corrector["residual"] <= 0.5 * corrector[
+                    "initial_residual"]):
+            warnings.warn(
+                f"{who}: the corrector spent "
+                f"{corrector['iterations']} back-solve(s) and moved the "
+                f"residual from {corrector['initial_residual']:.2e} to "
+                f"{corrector['residual']:.2e}, measured from the point the "
+                "iterations start at rather than from the step handed in, "
+                "so the estimate is close to the uncorrected step. One "
+                "cause is a bound that must leave the active set with "
+                "nothing else for the iterations to reduce; "
+                "mode=\"fix_relax\" and mode=\"path\" decide such releases "
+                "where the step shows them.")
+
+    dx = session.scatter_x(np.asarray(step))
+    x_new = session.base_x + dx
+
+    lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
+    if mode in ("fix_relax", "path"):
+        # The refinement holds each pinned coordinate AT its bound and
+        # lets the others move, so a coordinate can still be left
+        # outside one, either because the pass budget ran out or because
+        # the pins have exhausted the problem's degrees of freedom.
+        # `clamp` decides what happens then, exactly as it does under
+        # `linear`, and the warning says which of the two stopped it.
+        #
+        # One tolerance for "outside its bound", taken from the solve
+        # rather than chosen here: it was willing to leave a converged
+        # point `bound_relax_factor` outside, so anything within that is
+        # on the bound. The refinement pins against the same number.
+        # The comparison is absolute, as the refinement's own is, so the
+        # clamp and the pins agree on a coordinate of any magnitude.
+        eps = _bound_margin(
+            session, bound_eps if mode == "fix_relax" else None)
+        out = np.where((x_new < lo - eps) | (x_new > hi + eps))[0]
+        if out.size:
+            names = [session.var_names[i] for i in out]
+            if mode == "fix_relax":
+                did = f"pinned {len(pinned)} variable(s)"
+                # The refinement says why it stopped rather than the
+                # count being read as a proxy for it: a pass pins every
+                # crossing it sees, so the number of pins says nothing
+                # about whether predictor_iter bound the work (gh#732).
+                why = {
+                    "iteration_limit":
+                        "the safety limit of %d pass(es) was reached, so "
+                        "raising predictor_iter may finish it" % predictor_iter,
+                    "degrees_of_freedom":
+                        "holding them all would need more pins than the "
+                        "problem has degrees of freedom, so no step does",
+                    "worse_than_plain":
+                        "the refinement ended further outside the bounds "
+                        "than the plain step, which was returned instead",
+                }.get(stop, "the refinement settled here")
+            else:
+                n_changes = len(segments)
+                did = f"applied {n_changes} active-set change(s)"
+                why = ("the limit of %d was reached, so raising "
+                       "predictor_iter may finish it" % predictor_iter
+                       if n_changes >= predictor_iter else
+                       "the path settled the active set here")
+            warnings.warn(
+                f"{who}: {mode} {did} and "
+                f"still leaves the bounds for {names}, because {why}."
+                + (" The values were clamped, which breaks the constraints "
+                   "the pins were solved against." if clamp else
+                   " The values are returned unclamped."))
+            if clamp:
+                x_new = np.clip(x_new, lo, hi)
+    elif clamp:
+        # `linear` takes the step as the predictor gives it, so a
+        # crossing shows up as a value outside its bound and clamping is
+        # all this mode can do about it. The active set changed and the
+        # step does not know, which is what `fix_relax` addresses.
+        # The comparison is absolute, as the refinement's own is.
+        eps = _bound_margin(session, None)
+        clamped = (x_new < lo - eps) | (x_new > hi + eps)
+        if clamped.any():
+            names = [session.var_names[i] for i in np.where(clamped)[0]]
+            warnings.warn(
+                f"{who}: linear step leaves the variable bounds for "
+                f"{names}; values were clamped and the active set likely "
+                "changed, so the estimate is unreliable there. mode="
+                "'fix_relax' pins them and re-solves instead.")
+        x_new = np.clip(x_new, lo, hi)
+
+    return x_new
+
+
+class SolutionReport:
+    """What the linear step behind `solution()` does about the bounds.
+
+    Attributes
+    ----------
+    alpha : float
+        The fraction of the requested perturbation that can be taken
+        before the first bound is reached, from the ratio test along
+        the step. On a solve that kept its bounds, at least 1.0 means
+        the full step stays inside every one of them. That does not
+        follow when `bounds_relaxed` is true, since the solve can leave
+        a coordinate outside a bound before the step starts. Infinity
+        means no bound lies in the step direction.
+    first : str or None
+        Name of the variable or constraint reaching its bound at
+        `alpha`, None when `alpha` is infinite.
+    first_kind : str or None
+        Either "variable" or "constraint", naming what `first` is.
+    crossed : mapping
+        Variable data to the distance by which the full step leaves
+        that variable's bound. These are the variables `solution()`
+        clamps. Measured at the predicted point against both bounds, so
+        on a relaxed solve an entry can be a coordinate the SOLVE left
+        outside its bound rather than one the step carried past. The
+        step fraction looks only along the step direction, so the two
+        answer different questions there and `alpha` can be at or above
+        one while this is non-empty.
+    crossed_rows : mapping
+        Constraint data to the same distance, for inequality
+        constraints.
+
+    Those two are keyed by model components, because every coordinate
+    that crosses has one. The two classifications below are keyed by
+    solve-space name instead, because they cover every coordinate of
+    the solve, including the ones the declared-parameter surgery
+    created, which have no counterpart on the model.
+    violation : float
+        Largest constraint violation at the predicted point, measured
+        against the perturbed right-hand sides. This is the primal
+        half of the residual. The dual half needs the multipliers at
+        the perturbed point, so it is computed by the corrector, which
+        holds them, rather than assembled here.
+    mu : float
+        Barrier parameter of the held factorization.
+    activity, row_activity : dict
+        Name to activity classification from the core classifier, over
+        variables and over constraints. Both are empty when
+        `bounds_relaxed` is true.
+    perturbations : list
+        The held factor's inertia-correction perturbations. Any
+        non-zero entry means the factor is regularized, so the step is
+        taken against a modified matrix and differs from the exact
+        active-set answer by that much.
+    corrector : dict or None
+        What `corrector_iter` iterations did, None when none were run.
+        Holds the back-solves spent under `iterations`, the residual
+        before and after under `initial_residual` and `residual`
+        (`initial_residual` is measured at the point the iterations
+        start from, after the active-set decision and the clamp, not at
+        the step handed in), and
+        that residual split into `stationarity`, `feasibility` and
+        `complementarity`. `released` counts the bounds the step took
+        out of the active set and `pinned` the ones it brought in, with
+        `active_set_changes` their total. `converged` says the loop
+        stopped because an iteration failed to improve rather than
+        because it ran out of budget. This is the dual half `violation`
+        refers to: it needs the multipliers at the perturbed point,
+        which the corrector holds.
+    refine_stop : str or None
+        Why the `mode="fix_relax"` refinement stopped, one of
+        "settled", "iteration_limit", "degrees_of_freedom" or
+        "worse_than_plain". None under the other two modes, which run
+        no refinement. A pass pins every crossing it sees, so the
+        number of pins says nothing about which limit was reached and
+        this is the only thing that does. "worse_than_plain" means the
+        step reported here is the unrefined one.
+    bounds_relaxed : bool
+        True when the solve ran with a non-zero `bound_relax_factor`,
+        which lets a variable settle outside the bound the model
+        declares. The classifier raises for such a solve, since relaxed
+        bounds shift the slacks it reads, and the ratio test measures
+        distances to bounds the solve did not hold to.
+
+    The last three, with `mu`, are what separate this predictor from
+    the exact value at the perturbed active set. A caller comparing the
+    estimate against a re-solve reads them to tell which one explains
+    the difference.
+    """
+
+    def __init__(self, alpha, first, first_kind, crossed, crossed_rows,
+                 violation, mu, activity, row_activity, perturbations,
+                 bounds_relaxed, corrector=None, refine_stop=None):
+        self.alpha = alpha
+        self.first = first
+        self.first_kind = first_kind
+        self.crossed = crossed
+        self.crossed_rows = crossed_rows
+        self.violation = violation
+        self.mu = mu
+        self.activity = activity
+        self.row_activity = row_activity
+        self.perturbations = perturbations
+        self.bounds_relaxed = bounds_relaxed
+        self.corrector = corrector
+        self.refine_stop = refine_stop
+
+    def __repr__(self):
+        n = len(self.crossed) + len(self.crossed_rows)
+        where = f", first {self.first_kind} {self.first}" if self.first else ""
+        flags = "".join([
+            ", regularized" if any(self.perturbations) else "",
+            ", bounds relaxed" if self.bounds_relaxed else "",
+        ])
+        return (f"SolutionReport(alpha={self.alpha:.6g}{where}, "
+                f"crossed={n}, violation={self.violation:.3e}, "
+                f"mu={self.mu:.3e}{flags})")
+
+
+def _row_step(session, dx):
+    """Jacobian at the base point times the step, in row order."""
+    rows, cols = session.nl.jacobian_structure()
+    vals = np.asarray(session.nl.jacobian(session.base_x))
+    return np.bincount(np.asarray(rows),
+                       weights=vals * dx[np.asarray(cols)],
+                       minlength=len(session.con_names))
+
+
+
+#: No bound at all reaches here as the reader's sentinel rather than an
+#: infinity: `read_nl` seeds every bound vector with +-1e19, so an
+#: `isfinite` test passes on it and scores a crossing at 1e18 times the
+#: perturbation. The magnitude test is the convention the rest of the
+#: package already uses (`preflight`, `block_init`, gh #401 / #403).
+_NO_BOUND = 1e19
+
+
+def _ratio_test(base, step, lo, hi, names, live=None, on_bound=None,
+                mu=float("nan"), tol=None):
+    """Smallest fraction of `step` that reaches a bound, and where.
+
+    Only coordinates strictly inside their bounds take part, because a
+    coordinate already on a bound is not one the step can cross. That
+    exclusion is what makes the answer mean anything: at an active
+    bound the remaining gap is the small slack the barrier leaves, the
+    step component is the same size, and their quotient can take any
+    value. It would then become the minimum on any model carrying an
+    active bound. Activity is reported through the classification
+    instead.
+
+    A coordinate the full step carries past a bound is always scored,
+    whatever the exclusion would otherwise say. That case IS a crossing,
+    at a fraction below one by construction, and the caller reads it in
+    `crossed` off the same predicate and the same tolerance. Deciding it
+    twice is what let the two disagree, reporting that 998 times the
+    perturbation fits while naming a coordinate the single step leaves
+    its bound by 0.25.
+
+    So the exclusion below only ever applies to coordinates that do not
+    cross, and cannot cost a crossing. Two things drive it. `on_bound`
+    carries the classification, which is exact where the classifier
+    commits, applied per SIDE rather than per coordinate, since a
+    coordinate held at one bound can still be carried across its other
+    one.
+
+    The distance test covers the coordinates the classifier declines to
+    rule on, where the label cannot answer the question because
+    `ambiguous` spans both a coordinate near its bound with room left
+    and one already on it. What separates those is the size of the
+    remaining gap, which is O(mu) at a strongly active bound and
+    O(sqrt(mu)) at a weakly active one, against O(1) room in the
+    interior. So the threshold scales with sqrt(mu), measured four
+    orders of magnitude clear of the interior case. It is capped
+    because it is applied relative to the coordinate's own magnitude,
+    and a loose `mu` at termination would otherwise widen it without
+    limit. Without a classification there is no `mu` either, and it
+    falls back to a fixed threshold.
+
+    Coordinates whose step is below the roundoff of their own magnitude
+    also take no part, since dividing by one puts the crossing at an
+    enormous multiple of the perturbation, which is not a finding.
+    """
+    scale = np.maximum(1.0, np.abs(base))
+    toward_hi = step > 0
+    bound = np.where(toward_hi, hi, lo)
+    distance = bound - base
+    present = np.abs(bound) < _NO_BOUND
+    moving = np.abs(step) > 1e-12 * scale
+
+    # The same predicate, and the same tolerance, that fills `crossed`
+    # or `crossed_rows`. The caller passes the tolerance it fills with,
+    # and the default is the rows' own.
+    reached = base + step
+    if tol is None:
+        tol = 1e-9 * np.maximum(1.0, np.abs(reached))
+    crosses = present & moving & np.where(
+        toward_hi, reached > bound + tol, reached < bound - tol)
+
+    floor = 1e-9 if not np.isfinite(mu) else min(
+        1e-2, max(1e-9, 10.0 * mu ** 0.5))
+    interior = np.abs(distance) > floor * scale
+    if on_bound is not None:
+        # the nearer bound is the one the coordinate is held at, and it
+        # is only that side the classification rules out
+        at_hi = (hi - base) <= (base - lo)
+        interior &= ~(on_bound & (toward_hi == at_hi))
+
+    ok = present & moving & (crosses | interior)
+    if live is not None:
+        ok &= live
+    if not ok.any():
+        return float("inf"), None
+    fraction = np.full(base.shape, np.inf)
+    # a relaxed solve can settle outside a bound, which leaves no room
+    # to move rather than a negative amount of it
+    fraction[ok] = np.maximum(distance[ok] / step[ok], 0.0)
+    i = int(np.argmin(fraction))
+    return float(fraction[i]), names[i]
+
+
+
+#: Classifications that put a coordinate ON its bound. Both have the
+#: slack going to zero, so neither can be crossed by a step. Strongly
+#: active leaves an O(mu) gap and weakly active an O(sqrt(mu)) one, and
+#: neither gap is room the step can move through. `ambiguous` and
+#: `unidentified` are absent on purpose: the first spans coordinates on
+#: their bound AND coordinates near it with room left, and the second
+#: says only that the curvature is below scale, so neither label
+#: answers the question. `_ratio_test`'s distance test rules on those.
+_AT_BOUND = ("strongly_active", "weakly_active")
+
+
+def _on_bound(statuses):
+    return np.array([s in _AT_BOUND for s in statuses])
+
+
+def solution_report(session, pin_rows, deltas, max_iter=None,
+                    degeneracy="directional", degeneracy_iter=None,
+                    corrector_iter=0, mode="linear", predictor_iter=16,
+                    bound_eps=None, max_pdpert=None,
+                    who="solution_report"):
+    """Report what `solution()`'s step does about the bounds.
+
+    degeneracy and degeneracy_iter match `solution()`'s arguments of
+    the same names, so the step measured here is the step `solution()`
+    takes for the same arguments, including the directional-derivative
+    correction at a degenerate base point. degeneracy_iter budgets that
+    correction's back-solves.
+
+    max_iter is accepted for positional compatibility and does nothing.
+    It used to budget the directional decision here, so passing it, in
+    particular `max_iter=0` to force the one-sided fallback, changed the
+    reported step. `degeneracy_iter` is that knob now. Passing it raises
+    a DeprecationWarning rather than being ignored in silence, since the
+    two readings differ and nothing else would say so.
+
+    mode and predictor_iter match `solution()`'s arguments of the same
+    names, so the step measured here is the step `solution()` takes for
+    the same arguments. `violation` and `corrector` are properties of
+    that step and move with the mode. Reporting the linear step's
+    violation for a `fix_relax` estimate would describe a step the
+    caller did not take.
+
+    `alpha`, `first`, `crossed` and `crossed_rows` measure where the
+    step leaves a bound. Under "fix_relax" and "path" it does not,
+    since both stop at the bound by construction, so `alpha` is 1.0 and
+    `crossed` is empty for every model. That is the correct answer for
+    such a step rather than a missing one. A `bound_eps` wide enough to
+    cover the crossing is the exception: the refinement then pins
+    nothing, so the step reaches a bound at a fraction below one. It is
+    not quite the linear step either, since the release test keeps the
+    solve's own margin whatever `bound_eps` is, so a bound the step
+    drives negative is released and the step moves by that multiplier's
+    size. The reason to run those modes is what "linear" reports at the
+    same perturbation.
+
+    `activity`, `row_activity` and `mu` come from the converged base
+    point and `perturbations` and `bounds_relaxed` from the solve, so
+    none of the five depends on the mode.
+
+    bound_eps sets how far outside a variable bound a step has to end
+    to count as having left it, which decides what mode="fix_relax"
+    pins and what `crossed` and `alpha` measure against. It is absolute,
+    as the refinement's own test is. Unset, it is how far outside the
+    solve itself was willing to settle, floored so an unrelaxed solve
+    does not pin on roundoff, and `crossed` keeps that floor so a
+    coordinate the solve itself left outside a relaxed bound is still
+    named. A constraint row keeps its own floor, and a bound is released
+    when the step drives its multiplier negative past the solve's own
+    margin, whatever bound_eps is. Only mode="fix_relax" reads it, and
+    passing it under another mode warns. It must be positive, as the
+    CLI's sens_bound_eps is.
+
+    max_pdpert refuses rather than answering when the converged KKT
+    factor carries an inertia correction larger than the value given.
+    Every sensitivity output inverts that factor, so a perturbed one
+    answers for a nearby problem rather than this one.
+    `solution_report().perturbations` reports the same numbers for a
+    caller who would rather read them than stop. It must be positive,
+    as the CLI's sens_max_pdpert is, and the same argument is on
+    sens_jacobian(), solution(), solution_report(),
+    active_set_changes(),
+    covariance() and information().
+
+    corrector_iter runs the same Newton iterations `solution()` runs and
+    reports what they did on the `corrector` attribute, without changing
+    anything the rest of the report measures. Those describe the step
+    handed to the corrector, which is what a caller comparing the two
+    wants.
+
+    Takes the same perturbation argument `solution()` takes and returns
+    a SolutionReport. Nothing about the estimate changes: this runs
+    the same step and measures it.
+
+    The ratio test divides each bounded coordinate's distance to the
+    bound it moves toward by the size of its step component and keeps
+    the smallest value, over variables and over inequality constraint
+    constraints. Equality constraints do not take part, since the step
+    holds them to first order and they admit no activity change. The
+    constraints pinning the declared Params are excluded on the same
+    grounds, because the perturbation moves their right-hand sides by
+    construction.
+    """
+    if mode not in ("linear", "fix_relax", "path"):
+        raise ValueError(
+            f"{who}: mode must be 'linear', 'fix_relax' or "
+            f"'path', got {mode!r}")
+    if degeneracy not in ("directional", "one_sided", "release_all"):
+        raise ValueError(
+            f"{who}: degeneracy must be 'directional', "
+            f"'one_sided' or 'release_all', got {degeneracy!r}")
+    degeneracy_iter = _degeneracy_iter(
+        degeneracy_iter, degeneracy, who)
+    check_margins(bound_eps, max_pdpert, who)
+    if bound_eps is not None and mode != "fix_relax":
+        warnings.warn(
+            f"{who}: bound_eps is the margin the fix_relax "
+            f"refinement pins against and mode={mode!r} runs no "
+            "refinement, so it changes nothing here.")
+    refuse_on_pdpert(session, max_pdpert, who)
+    if max_iter is not None:
+        warnings.warn(
+            f"{who}: max_iter no longer does anything "
+            "here and is "
+            "ignored; it used to budget the directional decision, which "
+            "degeneracy_iter budgets now. Pass degeneracy_iter instead.",
+            DeprecationWarning, stacklevel=2)
+    pin_idx, deltas = list(pin_rows), list(deltas)
+    # the same dispatch `solution()` runs, so the step measured here is
+    # the step it takes for these arguments
+    fell_back = False
+    refine_stop = None
+    if degeneracy == "directional":
+        try:
+            step, held_rows, _ = session.solver.parametric_step_directional(
+                pin_idx, deltas, degeneracy_iter)
+            if mode == "fix_relax":
+                step, _, refine_stop = (
+                    session.solver.parametric_step_bounded_decided(
+                        pin_idx, deltas, held_rows, predictor_iter,
+                        bound_eps))
+            elif mode == "path":
+                step, _ = session.solver.parametric_step_path_decided(
+                    pin_idx, deltas, held_rows, predictor_iter)
+        except RuntimeError as e:
+            if "directional derivative" not in str(e):
+                raise
+            warnings.warn(
+                f"{who}: {e}. Falling back to the one-sided "
+                "step, the degeneracy='one_sided' behavior.")
+            fell_back = True
+    if degeneracy == "release_all":
+        if mode == "fix_relax":
+            step, _, refine_stop = (
+                session.solver.parametric_step_bounded_decided(
+                    pin_idx, deltas, [], predictor_iter, bound_eps))
+        elif mode == "path":
+            step, _ = session.solver.parametric_step_path_decided(
+                pin_idx, deltas, [], predictor_iter)
+        else:
+            step, _released = session.solver.parametric_step_release_all(
+                pin_idx, deltas)
+    if degeneracy == "one_sided" or fell_back:
+        if mode == "fix_relax":
+            step, _, refine_stop = session.solver.parametric_step_bounded(
+                pin_idx, deltas, predictor_iter, bound_eps)
+        elif mode == "path":
+            step, _ = session.solver.parametric_step_path(
+                pin_idx, deltas, predictor_iter)
+        else:
+            step = session.solver.parametric_step(pin_idx, deltas)
+    dx = session.scatter_x(np.asarray(step))
+    base = np.asarray(session.base_x)
+    x_new = base + dx
+
+    lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
+    g_l, g_u = np.asarray(session.nl.g_l), np.asarray(session.nl.g_u)
+
+    # The margin the refinement pinned against, so `alpha` and `crossed`
+    # answer with the number that decided the step. It is absolute, as
+    # the refinement's own test is, so a coordinate of order 1e4 does not
+    # get a tolerance the refinement never gave it. Unset keeps the
+    # fixed floor rather than the solve's relaxation: `crossed` reports
+    # a coordinate the SOLVE left outside its bound, and the relaxation
+    # is exactly how far out that is, so taking it as the margin would
+    # hide the case this report exists to name.
+    eps = (1e-9 if bound_eps is None or mode != "fix_relax"
+           else float(bound_eps))
+    # The refinement pins variable bounds only, so a constraint row
+    # keeps its floor whatever margin the caller set: a wide margin has
+    # no say over a row the step carries past its limit. Its tolerance
+    # is set beside the row ratio test below.
+
+    row_names = user_row_names(session)
+
+    # The classifier raises for a solve that relaxed its bounds, since
+    # relaxed bounds shift the slacks it reads. Ask the solve what it
+    # ran under instead of provoking that and reading the message, and
+    # report it as the fact it is. The rest of the report is still
+    # measured, where a diagnostic that raised would give the caller
+    # nothing exactly when they are trying to find out why the estimate
+    # disagrees with a re-solve. `mu` comes from the classifier, so it
+    # is unavailable on that path too.
+    mu, activity, row_status = float("nan"), {}, {}
+    var_on_bound = row_on_bound = None
+    bounds_relaxed = bool(session.solver.bound_relax_factor)
+    if not bounds_relaxed:
+        act = session.solver.classify_activity()
+        mu = float(act["mu"])
+        activity = dict(zip(session.var_names, act["var_status"]))
+        row_status = dict(zip(row_names, act["row_status"]))
+        var_on_bound = _on_bound(act["var_status"])
+        row_on_bound = _on_bound(act["row_status"])
+
+    alpha, first = _ratio_test(base, dx, lo, hi, session.var_names, tol=eps,
+                               on_bound=var_on_bound, mu=mu)
+    first_kind = None if first is None else "variable"
+    dg = _row_step(session, dx)
+    g_base = np.asarray(session.nl.constraints(base))
+    # an equality constraint is held to first order and cannot change
+    # activity, and a pin constraint moves by construction
+    live = g_l < g_u
+    live[list(pin_idx)] = False
+    g_pred = g_base + dg
+    gtol = 1e-9 * np.maximum(1.0, np.abs(g_pred))
+    a_row, f_row = _ratio_test(g_base, dg, g_l, g_u, row_names, live=live,
+                               on_bound=row_on_bound, mu=mu, tol=gtol)
+    if a_row < alpha:
+        alpha, first, first_kind = a_row, f_row, "constraint"
+
+    crossed = session.new_keymap()
+    for i in np.where((x_new < lo - eps) | (x_new > hi + eps))[0]:
+        ov = session.var_key(i)
+        if ov is not None:
+            crossed[ov] = float(max(lo[i] - x_new[i], x_new[i] - hi[i]))
+    crossed_rows = session.new_keymap()
+    out_of_bounds = (g_pred < g_l - gtol) | (g_pred > g_u + gtol)
+    rows_out = np.where(live & out_of_bounds)[0]
+    # resolved only when a row actually crossed: the resolution is
+    # once per session, but the common case has nothing to resolve for
+    row_data = session.user_row_data() if rows_out.size else ()
+    for j in rows_out:
+        oc = row_data[j]
+        if oc is not None:
+            crossed_rows[oc] = float(
+                max(g_l[j] - g_pred[j], g_pred[j] - g_u[j]))
+
+    # the perturbation IS the shift of the pin constraints' right-hand
+    # sides, so the violation is measured against the shifted ones
+    gl_p, gu_p = g_l.copy(), g_u.copy()
+    for pin, d in zip(pin_idx, deltas):
+        gl_p[pin] += d
+        gu_p[pin] += d
+    g_at = np.asarray(session.nl.constraints(x_new))
+    violation = float(np.max(np.maximum.reduce(
+        [gl_p - g_at, g_at - gu_p, np.zeros_like(g_at)])))
+
+    corrector = None
+    if corrector_iter:
+        _, corrector = _correct(
+            session, pin_idx, deltas, np.asarray(step), corrector_iter)
+
+    return SolutionReport(
+        alpha=alpha, first=first, first_kind=first_kind,
+        crossed=crossed, crossed_rows=crossed_rows, violation=violation,
+        mu=mu, activity=activity, row_activity=row_status,
+        perturbations=np.asarray(session.solver.kkt_perturbations).tolist(),
+        bounds_relaxed=bounds_relaxed, corrector=corrector,
+        refine_stop=refine_stop,
+    )
+
+
+
+#: One active-set change along `solution(mode="path")`'s path.
+#: `fraction` is how far along the perturbation the change happens,
+#: `var` is the variable (its solve-space name when the solve created
+#: it without a model counterpart), `bound` is "lower" or "upper", and
+#: `action` is "reaches" when the variable arrives at the bound and is
+#: held there, "leaves" when it comes off it.
+#:
+#: A weakly active bound can be recorded as "reaches" at a fraction of
+#: essentially zero, which does not contradict the variable having been
+#: on that bound at the base point: what the working set gained there
+#: is the *hold*. Undecided, such a bound sits in the factorization as
+#: an order-one penalty that bends the step without enforcing anything,
+#: so a perturbation pressing into it is a breakpoint like any other
+#: (gh#852).
+ActiveSetChange = namedtuple(
+    "ActiveSetChange", ["fraction", "var", "bound", "action"])
+
+
+def active_set_changes(session, pin_rows, deltas, predictor_iter=16,
+                       degeneracy="directional", degeneracy_iter=None,
+                       max_pdpert=None, who="active_set_changes"):
+    """The active-set changes `solution(mode="path")` applies, in order.
+
+    Takes the same perturbation argument `solution()` takes and returns
+    a list of `ActiveSetChange` entries, one per change, in the order
+    the path applies them. Nothing about the estimate changes: this
+    runs the same path and returns its record.
+
+    The record is what `mode="path"` produces that no other mode does.
+    The first entry's fraction is how much of the measurement
+    discrepancy the held solve's active set survives unchanged, and the
+    list as a whole says which bounds the re-optimized solution enters
+    and leaves between the predicted state and the measured one.
+
+    A list of length `predictor_iter` means the cap stopped the path before
+    the target, the same condition `solution()` warns about.
+
+    degeneracy and degeneracy_iter match `solution()`'s arguments of the
+    same names. Under "directional" (the default), a weakly active bound
+    the perturbation releases appears in the record as a departure at
+    the fraction where its multiplier reaches zero: essentially zero at
+    an exact kink, and partway along the step when the held solve sits
+    inside the ambiguous band, where the bound is genuinely active for
+    the first stretch. degeneracy_iter budgets that decision's
+    back-solves, and a budget it cannot fit falls back to the one-sided
+    record with a warning, and predictor_iter above still caps the path
+    itself. Under "release_all" every weakly active bound starts the
+    path released undecided, so a bound the perturbation holds appears
+    as a return to its bound along the path rather than a decision at
+    the base point.
+
+    max_pdpert refuses rather than answering when the converged KKT
+    factor carries an inertia correction larger than the value given.
+    This runs the same predictor `solution(mode="path")` runs and
+    inverts the same factor, so it takes the same cap. There is no
+    bound_eps here, since the path decides its changes from where a
+    multiplier reaches zero and reads no margin.
+    """
+    if degeneracy not in ("directional", "one_sided", "release_all"):
+        raise ValueError(
+            f"{who}: degeneracy must be 'directional', "
+            f"'one_sided' or 'release_all', got {degeneracy!r}")
+    degeneracy_iter = _degeneracy_iter(
+        degeneracy_iter, degeneracy, who)
+    check_margins(None, max_pdpert, who)
+    refuse_on_pdpert(session, max_pdpert, who)
+    pin_idx, deltas = list(pin_rows), list(deltas)
+    if degeneracy == "directional":
+        try:
+            _, held_rows, _ = (
+                session.solver.parametric_step_directional(
+                    pin_idx, deltas, degeneracy_iter))
+            _, segments = session.solver.parametric_step_path_decided(
+                pin_idx, deltas, held_rows, predictor_iter)
+        except RuntimeError as e:
+            if "directional derivative" not in str(e):
+                raise
+            warnings.warn(
+                f"{who}: {e}. Falling back to the "
+                "one-sided record, the degeneracy='one_sided' behavior.")
+            _, segments = session.solver.parametric_step_path(
+                pin_idx, deltas, predictor_iter)
+    elif degeneracy == "release_all":
+        _, segments = session.solver.parametric_step_path_decided(
+            pin_idx, deltas, [], predictor_iter)
+    else:
+        _, segments = session.solver.parametric_step_path(
+            pin_idx, deltas, predictor_iter)
+
+    # segments carry var-x rows (the factor's x block); var_names is
+    # full-x, so invert the same map scatter_x applies
+    full_of = {row: full
+               for full, row in enumerate(session._primal_row_map())
+               if row is not None}
+    out = []
+    for frac, var_row, lower, pinned in segments:
+        full = full_of[var_row]
+        name = session.var_names[full]
+        comp = session.var_key(full)
+        out.append(ActiveSetChange(
+            fraction=float(frac),
+            var=comp if comp is not None else name,
+            bound="lower" if lower else "upper",
+            action="reaches" if pinned else "leaves",
+        ))
+    return out

--- a/python/tests/test_sensitivity_core.py
+++ b/python/tests/test_sensitivity_core.py
@@ -1,0 +1,231 @@
+"""`pounce.sensitivity` against models built with no modelling layer.
+
+The point of these: every number here used to be reachable only through
+`pyomo_pounce`, so the whole surface was untestable without Pyomo
+installed and unusable from a `.nl` file, the CLI or CasADi. Nothing in
+this file imports Pyomo, and `test_the_core_does_not_import_pyomo`
+asserts that stays true.
+
+The fixtures are small enough to have closed-form answers, so these are
+checks against arithmetic done by hand rather than against a previous
+run of the same code.
+"""
+import numpy as np
+import pytest
+
+import pounce
+from pounce.sensitivity import (
+    active_set_changes,
+    covariance,
+    information,
+    solution,
+    solution_report,
+    solve_for_sensitivity,
+)
+
+P0 = 2.0
+
+
+def parametric_model(fixed_variable=False):
+    """min (x - p)^2 + 3 p^2  s.t.  x + y == 5,  p == P0.
+
+    With `p` held at P0 the optimum is x = P0, y = 5 - P0, so
+    dx/dp = 1, dy/dp = -1 and df/dp = 6 p -- the example from gh#878,
+    where a chain-rule-only reading of df/dp returns 0 because every
+    df/dx_i vanishes at the optimum.
+
+    `fixed_variable` inserts an equal-bounds variable AHEAD of `p`, so
+    the solve removes it and full-x stops agreeing with the factor's
+    var-x from that column on (gh#450).
+    """
+    if fixed_variable:
+        v = pounce.NlExpr.vars(4)                   # x, y, z, p
+        return pounce.build_nl_problem(
+            n=4,
+            objective=(v[0] - v[3]) ** 2 + 3.0 * v[3] ** 2 + v[2] ** 2,
+            constraints=[v[0] + v[1], v[3]],
+            g_l=[5.0, P0], g_u=[5.0, P0],
+            x_l=[-50.0, -50.0, 1.0, -100.0],
+            x_u=[10.0, 50.0, 1.0, 100.0],
+            x0=[0.0, 0.0, 1.0, P0],
+            var_names=["x", "y", "z", "p"],
+            con_names=["c1", "pin_p"],
+        )
+    v = pounce.NlExpr.vars(3)                       # x, y, p
+    return pounce.build_nl_problem(
+        n=3,
+        objective=(v[0] - v[2]) ** 2 + 3.0 * v[2] ** 2,
+        constraints=[v[0] + v[1], v[2]],
+        g_l=[5.0, P0], g_u=[5.0, P0],
+        x_l=[-50.0, -50.0, -100.0], x_u=[10.0, 50.0, 100.0],
+        x0=[0.0, 0.0, P0],
+        var_names=["x", "y", "p"], con_names=["c1", "pin_p"],
+    )
+
+
+def parametric_session(**kw):
+    return solve_for_sensitivity(parametric_model(**kw), pins={"p": 1},
+                                 options={"print_level": 0})
+
+
+# ── the step ─────────────────────────────────────────────────────────────────
+
+def test_the_step_matches_the_analytic_derivative():
+    sess = parametric_session()
+    np.testing.assert_allclose(sess.base_x, [P0, 5.0 - P0, P0], atol=1e-8)
+
+    delta = 0.1
+    x_new = solution(sess, [1], [delta])
+    np.testing.assert_allclose(
+        x_new, [P0 + delta, 5.0 - P0 - delta, P0 + delta], atol=1e-8)
+
+
+def test_the_total_objective_derivative_carries_the_explicit_partial():
+    """df/dp = 6p, not the 0 a chain-rule-only reading gives (gh#878)."""
+    sess = parametric_session()
+    df_dp = sess.total_objective_derivative(sess.column(1))
+    assert df_dp == pytest.approx(6.0 * P0, abs=1e-7)
+    # every df/dx_i IS zero at the optimum, which is what makes the
+    # explicit partial the whole answer here
+    step = sess.scatter_x(np.asarray(
+        pounce.Solver.parametric_step(sess.solver, [1], [1.0])))
+    assert sess.objective_gradient()[:2] @ step[:2] == pytest.approx(0.0,
+                                                                    abs=1e-7)
+
+
+def test_results_are_keyed_by_variable_name_with_no_modelling_layer():
+    """`crossed` comes back keyed by `.col` name, not by a component."""
+    sess = parametric_session()
+    # p driven to 12 pushes x past its upper bound of 10
+    rep = solution_report(sess, [1], [10.0], mode="linear")
+    assert isinstance(rep.crossed, dict)
+    assert list(rep.crossed) == ["x"], "x is the only variable that can bind"
+    assert all(isinstance(k, str) for k in rep.crossed)
+
+
+def test_active_set_changes_names_the_variable_that_moves():
+    sess = parametric_session()
+    changes = active_set_changes(sess, [1], [10.0])
+    assert changes, "driving p to 12 must push x onto its upper bound"
+    assert [c.var for c in changes] == ["x"]
+    assert [(c.bound, c.action) for c in changes] == [("upper", "reaches")]
+
+
+# ── the index spaces (gh#450) ────────────────────────────────────────────────
+
+def test_a_fixed_variable_makes_full_x_and_var_x_diverge():
+    """The precondition for the next test: without it the two spaces
+    coincide and reading one as the other cannot be caught."""
+    sess = parametric_session(fixed_variable=True)
+    assert sess._primal_row_map() == [0, 1, None, 2], (
+        "the solve should have removed z, shifting p's factor row")
+    with pytest.raises(ValueError, match="fixed variable"):
+        sess.primal_row(2, "test")
+
+
+def test_the_step_is_right_across_a_removed_variable():
+    """Reading a full-x index as a factor row returns a NEIGHBOURING
+    variable's sensitivity -- plausible and wrong. p sits one column
+    past the removed z, so that is exactly what this would show."""
+    sess = parametric_session(fixed_variable=True)
+    delta = 0.1
+    x_new = solution(sess, [1], [delta])
+    np.testing.assert_allclose(
+        x_new, [P0 + delta, 5.0 - P0 - delta, 1.0, P0 + delta], atol=1e-8)
+    assert sess.total_objective_derivative(
+        sess.column(1)) == pytest.approx(6.0 * P0, abs=1e-7)
+
+
+# ── the statistics ───────────────────────────────────────────────────────────
+
+T = np.array([1.0, 2.0, 3.0])
+Y = np.array([2.1, 3.9, 6.2])
+
+
+def estimation_session():
+    """Fit y = a t to three points, residuals carried as variables.
+
+    Ordinary linear least squares, so a-hat, the residual variance and
+    var(a) all have closed forms to check against.
+    """
+    v = pounce.NlExpr.vars(4)                        # a, r0, r1, r2
+    nl = pounce.build_nl_problem(
+        n=4,
+        objective=pounce.NlExpr.sum([v[1] ** 2, v[2] ** 2, v[3] ** 2]),
+        constraints=[v[1 + i] - v[0] * float(T[i]) for i in range(3)],
+        g_l=[-y for y in Y], g_u=[-y for y in Y],
+        x_l=[-50.0] * 4, x_u=[50.0] * 4,
+        x0=[1.0, 0.0, 0.0, 0.0],
+        var_names=["a", "r[0]", "r[1]", "r[2]"],
+        con_names=["res0", "res1", "res2"],
+    )
+    return solve_for_sensitivity(nl, fit_rows={"a": 0},
+                                 res_rows={None: [1, 2, 3]},
+                                 options={"print_level": 0})
+
+
+def test_covariance_matches_the_least_squares_closed_form():
+    sess = estimation_session()
+    a_hat = float(T @ Y) / float(T @ T)
+    assert sess.base_x[0] == pytest.approx(a_hat, abs=1e-9)
+
+    resid = T * sess.base_x[0] - Y
+    sigma_sq = float(resid @ resid) / (len(T) - 1)     # n - #fitted
+    cov = covariance(sess)
+    assert cov["a"] == pytest.approx(sigma_sq / float(T @ T), rel=1e-9)
+    assert cov.std_err["a"] == pytest.approx(np.sqrt(cov["a"]), rel=1e-12)
+    assert cov.sigma_sq == pytest.approx(sigma_sq, rel=1e-9)
+
+
+def test_information_is_the_hessian_the_covariance_inverts():
+    """`pcov = 2 sigma^2 inv(H_S)`, so H_S is 2 sum(t^2) here."""
+    sess = estimation_session()
+    assert information(sess)["a"] == pytest.approx(2.0 * float(T @ T),
+                                                   rel=1e-9)
+
+
+def test_an_explicit_block_overrides_the_declared_one():
+    sess = estimation_session()
+    cov = covariance(sess, ["r[0]"], [1])
+    assert cov.params == ["r[0]"]
+    assert cov["r[0]"] > 0.0
+
+
+# ── the caller's own name in diagnostics ─────────────────────────────────────
+
+def test_who_names_the_caller_in_diagnostics():
+    sess = parametric_session()
+    with pytest.raises(ValueError, match=r"^solution: mode must be"):
+        solution(sess, [1], [0.1], mode="nonsense")
+    with pytest.raises(ValueError, match=r"^sens_solution: mode must be"):
+        solution(sess, [1], [0.1], mode="nonsense", who="sens_solution")
+
+
+def test_hints_name_the_callers_own_declarations():
+    """The message points at how the CALLER declares residuals, because
+    a message naming the wrong layer's spelling is worse than none."""
+    sess = parametric_session()
+    with pytest.raises(RuntimeError, match=r"fit_rows="):
+        covariance(sess)
+    with pytest.raises(RuntimeError, match=r"declare_sens_fitted\(\)"):
+        covariance(sess, hints={"fitted": "declare_sens_fitted()",
+                                "residual": "declare_sens_residual()",
+                                "residual_group": "..."})
+
+
+# ── the packaging claim itself ───────────────────────────────────────────────
+
+def test_the_core_does_not_import_pyomo():
+    """The reason this package exists. Run in a subprocess so an earlier
+    test that imported Pyomo cannot mask a real import here."""
+    import subprocess
+    import sys
+
+    code = ("import sys, pounce.sensitivity;"
+            "assert 'pyomo' not in sys.modules, sorted("
+            "m for m in sys.modules if m.startswith('pyomo'));"
+            "print('clean')")
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                         text=True)
+    assert out.returncode == 0, out.stderr
+    assert "clean" in out.stdout


### PR DESCRIPTION
## What

Moves the sensitivity analysis layer out of `pyomo-pounce` and into `pounce.sensitivity`, so it is reachable from a `.nl` file, the CLI, CasADi or plain Python — not only from a Pyomo model. `pyomo_pounce` becomes one of its callers.

`pyomo-pounce/pyomo_pounce/sens.py`: **4256 → 1649 lines**. 2400 lines move to `python/pounce/sensitivity/`.

## Why this was possible

The code was packaged Pyomo-first, not written that way. Measured before the move, on executable code only (comments and docstrings stripped):

| function | lines | Pyomo references |
|---|---|---|
| `sens_covariance` | 454 | **0** |
| `sens_solution` | 312 | **0** |
| `_classify_fitted_block` | 240 | **0** |
| `sens_information` | 231 | **0** |
| `sens_active_set_changes` | 96 | **0** |
| `sens_solution_report` | 261 | 2 — both `ComponentMap()` for the return container |

82 of 100 functions carried no Pyomo reference at all. They already worked in row indices and numpy against `session.solver`.

## The seam

`SensSession` — a solved NL plus its held KKT factor, addressed by row and keyed by whatever the caller keys it with:

```python
nl   = pounce.read_nl("model.nl")
sess = solve_for_sensitivity(nl, pins={"p": 4})
solution(sess, [4], [0.05], mode="fix_relax")
covariance(sess)
```

`pyomo_pounce._Session` subclasses it and supplies three hooks — `var_key`, `user_row_data`, `new_keymap` — so a Pyomo caller still gets `ComponentMap`s of component data back and a bare-NL caller gets `.col` names. `who=` keeps each wrapper's own function name in its users' messages; a `hints` mapping keeps the declarations those messages *point at* spelled the caller's way (`declare_sens_residual()` for Pyomo, `res_rows=` for everyone else).

**The Pyomo API is unchanged** — same functions, arguments, result types (`Covariance`, `Information`, `SolutionReport`, `ActiveSetChange` are re-exported from the core) and messages.

## The risk this creates, and the tests for it

The refactor puts a package boundary **exactly where full-x meets var-x**. `python/tests/test_sensitivity_core.py` has two tests for it: a fixture with an equal-bounds variable placed *ahead* of the parameter makes the spaces genuinely diverge (`_primal_row_map() == [0, 1, None, 2]`) and pins the step across it. Reading one space as the other returns a neighbouring variable's answer — plausible, wrong, and gh#450 / gh#672 finding 1 already.

The other ten check closed forms rather than a previous run: the step against `dx/dp = 1`, `df/dp` against `6p` on the gh#878 model where a chain-rule-only reading returns 0, covariance against the linear least-squares formula, information against `2 Σt²`. None imports Pyomo, and one asserts that in a subprocess.

## Duplication removed — and one deliberately kept

`_NlBridge` is now `pounce.sensitivity.NlBridge`, shared. `_curve_fit.py` and the covariance code each carried their own SVD nullspace basis (same formula, same rank tolerance, written twice); both now call `pounce._stats_util.nullspace`.

Their **covariance routines are deliberately not merged**: `curve_fit` reads `inv(H_S)` straight off the factor because its parameters *are* the decision variables and `K = H_S`, while `pounce.sensitivity` recovers a tangent map because its fitted block sits inside a larger model with equalities. Same word, different computation.

## Dependency floor

`pyomo-pounce` now requires `pounce-solver>=0.11.0`, the release this lands in — an older wheel imports but every sensitivity entry point raises `ImportError`. That floor subsumes the `pyomo-v2` extra's `pounce-solver>0.9.0`, so the extra's comment no longer claims both its floors are tighter than the base; the constraint stays because it records *why* the v2 route needs it (gh#553).

## Verification

- `pytest python/tests` — 1405 passed, 4 skipped (1393 baseline + 12 new)
- `pytest pyomo-pounce/tests` — 500 passed, 13 skipped, **identical to baseline**; five imports of moved internals updated, no test logic touched
- `ruff` — 112 findings before, 112 after (true `git stash -u` baseline); new files clean
- `scripts/check-release-consistency.sh` OK, `scripts/check-docs-consistency.sh` OK

Not run locally: `cargo test --workspace` (no Rust changed; the compiled extension was already stale before this branch). **The job to watch is `pyomo-pounce-smoke`** — it installs the built wheel, which is what actually proves `pounce/sensitivity/` ships.

No trajectory change: this is post-solve analysis, so `scripts/sweep-fixtures.sh` does not apply, and no Rust means the `pounce-sensitivity` invariance legs are unaffected.

## Also in this PR

The first commit is the earlier docs task: `docs/src/sensitivity.md` said three separate things about `pyomo.contrib.sensitivity_toolbox`; they are now one section, including three defects measured against Pyomo 6.10.0 and why none is reachable from POUNCE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXuHz55zzpfSMGN6wSzHCk