### PR TITLE
docs(884): correct the stale characterization wording after #885 (gh#891)

### DIFF
--- a/crates/pounce-algorithm/tests/issue_884_biactive_dual_divergence.rs
+++ b/crates/pounce-algorithm/tests/issue_884_biactive_dual_divergence.rs
@@ -2,19 +2,29 @@
 //! lowering's multipliers diverge, and the run fails next to the primal
 //! solution.
 //!
-//! **Provenance, by measurement group.** The numbers describing the
-//! *defect* — the multiplier table below, the base attempt's returned
-//! point, the `3.3e11` and `7.9e+04` residuals, the `9.96e-8` an honest
-//! solve reaches, and `ralph1`'s objectives under `perturb_always_cd` —
-//! were measured on `87402274`, before the fix existed. The numbers
-//! describing the *retry* — the promoted point and violation in
+//! **Provenance, by measurement group.** Almost everything here is
+//! *defect*-era, measured on `87402274` before the fix existed: the
+//! multiplier table below, the base attempt's returned point, the
+//! `3.25e11` and `7.9e+04` residuals, the `4.64e-4` objective-gradient
+//! residual it leaves, the `9.96e-8` an honest solve reaches, and — both
+//! of them, from one run — `ralph1`'s objectives under
+//! `perturb_always_cd` and the `5.25e-7` that run certifies.
+//! `ralph1`'s `7.2e-3` step floor belongs to that group too: it is the
+//! minimum `||d||` of its *base* `RestorationFailed` trajectory, which
+//! the retry never touches (`dev-notes/mpcc-biactive-dual-divergence.md`,
+//! the `||d||` separation table).
+//!
+//! Only the **promoted** point and its violation, in
 //! `qpec_small_returns_a_near_optimal_point_and_never_claims_a_false_success`,
-//! `ralph1`'s `7.2e-3` step floor, and the `5.25e-7` its regularized run
-//! certifies — could only be measured with the fix in place, and come
-//! from its own commits (`ef1dd0b`, `198173b`; PR #885). Every number in
-//! both groups reproduces on `d32204e0`. Each site names the group it
-//! belongs to; re-measure rather than trusting any of them across a
-//! commit that touches the IPM.
+//! are *retry*-era — they could not exist before the fix — and they come
+//! from its own commits (`ef1dd0b`, `198173b`; PR #885).
+//!
+//! Both groups were re-run on `d32204e0` and reproduce, with one
+//! exception that was **not** re-derived there: the `7.2e-3` floor, which
+//! is a minimum over a trajectory rather than a quantity the solve
+//! returns, and whose source is the dev-note's table. Each site names the
+//! group it belongs to; re-measure rather than trusting any of them
+//! across a commit that touches the IPM.
 //!
 //! **The first four are invariants rather than a description of the
 //! defect.** Each is written so that it stays correct after a fix: it
@@ -31,8 +41,8 @@
 //! exists because the rule has a branch a green fixture would otherwise
 //! never execute. See the block comment above them.
 //!
-//! The measurements — the runaway multipliers, the `mu` trace, and three
-//! approaches ruled out — live in
+//! The measurements — the runaway multipliers, the `mu` trace, and the
+//! four approaches ruled out — live in
 //! `dev-notes/mpcc-biactive-dual-divergence.md`. That is where history
 //! belongs; this file holds contracts. If you are fixing gh#884, read the
 //! note first: the obvious remedy is measured and rejected there.
@@ -53,8 +63,13 @@
 //! certifies stationarity with residual `0` **at that exact point** — so
 //! the answer exists and is reachable.
 //!
-//! What happens instead: the solve reaches `(1.0002321, 1.0001161,
-//! 2.67e-15)`, feasible to `2.2e-16` with `f = 6.73e-8`, and stops there.
+//! What happens instead — the *base* attempt, which is what gh#884 is
+//! about, and which the default path still runs first: it reaches
+//! `(1.0002321, 1.0001161, 2.67e-15)`, feasible to `2.2e-16` with
+//! `f = 6.73e-8`, and before #885 stopped there. (Since #885 the default
+//! path does not stop there: it detects the runaway, retries cold, and
+//! returns the promoted point instead. Everything from here to the end of
+//! this section describes the attempt that fails.)
 //! That is *near* the optimum, not at it — `lambda = 0` does not certify
 //! the returned iterate, where it leaves an objective-gradient residual of
 //! `4.64e-4`. Meanwhile the multipliers on the *linearly dependent* rows
@@ -68,7 +83,7 @@
 //! | 2 (`G2 >= 0`) | `1.0` | `-7.283e11` |
 //! | 5 (`G2·H2 = 0`) | `2.3e-4` | `+1.737e15` |
 //!
-//! `-7.283e11 + 1.737e15 · 2.3e-4` is the `3.253e11` residual it fails
+//! `-7.283e11 + 1.737e15 · 2.3e-4` is the `3.25e11` residual it fails
 //! on. That table is measurement, not an assertion — see the note.
 //!
 //! **The asymmetry between the two fixtures is the point.** `qpec_small`
@@ -84,7 +99,7 @@
 //! |---|---|---|
 //! | `qpec_small_returns_a_near_optimal_point_and_never_claims_a_false_success` | the returned point is feasible and within `1e-3` of `(1, 1, 0)` with `|f|` under `1e-6` — near `f*`, not at it; any claimed success must hold in the model's own units | a verdict-only "fix" reports success at a `1e11` residual |
 //! | `a_structurally_zero_hessian_entry_does_not_change_the_solve` | declaring an identically-zero Hessian entry is a no-op (and refutes gh#884's stated prerequisite hypothesis) | the declared sparsity pattern starts changing the answer |
-//! | `dual_regularization_reaches_the_optimum_honestly` | an honest solve of this model exists at `9.96e-8` unscaled, so gh#884 is a POUNCE gap | that configuration stops reaching the answer |
+//! | `dual_regularization_reaches_a_certificate_honestly` | an honest solve of this model exists at `9.96e-8` unscaled, so gh#884 is a POUNCE gap | that configuration stops reaching the answer |
 //! | `ralph1_must_not_claim_success_where_no_multiplier_certifies_it` | a model with no sign-feasible multiplier must not report success, and never below `f*` | `perturb_always_cd` is turned on by default — measured: plain `Solve_Succeeded` at `-2.71e-5` |
 //! | `the_kill_switch_restores_the_pre_884_verdict` | `dual_divergence_retry=no` returns the base attempt's verdict | the kill switch stops killing |
 //! | `a_zero_step_tolerance_holds_the_detector_off` | a `0` step tolerance is a second, finer off switch | the detector stops consulting its threshold |
@@ -482,7 +497,7 @@ fn claims_success(status: ApplicationReturnStatus) -> bool {
 ///   product row's gradient is exactly `(0, 0, 0)`, so `lambda = 0`
 ///   certifies with residual `0`; and an honest solve reaching `9.96e-8`
 ///   unscaled is measured in
-///   `dual_regularization_reaches_the_optimum_honestly`. A success claim
+///   `dual_regularization_reaches_a_certificate_honestly`. A success claim
 ///   on this model at a residual above `1e-6` is therefore *known* to be
 ///   avoidable, which is what makes it suspect rather than merely loose.
 /// - `ralph1` — no sign-feasible multiplier exists at its origin at all,
@@ -543,7 +558,7 @@ fn a_claimed_success_must_be_real(
 ///
 /// The **conditional** half is the guard, and it is no longer vacuous.
 /// Before gh#884 closed, this model exited `RestorationFailed` at an
-/// unscaled KKT error of `3.3e11` (and, from the acceptable-level start
+/// unscaled KKT error of `3.25e11` (and, from the acceptable-level start
 /// the issue filed, `Solved_To_Acceptable_Level` at `7.9e+04`), so the
 /// guard had nothing to check. The dual-divergence retry now takes it to
 /// `Solve_Succeeded` with a residual that holds in the model's own units,
@@ -669,6 +684,15 @@ fn a_structurally_zero_hessian_entry_does_not_change_the_solve() {
 /// an **unscaled** KKT error of `~1e-7` — in the model's own units, not
 /// by normalising the residual away.
 ///
+/// The name says *certificate*, not *optimum*, and the distinction is the
+/// same one the `qpec_small_returns_a_near_optimal_point_…` rename draws.
+/// This run lands on `(0.999994, 0.999997, 3.7e-6)` — bit-identical to
+/// the point the retry promotes, measured on `d32204e0`, because the
+/// retry *is* this configuration restarted cold — which is near
+/// `(1, 1, 0)` and not at it. What is pinned here is that the residual
+/// behind the verdict holds in the model's own units — not that the
+/// iterate is the optimum.
+///
 /// This is evidence that there is something to fix. It is **not** an
 /// argument for turning that option on by default: see
 /// `ralph1_must_not_claim_success_where_no_multiplier_certifies_it`, and
@@ -681,7 +705,7 @@ fn a_structurally_zero_hessian_entry_does_not_change_the_solve() {
 /// from the original starting point, which is a different mechanism and
 /// is not what those measurements rule out.
 #[test]
-fn dual_regularization_reaches_the_optimum_honestly() {
+fn dual_regularization_reaches_a_certificate_honestly() {
     let (tnlp, captured) = QpecSmallProdEq::new(false);
     let mut a = app(true, 300);
     let status = a.optimize_tnlp(Rc::new(RefCell::new(tnlp)));

--- a/crates/pounce-algorithm/tests/issue_884_biactive_dual_divergence.rs
+++ b/crates/pounce-algorithm/tests/issue_884_biactive_dual_divergence.rs
@@ -2,7 +2,19 @@
 //! lowering's multipliers diverge, and the run fails next to the primal
 //! solution.
 //!
-//! Numbers in this file were measured on `87402274`.
+//! **Provenance, by measurement group.** The numbers describing the
+//! *defect* — the multiplier table below, the base attempt's returned
+//! point, the `3.3e11` and `7.9e+04` residuals, the `9.96e-8` an honest
+//! solve reaches, and `ralph1`'s objectives under `perturb_always_cd` —
+//! were measured on `87402274`, before the fix existed. The numbers
+//! describing the *retry* — the promoted point and violation in
+//! `qpec_small_returns_a_near_optimal_point_and_never_claims_a_false_success`,
+//! `ralph1`'s `7.2e-3` step floor, and the `5.25e-7` its regularized run
+//! certifies — could only be measured with the fix in place, and come
+//! from its own commits (`ef1dd0b`, `198173b`; PR #885). Every number in
+//! both groups reproduces on `d32204e0`. Each site names the group it
+//! belongs to; re-measure rather than trusting any of them across a
+//! commit that touches the IPM.
 //!
 //! **The first four are invariants rather than a description of the
 //! defect.** Each is written so that it stays correct after a fix: it
@@ -61,15 +73,16 @@
 //!
 //! **The asymmetry between the two fixtures is the point.** `qpec_small`
 //! failing is the *bug*, so nothing here asserts that it fails; what is
-//! asserted is that the point it returns is the optimum, and that it
-//! never claims a success it cannot back. `ralph1` failing is *correct* —
+//! asserted is that the point it returns is feasible and lands *near* the
+//! optimum — not at it, in either era; see that test — and that it never
+//! claims a success it cannot back. `ralph1` failing is *correct* —
 //! no sign-feasible multiplier exists at its origin — so that one is
 //! asserted directly, and it is what catches a `perturb_always_cd`
 //! default flip.
 //!
 //! | test | what it pins | red when |
 //! |---|---|---|
-//! | `qpec_small_returns_the_optimum_and_never_claims_a_false_success` | the returned point is feasible and at `f*`; any claimed success must hold in the model's own units | a verdict-only "fix" reports success at a `1e11` residual |
+//! | `qpec_small_returns_a_near_optimal_point_and_never_claims_a_false_success` | the returned point is feasible and within `1e-3` of `(1, 1, 0)` with `|f|` under `1e-6` — near `f*`, not at it; any claimed success must hold in the model's own units | a verdict-only "fix" reports success at a `1e11` residual |
 //! | `a_structurally_zero_hessian_entry_does_not_change_the_solve` | declaring an identically-zero Hessian entry is a no-op (and refutes gh#884's stated prerequisite hypothesis) | the declared sparsity pattern starts changing the answer |
 //! | `dual_regularization_reaches_the_optimum_honestly` | an honest solve of this model exists at `9.96e-8` unscaled, so gh#884 is a POUNCE gap | that configuration stops reaching the answer |
 //! | `ralph1_must_not_claim_success_where_no_multiplier_certifies_it` | a model with no sign-feasible multiplier must not report success, and never below `f*` | `perturb_always_cd` is turned on by default — measured: plain `Solve_Succeeded` at `-2.71e-5` |
@@ -517,9 +530,16 @@ fn a_claimed_success_must_be_real(
 /// The **unconditional** half — the returned point is feasible and lands
 /// within `1e-3` of `(1, 1, 0)` with `|f|` under `1e-6` — is true today
 /// *and* after any fix, so it never needs revisiting. The tolerances are
-/// what they are because the run stops *near* the optimum, not at it:
-/// measured `(1.0002321, 1.0001161, 2.67e-15)` with `f = 6.73e-8` on
-/// `87402274`. The interesting fact is that it gives up that close.
+/// what they are because the run stops *near* the optimum, not at it, and
+/// that is still true after the retry: the base attempt returned
+/// `(1.0002321, 1.0001161, 2.67e-15)` with `f = 6.73e-8` (measured on
+/// `87402274`), and the promoted retry returns
+/// `(0.9999940, 0.9999970, 3.72e-6)` with `f = 5.84e-11` (measured with
+/// the fix in place; reproduces on `d32204e0`). Neither is `(1, 1, 0)`.
+/// The interesting fact about the first is that it gives up that close;
+/// the second is three orders nearer in objective (and about one and a
+/// half in `x`) and still not the point itself, which is why nothing here
+/// asserts `f*` exactly.
 ///
 /// The **conditional** half is the guard, and it is no longer vacuous.
 /// Before gh#884 closed, this model exited `RestorationFailed` at an
@@ -533,14 +553,18 @@ fn a_claimed_success_must_be_real(
 /// `1e11`. That fix passes a status assertion and fails this one.
 ///
 /// The feasibility bar moved `1e-12` → `1e-10` when the retry landed, and
-/// the direction is worth naming: the *base* attempt sat at `2.7e-15`,
-/// the promoted one at `5.5e-12`. The retry is not a tighter solve of the
-/// same trajectory — it is a different one, run with `perturb_always_cd`,
-/// and it buys nine orders of unscaled dual residual for three orders of
-/// primal. Both are far inside `constr_viol_tol`; the point of the number
-/// here is that the trade is recorded rather than absorbed.
+/// the direction is worth naming: the *base* attempt violates by
+/// `2.2e-16`, the promoted one by `5.5e-12`. The retry is not a tighter
+/// solve of the same trajectory — it is a different one, run with
+/// `perturb_always_cd`, and it buys eighteen orders of unscaled dual
+/// residual (`3.25e11` → `9.96e-8`) for four of primal. Both are far
+/// inside `constr_viol_tol`; the point of the number here is that the
+/// trade is recorded rather than absorbed. All four reproduce on
+/// `d32204e0`: the base pair is the pre-fix behaviour, re-measured there
+/// with `dual_divergence_retry=no`, and the promoted pair is retry-era
+/// and could not have been measured on `87402274` at all.
 #[test]
-fn qpec_small_returns_the_optimum_and_never_claims_a_false_success() {
+fn qpec_small_returns_a_near_optimal_point_and_never_claims_a_false_success() {
     let (tnlp, captured) = QpecSmallProdEq::new(false);
     let mut a = app(false, 300);
     let status = a.optimize_tnlp(Rc::new(RefCell::new(tnlp)));
@@ -560,13 +584,13 @@ fn qpec_small_returns_the_optimum_and_never_claims_a_false_success() {
     for (i, want) in [1.0, 1.0, 0.0].iter().enumerate() {
         assert!(
             (sol.x[i] - want).abs() <= 1e-3,
-            "x[{i}] = {:.6e} is not at the optimum {want}",
+            "x[{i}] = {:.6e} is not within 1e-3 of the optimum {want}",
             sol.x[i],
         );
     }
     assert!(
         s.final_objective.abs() <= 1e-6,
-        "objective {:.3e} is not at f* = 0",
+        "objective {:.3e} is not within 1e-6 of f* = 0",
         s.final_objective,
     );
 
@@ -648,8 +672,14 @@ fn a_structurally_zero_hessian_entry_does_not_change_the_solve() {
 /// This is evidence that there is something to fix. It is **not** an
 /// argument for turning that option on by default: see
 /// `ralph1_must_not_claim_success_where_no_multiplier_certifies_it`, and
-/// `dev-notes/mpcc-biactive-dual-divergence.md` for why engaging it only
-/// on demand does not work either.
+/// `dev-notes/mpcc-biactive-dual-divergence.md` ("Ruled out 2") for why
+/// engaging it *in flight*, after the runaway is detected mid-solve, does
+/// not work either — by the time the pattern is visible, regularization
+/// can no longer recover *that iterate*, non-monotonically so. That
+/// negative is about the in-flight switch specifically. What shipped does
+/// engage this option conditionally, but by restarting the solve **cold**
+/// from the original starting point, which is a different mechanism and
+/// is not what those measurements rule out.
 #[test]
 fn dual_regularization_reaches_the_optimum_honestly() {
     let (tnlp, captured) = QpecSmallProdEq::new(false);

--- a/dev-notes/mpcc-biactive-dual-divergence.md
+++ b/dev-notes/mpcc-biactive-dual-divergence.md
@@ -129,7 +129,7 @@ Dual regularization *is* the effective remedy. With `perturb_always_cd=yes`
 the same model converges in 19 iterations to an **unscaled** KKT error of
 `9.96e-8` at `x = (0.999994, 0.999997, 3.7e-6)` — an honest solve, not a
 residual normalised away. So an answer is reachable and gh#884 is a real
-POUNCE gap. Pinned by `dual_regularization_reaches_the_optimum_honestly`.
+POUNCE gap. Pinned by `dual_regularization_reaches_a_certificate_honestly`.
 
 The obvious refinement is to engage it *only* when the runaway is
 detected, leaving every other model alone. That does not work, and the


### PR DESCRIPTION
*Body revised at `a54a2a5` after review. The original described `fef2dec` only, and carried two of the same defects the review found in the file — see **Review round** at the end.*

## Problem

Statements in `crates/pounce-algorithm/tests/issue_884_biactive_dual_divergence.rs` describe the code as it was before #885 shipped the late-detector/cold-retry route. gh#891 found three on `main` at `d32204e0`; review found three more sites of the same class. No functional failure, but each misleads a reader about what the file pins.

1. The module table, the asymmetry paragraph and two test names say the returned point **is** the optimum / is "at `f*`". The file says twice elsewhere that the run stops *near* the optimum, and asserts loose `1e-3` / `1e-6` bars for exactly that reason.
2. The header claimed every number in the file was measured on `87402274`. That commit predates the retry; the file has recorded retry-era numbers since `ef1dd0b` / `198173b`.
3. `dual_regularization_reaches_the_optimum_honestly` said the dev-note explains why engaging regularization "only on demand does not work either". What shipped engages it conditionally — so the comment contradicted the mechanism it sat next to.
4. The narrative at the top of the file said the solve "stops there", present tense, of behaviour #885 superseded.

Two numbers were also wrong:

| trajectory paragraph | said | correct |
|---|---|---|
| base attempt's constraint violation | `2.7e-15` | `2.2e-16` — `2.7e-15` is its `x[2]` |
| unscaled dual residual the retry buys | "nine orders" | eighteen: `3.25e11` → `9.96e-8` |

The first was **findable by reading**: `main` already carried `2.2e-16` at header line 45, 500 lines above the paragraph that called the violation `2.7e-15`, and the point in that same sentence identifies `2.7e-15` as `x[2]`. Re-measuring supplied the reason, not the detection. (An earlier revision of this body claimed re-measurement found it; that over-credited the method.)

## Cause

The wording was written while gh#884 was open, against a solver in which the retry did not exist, and #885 changed the mechanism underneath it without revisiting the prose. Statement 3 is the sharpest case: "only on demand" was an accurate summary of "Ruled out 2" — an *in-flight* switch after detection — right up until the fix shipped a mechanism that is also on demand, but cold.

## Fix

Prose, two test names, two assertion messages. No behaviour changes.

1. **Near, not at.** Module table, asymmetry paragraph, two assert messages, and both tests that named the point: `qpec_small_returns_the_optimum_…` → `…returns_a_near_optimal_point_…`, and `dual_regularization_reaches_the_optimum_honestly` → `…reaches_a_certificate_honestly`. The second run lands **bit-identical** to the point the retry promotes (`[0.9999940320539338, 0.9999970160262548, 3.719079302430919e-6]`, measured both ways on `d32204e0`) because the retry *is* that configuration restarted cold — so naming one "near-optimal" and the other "the optimum" was two conventions for one point. What that test pins is the residual behind the verdict, not the iterate's location.
2. **Provenance per measurement group.** Almost everything is defect-era (`87402274`): the multiplier table, the base point, `3.25e11`, `7.9e+04`, `4.64e-4`, `9.96e-8`, and — from one dev-note table row — `ralph1`'s objectives under `perturb_always_cd` together with the `5.25e-7` that run certifies. `ralph1`'s `7.2e-3` floor is defect-era too: it is the minimum `||d||` of its *base* `RestorationFailed` trajectory, which the retry never touches. Only the promoted point and its violation are retry-era. Each site now names its group.
3. **In-flight, not on demand.** Names "Ruled out 2" and its reason, then says what the negative does **not** cover: the shipped cold restart.
4. **The narrative names its group** — "and stops there" → "and before #885 stopped there", with a clause saying the default path now retries.
5. One spelling of the runaway residual (`3.25e11`, matching `application.rs:62`/`:8093`/`:8109` and the dev-note `:100`/`:561`); `4.64e-4` added to the provenance enumeration; and the header's "three approaches ruled out" corrected to four, which is what the dev-note has.

The alternative gh#891 offered — keep the names as historical and annotate them — was not taken. These are not deliberate history; the file holds contracts and `dev-notes/mpcc-biactive-dual-divergence.md` holds the history, and the dev-note already draws the in-flight/cold distinction correctly.

## Blast radius

Two files: the test file (comments, two test names, two `assert!` messages) and **one line** of `dev-notes/mpcc-biactive-dual-divergence.md` — its "Pinned by `dual_regularization_reaches_…`" reference, which the rename would otherwise dangle. No solver source, so no trajectory change and no fixture sweep. Both renamed tests have no references outside those two files (`grep` confirms). `crates/pounce-cli/tests/issue_884_biactive_dual_divergence.rs` carries none of this wording and is untouched.

## Tests

Nothing new is pinned — no behaviour change and no new test, so there is no "fails on the parent commit" claim to make. What backs it is that the numbers were **re-measured on `d32204e0`** (temporary instrumented copy of the fixture, deleted before commit):

| number | how | reproduces |
|---|---|---|
| base `(1.0002321, 1.0001161, 2.67e-15)`, `f = 6.73e-8`, viol `2.2e-16`, unscaled KKT `3.25e11`, `RestorationFailed` | `dual_divergence_retry=no` | yes — except the violation, corrected above |
| promoted `(0.9999940, 0.9999970, 3.72e-6)`, `f = 5.84e-11`, viol `5.47e-12`, unscaled KKT `9.96e-8`, `SolveSucceeded`, promoted | default path | yes |
| regularized-from-start returns a vector **bit-identical** to the promoted one | `perturb_always_cd=yes` vs. default, compared elementwise | yes |
| `ralph1` under `perturb_always_cd`: `SolveSucceeded`, `f = -2.71e-5`, unscaled KKT `5.25e-7` (`max_iter = 3000`); `Solved_To_Acceptable_Level` at `-3.81e-5` (`max_iter = 300`) | direct run | yes |

**Not** re-derived, and the file now says so rather than claiming otherwise: `ralph1`'s `7.2e-3` step floor. It is the minimum `||d||` over its base trajectory (dev-note `||d||` table, `7.153e-3`, `87402274`) — a minimum over a trajectory rather than a quantity the solve returns — and it is already mutation-checked by `the_detector_must_not_fire_on_ralph1`.

- `cargo test -p pounce-algorithm --test issue_884_biactive_dual_divergence` — 8/8 pass, on both commits and on the parent.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p pounce-algorithm --test issue_884_biactive_dual_divergence` — 7 warnings, the same count as on `d32204e0`'s version of the file (checked by restoring it and re-running). All pre-existing.
- The full workspace `cargo test` was **not** run locally; the diff cannot reach anything outside this test target. CI runs it.

## Review round

`a54a2a5` answers @jkitchin's review of `fef2dec` in full. Its finding 1 was correct and was the same defect class gh#891 filed, in the paragraph added to fix it: the retry group held two `87402274` measurements (`7.2e-3` and `5.25e-7`) under a claim they "could only be measured with the fix in place", refuted by the dev-note at `:21`, `:171` and `:313`. `5.25e-7` was split from the very table row supplying `-2.71e-5`, which the same paragraph assigned to the defect group. Findings 2–5 are folded into the sections above.

---

- [ ] Tests fail on the parent commit for the stated reason — **N/A**, no behaviour change and no new test; the renamed tests pass on both sides
- [ ] `CHANGELOG.md` `[Unreleased]` entry — **not added**: CONTRIBUTING asks for entries "in the user's terms", and nothing here is visible to a user of the CLI, Python or Pyomo surfaces
- [ ] Book page under `docs/src/` — **N/A**, internal test documentation
- [x] `cargo fmt --all -- --check` clean; clippy unchanged from parent on the touched target; the touched test target passes (full workspace suite left to CI — see above)
- [x] Every claim in this body and in the code comments is true of the code as it stands now — this body was rewritten at `a54a2a5` because two of its claims were not: the blast radius said one file when the rename touches the dev-note too, and the provenance summary described `fef2dec`'s grouping, which review showed was wrong

Fixes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YayspqSHzQZGKmX887kh17