### PR TITLE
Attaching the debugger must not change the solve (gh #892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,50 @@ changes.
 
 ### Fixed
 
+- **Attaching the interactive debugger no longer changes the solve
+  (gh#892).** `pounce model.nl --debug` on a convex QCQP ran a *different
+  algorithm* than the same command without it. The conic debug entry point
+  built its own interior-point iteration and never consulted `qp_hsde`, so
+  the debugger silently substituted the direct IPM for the default HSDE
+  embedding and dropped the objective normalization and the
+  verify-and-retry guards that live on the embedding's side. On the
+  reported 5-variable model:
+
+  ```text
+  $ pounce repro.nl solver_selection=socp --no-sol
+  POUNCE (convex QCQP conic IPM): Optimal Solution Found.  obj=0.46851408  iters=38   # exit 0
+
+  $ pounce repro.nl solver_selection=socp --debug-script cont.pdbg --no-sol
+  POUNCE (convex QCQP conic IPM): Numerical failure (no verified KKT point). iters=21 # exit 1
+  ```
+
+  where the script contained nothing but `continue`. The plain run agrees
+  with Clarabel 0.11.1 to `1.3e-10`; the debugged one failed on a problem
+  the very same engine solves. Under `solver_selection=auto` the failure
+  was then masked by a silent extra solve on the NLP path. Measured over
+  the reported model plus 24 freshly drawn convex QCQPs, **all 25**
+  disagreed on status, objective or iteration count, 16 of them turning an
+  `Optimal` into a failure or a reduced-accuracy exit — so this was the
+  normal case on that arm, not an unlucky instance. The missing `tau` block
+  users saw under `print tau` was the same fact from the debugger's side.
+
+  Both convex debug entry points are now the ordinary solve entry points
+  reached with a hook rather than parallel implementations, so driver
+  selection, scaling and every recovery guard are the ones the plain run
+  uses. Two consequences worth knowing:
+
+  - **Presolve now runs under the debugger**, on the convex paths where it
+    used to be skipped. The blocks you inspect are the reduced model's —
+    which is the model being solved. Pass `qp_presolve=no` to step your own
+    rows instead, and the plain run then matches, because both skip it.
+  - **`quit` stops the solve.** The recovery machinery that re-solves after
+    a failed or capped solve runs unhooked, so it now declines to start
+    once you have halted the run rather than reporting success for a solve
+    you deliberately stopped.
+
+  Solves without a debugger attached are bit-identical: the fixture corpus
+  sweep is empty across all 186 legs.
+
 - **A settled iterate with a runaway multiplier no longer ships as
   `Solved_To_Acceptable_Level` (gh#884).** Some models have a solution at
   which a constraint's gradient vanishes — the row is satisfied, the primal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,7 +398,11 @@ changes.
     you deliberately stopped.
 
   Solves without a debugger attached are bit-identical: the fixture corpus
-  sweep is empty across all 186 legs.
+  sweep is empty across all 186 legs. That sweep is the check for *collateral*
+  damage — only 4 of its fixtures (8 legs) reach the conic arm this touches, so
+  what carries the claim about that arm is the 25-instance measurement above
+  and the CLI checks on `qcqp_ball` / `qcqp_columns_illcond` under both `socp`
+  and `auto`, not the empty diff.
 
 - **A settled iterate with a runaway multiplier no longer ships as
   `Solved_To_Acceptable_Level` (gh#884).** Some models have a solution at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,7 +391,12 @@ changes.
   - **Presolve now runs under the debugger**, on the convex paths where it
     used to be skipped. The blocks you inspect are the reduced model's —
     which is the model being solved. Pass `qp_presolve=no` to step your own
-    rows instead, and the plain run then matches, because both skip it.
+    rows instead, and the plain run then matches, because both skip it. When
+    presolve *settles* the model there is no iteration left to step at all,
+    so an unbounded presolve verdict now prints `Presolve: proved unbounded
+    below — a free column with a nonzero objective coefficient`, the sibling
+    of the primal-infeasible line gh#523 added; it was the one presolve
+    verdict that arrived with no record of why.
   - **`quit` stops the solve.** The recovery machinery that re-solves after
     a failed or capped solve runs unhooked, so it now declines to start
     once you have halted the run rather than reporting success for a solve

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2723,6 +2723,31 @@ fn run_convex_qp(
         )
     };
     let solve_opts = || solve_opts_offset(0.0);
+    // The interior-point solve, with the interactive debugger attached when
+    // there is one (gh #892).
+    //
+    // Routing the hook through here rather than through an arm of its own is
+    // what keeps presolve on under the debugger. It used to be skipped, so
+    // that the inspected `x`/`s`/`y`/`z` blocks were the user's rows rather
+    // than a reduced set — but the price was that the debugged run solved a
+    // *different, smaller* problem than the plain one, which is the same
+    // "attaching the debugger changes the solve" defect gh #892 is about, one
+    // level up from the driver substitution. A user who wants the unreduced
+    // blocks asks for them with `qp_presolve=no`, and then both runs agree
+    // again because both skip it.
+    //
+    // Guarded on `!use_active_set`: the debugger hooks barrier-IPM iterations
+    // and has no active-set analogue, so under that engine it must not engage
+    // — the caller has already printed the note saying so.
+    let ipm_solve = |p: &pounce_convex::QpProblem, o: &QpOptions| -> pounce_convex::QpSolution {
+        match debug_hook.filter(|_| !use_active_set) {
+            Some(hook) => {
+                let mut h = hook.borrow_mut();
+                solve_qp_ipm_debug(p, o, &mut *h, backend)
+            }
+            None => solve_qp_ipm(p, o, backend),
+        }
+    };
     // What presolve did, held back until we know this solve is the one that
     // reports (gh #535). These lines describe the reduction, not the verdict,
     // but they are the *only* stdout a declined convex attempt would otherwise
@@ -2738,19 +2763,6 @@ fn run_convex_qp(
         // enforce the zero-iteration stop here before any solve runs
         // (pounce#186). Mirrors the NLP path's MaximumIterationsExceeded.
         trivial(QpStatus::IterationLimit)
-    } else if let Some(hook) = debug_hook.filter(|_| !use_active_set) {
-        // Interactive debug: step the IPM on the extracted QP directly.
-        // Presolve is skipped so the debugger's `x`/`s`/`y`/`z` blocks
-        // correspond to the user's problem rather than a reduced one.
-        //
-        // Guarded on `!use_active_set`: the debugger hooks barrier-IPM
-        // iterations and has no active-set analogue, so on that engine this
-        // arm would quietly solve with a *different solver* than the one the
-        // user selected. The caller has already printed the note explaining
-        // the debugger does not engage; fall through and solve normally.
-        let mut h = hook.borrow_mut();
-        let _t = timing.solve.guard();
-        solve_qp_ipm_debug(&qp, &solve_opts(), &mut *h, backend)
     } else if presolve_on {
         let outcome = {
             let _t = timing.presolve.guard();
@@ -2817,7 +2829,7 @@ fn run_convex_qp(
                             &mut mk,
                         )
                     } else {
-                        solve_qp_ipm(&ps.reduced, &solve_opts_offset(ps.obj_offset()), backend)
+                        ipm_solve(&ps.reduced, &solve_opts_offset(ps.obj_offset()))
                     }
                 };
                 // The postsolve lift is presolve's other half, so it is
@@ -2840,7 +2852,7 @@ fn run_convex_qp(
         solve_qp_active_set_inertia(&qp, &solve_opts(), &engine_overrides, inertia, &mut mk)
     } else {
         let _t = timing.solve.guard();
-        solve_qp_ipm(&qp, &solve_opts(), backend)
+        ipm_solve(&qp, &solve_opts())
     };
     let elapsed = t0.elapsed().as_secs_f64();
 
@@ -3174,19 +3186,29 @@ fn run_convex_socp(
     // exactly as `run_convex_qp` does: these lines describe the reduction,
     // not the verdict, and a declined conic attempt must leave no stdout.
     let mut presolve_log: Vec<String> = Vec::new();
+    // The conic solve, with the interactive debugger attached when there is
+    // one (gh #892). See the twin in `run_convex_qp` for why the hook goes
+    // through here instead of an arm of its own: it is what keeps presolve on
+    // under the debugger, so the debugged run is the same problem the plain
+    // run solves. `qp_presolve=no` is how you ask for the unreduced blocks.
+    let conic_solve = |p: &pounce_convex::QpProblem,
+                       k: &[pounce_convex::ConeSpec],
+                       o: &QpOptions|
+     -> pounce_convex::QpSolution {
+        match debug_hook {
+            Some(hook) => {
+                let mut h = hook.borrow_mut();
+                solve_socp_ipm_debug(p, k, o, &mut *h, backend)
+            }
+            None => solve_socp_ipm(p, k, o, backend),
+        }
+    };
     let sol = if qp_opts.max_iter == 0 {
         // `max_iter=0` cannot reach optimality — stop before any solve, the
         // same zero-iteration contract the QP path enforces (pounce#186).
         // Above the presolve arm for the same reason it is on the QP path:
         // presolve can otherwise settle a trivial problem without iterating.
         trivial(pounce_convex::QpStatus::IterationLimit)
-    } else if let Some(hook) = debug_hook {
-        // Interactive debug steps the conic IPM on the *extracted* problem,
-        // so the debugger's blocks correspond to the user's rows rather than
-        // a reduced set. Same carve-out as the QP path.
-        let mut h = hook.borrow_mut();
-        let _t = timing.solve.guard();
-        solve_socp_ipm_debug(&qp, &cones, &solve_opts(), &mut *h, backend)
     } else if presolve_on {
         // **`presolve_conic`, never `presolve`.** The orthant entry point
         // would hand `dedup_rows` an unprotected row list, and this driver's
@@ -3241,7 +3263,7 @@ fn run_convex_socp(
                 let red_cones = ps.reduced_cones(&cones);
                 let red = {
                     let _t = timing.solve.guard();
-                    solve_socp_ipm(&ps.reduced, &red_cones, &solve_opts(), backend)
+                    conic_solve(&ps.reduced, &red_cones, &solve_opts())
                 };
                 // The postsolve lift is presolve's other half.
                 let _t = timing.presolve.guard();
@@ -3255,7 +3277,7 @@ fn run_convex_socp(
         }
     } else {
         let _t = timing.solve.guard();
-        solve_socp_ipm(&qp, &cones, &solve_opts(), backend)
+        conic_solve(&qp, &cones, &solve_opts())
     };
     let elapsed = t0.elapsed().as_secs_f64();
 

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2844,7 +2844,21 @@ fn run_convex_qp(
                 presolve_log.push(format!("Presolve: proved primal infeasible — {trigger}"));
                 trivial(QpStatus::PrimalInfeasible)
             }
-            PresolveOutcome::Unbounded => trivial(QpStatus::DualInfeasible),
+            PresolveOutcome::Unbounded => {
+                // The sibling of the line above, and it exists for the same
+                // reason (gh #523, gh #892 re-review): a presolve verdict
+                // arrives with no iteration behind it, so this line is the
+                // whole record of *why*. `Unbounded` carries no trigger
+                // payload because it has exactly one cause — a free column
+                // with a nonzero objective coefficient — so the cause is
+                // named here instead.
+                presolve_log.push(
+                    "Presolve: proved unbounded below — a free column with a \
+                     nonzero objective coefficient"
+                        .to_string(),
+                );
+                trivial(QpStatus::DualInfeasible)
+            }
         }
     } else if use_active_set {
         let mut mk = backend;
@@ -3273,7 +3287,15 @@ fn run_convex_socp(
                 presolve_log.push(format!("Presolve: proved primal infeasible — {trigger}"));
                 trivial(pounce_convex::QpStatus::PrimalInfeasible)
             }
-            PresolveOutcome::Unbounded => trivial(pounce_convex::QpStatus::DualInfeasible),
+            PresolveOutcome::Unbounded => {
+                // See the twin in `run_convex_qp`.
+                presolve_log.push(
+                    "Presolve: proved unbounded below — a free column with a \
+                     nonzero objective coefficient"
+                        .to_string(),
+                );
+                trivial(pounce_convex::QpStatus::DualInfeasible)
+            }
         }
     } else {
         let _t = timing.solve.guard();

--- a/crates/pounce-cli/tests/issue892_debugger_does_not_change_the_solve.rs
+++ b/crates/pounce-cli/tests/issue892_debugger_does_not_change_the_solve.rs
@@ -39,6 +39,7 @@
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn pounce_exe() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
@@ -53,12 +54,22 @@ fn fixture(name: &str) -> PathBuf {
 }
 
 /// A `--debug-script` holding the issue's script: `continue`, and nothing
-/// else. Written under the target dir so the test needs no fixture of its own.
+/// else. Written under the temp dir so the test needs no fixture of its own.
+///
+/// The name carries a per-call counter as well as the pid, because the four
+/// `#[test]` functions below run as parallel threads of **one** process and
+/// [`assert_unmoved`] deletes its script when it is done. On a pid-only name
+/// all nine calls share one path, and one thread's `remove_file` lands between
+/// another's create and its `--debug-script` read — a race whose window is
+/// wide enough to matter at nine calls, and which green CI is no evidence
+/// against.
 fn continue_script() -> PathBuf {
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
     let mut p = std::env::temp_dir();
     p.push(format!(
-        "pounce_issue892_continue_{}.pdbg",
-        std::process::id()
+        "pounce_issue892_continue_{}_{}.pdbg",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
     ));
     let mut f = std::fs::File::create(&p).expect("write debug script");
     writeln!(f, "continue").expect("write debug script");

--- a/crates/pounce-cli/tests/issue892_debugger_does_not_change_the_solve.rs
+++ b/crates/pounce-cli/tests/issue892_debugger_does_not_change_the_solve.rs
@@ -1,0 +1,168 @@
+//! gh #892 — end to end, attaching the debugger must not change the solve.
+//!
+//! `crates/pounce-convex/tests/issue892_debug_routes_like_the_plain_solve.rs`
+//! pins the library-level routing. This file pins what the reporter actually
+//! ran: the `pounce` binary, with and without a `--debug-script` containing
+//! nothing but `continue`, which is a pure no-op on the trajectory.
+//!
+//! It exists because the CLI carried the *second* half of the defect, and the
+//! library legs cannot see it. Until this issue the convex entry points
+//! skipped presolve while a debugger was attached — deliberately, so the
+//! inspected blocks were the user's rows rather than a reduced set — which
+//! meant the debugged run solved a different, smaller problem. Both halves
+//! have to be closed for "attaching the debugger changes nothing" to be true
+//! of the command the user types, and only a process-level test says so.
+//!
+//! What each check reaches, in the terms `CLAUDE.md` sets for branch coverage:
+//!
+//! | check | path | the half it covers |
+//! | --- | --- | --- |
+//! | `conic_qcqp_is_unmoved_by_the_debugger` | `solver_selection=socp` | driver substitution (the reported symptom) |
+//! | `conic_qcqp_is_unmoved_under_auto` | `solver_selection=auto` | the same, plus the NLP fallback that masked it |
+//! | `presolve_still_runs_under_the_debugger` | conic, presolve reduces | the CLI carve-out |
+//! | `convex_qp_is_unmoved_by_the_debugger` | `solver_selection=qp-ipm` | the LP/QP twin of the same carve-out |
+//!
+//! **Mutation table** — measured, not asserted:
+//!
+//! | mutation | red |
+//! | --- | --- |
+//! | reinstate the CLI presolve carve-out (a `debug_hook` arm ahead of `presolve_on` in both `run_convex_qp` and `run_convex_socp`) | `presolve_still_runs_under_the_debugger`, `convex_qp_is_unmoved_by_the_debugger` |
+//! | `solve_socp_ipm_debug` builds its own iteration for symmetric cones | `conic_qcqp_is_unmoved_by_the_debugger`, `conic_qcqp_is_unmoved_under_auto` |
+//!
+//! The two halves are independent, and each mutation leaves the other half's
+//! checks green — which is the argument for keeping both files.
+//!
+//! Not evidence about: the NLP filter-IPM (which never had the carve-out),
+//! the active-set engine (where the debugger deliberately does not engage and
+//! the caller says so), or `--debug-json`.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// A `--debug-script` holding the issue's script: `continue`, and nothing
+/// else. Written under the target dir so the test needs no fixture of its own.
+fn continue_script() -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "pounce_issue892_continue_{}.pdbg",
+        std::process::id()
+    ));
+    let mut f = std::fs::File::create(&p).expect("write debug script");
+    writeln!(f, "continue").expect("write debug script");
+    p
+}
+
+/// The verdict line the CLI prints, reduced to the three fields a trajectory
+/// change shows up in: status, objective and iteration count. The wall-clock
+/// suffix is stripped — it moves run to run and says nothing about the solve.
+///
+/// e.g. `POUNCE (convex QCQP conic IPM, pounce-convex): Optimal Solution
+/// Found.  obj=0.46851408  iters=38  (0.049s)`
+fn verdict(stdout: &str) -> String {
+    let line = stdout
+        .lines()
+        .find(|l| l.starts_with("POUNCE (") && l.contains("iters="))
+        .unwrap_or_else(|| panic!("no verdict line in stdout:\n{stdout}"));
+    let cut = line.rfind("  (").unwrap_or(line.len());
+    line[..cut].to_string()
+}
+
+/// Run the binary on `model` with `opts`, optionally with the debugger
+/// attached. Returns `(verdict line, exit code)`.
+fn run(model: &str, opts: &[&str], script: Option<&PathBuf>) -> (String, Option<i32>) {
+    let mut cmd = Command::new(pounce_exe());
+    cmd.arg(fixture(model)).arg("--no-sol");
+    for o in opts {
+        cmd.arg(o);
+    }
+    if let Some(s) = script {
+        cmd.arg("--debug-script").arg(s);
+    }
+    cmd.stdin(std::process::Stdio::null());
+    let out = cmd.output().expect("spawn pounce");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    (verdict(&stdout), out.status.code())
+}
+
+/// Plain and debugged runs must agree on status, objective, iteration count
+/// **and exit code**. The iteration count is the sensitive field: gh #892's
+/// two `Optimal` instances carried the same substituted driver as its two
+/// failing ones, and only the count showed it.
+fn assert_unmoved(model: &str, opts: &[&str]) {
+    let script = continue_script();
+    let (plain, plain_rc) = run(model, opts, None);
+    let (dbg, dbg_rc) = run(model, opts, Some(&script));
+    let _ = std::fs::remove_file(&script);
+    assert_eq!(
+        plain, dbg,
+        "{model} {opts:?}: the debugger changed the solve\n  plain: {plain}\n  debug: {dbg}"
+    );
+    assert_eq!(
+        plain_rc, dbg_rc,
+        "{model} {opts:?}: the debugger changed the exit code ({plain_rc:?} vs {dbg_rc:?})"
+    );
+}
+
+/// The reported symptom. On `d32204e` the plain run returned `Optimal` and the
+/// debugged one `Numerical failure (no verified KKT point)` with exit 1,
+/// because the debug entry point ran the direct IPM where the plain one ran
+/// the HSDE embedding.
+#[test]
+fn conic_qcqp_is_unmoved_by_the_debugger() {
+    assert_unmoved("qcqp_ball.nl", &["solver_selection=socp"]);
+    assert_unmoved("qcqp_columns_illcond.nl", &["solver_selection=socp"]);
+}
+
+/// Under `auto` the same conic failure was *masked* by the NLP fallback, at
+/// the cost of a silent second solve — so the run disagreed with the plain one
+/// in engine and iteration count even where the objective survived.
+#[test]
+fn conic_qcqp_is_unmoved_under_auto() {
+    assert_unmoved("qcqp_ball.nl", &["solver_selection=auto"]);
+}
+
+/// The CLI half. `qcqp_shared_linear_rows.nl` is the fixture whose rows
+/// `presolve_conic` is the correct entry point for, so presolve has something
+/// to do on it; before this issue the debugged run skipped the reduction and
+/// solved a different problem. Checked both ways round, because
+/// `qp_presolve=no` is the documented escape hatch for inspecting unreduced
+/// blocks and it has to agree too.
+#[test]
+fn presolve_still_runs_under_the_debugger() {
+    assert_unmoved("qcqp_shared_linear_rows.nl", &["solver_selection=socp"]);
+    assert_unmoved(
+        "qcqp_shared_linear_rows.nl",
+        &["solver_selection=socp", "qp_presolve=no"],
+    );
+}
+
+/// The LP/QP entry point, which carried the same CLI carve-out. The library
+/// legs report this path as already agreeing on the *driver*; presolve is the
+/// part only a process-level run can see.
+#[test]
+fn convex_qp_is_unmoved_by_the_debugger() {
+    // `convex_qp_share1b.nl` is the reducible one — presolve takes it
+    // 225 -> 208 vars and 117 -> 98 rows, so the debugged run was solving a
+    // visibly different problem. `bound_active_qp.nl` reduces by nothing,
+    // and is here as the control: the two runs have to agree there too, for
+    // a reason that has nothing to do with presolve.
+    assert_unmoved("convex_qp_share1b.nl", &["solver_selection=qp-ipm"]);
+    assert_unmoved(
+        "convex_qp_share1b.nl",
+        &["solver_selection=qp-ipm", "qp_presolve=no"],
+    );
+    assert_unmoved("bound_active_qp.nl", &["solver_selection=qp-ipm"]);
+}

--- a/crates/pounce-convex/src/debug.rs
+++ b/crates/pounce-convex/src/debug.rs
@@ -275,7 +275,16 @@ pub(crate) fn fire(
     state: &mut dyn DebugState,
 ) -> DebugAction {
     match hook.as_mut() {
-        Some(h) => h.at_checkpoint(state),
+        Some(h) => {
+            let action = h.at_checkpoint(state);
+            if action == DebugAction::Stop {
+                // Latch it for the recovery gates in `ipm.rs` (gh #892). This
+                // is the one place a `DebugAction` is read, so routing the
+                // report through here means no driver can forget to make one.
+                crate::debug_stop::mark();
+            }
+            action
+        }
         None => DebugAction::Resume,
     }
 }

--- a/crates/pounce-convex/src/debug_stop.rs
+++ b/crates/pounce-convex/src/debug_stop.rs
@@ -1,0 +1,73 @@
+//! "The debugger asked us to stop" — a solve-wide latch, on the same rails as
+//! [`crate::deadline`].
+//!
+//! A [`DebugAction::Stop`](pounce_common::debug::DebugAction::Stop) breaks the
+//! interior-point loop where it stands and leaves the solution carrying
+//! whatever non-converged status the loop had reached. That is the whole point
+//! of the debugger's `quit`: you get the run you were watching, stopped where
+//! you stopped it.
+//!
+//! It becomes a problem the moment the debug entry points stop being parallel
+//! implementations and enter the ordinary solve path instead (gh #892). The
+//! ordinary path reads a non-converged status as *something to recover from*
+//! and re-solves — the gh #293 equilibrated retry, the gh #414 verify, the
+//! gh #226 PSD HSDE retry, the LP crossover. Those re-solves run unhooked, by
+//! design, so they would run to completion after you quit and hand back a
+//! clean `Optimal` for a solve you deliberately halted: `quit` would report
+//! success. Measured on `debug.rs::stop_action_halts_the_solve`, which is what
+//! caught it.
+//!
+//! So a stop is latched here when it happens and every recovery gate consults
+//! it, exactly as each already consults [`crate::deadline::expired`]. Unlike a
+//! deadline this never restamps a verdict — it only declines to start another
+//! solve, which leaves the halted run's own status standing.
+//!
+//! The latch is per-solve (scoped by [`with_scope`], which the public debug
+//! entry points open) and per-thread, so a stopped solve cannot affect the
+//! next one or a concurrent one.
+
+use std::cell::Cell;
+
+thread_local! {
+    /// `Some(false)` inside a debug scope that has not been stopped;
+    /// `Some(true)` once a hook has asked to stop; `None` outside any scope
+    /// (no debugger attached, so there is nothing to latch).
+    static STOPPED: Cell<Option<bool>> = const { Cell::new(None) };
+}
+
+/// Run `f` with a fresh stop latch. Nested scopes reuse the outer one, so a
+/// stop inside a sub-solve is still visible to the entry point that owns it.
+pub(crate) fn with_scope<T>(f: impl FnOnce() -> T) -> T {
+    STOPPED.with(|slot| {
+        if slot.get().is_some() {
+            return f();
+        }
+        slot.set(Some(false));
+        struct Reset<'a>(&'a Cell<Option<bool>>);
+        impl Drop for Reset<'_> {
+            fn drop(&mut self) {
+                self.0.set(None);
+            }
+        }
+        let _reset = Reset(slot);
+        f()
+    })
+}
+
+/// Latch a stop. Called from [`crate::debug::fire`], the one place a
+/// `DebugAction` is read, so no driver can forget to report one.
+#[inline]
+pub(crate) fn mark() {
+    STOPPED.with(|slot| {
+        if slot.get().is_some() {
+            slot.set(Some(true));
+        }
+    });
+}
+
+/// Has a hook asked this solve to stop? `false` when no debugger is attached,
+/// which is what makes every gate below a no-op on the ordinary path.
+#[inline]
+pub(crate) fn requested() -> bool {
+    STOPPED.with(|slot| slot.get() == Some(true))
+}

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -396,7 +396,11 @@ where
     // never-regressing — a no-op for QPs and whenever the vertex is not a
     // strict improvement. Runs against the same un-equilibrated `prob` so the
     // `z`/`s` conventions line up. See [`crate::crossover`].
-    let sol = crate::crossover::maybe_crossover(prob, sol, opts, &mut make_backend);
+    let sol = if crate::debug_stop::requested() {
+        sol
+    } else {
+        crate::crossover::maybe_crossover(prob, sol, opts, &mut make_backend)
+    };
     // Crossover declines rather than restamps when the budget runs out mid-
     // refinement, so account for a deadline crossed in there here — where
     // `mark_timed_out`'s verdict rule applies and an `Optimal` cannot be lost.
@@ -485,7 +489,15 @@ where
         sol.status,
         QpStatus::NumericalFailure | QpStatus::IterationLimit | QpStatus::OptimalInaccurate
     );
-    if opts.use_hsde && opts.equilibrate && retry_on {
+    // `!debug_stop::requested()` guards every recovery re-solve in this
+    // function and its neighbours (gh #892): each of them re-solves unhooked,
+    // so after a debugger `quit` they would run to completion and hand back a
+    // verdict for a solve the user deliberately halted. Declining to start one
+    // leaves the halted run's own status standing, which is the honest answer
+    // and the one the debug path returned before it shared this code. The
+    // predicate is `false` whenever no debugger is attached, so the ordinary
+    // path is bit-for-bit unchanged.
+    if opts.use_hsde && opts.equilibrate && retry_on && !crate::debug_stop::requested() {
         if crate::deadline::expired() {
             return mark_timed_out(sol);
         }
@@ -566,7 +578,11 @@ where
     // it converged but did not. See [`verify_or_repair_optimum`]. Touches only
     // an `Optimal` verdict, so it composes with (and cannot disturb) the
     // certificate handling below.
-    let sol = verify_or_repair_optimum(prob, opts, sol, &mut make_backend);
+    let sol = if crate::debug_stop::requested() {
+        sol
+    } else {
+        verify_or_repair_optimum(prob, opts, sol, &mut make_backend)
+    };
     // gh #293 (extreme tail): refute a *spurious* unboundedness certificate on a
     // QP with genuine curvature. A `DualInfeasible` verdict rests on finding a
     // recession ray whose normalized curvature `dᵀPd/‖d‖²` is below
@@ -587,6 +603,7 @@ where
         && opts.equilibrate
         && sol.status == QpStatus::DualInfeasible
         && prob.p_lower.iter().any(|t| t.val != 0.0)
+        && !crate::debug_stop::requested()
     {
         if crate::deadline::expired() {
             return mark_timed_out(sol);
@@ -636,7 +653,7 @@ where
     // Costs one extra solve, and only on a `DualInfeasible` verdict. The twin
     // cannot re-enter this branch: with `c = 0` no direction has `cᵀd < 0`, so
     // `DualInfeasible` is unreachable for it.
-    if sol.status == QpStatus::DualInfeasible {
+    if sol.status == QpStatus::DualInfeasible && !crate::debug_stop::requested() {
         if crate::deadline::expired() {
             return mark_timed_out(sol);
         }
@@ -1117,7 +1134,7 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     crate::deadline::with_deadline(opts.time_limit, || {
-        solve_qp_ipm_scoped(prob, opts, make_backend, Some(hook))
+        crate::debug_stop::with_scope(|| solve_qp_ipm_scoped(prob, opts, make_backend, Some(hook)))
     })
 }
 
@@ -1366,6 +1383,7 @@ where
                 sol.status,
                 QpStatus::NumericalFailure | QpStatus::IterationLimit | QpStatus::OptimalInaccurate
             )
+            && !crate::debug_stop::requested()
         {
             let hsde_opts = QpOptions {
                 use_hsde: true,
@@ -1387,7 +1405,7 @@ where
     // rests on — is a per-row scaling and stays sound exactly on the orthant,
     // so the check is gated on that and every genuine cone program is
     // untouched. See [`verify_or_repair_optimum`].
-    if cones.iter().all(|c| matches!(c, ConeSpec::Nonneg(_))) {
+    if cones.iter().all(|c| matches!(c, ConeSpec::Nonneg(_))) && !crate::debug_stop::requested() {
         return verify_or_repair_optimum(prob, opts, sol, &mut make_backend);
     }
     sol
@@ -1429,7 +1447,9 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     crate::deadline::with_deadline(opts.time_limit, || {
-        solve_socp_ipm_scoped(prob, cones, opts, make_backend, Some(hook))
+        crate::debug_stop::with_scope(|| {
+            solve_socp_ipm_scoped(prob, cones, opts, make_backend, Some(hook))
+        })
     })
 }
 
@@ -3118,7 +3138,12 @@ where
             // actually collapsed τ, which is exactly the ‖c‖ ≪ σ regime — reaches
             // the real optimum; if that solve cannot converge either, its honest
             // non-`Optimal` status stands (never a false `Optimal`).
+            // A debugger stop lands here as a non-`Optimal` status, and the
+            // re-solves below run unhooked — so the halted run would be
+            // replaced by one the debugger never saw (gh #892). Take the
+            // stopped result as it stands.
             if sol.status != QpStatus::Optimal
+                || crate::debug_stop::requested()
                 || normalized_optimum_is_genuine(prob, cone, &sol, opts.tol)
             {
                 tracing::debug!(

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -341,11 +341,26 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     crate::deadline::with_deadline(opts.time_limit, || {
-        solve_qp_ipm_scoped(prob, opts, make_backend)
+        solve_qp_ipm_scoped(prob, opts, make_backend, None)
     })
 }
 
-fn solve_qp_ipm_scoped<F>(prob: &QpProblem, opts: &QpOptions, make_backend: F) -> QpSolution
+/// The body of [`solve_qp_ipm`], with an optional [`DebugHook`] threaded to
+/// the *primary* solve.
+///
+/// `hook` is what makes [`solve_qp_ipm_debug`] the same function as
+/// [`solve_qp_ipm`] rather than a parallel one (gh #892). It is handed to the
+/// first driver invocation only; the recovery re-solves below (the
+/// equilibrated retry, the reverify, the infeasibility twin) run unhooked, so
+/// the debugger observes the solve the caller asked for and every fallback
+/// still runs exactly as it does without a debugger attached. The *answer* is
+/// therefore identical with and without the hook.
+fn solve_qp_ipm_scoped<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    make_backend: F,
+    hook: Option<&mut dyn DebugHook>,
+) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
@@ -372,7 +387,7 @@ where
     };
     // Interior-point solve in the original problem's coordinates (the core
     // already unscales any internal Ruiz equilibration before returning).
-    let sol = solve_qp_ipm_core(prob, opts, &mut make_backend);
+    let sol = solve_qp_ipm_core(prob, opts, &mut make_backend, hook);
     if crate::deadline::expired() {
         return mark_timed_out(sol);
     }
@@ -397,7 +412,12 @@ where
 /// orthant solve with optional Ruiz equilibration, returning a solution in the
 /// original problem's coordinates. Factored out so [`solve_qp_ipm`] can layer
 /// the LP-crossover refinement on top.
-fn solve_qp_ipm_core<F>(prob: &QpProblem, opts: &QpOptions, make_backend: F) -> QpSolution
+fn solve_qp_ipm_core<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    make_backend: F,
+    hook: Option<&mut dyn DebugHook>,
+) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
@@ -415,9 +435,15 @@ where
     // See `crate::equilibrate`.
     let mut make_backend = make_backend;
     if opts.equilibrate && !opts.use_hsde {
-        return equilibrated_solve(prob, opts, /* use_hsde */ false, &mut make_backend);
+        return equilibrated_solve(
+            prob,
+            opts,
+            /* use_hsde */ false,
+            &mut make_backend,
+            hook,
+        );
     }
-    let sol = solve_qp_ipm_unscaled(prob, opts, &mut make_backend);
+    let sol = solve_qp_ipm_unscaled(prob, opts, &mut make_backend, hook);
     // HSDE robustness fallback. The self-dual driver normally conditions itself
     // through its per-cone NT scaling and so deliberately skips Ruiz pre-scaling
     // (see the comment above). But on a *severely* ill-scaled system — e.g. the
@@ -507,6 +533,7 @@ where
             &retry_opts,
             /* use_hsde */ true,
             &mut make_backend,
+            None,
         );
         // An `Optimal` from this retry has to earn the same way the one in
         // [`verify_or_repair_optimum`] does (gh #712). This retry runs *inside*
@@ -564,7 +591,13 @@ where
         if crate::deadline::expired() {
             return mark_timed_out(sol);
         }
-        let verify = equilibrated_solve(prob, opts, /* use_hsde */ false, &mut make_backend);
+        let verify = equilibrated_solve(
+            prob,
+            opts,
+            /* use_hsde */ false,
+            &mut make_backend,
+            None,
+        );
         if verify.status == QpStatus::Optimal {
             return verify;
         }
@@ -612,7 +645,7 @@ where
             c: vec![0.0; prob.n],
             ..prob.clone()
         };
-        if solve_qp_ipm_unscaled(&twin, opts, &mut make_backend).status
+        if solve_qp_ipm_unscaled(&twin, opts, &mut make_backend, None).status
             == QpStatus::PrimalInfeasible
         {
             let mut infeasible = sol;
@@ -652,6 +685,7 @@ fn equilibrated_solve<F>(
     opts: &QpOptions,
     use_hsde: bool,
     make_backend: &mut F,
+    hook: Option<&mut dyn DebugHook>,
 ) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
@@ -666,7 +700,11 @@ where
         obj_constant: opts.obj_constant * scaling.sigma(),
         ..*opts
     };
-    let mut sol = solve_qp_ipm_unscaled(&scaled, &inner, make_backend);
+    // A hook rides into the *scaled* problem: this is the driver the caller's
+    // solve actually runs, so it is the one a debugger has to watch, and the
+    // blocks it sees are the Ruiz-scaled ones (the returned solution is
+    // unscaled below, as always).
+    let mut sol = solve_qp_ipm_unscaled(&scaled, &inner, make_backend, hook);
     scaling.unscale_solution(prob, &mut sol);
     if use_hsde {
         sol
@@ -967,7 +1005,7 @@ where
     {
         return sol;
     }
-    let retry = equilibrated_solve(prob, opts, /* use_hsde */ true, make_backend);
+    let retry = equilibrated_solve(prob, opts, /* use_hsde */ true, make_backend, None);
     let genuine = |c: &QpSolution| {
         c.status == QpStatus::Optimal && optimum_is_genuine(prob, c, opts.tol, opts.obj_constant)
     };
@@ -1010,7 +1048,7 @@ where
     // function's neighbour already makes to refute a spurious unboundedness
     // certificate, on the same LP/QP-only entry point, so it carries no new
     // exposure to cone-carrying problems.
-    let direct = equilibrated_solve(prob, opts, /* use_hsde */ false, make_backend);
+    let direct = equilibrated_solve(prob, opts, /* use_hsde */ false, make_backend, None);
     let best = [retry, direct]
         .into_iter()
         .filter(genuine)
@@ -1030,17 +1068,22 @@ where
 /// The bounds-aware orthant solve without equilibration (the historical
 /// [`solve_qp_ipm`] body). Factored out so [`solve_qp_ipm`] can wrap it with
 /// Ruiz scaling.
-fn solve_qp_ipm_unscaled<F>(prob: &QpProblem, opts: &QpOptions, make_backend: F) -> QpSolution
+fn solve_qp_ipm_unscaled<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    make_backend: F,
+    hook: Option<&mut dyn DebugHook>,
+) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     if !prob.has_bounds() {
         let cone = CompositeCone::single_nonneg(prob.m_ineq());
-        return solve_qp_core(prob, &cone, opts, None, make_backend);
+        return solve_qp_core(prob, &cone, opts, None, make_backend, hook);
     }
     let (expanded, bound_rows) = expand_bounds(prob);
     let cone = CompositeCone::single_nonneg(expanded.m_ineq());
-    let sol = solve_qp_core(&expanded, &cone, opts, None, make_backend);
+    let sol = solve_qp_core(&expanded, &cone, opts, None, make_backend, hook);
     split_bound_duals(prob, &bound_rows, sol)
 }
 
@@ -1049,11 +1092,21 @@ where
 /// the Newton step, after the step is applied, and at termination) so a
 /// debugger can step, inspect, and break on the solve.
 ///
-/// Targets the direct (non-HSDE) convex IPM, so the debugged `x` block is
-/// the user's variables (finite bounds are expanded into a trailing
-/// nonnegative block, as in [`solve_qp_ipm`], and surface in the `s`/`z`
-/// blocks). Apart from the hook the result is identical to
-/// [`solve_qp_ipm`].
+/// **This is [`solve_qp_ipm`] with a hook, not a parallel implementation.**
+/// It is the same function body, reached with `hook = Some(..)`, so driver
+/// selection (`use_hsde`), Ruiz equilibration, the `σ` cost normalization,
+/// every verify-and-retry guard and the LP crossover all run exactly as they
+/// do without a debugger attached, and the returned solution is unchanged.
+/// That identity is the point (gh #892): a debugger that substitutes a
+/// different algorithm is debugging a run the user never shipped.
+///
+/// The hook rides the *primary* solve. The recovery re-solves — the
+/// equilibrated retry, the `σ` re-solve, the reverify, the infeasibility twin
+/// — run unhooked, so what the debugger observes is the solve proper. Which
+/// blocks it sees follows from the driver that solve actually uses: the HSDE
+/// drivers expose the embedding (with `tau`/`kappa`), the direct driver the
+/// user's variables; finite bounds are expanded into a trailing nonnegative
+/// block either way and surface in `s`/`z`.
 pub fn solve_qp_ipm_debug<F>(
     prob: &QpProblem,
     opts: &QpOptions,
@@ -1064,61 +1117,8 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     crate::deadline::with_deadline(opts.time_limit, || {
-        solve_qp_ipm_debug_scoped(prob, opts, hook, make_backend)
+        solve_qp_ipm_scoped(prob, opts, make_backend, Some(hook))
     })
-}
-
-fn solve_qp_ipm_debug_scoped<F>(
-    prob: &QpProblem,
-    opts: &QpOptions,
-    hook: &mut dyn DebugHook,
-    mut make_backend: F,
-) -> QpSolution
-where
-    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
-{
-    if crate::deadline::expired() {
-        return timed_out_solution(prob);
-    }
-    // Screen the variable box before bound expansion, as the non-debug path
-    // does (gh #295, gh #491).
-    let snapped;
-    let prob = match screen_variable_box(prob) {
-        BoxScreen::Feasible => prob,
-        BoxScreen::Empty => return trivial_primal_infeasible_solution(prob),
-        BoxScreen::Snapped(p) => {
-            snapped = p;
-            &snapped
-        }
-    };
-    // Build the factorization and run the core loop directly with the hook
-    // (mirrors `solve_qp_core`'s non-HSDE path; `solve_qp_core` itself can't
-    // carry the borrowed hook through its generic plumbing). When the HSDE
-    // driver is selected, debug it instead — it self-starts and builds its
-    // own factorization.
-    let run = |p: &QpProblem, cone: &CompositeCone, mk: &mut F, hook: &mut dyn DebugHook| {
-        if opts.use_hsde {
-            return crate::hsde::solve_conic_hsde(p, cone, opts, mk, Some(hook));
-        }
-        match build_factorization(p, cone, opts, mk) {
-            Ok((kkt, mut fact)) => run_ipm(p, cone, opts, &kkt, &mut fact, None, Some(hook)),
-            Err(()) => failed_solution(
-                p,
-                vec![0.0; p.n],
-                vec![0.0; p.m_eq()],
-                vec![0.0; p.m_ineq()],
-                0,
-            ),
-        }
-    };
-    if !prob.has_bounds() {
-        let cone = CompositeCone::single_nonneg(prob.m_ineq());
-        return run(prob, &cone, &mut make_backend, hook);
-    }
-    let (expanded, bound_rows) = expand_bounds(prob);
-    let cone = CompositeCone::single_nonneg(expanded.m_ineq());
-    let sol = run(&expanded, &cone, &mut make_backend, hook);
-    split_bound_duals(prob, &bound_rows, sol)
 }
 
 /// Solve a convex QP starting from a warm point (typically a previous
@@ -1216,7 +1216,7 @@ where
             z: warm.z.clone(),
         };
         let cone = CompositeCone::single_nonneg(prob.m_ineq());
-        return solve_qp_core(prob, &cone, &direct, Some(&w), make_backend);
+        return solve_qp_core(prob, &cone, &direct, Some(&w), make_backend, None);
     }
     let (expanded, bound_rows) = expand_bounds(prob);
     let w = WarmStart {
@@ -1225,7 +1225,7 @@ where
         z: merge_bound_duals(prob, &bound_rows, warm),
     };
     let cone = CompositeCone::single_nonneg(expanded.m_ineq());
-    let sol = solve_qp_core(&expanded, &cone, &direct, Some(&w), make_backend);
+    let sol = solve_qp_core(&expanded, &cone, &direct, Some(&w), make_backend, None);
     split_bound_duals(prob, &bound_rows, sol)
 }
 
@@ -1245,18 +1245,36 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     crate::deadline::with_deadline(opts.time_limit, || {
-        if crate::deadline::expired() {
-            timed_out_solution(prob)
-        } else {
-            // One gate over every exit of the body below — see [`finite_or_failed`].
-            let sol = finite_or_failed(prob, solve_socp_ipm_inner(prob, cones, opts, make_backend));
-            if crate::deadline::expired() {
-                mark_timed_out(sol)
-            } else {
-                sol
-            }
-        }
+        solve_socp_ipm_scoped(prob, cones, opts, make_backend, None)
     })
+}
+
+/// The body of [`solve_socp_ipm`], with an optional [`DebugHook`] threaded to
+/// the primary solve. See [`solve_socp_ipm_debug`] for why the debugger enters
+/// here rather than through a path of its own (gh #892).
+fn solve_socp_ipm_scoped<F>(
+    prob: &QpProblem,
+    cones: &[ConeSpec],
+    opts: &QpOptions,
+    make_backend: F,
+    hook: Option<&mut dyn DebugHook>,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    if crate::deadline::expired() {
+        return timed_out_solution(prob);
+    }
+    // One gate over every exit of the body below — see [`finite_or_failed`].
+    let sol = finite_or_failed(
+        prob,
+        solve_socp_ipm_inner(prob, cones, opts, make_backend, hook),
+    );
+    if crate::deadline::expired() {
+        mark_timed_out(sol)
+    } else {
+        sol
+    }
 }
 
 fn solve_socp_ipm_inner<F>(
@@ -1264,6 +1282,7 @@ fn solve_socp_ipm_inner<F>(
     cones: &[ConeSpec],
     opts: &QpOptions,
     make_backend: F,
+    hook: Option<&mut dyn DebugHook>,
 ) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
@@ -1310,7 +1329,7 @@ where
         );
     }
     if has_nonsym {
-        return solve_nonsym(prob, cones, opts, make_backend, None);
+        return solve_nonsym(prob, cones, opts, make_backend, hook);
     }
     // Sparsity: split any block-diagonal PSD cone into independent smaller
     // cones (one dense O(m²) KKT block → several small ones, exploited by the
@@ -1324,12 +1343,12 @@ where
         let mut make_backend = make_backend;
         let (prob1, cones1, row_map) = decompose_psd(prob, cones);
         let (prob2, cones2, recon) = chordal_decompose(&prob1, &cones1);
-        let run = |o: &QpOptions, mk: &mut F| {
-            let sol2 = solve_socp_symmetric(&prob2, &cones2, o, mk);
+        let run = |o: &QpOptions, mk: &mut F, hook: Option<&mut dyn DebugHook>| {
+            let sol2 = solve_socp_symmetric(&prob2, &cones2, o, mk, hook);
             let sol1 = chordal_reconstruct(sol2, &recon, &prob1);
             remap_decomposed_z(sol1, &row_map, prob.m_ineq())
         };
-        let sol = run(opts, &mut make_backend);
+        let sol = run(opts, &mut make_backend, hook);
         // gh #226: the direct symmetric driver is known-weak on PSD programs
         // whose optimum sits on the cone boundary (a rank-deficient slack,
         // where the NT scaling's condition number blows up) — a small
@@ -1352,7 +1371,7 @@ where
                 use_hsde: true,
                 ..*opts
             };
-            let retry = run(&hsde_opts, &mut make_backend);
+            let retry = run(&hsde_opts, &mut make_backend, None);
             if hsde_retry_is_upgrade(sol.status, retry.status) {
                 return retry;
             }
@@ -1360,7 +1379,7 @@ where
         return sol;
     }
     let mut make_backend = make_backend;
-    let sol = solve_socp_symmetric(prob, cones, opts, &mut make_backend);
+    let sol = solve_socp_symmetric(prob, cones, opts, &mut make_backend, hook);
     // gh #414: a cone program whose cones are *all* nonnegative is an LP/QP
     // wearing the conic entry point's clothes (`solver_selection=socp` on a
     // box-constrained QP lands here), and it inherits the same false `Optimal`
@@ -1375,11 +1394,30 @@ where
 }
 
 /// Debug-enabled [`solve_socp_ipm`]: fires the interactive [`DebugHook`] at
-/// each interior-point checkpoint. Exponential / power cones run on the
-/// non-symmetric HSDE driver; all other cones (orthant / SOC / PSD) run on
-/// the direct symmetric IPM. Under the debugger a PSD cone is solved
-/// *directly* (no chordal decomposition) so the debugged `x`/`s`/`y`/`z`
-/// blocks correspond to the user's problem; the solution is unchanged.
+/// each interior-point checkpoint.
+///
+/// **This is [`solve_socp_ipm`] with a hook, not a parallel implementation.**
+/// It enters the same body with `hook = Some(..)`, so cone routing, driver
+/// selection (`use_hsde`), the `σ` cost normalization, the PSD chordal
+/// decomposition and every verify-and-retry guard run exactly as they do
+/// without a debugger, and the returned solution is unchanged.
+///
+/// gh #892 is why that identity is spelled out. This entry point used to
+/// build its own factorization and call the core loop directly for symmetric
+/// cones, which never consulted `use_hsde` — so attaching the debugger
+/// silently substituted the *direct* IPM for the default HSDE embedding, and
+/// with it dropped the `σ` normalization and the equilibrate-and-verify
+/// guards. On a 5-variable convex QCQP that turned an `Optimal` agreeing with
+/// Clarabel to `1.3e-10` into `NumericalFailure`; the iteration count moved on
+/// every instance tried. A debugger that changes the trajectory is debugging a
+/// run the user never shipped.
+///
+/// The hook rides the *primary* solve; the recovery re-solves (the HSDE retry
+/// on a failed PSD solve, the `σ` re-solves, [`verify_or_repair_optimum`]) run
+/// unhooked. Which blocks the hook sees therefore follows from the driver that
+/// solve actually uses — the HSDE drivers expose the embedding, with
+/// `tau`/`kappa`; the direct driver (`qp_hsde=no`) exposes the user's
+/// variables — and a decomposed PSD cone is debugged in its clique blocks.
 pub fn solve_socp_ipm_debug<F>(
     prob: &QpProblem,
     cones: &[ConeSpec],
@@ -1391,73 +1429,8 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     crate::deadline::with_deadline(opts.time_limit, || {
-        solve_socp_ipm_debug_scoped(prob, cones, opts, hook, make_backend)
+        solve_socp_ipm_scoped(prob, cones, opts, make_backend, Some(hook))
     })
-}
-
-fn solve_socp_ipm_debug_scoped<F>(
-    prob: &QpProblem,
-    cones: &[ConeSpec],
-    opts: &QpOptions,
-    hook: &mut dyn DebugHook,
-    mut make_backend: F,
-) -> QpSolution
-where
-    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
-{
-    if crate::deadline::expired() {
-        return timed_out_solution(prob);
-    }
-    if !cone_dims_cover(cones, prob.m_ineq()) {
-        return failed_solution(
-            prob,
-            vec![0.0; prob.n],
-            vec![0.0; prob.m_eq()],
-            vec![0.0; prob.m_ineq()],
-            0,
-        );
-    }
-    let has_nonsym = cones
-        .iter()
-        .any(|c| matches!(c, ConeSpec::Exponential | ConeSpec::Power(_)));
-    let has_psd = cones.iter().any(|c| matches!(c, ConeSpec::Psd(_)));
-    if has_nonsym && has_psd {
-        return failed_solution(
-            prob,
-            vec![0.0; prob.n],
-            vec![0.0; prob.m_eq()],
-            vec![0.0; prob.m_ineq()],
-            0,
-        );
-    }
-    if has_nonsym {
-        return solve_nonsym(prob, cones, opts, make_backend, Some(hook));
-    }
-    // Symmetric cones: debug the direct IPM (build the factorization and run
-    // the core loop with the hook), bound-expanded as in
-    // `solve_socp_symmetric`. PSD is solved directly here (no decomposition).
-    let run = |p: &QpProblem, cone: &CompositeCone, mk: &mut F, hook: &mut dyn DebugHook| {
-        match build_factorization(p, cone, opts, mk) {
-            Ok((kkt, mut fact)) => run_ipm(p, cone, opts, &kkt, &mut fact, None, Some(hook)),
-            Err(()) => failed_solution(
-                p,
-                vec![0.0; p.n],
-                vec![0.0; p.m_eq()],
-                vec![0.0; p.m_ineq()],
-                0,
-            ),
-        }
-    };
-    if !prob.has_bounds() {
-        let cone = CompositeCone::from_specs(cones);
-        return run(prob, &cone, &mut make_backend, hook);
-    }
-    let (expanded, bound_rows) = expand_bounds(prob);
-    let mut specs = cones.to_vec();
-    specs.push(ConeSpec::Nonneg(bound_rows.len()));
-    let cone = CompositeCone::from_specs(&specs);
-    let sol = run(&expanded, &cone, &mut make_backend, hook);
-    split_bound_duals(prob, &bound_rows, sol)
 }
 
 /// The symmetric-cone solve (orthant / SOC / PSD): expand finite bounds into
@@ -1468,20 +1441,21 @@ fn solve_socp_symmetric<F>(
     cones: &[ConeSpec],
     opts: &QpOptions,
     make_backend: F,
+    hook: Option<&mut dyn DebugHook>,
 ) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     if !prob.has_bounds() {
         let cone = CompositeCone::from_specs(cones);
-        return solve_qp_core(prob, &cone, opts, None, make_backend);
+        return solve_qp_core(prob, &cone, opts, None, make_backend, hook);
     }
     // Bounds expand into a trailing nonnegative block after the user cones.
     let (expanded, bound_rows) = expand_bounds(prob);
     let mut specs = cones.to_vec();
     specs.push(ConeSpec::Nonneg(bound_rows.len()));
     let cone = CompositeCone::from_specs(&specs);
-    let sol = solve_qp_core(&expanded, &cone, opts, None, make_backend);
+    let sol = solve_qp_core(&expanded, &cone, opts, None, make_backend, hook);
     split_bound_duals(prob, &bound_rows, sol)
 }
 
@@ -1956,7 +1930,14 @@ where
             y: warm.y.clone(),
             z: merge_bound_duals(prob, &bound_rows, warm),
         };
-        let sol = solve_qp_core(&expanded, &cone, &direct_opts, Some(&w), &mut make_backend);
+        let sol = solve_qp_core(
+            &expanded,
+            &cone,
+            &direct_opts,
+            Some(&w),
+            &mut make_backend,
+            None,
+        );
         split_bound_duals(prob, &bound_rows, sol)
     };
 
@@ -1967,7 +1948,7 @@ where
             use_hsde: true,
             ..*opts
         };
-        let retry = solve_socp_ipm_inner(prob, cones, &hsde_opts, &mut make_backend);
+        let retry = solve_socp_ipm_inner(prob, cones, &hsde_opts, &mut make_backend, None);
         if hsde_retry_is_upgrade(direct.status, retry.status) {
             return retry;
         }
@@ -2260,11 +2241,12 @@ fn cost_normalized_hsde_solve<F>(
     inner: &QpOptions,
     sigma: f64,
     make_backend: &mut F,
+    hook: Option<&mut dyn DebugHook>,
 ) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    let mut sol = crate::hsde::solve_conic_hsde(scaled, cone, inner, make_backend, None);
+    let mut sol = crate::hsde::solve_conic_hsde(scaled, cone, inner, make_backend, hook);
     for v in sol.y.iter_mut().chain(sol.z.iter_mut()) {
         *v *= sigma;
     }
@@ -3065,7 +3047,7 @@ fn direct_driver_fallback(
         use_hsde: false,
         ..*opts
     };
-    solve_qp_ipm_core(prob, &direct, make_backend)
+    solve_qp_ipm_core(prob, &direct, make_backend, None)
 }
 
 /// Bounds-agnostic Mehrotra predictor-corrector core. `prob.lb`/`ub` are
@@ -3076,6 +3058,7 @@ fn solve_qp_core<F>(
     opts: &QpOptions,
     warm: Option<&WarmStart>,
     mut make_backend: F,
+    hook: Option<&mut dyn DebugHook>,
 ) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
@@ -3121,7 +3104,8 @@ where
                 obj_constant: opts.obj_constant / sigma,
                 ..*opts
             };
-            let sol = cost_normalized_hsde_solve(&scaled, cone, &inner, sigma, &mut make_backend);
+            let sol =
+                cost_normalized_hsde_solve(&scaled, cone, &inner, sigma, &mut make_backend, hook);
             // gh #324: the cost normalization divides the objective by σ (sized
             // to ‖P‖∞). When ‖c‖ ≪ σ — a huge Hessian coefficient paired with a
             // modest gradient, e.g. `P = diag(1e-10, 1e10)`, `c = [-1, -1]` — the
@@ -3257,7 +3241,7 @@ where
             );
             return candidates.swap_remove(pick);
         }
-        return crate::hsde::solve_conic_hsde(prob, cone, opts, make_backend, None);
+        return crate::hsde::solve_conic_hsde(prob, cone, opts, make_backend, hook);
     }
 
     // Build the fixed KKT pattern and an initial factorization, then run
@@ -3281,7 +3265,7 @@ where
     if crate::deadline::expired() {
         return timed_out_solution(prob);
     }
-    run_ipm(prob, cone, opts, &kkt, &mut fact, warm, None)
+    run_ipm(prob, cone, opts, &kkt, &mut fact, warm, hook)
 }
 
 /// Build the constant KKT pattern for `prob` and a `Factorization` over
@@ -5844,7 +5828,7 @@ mod false_optimum_metric_tests {
             obj_constant: opts.obj_constant / sigma,
             ..*opts
         };
-        let sol = cost_normalized_hsde_solve(&scaled, &cone, &inner, sigma, &mut backend);
+        let sol = cost_normalized_hsde_solve(&scaled, &cone, &inner, sigma, &mut backend, None);
         split_bound_duals(prob, &bound_rows, sol)
     }
 
@@ -5971,7 +5955,7 @@ mod false_optimum_metric_tests {
             ub: vec![5.0, 5.0],
         };
         let opts = QpOptions::default();
-        let sol = solve_qp_ipm_unscaled(&prob, &opts, backend);
+        let sol = solve_qp_ipm_unscaled(&prob, &opts, backend, None);
         assert_eq!(sol.status, QpStatus::Optimal);
         assert!(
             sol.kkt_residuals(&prob).kkt_error() <= opts.tol,

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -41,6 +41,7 @@ pub(crate) mod correctors;
 pub mod crossover;
 mod deadline;
 pub(crate) mod debug;
+mod debug_stop;
 pub(crate) mod equilibrate;
 pub mod hsde;
 pub mod hsde_nonsym;

--- a/crates/pounce-convex/tests/issue892_debug_routes_like_the_plain_solve.rs
+++ b/crates/pounce-convex/tests/issue892_debug_routes_like_the_plain_solve.rs
@@ -1,0 +1,392 @@
+//! gh #892 — attaching the debugger must not change the solve.
+//!
+//! The conic debug entry point used to be a *parallel implementation*: for
+//! symmetric cones it built its own factorization and ran the core loop
+//! directly, which never consulted `QpOptions::use_hsde`. Since that flag
+//! defaults to `true`, attaching a debugger to a convex QCQP silently
+//! substituted the direct IPM for the HSDE embedding — and with it dropped
+//! the `σ` cost normalization and the equilibrate-and-verify guards that live
+//! on the embedding's side of `solve_qp_core`. On the model below that turned
+//! an `Optimal` agreeing with Clarabel to `1.3e-10` into a `NumericalFailure`.
+//! Both entry points now enter the same body with an `Option<&mut DebugHook>`,
+//! so the routing is the routing and the answer is the answer.
+//!
+//! **Measured at the CLI**, `solver_selection=socp` with and without
+//! `--debug-script` containing only `continue`, over the reported model plus
+//! 24 freshly drawn convex QCQPs at `n = 4, 5, 7, 9`: on `d32204e` all 25
+//! disagree on status, objective or iteration count — 16 of them turning an
+//! `Optimal` into a `Numerical failure` or a `Solved to acceptable level`.
+//! After the fix all 25 agree on all three, and the plain column is unmoved.
+//! The issue's own four-instance sample understated it; the corpus is
+//! uniformly affected, which is what a substituted driver looks like.
+//!
+//! **Which branch each leg takes** (the rule `CLAUDE.md` states for the
+//! sensitivity legs applies verbatim here: a leg is evidence only about the
+//! branch its fixture reaches, and the *routing* is exactly what is under
+//! test). `solve_qp_core` forks on `use_hsde`, so a leg that only ever runs
+//! the default is blind to the direct driver's own divergence — which was
+//! real, and is why `leg_qcqp_direct_driver` and `leg_qp_direct_driver` are
+//! here and are not duplicates of their defaulted neighbours:
+//!
+//! | leg | entry point | driver | what the old code did instead |
+//! | --- | --- | --- | --- |
+//! | `leg_qcqp_hsde_default` | `solve_socp_ipm` | HSDE (`σ` reachable) | direct IPM, no `σ`, no verify |
+//! | `leg_qcqp_direct_driver` | `solve_socp_ipm` | direct (`use_hsde=false`) | (same driver, but no box screen / `finite_or_failed`) |
+//! | `leg_orthant_cone_verify` | `solve_socp_ipm`, all-`Nonneg` cones | HSDE + `verify_or_repair_optimum` | skipped the gh #414 verify entirely |
+//! | `leg_qp_hsde_default` | `solve_qp_ipm` | HSDE | already agreed — the pin against a regression |
+//! | `leg_qp_direct_driver` | `solve_qp_ipm` | direct + Ruiz | direct **without** equilibration |
+//! | `leg_lp_crossover` | `solve_qp_ipm` | HSDE + LP crossover | skipped crossover |
+//!
+//! **Mutation table** — reintroduce the historical shape and exactly the
+//! named legs go red:
+//!
+//! | mutation | red |
+//! | --- | --- |
+//! | `solve_socp_ipm_debug` builds its own `build_factorization` + `run_ipm` for symmetric cones | `leg_qcqp_hsde_default`, `leg_orthant_cone_verify` |
+//! | `solve_qp_ipm_debug` re-enters at `solve_qp_ipm_core` with `equilibrate: false` — the historical shape, which is *both* "no Ruiz" and "no crossover" | `leg_qp_direct_driver`, `leg_lp_crossover` |
+//! | `solve_qp_core` hands `solve_conic_hsde` a `None` hook instead of `hook` | every leg's `hook.fired > 0` |
+//!
+//! What these legs are **not** evidence about: the non-symmetric (exp/power)
+//! drivers, which route through `solve_nonsym` and already took the hook —
+//! `debug.rs::solve_socp_ipm_debug_routes_and_fires` owns that; PSD cones,
+//! whose chordal decomposition the debugger now shares with the plain path
+//! but which no fixture here reaches; and anything at benchmark scale.
+
+use pounce_common::debug::{DebugAction, DebugHook, DebugState};
+use pounce_convex::{
+    ConeSpec, QpOptions, QpProblem, QpSolution, QpStatus, Triplet, solve_qp_ipm,
+    solve_qp_ipm_debug, solve_socp_ipm, solve_socp_ipm_debug,
+};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+/// The debugger script from the issue — `continue`, and nothing else. A pure
+/// no-op on the trajectory, which is the whole premise being tested.
+#[derive(Default)]
+struct JustContinue {
+    fired: usize,
+    saw_tau: bool,
+}
+
+impl DebugHook for JustContinue {
+    fn at_checkpoint(&mut self, st: &mut dyn DebugState) -> DebugAction {
+        self.fired += 1;
+        if st.block("tau").is_some() {
+            self.saw_tau = true;
+        }
+        DebugAction::Resume
+    }
+}
+
+/// Assert two solves are the same solve: same verdict, same iterate, same
+/// iteration count. The count is the sensitive one — a status and an
+/// objective can agree while the trajectory underneath has been replaced,
+/// which is how gh #892's two `Optimal` instances hid the same defect its
+/// two failing ones exposed.
+fn assert_same_solve(leg: &str, plain: &QpSolution, debugged: &QpSolution) {
+    assert_eq!(
+        plain.status, debugged.status,
+        "{leg}: status moved under the debugger"
+    );
+    assert_eq!(
+        plain.iters, debugged.iters,
+        "{leg}: iteration count moved under the debugger ({} → {}) — the \
+         debugged run is on a different trajectory",
+        plain.iters, debugged.iters
+    );
+    assert!(
+        (plain.obj - debugged.obj).abs() <= 1e-12 * (1.0 + plain.obj.abs()),
+        "{leg}: objective moved under the debugger ({} → {})",
+        plain.obj,
+        debugged.obj
+    );
+    for (i, (a, b)) in plain.x.iter().zip(&debugged.x).enumerate() {
+        assert!(
+            (a - b).abs() <= 1e-12 * (1.0 + a.abs()),
+            "{leg}: x[{i}] moved under the debugger ({a} vs {b})"
+        );
+    }
+}
+
+/// The issue's 5-variable convex QCQP, in the SOC form the CLI extracts:
+///
+/// ```text
+/// min ½xᵀPx + cᵀx   s.t. ‖Fx − g‖ ≤ 2,  −10 ≤ x ≤ 10
+/// ```
+///
+/// Clarabel 0.11.1 at `tol = 1e-12` gives `f* = 0.46851407987426236` with
+/// `‖Fx − g‖² = 4` active, so the cone binds and the solve is a real conic
+/// one rather than an unconstrained quadratic wearing a cone.
+fn issue892_qcqp() -> (QpProblem, Vec<ConeSpec>) {
+    #[rustfmt::skip]
+    let p = [
+        [ 8.081237476191625, -1.3357111717521042, -3.177837792578595,   4.113912068867745,   -0.6167885305951004  ],
+        [-1.3357111717521042, 6.166783520955787,   1.6776136382871059, -1.610501780331925,   -0.031514743829699654],
+        [-3.177837792578595,  1.6776136382871059, 10.180019811121928,  -6.589542601208363,   -0.860089836489867   ],
+        [ 4.113912068867745, -1.610501780331925,  -6.589542601208363,   5.887751599792348,    0.009833639085611079],
+        [-0.6167885305951004,-0.031514743829699654,-0.860089836489867,  0.009833639085611079, 3.350517527917375   ],
+    ];
+    let c = [
+        -0.7652887415836972,
+        2.020688272883008,
+        0.16922834928772218,
+        -0.8979265392629115,
+        -0.9539822990406178,
+    ];
+    #[rustfmt::skip]
+    let f = [
+        [1.8378244304667402, -0.5783508965433001,  1.1887040918656822,  1.42327388117323,    -2.324401356345807  ],
+        [1.3509748934963017, -0.20843213237772143,-1.0841285882683698, -0.5438424479925973,   0.5608957690673765 ],
+        [0.3739765553621166,  0.42551413722873815,-0.7248960165356201,  1.2790838213635174,   1.502130478896611  ],
+        [1.8340638101929774,  1.000462644464517,   1.894314546207076,   2.0939269544234835,   0.7042559943816945 ],
+        [0.8811621128331931,  0.5822091166931507,  0.5514244021092147,  0.8632445387294106,  -1.7089819015275898 ],
+    ];
+    let g = [
+        -0.323798368729351,
+        0.4878567515797354,
+        -2.107331044865737,
+        -1.4418405493566442,
+        1.5844982856875247,
+    ];
+
+    // Lower triangle of P.
+    let mut p_lower = Vec::new();
+    for (i, row) in p.iter().enumerate() {
+        for (j, &v) in row.iter().enumerate().take(i + 1) {
+            p_lower.push(Triplet::new(i, j, v));
+        }
+    }
+    // s = h − Gx must lie in the 6-dimensional second-order cone
+    // `s₀ ≥ ‖s₁..₅‖`: row 0 is the constant radius 2, rows 1..5 are `Fx − g`.
+    let mut gm = Vec::new();
+    for (k, row) in f.iter().enumerate() {
+        for (i, &v) in row.iter().enumerate() {
+            gm.push(Triplet::new(k + 1, i, -v));
+        }
+    }
+    let mut h = vec![2.0];
+    h.extend(g.iter().map(|v| -v));
+
+    let prob = QpProblem {
+        n: 5,
+        p_lower,
+        c: c.to_vec(),
+        a: vec![],
+        b: vec![],
+        g: gm,
+        h,
+        lb: vec![-10.0; 5],
+        ub: vec![10.0; 5],
+    };
+    (prob, vec![ConeSpec::SecondOrder(6)])
+}
+
+/// Clarabel's answer on the same SOC formulation, as an outside number.
+const ISSUE892_OPTIMUM: f64 = 0.46851407987426236;
+
+/// The reported failure: default options, so `use_hsde` is on and the plain
+/// run reaches the embedding. Before the fix the debugged run reached the
+/// direct IPM instead and terminated `NumericalFailure`.
+#[test]
+fn leg_qcqp_hsde_default() {
+    let (prob, cones) = issue892_qcqp();
+    let opts = QpOptions::default();
+    assert!(opts.use_hsde, "this leg is about the HSDE branch");
+
+    let plain = solve_socp_ipm(&prob, &cones, &opts, backend);
+    let mut hook = JustContinue::default();
+    let debugged = solve_socp_ipm_debug(&prob, &cones, &opts, &mut hook, backend);
+
+    assert_eq!(
+        plain.status,
+        QpStatus::Optimal,
+        "the plain run must solve this — otherwise the leg proves nothing \
+         about the debugger (iters={})",
+        plain.iters
+    );
+    assert!(
+        (plain.obj - ISSUE892_OPTIMUM).abs() < 1e-8,
+        "the plain run must agree with the Clarabel oracle: {} vs {}",
+        plain.obj,
+        ISSUE892_OPTIMUM
+    );
+    assert_same_solve("qcqp/hsde", &plain, &debugged);
+    assert!(hook.fired > 0, "the hook must actually have been fired");
+    assert!(
+        hook.saw_tau,
+        "the conic solve routes to the HSDE embedding, so the debugger must \
+         see `tau` — its absence is the symptom gh #892 was diagnosed by"
+    );
+}
+
+/// The other side of `solve_qp_core`'s fork. `qp_hsde=no` takes the direct
+/// driver on both paths, so the *driver* always agreed here — but the plain
+/// path also screens the variable box and gates its exits through
+/// `finite_or_failed`, which the debug path did not.
+#[test]
+fn leg_qcqp_direct_driver() {
+    let (prob, cones) = issue892_qcqp();
+    let opts = QpOptions {
+        use_hsde: false,
+        ..QpOptions::default()
+    };
+
+    let plain = solve_socp_ipm(&prob, &cones, &opts, backend);
+    let mut hook = JustContinue::default();
+    let debugged = solve_socp_ipm_debug(&prob, &cones, &opts, &mut hook, backend);
+
+    assert_same_solve("qcqp/direct", &plain, &debugged);
+    assert!(hook.fired > 0, "the hook must actually have been fired");
+    assert!(
+        !hook.saw_tau,
+        "the direct driver has no homogenizing scalars to expose"
+    );
+}
+
+/// A cone program whose cones are *all* nonnegative reaches
+/// `verify_or_repair_optimum` (gh #414) on the way out of `solve_socp_ipm`.
+/// The debug path used to return before that guard ran, so a repaired verdict
+/// was another thing the debugger could not see.
+#[test]
+fn leg_orthant_cone_verify() {
+    // min ½(x0² + x1²) − x0 − x1  s.t. x0 + x1 ≤ 1, x ≥ 0. Optimum (½, ½).
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+        c: vec![-1.0, -1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+        h: vec![1.0],
+        lb: vec![0.0, 0.0],
+        ub: vec![f64::INFINITY; 2],
+    };
+    let cones = [ConeSpec::Nonneg(1)];
+    let opts = QpOptions::default();
+
+    let plain = solve_socp_ipm(&prob, &cones, &opts, backend);
+    let mut hook = JustContinue::default();
+    let debugged = solve_socp_ipm_debug(&prob, &cones, &opts, &mut hook, backend);
+
+    assert_eq!(plain.status, QpStatus::Optimal, "iters={}", plain.iters);
+    assert_same_solve("orthant/verify", &plain, &debugged);
+    assert!(hook.fired > 0, "the hook must actually have been fired");
+}
+
+/// The LP/QP entry point on its default driver. This one already agreed
+/// before the fix — the issue measured it as bit-stable — so the leg is a pin
+/// against losing that while unifying the paths, not a new claim.
+#[test]
+fn leg_qp_hsde_default() {
+    let prob = box_qp();
+    let opts = QpOptions::default();
+
+    let plain = solve_qp_ipm(&prob, &opts, backend);
+    let mut hook = JustContinue::default();
+    let debugged = solve_qp_ipm_debug(&prob, &opts, &mut hook, backend);
+
+    assert_eq!(plain.status, QpStatus::Optimal, "iters={}", plain.iters);
+    assert_same_solve("qp/hsde", &plain, &debugged);
+    assert!(hook.fired > 0, "the hook must actually have been fired");
+}
+
+/// `qp_hsde=no` on the QP entry point. The plain path Ruiz-equilibrates the
+/// direct driver (`solve_qp_ipm_core`'s first branch); the debug path ran the
+/// same driver on *un*-equilibrated data. Same defect class as the conic one,
+/// one option away — which is why this leg is not a duplicate of the one
+/// above.
+#[test]
+fn leg_qp_direct_driver() {
+    let prob = box_qp();
+    let opts = QpOptions {
+        use_hsde: false,
+        ..QpOptions::default()
+    };
+    assert!(
+        opts.equilibrate,
+        "the divergence was Ruiz, so it must be on"
+    );
+
+    let plain = solve_qp_ipm(&prob, &opts, backend);
+    let mut hook = JustContinue::default();
+    let debugged = solve_qp_ipm_debug(&prob, &opts, &mut hook, backend);
+
+    assert_eq!(plain.status, QpStatus::Optimal, "iters={}", plain.iters);
+    assert_same_solve("qp/direct", &plain, &debugged);
+    assert!(hook.fired > 0, "the hook must actually have been fired");
+}
+
+/// A pure LP, where `solve_qp_ipm` layers the active-set crossover on the
+/// interior iterate. The debug entry point did not, so the debugged run
+/// returned the un-purified point.
+#[test]
+fn leg_lp_crossover() {
+    // max x0 + x1 s.t. x0 + x1 ≤ 1, x ≥ 0. **Dual-degenerate on purpose**:
+    // every point of the edge `x0 + x1 = 1` is optimal, so the IPM converges
+    // to its analytic center `(½, ½)` and crossover pivots to a vertex. An LP
+    // with a unique optimal vertex would leave crossover nothing to do and the
+    // leg would stay green under the mutation that skips it.
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![-1.0, -1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+        h: vec![1.0],
+        lb: vec![0.0, 0.0],
+        ub: vec![f64::INFINITY; 2],
+    };
+    // Crossover is opt-in (`QpOptions::crossover` defaults to `false`, CLI
+    // `qp_crossover=yes`), so the leg has to ask for it.
+    let opts = QpOptions {
+        crossover: true,
+        ..QpOptions::default()
+    };
+
+    let plain = solve_qp_ipm(&prob, &opts, backend);
+    let mut hook = JustContinue::default();
+    let debugged = solve_qp_ipm_debug(&prob, &opts, &mut hook, backend);
+
+    assert_eq!(plain.status, QpStatus::Optimal, "iters={}", plain.iters);
+    // The leg is only evidence about crossover if crossover moved something:
+    // assert the plain answer really is a vertex rather than the analytic
+    // center the interior iteration converges to.
+    let at_vertex = |x: &[f64]| x[0].min(x[1]) < 1e-6;
+    assert!(
+        at_vertex(&plain.x),
+        "crossover must have pivoted to a vertex for this leg to test it: \
+         x = {:?}",
+        plain.x
+    );
+    assert_same_solve("lp/crossover", &plain, &debugged);
+    assert!(hook.fired > 0, "the hook must actually have been fired");
+}
+
+/// An ill-conditioned box QP: curvature spanning six orders, so Ruiz has
+/// something to do and the two drivers do not trivially coincide.
+fn box_qp() -> QpProblem {
+    QpProblem {
+        n: 3,
+        p_lower: vec![
+            Triplet::new(0, 0, 1.0e-3),
+            Triplet::new(1, 1, 1.0),
+            Triplet::new(2, 2, 1.0e3),
+        ],
+        c: vec![-1.0, -2.0, -3.0],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(0, 2, 1.0),
+        ],
+        h: vec![2.0],
+        lb: vec![-5.0; 3],
+        ub: vec![5.0; 3],
+    }
+}

--- a/crates/pounce-convex/tests/issue892_debug_routes_like_the_plain_solve.rs
+++ b/crates/pounce-convex/tests/issue892_debug_routes_like_the_plain_solve.rs
@@ -104,6 +104,16 @@ fn assert_same_solve(leg: &str, plain: &QpSolution, debugged: &QpSolution) {
         plain.obj,
         debugged.obj
     );
+    // Length first: `zip` stops at the shorter side, so without this a routing
+    // difference that changed the *shape* of `x` — a different bound
+    // expansion, a reduced model, a cone block split one way and not the other
+    // — would compare the common prefix and pass. That is the exact failure
+    // this file exists to catch, so the instrument must not be blind to it.
+    assert_eq!(
+        plain.x.len(),
+        debugged.x.len(),
+        "{leg}: x length moved under the debugger"
+    );
     for (i, (a, b)) in plain.x.iter().zip(&debugged.x).enumerate() {
         assert!(
             (a - b).abs() <= 1e-12 * (1.0 + a.abs()),

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -50,6 +50,15 @@ small set of commands whose availability is backend-conditional.
 > step your own rows, and the plain run then agrees with it because both skip
 > the reduction.
 >
+> One consequence to know before you go hunting for it: when presolve *settles*
+> the model — proving it primal-infeasible or unbounded outright — there is no
+> interior-point solve left to step, so **no checkpoint fires and your debug
+> script never runs**. That is the plain run's behaviour faithfully reproduced,
+> but it is a silent no-op at exactly the moment you were most likely trying to
+> find out *why* the model is infeasible. The `Presolve: proved primal
+> infeasible — <trigger>` line names the screen that decided it, and
+> `qp_presolve=no` puts the iteration back so you can step it.
+>
 > A stopped solve stops. `quit` leaves the run's own non-converged status
 > standing: the recovery machinery that would ordinarily re-solve after a
 > failed or capped solve — the equilibrated retry, the optimality reverify,

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -55,8 +55,10 @@ small set of commands whose availability is backend-conditional.
 > interior-point solve left to step, so **no checkpoint fires and your debug
 > script never runs**. That is the plain run's behaviour faithfully reproduced,
 > but it is a silent no-op at exactly the moment you were most likely trying to
-> find out *why* the model is infeasible. The `Presolve: proved primal
-> infeasible — <trigger>` line names the screen that decided it, and
+> find out *why* the model is infeasible. What you get instead is presolve's own
+> one-line record — `Presolve: proved primal infeasible — <trigger>`, naming the
+> screen that decided it and what it tripped on, or `Presolve: proved unbounded
+> below — a free column with a nonzero objective coefficient` — and
 > `qp_presolve=no` puts the iteration back so you can step it.
 >
 > A stopped solve stops. `quit` leaves the run's own non-converged status

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -40,14 +40,25 @@ small set of commands whose availability is backend-conditional.
 > embedding — different trajectory, and on the reported model a
 > `Numerical failure` where the plain run returned Clarabel's optimum.
 >
-> The one thing the debugger still changes is **presolve**, which the CLI
-> skips while a debugger is attached (on every engine, not just the convex
-> ones) so that the `x`/`s`/`y`/`z` blocks you inspect are the model you
-> wrote rather than a reduced one. On a model presolve can reduce, that is a
-> different — smaller — problem being solved, so expect the iteration count to
-> move; add `qp_presolve=no` to the plain run to compare like with like.
-> Anything *else* that differs between the debugged and the plain run is a
-> bug; please report it.
+> **Presolve runs under the debugger too**, so the model being solved is the
+> model the plain run solves. It used to be skipped on the convex paths, so
+> that the blocks you inspect were your own rows rather than a reduced set —
+> but the price was a debugged run solving a different, smaller problem, which
+> is the same defect one level up from the driver substitution. On a reduced
+> model the blocks are the reduced ones and `print` falls back to index labels
+> where a name no longer survives; pass `qp_presolve=no` if you would rather
+> step your own rows, and the plain run then agrees with it because both skip
+> the reduction.
+>
+> A stopped solve stops. `quit` leaves the run's own non-converged status
+> standing: the recovery machinery that would ordinarily re-solve after a
+> failed or capped solve — the equilibrated retry, the optimality reverify,
+> the LP crossover — declines to start once you have halted the run, because
+> those re-solves run *unhooked* and would otherwise report success for a
+> solve you deliberately stopped.
+>
+> Anything that differs between the debugged and the plain run is a bug;
+> please report it.
 
 ---
 

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -28,6 +28,26 @@ small set of commands whose availability is backend-conditional.
 > The checkpoint fire-sites short-circuit when no debugger is installed,
 > so the standard regression suite is bit-for-bit identical with and
 > without the feature compiled in.
+>
+> **Attaching it does not change the solver either.** Every debug entry point
+> is the ordinary solve entry point reached with a hook, not a second
+> implementation of it, so driver selection, scaling, and the verify-and-retry
+> guards are the ones the plain run uses, and the answer, the trajectory and
+> the iteration count are the same. This is worth stating because it was once
+> false: until gh #892 the conic entry point built its own iteration for
+> symmetric cones and never consulted `qp_hsde`, so attaching the debugger to
+> a convex QCQP silently substituted the direct IPM for the default HSDE
+> embedding — different trajectory, and on the reported model a
+> `Numerical failure` where the plain run returned Clarabel's optimum.
+>
+> The one thing the debugger still changes is **presolve**, which the CLI
+> skips while a debugger is attached (on every engine, not just the convex
+> ones) so that the `x`/`s`/`y`/`z` blocks you inspect are the model you
+> wrote rather than a reduced one. On a model presolve can reduce, that is a
+> different — smaller — problem being solved, so expect the iteration count to
+> move; add `qp_presolve=no` to the plain run to compare like with like.
+> Anything *else* that differs between the debugged and the plain run is a
+> bug; please report it.
 
 ---
 
@@ -1324,6 +1344,14 @@ additionally expose the homogenizing scalars `tau` / `kappa` as 1-element
 blocks (`print tau`). `set <block>` and `goto` work as on the NLP path;
 `set mu` is rejected, because the convex μ is *derived* from `⟨s, z⟩`
 (edit `s`/`z` to move it).
+
+Which blocks you get follows from the driver the *plain* run would have
+used, because it is the driver you get (gh #892). The HSDE embedding is the
+default on every convex arm, so `tau` / `kappa` are normally there; under
+`qp_hsde=no` you are on the direct IPM and they are not. A PSD cone that the
+chordal decomposition splits is debugged in its clique blocks, and a
+Ruiz-equilibrated solve exposes the scaled iterate — in each case, the thing
+the solver is actually iterating on.
 
 ```sh
 pounce model.nl --debug                 # LP / convex-QP (auto-routed) — IPM REPL


### PR DESCRIPTION
Fixes #892

## Problem

`pounce model.nl --debug` on a convex QCQP ran a **different algorithm** than the same command without it. A `--debug-script` containing nothing but `continue` — a pure no-op on the trajectory — turned a clean `Optimal` into `Numerical failure (no verified KKT point)` and exit 1.

The reported 5-variable model, against Clarabel 0.11.1 at `tol = 1e-12` as an independent oracle on the same SOC formulation:

| | status | objective | iters | exit |
|---|---|---|---|---|
| before, plain | `Optimal Solution Found` | 0.46851408 | 38 | 0 |
| before, `--debug-script` | **`Numerical failure`** | 0.46851433 | 21 | **1** |
| after, either | `Optimal Solution Found` | 0.46851408 | 38 | 0 |
| oracle (Clarabel) | — | 0.46851407987426236 | — | — |

The plain run agrees with the oracle to `1.3e-10`; the debugged one failed on a problem the very same engine solves. Under `solver_selection=auto` the failure was then **masked** by the NLP fallback, at the cost of a silent extra solve.

The issue reported 4 instances. Measured over the reported model plus 24 freshly drawn convex QCQPs at n = 4, 5, 7, 9, `solver_selection=socp`, plain vs `--debug-script`:

| | disagree on status / objective / iteration count |
|---|---|
| `d32204e` | **25 / 25** — 16 turning an `Optimal` into a `Numerical failure` or a `Solved to acceptable level` |
| this branch | **0 / 25** |

So this was the normal case on that arm, not an unlucky instance. The reporter's missing `tau` block was the same fact seen from the debugger's side.

## Cause

Two independent halves, and both had to be closed.

**1. The debug entry points were parallel implementations.** `solve_socp_ipm_debug` did not call `solve_socp_ipm`; for symmetric cones it built its own factorization and called `run_ipm` directly. That path never consulted `QpOptions::use_hsde`, which defaults to `true` — so attaching a debugger substituted the *direct* IPM for the HSDE embedding, and with it dropped the `σ` cost normalization and the equilibrate-and-verify guards that live on the embedding's side of `solve_qp_core`. `tau`/`kappa` are the embedding's blocks, which is why they vanished.

The same defect was latent on the LP/QP entry point, one option away: `solve_qp_ipm_debug` honoured `use_hsde` but re-entered *below* `solve_qp_ipm_scoped`, so under `qp_hsde=no` it ran the direct driver on un-equilibrated data, and on a pure LP it skipped the crossover refinement. The issue measured `qp-ipm` as bit-stable, which it is — at default options only.

**2. The CLI skipped presolve under a debugger.** Both convex entry points carried a `debug_hook` arm ahead of the `presolve_on` one, deliberately, so the inspected blocks were the user's own rows. The price was that the debugged run solved a *different, smaller* problem. On `convex_qp_share1b.nl` presolve is 225 → 208 vars and 117 → 98 rows — not a hairline difference.

## Fix

Thread an `Option<&mut DebugHook>` down the ordinary path and reduce both debug entry points to a delegation with `Some(hook)`. The two duplicated bodies are deleted, so there is no second implementation left to drift. At the CLI, route the hook through an `ipm_solve` / `conic_solve` closure called from inside the presolve arm rather than around it.

The hook rides the *primary* solve; the recovery re-solves (equilibrated retry, `σ` re-solves, `verify_or_repair_optimum`, PSD HSDE retry, infeasibility twin, LP crossover) run unhooked, so every fallback behaves exactly as it does without a debugger.

**Rejected: gating the debug path on `use_hsde` and leaving it otherwise separate.** That is the minimal edit and it fixes the reported transcript, but it leaves two implementations of the same routing to drift apart again — which is how this shipped. It also would not have reached `σ`, the gh #414 verify, or either presolve half. The whole point is that there stop being two paths.

**A stop must not be recovered from.** Sharing the ordinary path gave the debug entry points the recovery machinery along with the routing, and a `DebugAction::Stop` leaves a *non-converged* status. The recovery reads that as something to recover from and re-solves unhooked — so after `quit` it ran the problem to completion and reported `Optimal` for a solve the user had deliberately halted. `debug_stop` is a per-solve, per-thread latch on the same rails as `crate::deadline`, set in `debug::fire` (the one place a `DebugAction` is read, so no driver can forget), consulted by every recovery gate. Unlike a deadline it never restamps a verdict — it only declines to *start* another solve. `requested()` is `false` with no debugger attached, so every gate is a no-op on the ordinary path.

This was caught by `debug.rs::stop_action_halts_the_solve` and by nothing else.

Two user-visible consequences, both documented in `docs/src/debugger.md`:

- Presolve now runs under the debugger on the convex paths; blocks are the reduced model's. `qp_presolve=no` gets the unreduced rows, and then the plain run matches because both skip it.
- `quit` stops the solve rather than reporting a recovered success.

## Blast radius

**Bit-identical except the targeted case.** `scripts/sweep-fixtures.sh` against `d32204e`: **empty diff across all 186 fixture-legs**, both `exact` and `lbfgs` — status, objective, iteration count, engine, `q=` and `2nd=` columns all unmoved. Re-run after each of the three code commits, since two of them touched `ipm.rs` after the first sweep.

That is the expected result and the right thing to demand: every non-debug call site passes `None` through otherwise-untouched code, so a moved line would have meant an unintended change. Engine split on this corpus, recounted rather than trusted: 50 `nlp`, 39 `cvx-qp`, 4 `cvx-qcqp` per leg — the conic arm the fix touches is exercised on 8 of the 186 legs.

Public API signatures are unchanged. The active-set engine is untouched: the debugger still does not engage there, and the caller still says so.

## Tests

Two files, because the two halves need different instruments.

`crates/pounce-convex/tests/issue892_debug_routes_like_the_plain_solve.rs` — six legs pinning library-level routing. Per the branch rule in `CLAUDE.md`, `solve_qp_core` forks on `use_hsde`, so each entry point gets a leg on **both** sides of that fork; `leg_qcqp_direct_driver` and `leg_qp_direct_driver` are not duplicates of their defaulted neighbours. Plus the all-orthant conic leg that reaches the gh #414 verify and the LP leg that reaches crossover (with an assertion that crossover actually pivoted to a vertex, so the leg is not vacuous).

`crates/pounce-cli/tests/issue892_debugger_does_not_change_the_solve.rs` — four checks running the binary with and without `--debug-script`, comparing status, objective, iteration count and exit code. The presolve half is invisible to the library legs, and `convex_qp_share1b.nl` / `qcqp_shared_linear_rows.nl` are chosen because presolve measurably reduces them.

**Both mutation tables were measured, not asserted:**

| mutation | red |
|---|---|
| `solve_socp_ipm_debug` builds its own iteration for symmetric cones | `leg_qcqp_hsde_default`, `leg_orthant_cone_verify`; `conic_qcqp_is_unmoved_*` |
| `solve_qp_ipm_debug` re-enters at `solve_qp_ipm_core` with `equilibrate: false` | `leg_qp_direct_driver`, `leg_lp_crossover` |
| reinstate the CLI presolve carve-out | `presolve_still_runs_under_the_debugger`, `convex_qp_is_unmoved_by_the_debugger` |

Each mutation leaves the other half's checks green, which is the argument for keeping both files. The stop regression is pinned by the pre-existing `debug.rs::stop_action_halts_the_solve`, which fails on `800b3cc` for exactly the stated reason.

**Deliberately not pinned:** the exp/power non-symmetric drivers (they already took the hook; `debug.rs::solve_socp_ipm_debug_routes_and_fires` owns them), PSD cones under the debugger (no fixture here reaches one, and the chordal decomposition is now shared with the plain path), `--debug-json`, and anything at benchmark scale.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`debugger.md`; existing page, no `SUMMARY.md` change)
- [x] `cargo fmt --all -- --check` clean; `cargo clippy --release --workspace --all-targets` introduces no new warnings (the four in `ipm.rs` at 541/1995/2665/2928 predate this branch); `cargo test --release --workspace --exclude pounce-hsl` **3996 passed, 0 failed**
- [x] Every claim in this body and in the code comments is true of the code as it stands now

`pounce-hsl` is excluded because its MA57 tests need the proprietary HSL library, which this environment does not have; that exclusion is environmental and unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmfvDmzT6i5FZ5QfJPbsRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmfvDmzT6i5FZ5QfJPbsRD)_