### PR TITLE
Expose presolve and restoration APIs

### DIFF
--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -215,6 +215,10 @@ pub use pounce_presolve::{
 };
 
 /// Low-level presolve APIs for callers that drive a [`TNLP`] directly.
+/// [`IpoptApplication::optimize_tnlp`] applies `wrap_from_options` itself when
+/// `presolve=yes`; after wrapping manually, call
+/// [`IpoptApplication::set_presolve_already_applied`] with `true` to avoid a
+/// second wrapper.
 pub mod presolve {
     pub use pounce_nlp::expression_provider::ExpressionProvider;
     pub use pounce_presolve::{

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -210,14 +210,20 @@ pub use pounce_algorithm::application::IpoptApplication;
 
 // --- presolve ---------------------------------------------------------------
 pub use pounce_nlp::expression_provider::{FbbtOp, FbbtTape};
-pub use pounce_presolve::fbbt::FbbtReport;
+pub use pounce_presolve::{
+    AuxiliaryPreprocessingDiagnostics, CachedBounds, LicqVerdict, TightenReport, fbbt::FbbtReport,
+};
 
 /// Low-level presolve APIs for callers that drive a [`TNLP`] directly.
 pub mod presolve {
     pub use pounce_nlp::expression_provider::ExpressionProvider;
     pub use pounce_presolve::{
-        PresolveError, PresolveOptions, PresolveTnlp, wrap_with_presolve_provider,
+        AuxiliaryPreprocessingDiagnostics, CachedBounds, LicqVerdict, PresolveError,
+        PresolveOptions, PresolveTnlp, TightenReport, wrap_from_options, wrap_with_presolve,
+        wrap_with_presolve_provider,
     };
+
+    pub use pounce_presolve;
 }
 
 /// Second-opinion recovery for callers that manage the low-level solve loop.
@@ -225,6 +231,8 @@ pub mod restoration {
     pub use pounce_restoration::second_opinion_driver::{
         SecondOpinionOutcome, run_second_opinion_ladder,
     };
+
+    pub use pounce_restoration;
 }
 
 // --- iteration capture & observability --------------------------------------
@@ -241,6 +249,8 @@ pub use pounce_algorithm;
 pub use pounce_common;
 pub use pounce_nlp;
 pub use pounce_observability;
+pub use pounce_presolve;
+pub use pounce_restoration;
 
 // --- ergonomic builder API (argmin-style small trait + builder; #168) -------
 pub mod builder;

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -212,6 +212,21 @@ pub use pounce_algorithm::application::IpoptApplication;
 pub use pounce_nlp::expression_provider::{FbbtOp, FbbtTape};
 pub use pounce_presolve::fbbt::FbbtReport;
 
+/// Low-level presolve APIs for callers that drive a [`TNLP`] directly.
+pub mod presolve {
+    pub use pounce_nlp::expression_provider::ExpressionProvider;
+    pub use pounce_presolve::{
+        PresolveError, PresolveOptions, PresolveTnlp, wrap_with_presolve_provider,
+    };
+}
+
+/// Second-opinion recovery for callers that manage the low-level solve loop.
+pub mod restoration {
+    pub use pounce_restoration::second_opinion_driver::{
+        SecondOpinionOutcome, run_second_opinion_ladder,
+    };
+}
+
 // --- iteration capture & observability --------------------------------------
 // Thread-scoped helpers so an embedding library can record a solve's
 // trajectory (and turn on console logs) with no direct `tracing` deps.


### PR DESCRIPTION
## Problem

While bumping to pounce-rs v0.11 in oximo, I found that that I forgot to expose the presolve and restoration APIs

## Cause

I forgot

## Fix

Expose presolve and restoration APIs

## Blast radius

pounce-rs

## Tests

- [ ] Tests fail on the parent commit for the stated reason
- [ ] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now — no test named that does not exist, no doc describing a
      design that was revised mid-review, no measurement whose baseline has
      since moved
