### PR TITLE
docs: in-browser RAG assistant over the book and the wiki

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,16 @@ jobs:
       - name: Docs consistency check
         run: scripts/check-docs-consistency.sh
 
+      # The docs assistant's retrieval half (docs/src/ask.md). It has no
+      # exception to throw: a broken ranker returns the wrong passage,
+      # silently, and the only symptom is a reader not finding the page. This
+      # builds the real index from docs/src and runs the shipped ask.js
+      # against a labelled query set. `ubuntu-latest` has node preinstalled.
+      - name: Docs assistant retrieval check
+        run: |
+          python3 scripts/build-docs-index.py -o "$RUNNER_TEMP/ask-index.json" --quiet
+          node docs/tests/ask_retrieval.mjs "$RUNNER_TEMP/ask-index.json"
+
       - name: Format check
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,12 +59,49 @@ jobs:
         with:
           mdbook-version: ${{ env.MDBOOK_VERSION }}
 
+      # The docs assistant (docs/src/ask.md) searches the wiki as well as the
+      # book, so the wiki — a separate repository, jkitchin/pounce.wiki — has
+      # to be on disk when the index is built. Depth 1: only the current text
+      # is indexed, never the history.
+      #
+      # `continue-on-error` is deliberate and is the whole reason this is its
+      # own step. A wiki that is unreachable, renamed, or emptied must not
+      # take the docs site down with it; build-versioned-docs.sh then sees no
+      # POUNCE_WIKI_DIR (the `if` on the env below), builds a book-only index,
+      # and the assistant loses the wiki passages but nothing else. The step
+      # shows up amber in the run, so the degradation is visible rather than
+      # silent.
+      - name: Clone the wiki (assistant corpus)
+        id: wiki
+        continue-on-error: true
+        run: |
+          git clone --depth 1 https://github.com/jkitchin/pounce.wiki.git \
+            "$GITHUB_WORKSPACE/wiki"
+          ls -1 "$GITHUB_WORKSPACE/wiki"/*.md | wc -l
+
       # Builds stable (latest tag) -> site root, main -> site/dev/, and each
-      # v* tag -> site/<tag>/, then injects the version selector into every
-      # page. Strict: any version failing to build fails the job, so the last
-      # good site stays live.
+      # v* tag -> site/<tag>/, then builds the assistant's retrieval index and
+      # injects the version selector and the assistant into every page.
+      # Strict: any version failing to build fails the job, so the last good
+      # site stays live.
       - name: Build versioned site
+        env:
+          POUNCE_WIKI_DIR: ${{ steps.wiki.outcome == 'success' && format('{0}/wiki', github.workspace) || '' }}
         run: scripts/build-versioned-docs.sh "$GITHUB_WORKSPACE/site"
+
+      # The assistant fails soft in the browser — no index means it shows an
+      # error in its own panel and the rest of the page is fine — so a
+      # mis-staged index would only ever be found by a reader. Assert here
+      # instead: the index exists at the site root, and the injected tag
+      # actually reached a nested page (the depth case `data-index` exists to
+      # get right).
+      - name: Assert the assistant was staged
+        run: |
+          test -s "$GITHUB_WORKSPACE/site/ask-index.json"
+          test -s "$GITHUB_WORKSPACE/site/ask.js"
+          test -s "$GITHUB_WORKSPACE/site/ask.css"
+          grep -q 'data-index="../../ask-index.json"' \
+            "$GITHUB_WORKSPACE/site/dev/schema/solve-report-v1.html"
 
       # The in-browser solvers (docs/src/wasm.md) ride the same Pages
       # deployment: the drag-and-drop `.nl` app at <site>/demo/ and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,52 @@ changes.
 
 ### Added
 
+- **An in-browser docs assistant on the rendered site (`Ask`).** A question
+  box in the menu bar of every page of <https://jkitchin.github.io/pounce/>,
+  built from two halves that work independently. Retrieval is BM25 over an
+  index of the whole book *and* the GitHub wiki, deep-linked to the heading
+  that answers; generation is optional, a small instruct model
+  ([WebLLM](https://github.com/mlc-ai/web-llm) on WebGPU) that is handed only
+  the retrieved passages. Nothing leaves the browser: no API key, no server,
+  no telemetry, and no download at all until the reader clicks "Load model".
+
+  **The wiki is the reason it exists as much as the model is.** The four
+  long-form wiki pages carry the measured guidance — which of the 441 options
+  are worth setting, what to do when a solve dies at its starting point, why
+  bound relaxation costs what it costs — and they are what a reader asking
+  "why is my solve slow" actually wants. They are indexed and cited (marked
+  `wiki`, linking out to GitHub) but not rendered into the book, which stays
+  the reference manual.
+
+  The retrieval half degrades to something still useful rather than to a blank
+  panel: without WebGPU, without a model, or on a phone, a reader gets ranked
+  linked passages, and the panel says which of those it is. `navigator.gpu`
+  existing is not treated as WebGPU working — the adapter is queried up front,
+  because it resolves *null* on machines with no usable GPU and offering the
+  button there just buys a wait and an error from inside WebLLM.
+
+  Delivery rides the version selector's mechanism (`scripts/build-versioned-
+  docs.sh` injects it per page), so it reaches the site root and every
+  archived tag immediately rather than only `dev/` until the next release.
+  There is one index, built from `main` and shared by every version, so
+  citations resolve against the site root: an archived book's assistant
+  answers about current docs, and a passage naming a page that did not exist
+  at v0.2.0 still links somewhere real.
+
+  Guarded by `docs/tests/ask_retrieval.mjs` (`make ask-check`, and CI), which
+  runs the *shipped* `ask.js` — not a copy of the scoring — against a labelled
+  query set. Retrieval has no exception to throw: it returns the wrong passage
+  silently, and the only symptom is a reader not finding the page. Four
+  ranking defects were found and fixed by measuring against that set rather
+  than by inspection: unstemmed function words swamping natural-language
+  questions (top-1 11/20 → 15/20), a compound identifier being split so that
+  `fix_relax` outranked the documentation of `bound_relax_factor`, the heading
+  bonus rewarding nesting depth, and the wiki's link-farm `Home` page winning
+  multi-term queries. Now 18/20 top-1 and 20/20 top-5.
+
+  Book page: `docs/src/ask.md`. Index builder:
+  `scripts/build-docs-index.py`.
+
 - **A phase-changing flash as a complementarity problem
   (`pounce.examples.flash_mpcc`, notebook 38).** A single vapour–liquid
   equilibrium stage solved across a temperature path that crosses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,20 @@ changes.
   runs the *shipped* `ask.js` — not a copy of the scoring — against a labelled
   query set. Retrieval has no exception to throw: it returns the wrong passage
   silently, and the only symptom is a reader not finding the page. Four
-  ranking defects were found and fixed by measuring against that set rather
-  than by inspection: unstemmed function words swamping natural-language
-  questions (top-1 11/20 → 15/20), a compound identifier being split so that
-  `fix_relax` outranked the documentation of `bound_relax_factor`, the heading
-  bonus rewarding nesting depth, and the wiki's link-farm `Home` page winning
-  multi-term queries. Now 18/20 top-1 and 20/20 top-5.
+  ranking defects were found by measuring against that set rather than by
+  inspection, every one of which looked fine on the page: function words
+  swamping natural-language questions, a compound identifier being split so
+  that `fix_relax` outranked the documentation of `bound_relax_factor`, the
+  heading bonus rewarding nesting *depth* rather than specificity, and the
+  wiki's link-farm `Home` page winning multi-term queries. Final score 18/20
+  top-1 with the wiki, 17/20 book-only (as CI builds it), 20/20 top-5 in both.
+
+  Ablated against the final system, book-only top-1 of 17/20 falls to 13/20
+  without the heading and title bonuses, 14/20 without the stopword list, and
+  14/20 without stemming. A fifth component — a coordination factor scaling by
+  the fraction of query terms matched — measured *no* difference in either
+  configuration once the other four were right, and was removed rather than
+  kept on the strength of the argument for it.
 
   Book page: `docs/src/ask.md`. Index builder:
   `scripts/build-docs-index.py`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,45 @@ does not read ~0% (it can only be reached through the `.so`). Requires the
 `CODECOV_TOKEN` repository secret. Full rationale: CONTRIBUTING.md,
 "Measuring coverage".
 
+## The docs site has a fourth input: the wiki
+
+`.github/workflows/docs.yml` clones **jkitchin/pounce.wiki** — a separate
+repository — and `scripts/build-versioned-docs.sh` indexes it alongside
+`docs/src` into `ask-index.json`, the corpus the in-browser docs assistant
+(`docs/src/ask.md`) searches. So the deployed site now depends on a repo that
+is not this one. The clone step is `continue-on-error` and the build treats a
+missing `POUNCE_WIKI_DIR` as book-only, deliberately: an unreachable wiki must
+degrade the assistant, never take the docs site down. A run where that step is
+amber is a real signal — the wiki pages stopped being answerable — not noise.
+
+Two things about the assistant that are easy to get wrong:
+
+* **It is injected per page, not listed in `book.toml`.** `additional-js`
+  would reach `dev/` and nothing else until the next release, because the
+  site root is built from the newest *tag*, whose source predates any change
+  you just made. It rides the version selector's injection instead, so
+  editing `docs/assets/ask.js` changes every version's pages on the next
+  deploy. The corollary is that a plain `mdbook build docs` (`make book`) has
+  no **Ask** button at all — use `make book-site`, and serve it under the real
+  base path, or relative-path bugs stay invisible above the top level.
+* **One index, built from `main`, shared by every version.** Citations
+  therefore resolve against the *site root*, not the current version
+  (`data-root`, distinct from `data-p2r`). Resolving them against an archived
+  book 404s on every page and anchor added since that tag — measured, four of
+  six hits on one v0.2.0 page.
+
+Retrieval fails silently by construction: a broken ranker returns the wrong
+passage and the only symptom is a reader not finding the page. `make
+ask-check` (`docs/tests/ask_retrieval.mjs`, also in `ci.yml`) runs the
+**shipped** `ask.js` through a test seam against a labelled query set — a test
+of a reimplemented scorer would stay green while the real one regressed. Its
+thresholds sit deliberately below the measured score because it is a corpus
+test and honest doc edits move rankings; it exists to catch a scoring change
+that drops several queries at once. Change anything in the tokenizer, the
+stemmer, or the scorer and re-measure rather than reasoning about it — every
+one of the four ranking defects fixed while building it looked fine on
+inspection.
+
 ## Trajectory changes need the fixture sweep
 
 A change that reroutes **which** correction the solver reaches for, or that

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 #   make fmt              # rustfmt the workspace
 #   make doc              # build rustdoc
 #   make book             # build the mdbook documentation (docs/)
+#   make book-site        # build the full multi-version site + docs assistant
+#   make ask-check        # test the docs assistant's retrieval (needs node)
 #   make wasm             # build the browser (WebAssembly) solver + demo page
 #   make wasm-serve       # ...and serve it on http://localhost:8000
 #   make install          # install pounce CLI + cinterface cdylib under $(PREFIX)
@@ -80,7 +82,7 @@ endif
         test-ma57 \
         dev python-ext python-cli-bin python-test coverage coverage-quick \
         benchmark benchmark-rerun benchmark-report benchmark-gams wasm wasm-serve \
-        docker docker-release
+        docker docker-release book-site ask-check
 
 all: build
 
@@ -139,6 +141,27 @@ wasm-serve:
 
 book:
 	mdbook build docs
+
+# The full deployed site: stable at the root, dev/ and every archived v* tag,
+# plus the docs assistant (docs/src/ask.md) and its retrieval index. `make
+# book` deliberately does NOT include the assistant — it is injected per page
+# by this script, not configured in book.toml — so this is the target to use
+# when changing docs/assets/ask.{js,css}. Needs the release tags present
+# (`git fetch --tags`). Set POUNCE_WIKI_DIR to a pounce.wiki clone to index
+# the wiki as CI does; without it the index is book-only.
+book-site:
+	scripts/build-versioned-docs.sh ./site
+	@echo
+	@echo "Serve it under the real base path (the assistant resolves relative"
+	@echo "paths, and a bad one only shows up below the top level):"
+	@echo "  mkdir -p _serve/pounce && cp -a site/. _serve/pounce/"
+	@echo "  python3 -m http.server -d _serve 8000   # http://localhost:8000/pounce/"
+
+# Retrieval guard for the docs assistant: builds the index from docs/src and
+# runs the shipped ask.js against a labelled query set. Same two lines CI runs.
+ask-check:
+	python3 scripts/build-docs-index.py -o /tmp/pounce-ask-index.json --quiet
+	node docs/tests/ask_retrieval.mjs /tmp/pounce-ask-index.json
 
 # Record asciinema screencasts of `pounce --debug` (one per scenario in
 # scripts/demo/scenarios/) into docs/demo/*.{cast,gif}. Requires asciinema,

--- a/docs/assets/ask.css
+++ b/docs/assets/ask.css
@@ -1,0 +1,264 @@
+/* ==========================================================================
+   POUNCE docs assistant (docs/assets/ask.js) — panel styling.
+
+   Ships as its own stylesheet rather than as part of pounce.css because
+   ask.js is injected into EVERY built book by scripts/build-versioned-docs.sh,
+   including archived tag builds whose own pounce.css predates the assistant.
+   ask.js therefore links this file itself, from alongside its own <script src>.
+
+   For the same reason every color here falls back to a literal: an archived
+   book's theme defines mdBook's variables (--bg, --fg, --links, …) but not
+   necessarily POUNCE's brand tokens (--pounce-tiger), which were added later.
+   ========================================================================== */
+
+/* ---- Menu-bar toggle, sitting with the version selector ----------------- */
+.pounce-ask-toggle {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: var(--icons, #a88a5e);
+  border: 1px solid var(--icons, #a88a5e);
+  border-radius: 4px;
+  font: inherit;
+  font-size: 0.8rem;
+  line-height: 1.2;
+  padding: 0.15em 0.7em;
+  margin-right: 0.4rem;
+  cursor: pointer;
+}
+.pounce-ask-toggle:hover {
+  color: var(--pounce-tiger, #e87a1e);
+  border-color: var(--pounce-tiger, #e87a1e);
+}
+
+/* ---- Panel -------------------------------------------------------------- */
+.pounce-ask-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 1000;
+  width: min(30rem, 100vw);
+  height: 100vh;
+  /* Keeps the answer and the sources scrollable independently of the page. */
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1rem 1.1rem 1.2rem;
+  box-sizing: border-box;
+  overflow-y: auto;
+  background: var(--bg, #1a1411);
+  color: var(--fg, #f1e4cb);
+  border-left: 1px solid var(--table-border-color, #3a2c20);
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.28);
+  font-size: 0.9rem;
+}
+.pounce-ask-panel[hidden] {
+  display: none;
+}
+
+.pounce-ask-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.pounce-ask-title {
+  margin: 0;
+  font-size: 1.15rem;
+  border-bottom: none;
+  color: var(--pounce-tiger, #e87a1e);
+}
+.pounce-ask-close {
+  background: none;
+  border: none;
+  color: var(--icons, #a88a5e);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0 0.2em;
+  cursor: pointer;
+}
+.pounce-ask-close:hover {
+  color: var(--pounce-tiger, #e87a1e);
+}
+
+/* ---- Status line -------------------------------------------------------- */
+.pounce-ask-status {
+  font-size: 0.8rem;
+  opacity: 0.8;
+  min-height: 1.2em;
+}
+.pounce-ask-status-busy {
+  color: var(--pounce-amber, #b56a12);
+  opacity: 1;
+}
+.pounce-ask-status-ok {
+  color: var(--pounce-tiger, #e87a1e);
+  opacity: 1;
+}
+.pounce-ask-status-error {
+  color: var(--pounce-hot, #cc2200);
+  opacity: 1;
+}
+
+/* ---- Question ----------------------------------------------------------- */
+.pounce-ask-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.pounce-ask-input {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  font: inherit;
+  padding: 0.5em 0.6em;
+  border-radius: 5px;
+  border: 1px solid var(--searchbar-border-color, #3a2c20);
+  background: var(--searchbar-bg, #1f1813);
+  color: var(--searchbar-fg, #f1e4cb);
+}
+.pounce-ask-input:focus {
+  outline: none;
+  border-color: var(--pounce-tiger, #e87a1e);
+}
+.pounce-ask-submit {
+  align-self: flex-start;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.35em 1.2em;
+  border-radius: 5px;
+  border: 1px solid var(--pounce-tiger, #e87a1e);
+  background: var(--pounce-tiger, #e87a1e);
+  color: #1a1411;
+  cursor: pointer;
+}
+.pounce-ask-submit:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* ---- Model row ---------------------------------------------------------- */
+.pounce-ask-model {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem;
+  border-radius: 5px;
+  border: 1px solid var(--table-border-color, #3a2c20);
+  background: var(--quote-bg, #221a13);
+}
+.pounce-ask-select,
+.pounce-ask-load {
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.25em 0.6em;
+  border-radius: 4px;
+  border: 1px solid var(--icons, #a88a5e);
+  background: transparent;
+  color: var(--fg, #f1e4cb);
+  cursor: pointer;
+}
+.pounce-ask-select option {
+  color: var(--fg, #f1e4cb);
+  background: var(--bg, #1a1411);
+}
+.pounce-ask-load:hover:not(:disabled) {
+  border-color: var(--pounce-tiger, #e87a1e);
+  color: var(--pounce-tiger, #e87a1e);
+}
+.pounce-ask-load:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.pounce-ask-note {
+  flex: 1 1 100%;
+  font-size: 0.78rem;
+  opacity: 0.75;
+  line-height: 1.35;
+}
+
+/* ---- Answer ------------------------------------------------------------- */
+.pounce-ask-answer:empty {
+  display: none;
+}
+.pounce-ask-answer-body {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+.pounce-ask-answer-body code {
+  font-size: 0.85em;
+  color: var(--inline-code-color, #ffcf8f);
+}
+
+/* ---- Sources ------------------------------------------------------------ */
+.pounce-ask-sources:empty {
+  display: none;
+}
+.pounce-ask-sources-title {
+  margin: 0.4rem 0 0.3rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+  border-bottom: none;
+}
+.pounce-ask-source-list {
+  margin: 0;
+  padding-left: 1.4em;
+}
+.pounce-ask-source-list li {
+  margin-bottom: 0.7rem;
+}
+.pounce-ask-source-link {
+  font-weight: 600;
+  color: var(--links, #ffb262);
+}
+.pounce-ask-badge {
+  margin-left: 0.45em;
+  padding: 0.05em 0.4em;
+  border-radius: 3px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  vertical-align: 0.1em;
+  color: var(--bg, #1a1411);
+  background: var(--pounce-tan, #8a6d3b);
+}
+.pounce-ask-excerpt {
+  margin: 0.2rem 0 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  opacity: 0.78;
+}
+
+/* ---- Footer ------------------------------------------------------------- */
+.pounce-ask-foot {
+  margin-top: auto;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--table-border-color, #3a2c20);
+  font-size: 0.75rem;
+  opacity: 0.7;
+  line-height: 1.45;
+}
+.pounce-ask-foot a {
+  color: var(--links, #ffb262);
+}
+
+/* ---- Narrow screens ----------------------------------------------------- */
+@media (max-width: 700px) {
+  .pounce-ask-panel {
+    width: 100vw;
+    border-left: none;
+  }
+}
+
+/* Printing a page should not print the assistant. */
+@media print {
+  .pounce-ask-panel,
+  .pounce-ask-toggle {
+    display: none !important;
+  }
+}

--- a/docs/assets/ask.js
+++ b/docs/assets/ask.js
@@ -120,8 +120,8 @@
   // solve fails because of where it started") is mostly stopwords, and
   // without this list the short passages that happen to contain several of
   // them outrank the passage that contains the one term that matters.
-  // Measured on the 20-query eval set: removing these took top-1 from 11/20
-  // to 15/20 on its own.
+  // Ablated against the final system on the 20-query eval set, this list is
+  // worth top-1 17/20 -> 14/20 (book-only).
   //
   // Deliberately *not* included: "no", "not", "off", "on", "up", "down",
   // "over", "under" — each is load-bearing somewhere in this corpus
@@ -146,8 +146,8 @@
   // identifiers and proper nouns, and every extra rule is another chance to
   // collide two terms that a solver manual distinguishes.
   //
-  // Step 1 alone is what a reader's phrasing needs. Measured on the eval set,
-  // it is what connects "why does *relaxing* the bounds…" to the passages
+  // Step 1 alone is what a reader's phrasing needs. Ablated to an identity
+  // stem, top-1 falls 17/20 -> 14/20 (book-only); it is what connects "why does *relaxing* the bounds…" to the passages
   // about bound *relaxation*, and "my solve fails because of where it
   // *started*" to "*starting* point". The +e restoration in 1b matters as
   // much as the stripping: without it "scaling" stems to `scal` and no longer
@@ -304,12 +304,10 @@
   var HEAD_BONUS = 0.6;
   // The page title is the coarsest and most reliable topic signal in the
   // corpus: a reader asking about scaling wants the page called "Scaling"
-  // before a subsection of "Sensitivity Analysis" that mentions it.
+  // before a subsection of "Sensitivity Analysis" that mentions it. Ablated,
+  // this and HEAD_BONUS together are the largest single contributor to
+  // ranking quality: dropping both takes top-1 17/20 -> 13/20 (book-only).
   var TITLE_BONUS = 0.5;
-  // Weight of a passage that matched only one of several query terms,
-  // relative to one that matched them all. 0 would make coverage the whole
-  // ranking and drop legitimate single-rare-term hits ("bound_relax_factor").
-  var COORD_FLOOR = 0.3;
 
   // Query-side terms, deduplicated (a word repeated in the question must not
   // multiply its own idf).
@@ -358,12 +356,10 @@
     for (var i = 0; i < idx.N; i++) {
       var doc = idx.docs[i];
       var score = 0;
-      var matched = 0;
       for (var q = 0; q < qterms.length; q++) {
         var term = qterms[q];
         var f = doc.tf[term];
         if (!f) continue;
-        matched++;
         var n = idx.df[term] || 0;
         var idf = Math.log(1 + (idx.N - n + 0.5) / (n + 0.5));
         var denom = f + K1 * (1 - B + (B * doc.len) / idx.avgdl);
@@ -371,14 +367,13 @@
         if (doc.head[term]) score += HEAD_BONUS * idf;
         if (doc.title[term]) score += TITLE_BONUS * idf;
       }
-      if (score > 0) {
-        // Coordination: BM25 sums independently over terms, so a passage
-        // matching one term very well outranks one matching every term
-        // decently. On a question the second is nearly always what the
-        // reader meant, so scale by how much of the question was covered.
-        score *= COORD_FLOOR + (1 - COORD_FLOOR) * (matched / qterms.length);
-        scored.push({ i: i, score: score });
-      }
+      // A coordination factor (scaling by the fraction of query terms a
+      // passage matched) was tried here and removed: ablated, it moved
+      // neither configuration of the eval set — 17/20 book-only and 18/20
+      // with the wiki, either way. Once stopwords stopped inflating the term
+      // count and the heading bonus stopped rewarding nesting depth, it had
+      // nothing left to correct.
+      if (score > 0) scored.push({ i: i, score: score });
     }
 
     scored.sort(function (a, b) {

--- a/docs/assets/ask.js
+++ b/docs/assets/ask.js
@@ -1,0 +1,889 @@
+// POUNCE docs assistant — retrieval-augmented, entirely in the reader's browser.
+//
+// Two halves that are deliberately independent:
+//
+//   RETRIEVAL  BM25 over ask-index.json (built by scripts/build-docs-index.py
+//              from docs/src/**/*.md plus the GitHub wiki). Pure JS, no model,
+//              no network beyond the index itself. This half always works.
+//
+//   GENERATION WebLLM (https://github.com/mlc-ai/web-llm) running a small
+//              instruct model on WebGPU, fed *only* the retrieved passages.
+//              Strictly opt-in: the weights are hundreds of megabytes, so
+//              nothing is fetched until the reader clicks "Load model".
+//
+// The split is the point. A reader without WebGPU, without the patience for a
+// model download, or on a phone still gets ranked deep-linked passages — which
+// is most of the value — and a reader who loads the model gets those same
+// passages written up. Nothing degrades to a blank panel.
+//
+// Nothing leaves the browser. There is no API key, no server, no telemetry;
+// the only third-party traffic is the model weight download from the WebLLM
+// CDN, and that happens only after the explicit click.
+//
+// Delivery mirrors docs/assets/versions.js: scripts/build-versioned-docs.sh
+// copies this file into every built book — including archived tag builds whose
+// own source predates it — and injects
+//
+//     <script defer src="<p2r>ask.js" id="pounce-ask"
+//             data-p2r="<p2r>" data-index="<rel path to ask-index.json>"></script>
+//
+// into every page. We read both paths off our own tag, so this file never
+// hardcodes the site base (`/pounce/`) and works served at any path or domain.
+// The index is built once from `main` and shared by every version, so an
+// archived book's assistant answers about *current* docs and links to the
+// stable book; docs/src/ask.md says so where a reader will see it.
+(function () {
+  var SELF_ID = "pounce-ask";
+  var WEBLLM_URL = "https://esm.run/@mlc-ai/web-llm@0.2.84";
+
+  // Offered smallest-first: the first entry is what an undecided reader gets,
+  // and a 900 MB download that answers is worth more than a 2.3 GB one they
+  // abandon. `vram` is the MB figure from WebLLM's own prebuiltAppConfig.
+  var MODELS = [
+    { base: "Llama-3.2-1B-Instruct", label: "Llama 3.2 1B", vram: 879 },
+    { base: "Qwen2.5-1.5B-Instruct", label: "Qwen 2.5 1.5B", vram: 1630 },
+    { base: "Llama-3.2-3B-Instruct", label: "Llama 3.2 3B", vram: 2264 }
+  ];
+
+  var TOP_K = 5; // passages handed to the model
+  var TOP_SHOW = 6; // passages listed as sources
+  var MAX_CTX_CHARS = 900; // per passage, into the prompt
+  var LS_MODEL = "pounce-ask-model";
+
+  var state = {
+    index: null, // { chunks, N, avgdl, df, docs }
+    loading: null, // in-flight index fetch
+    engine: null, // WebLLM engine once loaded
+    engineModel: null,
+    busy: false,
+    lastHits: []
+  };
+
+  // ---------------------------------------------------------------- paths --
+
+  function self() {
+    return document.getElementById(SELF_ID) || document.currentScript;
+  }
+
+  function attr(name, fallback) {
+    var el = self();
+    var v = el && el.getAttribute(name);
+    return v === null || v === undefined ? fallback : v;
+  }
+
+  // This version's root ("" at a version's root page, "../" one level deep).
+  function versionRoot() {
+    return new URL(attr("data-p2r", "") || ".", window.location.href);
+  }
+
+  // The SITE root, i.e. the stable book. Distinct from versionRoot() inside
+  // dev/ and every archived vX.Y.Z/, and that distinction is load-bearing —
+  // see citationRoot().
+  function siteRoot() {
+    return new URL(attr("data-root", "") || ".", window.location.href);
+  }
+
+  function indexUrl() {
+    return new URL(attr("data-index", "ask-index.json"), window.location.href);
+  }
+
+  // Citations resolve against the SITE root, never the current version.
+  //
+  // There is one index and it is built from `main`, so a passage can name a
+  // page or an anchor that did not exist at an archived tag. Resolving
+  // `initialization.html#one-of-the-two-downgrades-has-since-gone-away-gh681`
+  // against v0.2.0/ is a 404 — measured, not hypothetical: four of six hits
+  // on one v0.2.0 page. Pointing at the stable book instead always resolves,
+  // and matches what the passage text actually says.
+  function citationRoot() {
+    var root = siteRoot();
+    // Fall back to the version root only if data-root is absent (a page
+    // injected by an older build); a wrong-but-present link beats none.
+    return root || versionRoot();
+  }
+
+  // A chunk's `u` is either an absolute wiki URL or a path relative to a
+  // book root — never to the current page.
+  function hrefFor(chunk) {
+    if (/^https?:/.test(chunk.u)) return chunk.u;
+    try {
+      return new URL(chunk.u, citationRoot()).href;
+    } catch (e) {
+      return chunk.u;
+    }
+  }
+
+  // ------------------------------------------------------------ retrieval --
+
+  // Function words carry no signal and actively mislead here. A question
+  // phrased as a question ("what does MaximumIterationsExceeded mean", "my
+  // solve fails because of where it started") is mostly stopwords, and
+  // without this list the short passages that happen to contain several of
+  // them outrank the passage that contains the one term that matters.
+  // Measured on the 20-query eval set: removing these took top-1 from 11/20
+  // to 15/20 on its own.
+  //
+  // Deliberately *not* included: "no", "not", "off", "on", "up", "down",
+  // "over", "under" — each is load-bearing somewhere in this corpus
+  // ("turning it off", "warm start up", "bound tightening").
+  var STOPWORDS = (
+    "a about all also am an and any are as at be because been but by can " +
+    "could did do does doing done for from get give go had has have he her " +
+    "here him his how i if in into is it its just like make me might more " +
+    "most much must my need of one only or other our out own please should " +
+    "since so some such than that the their them then there these they this " +
+    "those through to too us use used using very want was way we were what " +
+    "when where whether which while who why will with would you your"
+  ).split(" ").reduce(function (set, w) {
+    set[w] = 1;
+    return set;
+  }, Object.create(null));
+
+  // Porter step 1 — inflectional endings only (plurals, -ed, -ing, -y).
+  //
+  // Steps 2-5 are derivational (-ational -> -ate, -iveness -> -ive) and are
+  // left out: they buy little on a corpus whose distinctive vocabulary is
+  // identifiers and proper nouns, and every extra rule is another chance to
+  // collide two terms that a solver manual distinguishes.
+  //
+  // Step 1 alone is what a reader's phrasing needs. Measured on the eval set,
+  // it is what connects "why does *relaxing* the bounds…" to the passages
+  // about bound *relaxation*, and "my solve fails because of where it
+  // *started*" to "*starting* point". The +e restoration in 1b matters as
+  // much as the stripping: without it "scaling" stems to `scal` and no longer
+  // matches "scale".
+  var CONS = /[^aeiou]/;
+
+  function isCons(w, i) {
+    var c = w.charAt(i);
+    if (c === "y") return i === 0 ? true : !isCons(w, i - 1);
+    return CONS.test(c);
+  }
+
+  function hasVowel(w) {
+    for (var i = 0; i < w.length; i++) {
+      if (!isCons(w, i)) return true;
+    }
+    return false;
+  }
+
+  // Porter's `m`: the number of vowel-consonant sequences in the stem.
+  function measure(w) {
+    var n = 0;
+    var i = 0;
+    while (i < w.length && isCons(w, i)) i++;
+    while (i < w.length) {
+      while (i < w.length && !isCons(w, i)) i++;
+      if (i >= w.length) break;
+      n++;
+      while (i < w.length && isCons(w, i)) i++;
+    }
+    return n;
+  }
+
+  function endsDoubleCons(w) {
+    var n = w.length;
+    return n > 1 && w.charAt(n - 1) === w.charAt(n - 2) && isCons(w, n - 1);
+  }
+
+  // consonant-vowel-consonant where the final consonant is not w, x or y.
+  function cvc(w) {
+    var n = w.length;
+    if (n < 3) return false;
+    if (!isCons(w, n - 1) || isCons(w, n - 2) || !isCons(w, n - 3)) return false;
+    return "wxy".indexOf(w.charAt(n - 1)) < 0;
+  }
+
+  function restore(stem) {
+    if (/(at|bl|iz)$/.test(stem)) return stem + "e";
+    if (endsDoubleCons(stem) && !/[lsz]$/.test(stem)) return stem.slice(0, -1);
+    if (measure(stem) === 1 && cvc(stem)) return stem + "e";
+    return stem;
+  }
+
+  var stemCache = Object.create(null);
+
+  function normTok(t) {
+    // Identifiers keep their exact form: `bound_relax_factor` and
+    // `theta_max` are names, not English, and stemming their parts would
+    // make an exact-name lookup fuzzy in precisely the case where the
+    // reader was being precise.
+    if (t.length < 4 || t.indexOf("_") >= 0 || /\d/.test(t)) return t;
+
+    var hit = stemCache[t];
+    if (hit !== undefined) return hit;
+
+    var w = t;
+    // 1a — plurals.
+    if (/sses$/.test(w)) w = w.slice(0, -2);
+    else if (/ies$/.test(w)) w = w.slice(0, -3) + "i";
+    else if (/[^s]s$/.test(w)) w = w.slice(0, -1);
+
+    // 1b — -eed / -ed / -ing.
+    if (/eed$/.test(w)) {
+      if (measure(w.slice(0, -1)) > 0) w = w.slice(0, -1);
+    } else if (/ed$/.test(w) && hasVowel(w.slice(0, -2))) {
+      w = restore(w.slice(0, -2));
+    } else if (/ing$/.test(w) && hasVowel(w.slice(0, -3))) {
+      w = restore(w.slice(0, -3));
+    }
+
+    // 1c — terminal y after a vowel-containing stem.
+    if (/y$/.test(w) && hasVowel(w.slice(0, -1))) w = w.slice(0, -1) + "i";
+
+    stemCache[t] = w;
+    return w;
+  }
+
+  // Snake_case identifiers are emitted whole *and* split, so "bound relax
+  // factor" and "bound_relax_factor" both hit the same passages.
+  function tokenize(s) {
+    var raw = String(s).toLowerCase().match(/[a-z0-9_]+/g) || [];
+    var out = [];
+    for (var i = 0; i < raw.length; i++) {
+      var t = raw[i];
+      if (STOPWORDS[t]) continue;
+      out.push(normTok(t));
+      if (t.indexOf("_") > 0) {
+        var parts = t.split("_");
+        for (var j = 0; j < parts.length; j++) {
+          if (parts[j] && !STOPWORDS[parts[j]]) out.push(normTok(parts[j]));
+        }
+      }
+    }
+    return out;
+  }
+
+  function buildIndex(chunks) {
+    var df = Object.create(null);
+    var docs = new Array(chunks.length);
+    var total = 0;
+
+    for (var i = 0; i < chunks.length; i++) {
+      var c = chunks[i];
+      // The full trail goes into the searchable text — an ancestor heading is
+      // real context for recall. But the *bonus* below is keyed on the leaf
+      // heading and the page title only. Bonusing every ancestor token gives
+      // deeply nested sections a boost proportional to their depth, which is
+      // not a relevance signal: measured, it put
+      // "Active-Set SQP Warm Starts › … › 1.2 Design decisions" above the
+      // wiki page literally named "Recovering from a bad start".
+      var trail = c.h.split("›");
+      var leafTokens = tokenize(trail[trail.length - 1]);
+      var titleTokens = tokenize(c.t);
+      var tokens = tokenize(c.h).concat(titleTokens, tokenize(c.x));
+
+      var tf = Object.create(null);
+      for (var j = 0; j < tokens.length; j++) {
+        tf[tokens[j]] = (tf[tokens[j]] || 0) + 1;
+      }
+      var head = Object.create(null);
+      for (var k = 0; k < leafTokens.length; k++) head[leafTokens[k]] = 1;
+      var title = Object.create(null);
+      for (var m = 0; m < titleTokens.length; m++) title[titleTokens[m]] = 1;
+
+      for (var term in tf) df[term] = (df[term] || 0) + 1;
+      docs[i] = { tf: tf, len: tokens.length, head: head, title: title };
+      total += tokens.length;
+    }
+
+    return {
+      chunks: chunks,
+      docs: docs,
+      df: df,
+      N: chunks.length,
+      avgdl: chunks.length ? total / chunks.length : 1
+    };
+  }
+
+  // Okapi BM25 with the usual constants, plus a flat bonus for a query term
+  // that appears in the passage's heading trail — on a reference manual the
+  // heading is very often the whole question ("what does scaling do").
+  var K1 = 1.2;
+  var B = 0.75;
+  var HEAD_BONUS = 0.6;
+  // The page title is the coarsest and most reliable topic signal in the
+  // corpus: a reader asking about scaling wants the page called "Scaling"
+  // before a subsection of "Sensitivity Analysis" that mentions it.
+  var TITLE_BONUS = 0.5;
+  // Weight of a passage that matched only one of several query terms,
+  // relative to one that matched them all. 0 would make coverage the whole
+  // ranking and drop legitimate single-rare-term hits ("bound_relax_factor").
+  var COORD_FLOOR = 0.3;
+
+  // Query-side terms, deduplicated (a word repeated in the question must not
+  // multiply its own idf).
+  //
+  // Compound identifiers are handled asymmetrically to the index on purpose.
+  // Indexing emits `bound_relax_factor` AND its parts, so that a reader who
+  // types the name as three words still finds it. Querying must not: expanded
+  // into {bound_relax_factor, bound, relax, factor}, the query "bound_relax_
+  // factor" was won by a passage about `fix_relax` that matched three of the
+  // four parts and not the name. So an identifier the corpus actually
+  // contains is searched as itself, and only an unknown one falls back to its
+  // parts.
+  function queryTerms(idx, query) {
+    var raw = String(query).toLowerCase().match(/[a-z0-9_]+/g) || [];
+    var seen = Object.create(null);
+    var out = [];
+
+    function push(tok) {
+      if (tok && !seen[tok]) {
+        seen[tok] = 1;
+        out.push(tok);
+      }
+    }
+
+    for (var i = 0; i < raw.length; i++) {
+      var t = raw[i];
+      if (STOPWORDS[t]) continue;
+      var whole = normTok(t);
+      if (t.indexOf("_") > 0 && !idx.df[whole]) {
+        var parts = t.split("_");
+        for (var j = 0; j < parts.length; j++) {
+          if (parts[j] && !STOPWORDS[parts[j]]) push(normTok(parts[j]));
+        }
+      } else {
+        push(whole);
+      }
+    }
+    return out;
+  }
+
+  function search(idx, query, limit) {
+    var qterms = queryTerms(idx, query);
+    if (!qterms.length) return [];
+
+    var scored = [];
+    for (var i = 0; i < idx.N; i++) {
+      var doc = idx.docs[i];
+      var score = 0;
+      var matched = 0;
+      for (var q = 0; q < qterms.length; q++) {
+        var term = qterms[q];
+        var f = doc.tf[term];
+        if (!f) continue;
+        matched++;
+        var n = idx.df[term] || 0;
+        var idf = Math.log(1 + (idx.N - n + 0.5) / (n + 0.5));
+        var denom = f + K1 * (1 - B + (B * doc.len) / idx.avgdl);
+        score += idf * ((f * (K1 + 1)) / denom);
+        if (doc.head[term]) score += HEAD_BONUS * idf;
+        if (doc.title[term]) score += TITLE_BONUS * idf;
+      }
+      if (score > 0) {
+        // Coordination: BM25 sums independently over terms, so a passage
+        // matching one term very well outranks one matching every term
+        // decently. On a question the second is nearly always what the
+        // reader meant, so scale by how much of the question was covered.
+        score *= COORD_FLOOR + (1 - COORD_FLOOR) * (matched / qterms.length);
+        scored.push({ i: i, score: score });
+      }
+    }
+
+    scored.sort(function (a, b) {
+      return b.score - a.score;
+    });
+
+    // Two levels of diversification, both of which showed up as visible
+    // defects before they were added:
+    //
+    //   by anchor  a long section is split into several chunks, and they
+    //              score alike, so the list showed the *same heading and the
+    //              same link* twice in a row — which reads as a bug and
+    //              spends two of the five context slots on one section.
+    //   by page    three slices of one page is a worse context window, and a
+    //              worse thing to read, than three pages that each mention
+    //              the term.
+    var seenUrl = Object.create(null);
+    var perPage = Object.create(null);
+    var hits = [];
+    for (var s = 0; s < scored.length && hits.length < limit; s++) {
+      var chunk = idx.chunks[scored[s].i];
+      if (seenUrl[chunk.u]) continue;
+      var page = chunk.u.split("#")[0];
+      if ((perPage[page] || 0) >= 2) continue;
+      seenUrl[chunk.u] = 1;
+      perPage[page] = (perPage[page] || 0) + 1;
+      hits.push({ chunk: chunk, score: scored[s].score });
+    }
+    return hits;
+  }
+
+  function loadIndex() {
+    if (state.index) return Promise.resolve(state.index);
+    if (state.loading) return state.loading;
+    state.loading = fetch(indexUrl().href, { cache: "default" })
+      .then(function (r) {
+        if (!r.ok) throw new Error("index HTTP " + r.status);
+        return r.json();
+      })
+      .then(function (doc) {
+        state.index = buildIndex(doc.chunks || []);
+        state.index.counts = doc.counts || null;
+        return state.index;
+      })
+      .catch(function (err) {
+        state.loading = null;
+        throw err;
+      });
+    return state.loading;
+  }
+
+  // ------------------------------------------------------------------- ui --
+
+  var ui = {};
+
+  function el(tag, cls, text) {
+    var node = document.createElement(tag);
+    if (cls) node.className = cls;
+    if (text !== undefined && text !== null) node.textContent = text;
+    return node;
+  }
+
+  function injectStylesheet() {
+    if (document.getElementById("pounce-ask-css")) return;
+    var link = document.createElement("link");
+    link.id = "pounce-ask-css";
+    link.rel = "stylesheet";
+    // Alongside this script, so it reaches archived books the same way.
+    link.href = new URL("ask.css", self().src).href;
+    document.head.appendChild(link);
+  }
+
+  function setStatus(text, kind) {
+    if (!ui.status) return;
+    ui.status.textContent = text || "";
+    ui.status.className = "pounce-ask-status" + (kind ? " pounce-ask-status-" + kind : "");
+  }
+
+  function openPanel() {
+    injectStylesheet();
+    ui.panel.hidden = false;
+    document.body.classList.add("pounce-ask-open");
+    ui.input.focus();
+    loadIndex()
+      .then(function (idx) {
+        if (!ui.askBtn.dataset.ready) {
+          ui.askBtn.dataset.ready = "1";
+          ui.askBtn.disabled = false;
+          var c = idx.counts;
+          setStatus(
+            c
+              ? "Ready — " + c.total + " passages (" + c.book + " from the book, " + c.wiki + " from the wiki)."
+              : "Ready — " + idx.N + " passages."
+          );
+        }
+      })
+      .catch(function (err) {
+        setStatus("Could not load the search index (" + err.message + ").", "error");
+      });
+  }
+
+  function closePanel() {
+    ui.panel.hidden = true;
+    document.body.classList.remove("pounce-ask-open");
+    ui.toggle.focus();
+  }
+
+  function buildToggle() {
+    var bar = document.querySelector(".right-buttons");
+    if (!bar || document.getElementById("pounce-ask-toggle")) return false;
+    var btn = el("button", "pounce-ask-toggle", "Ask");
+    btn.id = "pounce-ask-toggle";
+    btn.type = "button";
+    btn.title = "Ask a question about the POUNCE docs (runs in your browser)";
+    btn.setAttribute("aria-label", "Ask the docs assistant");
+    btn.addEventListener("click", function () {
+      if (ui.panel.hidden) openPanel();
+      else closePanel();
+    });
+    bar.insertBefore(btn, bar.firstChild);
+    ui.toggle = btn;
+    return true;
+  }
+
+  function modelOptions(useF16) {
+    var quant = useF16 ? "q4f16_1" : "q4f32_1";
+    return MODELS.map(function (m) {
+      return {
+        id: m.base + "-" + quant + "-MLC",
+        // f32 weights are roughly a third larger than the f16 figure; say the
+        // number for the build the reader will actually download.
+        label: m.label + " (~" + Math.round((useF16 ? m.vram : m.vram * 1.3) / 100) / 10 + " GB)"
+      };
+    });
+  }
+
+  function buildPanel() {
+    var panel = el("aside", "pounce-ask-panel");
+    panel.id = "pounce-ask-panel";
+    panel.hidden = true;
+    panel.setAttribute("role", "dialog");
+    panel.setAttribute("aria-label", "POUNCE docs assistant");
+
+    var head = el("div", "pounce-ask-head");
+    head.appendChild(el("h2", "pounce-ask-title", "Ask POUNCE"));
+    var close = el("button", "pounce-ask-close", "×");
+    close.type = "button";
+    close.setAttribute("aria-label", "Close");
+    close.addEventListener("click", closePanel);
+    head.appendChild(close);
+    panel.appendChild(head);
+
+    ui.status = el("div", "pounce-ask-status", "Loading the search index…");
+    panel.appendChild(ui.status);
+
+    // --- question -----------------------------------------------------
+    var form = el("form", "pounce-ask-form");
+    ui.input = el("textarea", "pounce-ask-input");
+    ui.input.rows = 2;
+    ui.input.placeholder = "e.g. why does relaxing the bounds cost iterations?";
+    ui.input.setAttribute("aria-label", "Your question");
+    // Enter submits, Shift+Enter newlines — the panel is a question box, not
+    // an editor.
+    ui.input.addEventListener("keydown", function (e) {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        form.dispatchEvent(new Event("submit", { cancelable: true }));
+      }
+    });
+    form.appendChild(ui.input);
+
+    ui.askBtn = el("button", "pounce-ask-submit", "Ask");
+    ui.askBtn.type = "submit";
+    ui.askBtn.disabled = true;
+    form.appendChild(ui.askBtn);
+
+    form.addEventListener("submit", function (e) {
+      e.preventDefault();
+      ask(ui.input.value.trim());
+    });
+    panel.appendChild(form);
+
+    // --- model --------------------------------------------------------
+    ui.modelRow = el("div", "pounce-ask-model");
+    panel.appendChild(ui.modelRow);
+
+    ui.answer = el("div", "pounce-ask-answer");
+    panel.appendChild(ui.answer);
+
+    ui.sources = el("div", "pounce-ask-sources");
+    panel.appendChild(ui.sources);
+
+    var foot = el("div", "pounce-ask-foot");
+    foot.appendChild(
+      document.createTextNode(
+        "Searches this book and the project wiki. Answers, when a model is loaded, " +
+          "are generated on your own device — nothing you type is sent anywhere. "
+      )
+    );
+    var docLink = el("a", null, "How this works");
+    // Site root, not version root: ask.html does not exist in any book built
+    // before this feature, which is every archived tag.
+    docLink.href = new URL("ask.html", citationRoot()).href;
+    foot.appendChild(docLink);
+    foot.appendChild(document.createTextNode("."));
+    panel.appendChild(foot);
+
+    document.body.appendChild(panel);
+    ui.panel = panel;
+    buildModelRow();
+  }
+
+  function noGpuNote(why) {
+    ui.modelRow.textContent = "";
+    ui.modelRow.appendChild(
+      el(
+        "span",
+        "pounce-ask-note",
+        why + " — showing matching passages only. Written answers need WebGPU: " +
+          "a recent Chrome or Edge, Safari 26+, or Firefox with WebGPU enabled."
+      )
+    );
+  }
+
+  function buildModelRow() {
+    // `navigator.gpu` existing is NOT the same as WebGPU working:
+    // requestAdapter() resolves *null* on a machine with no usable GPU
+    // (headless browsers, blocklisted drivers, some VMs). Offering the button
+    // anyway means the reader waits, then gets an error from deep inside
+    // WebLLM. Ask the adapter first and say so up front instead.
+    if (!navigator.gpu) {
+      noGpuNote("No WebGPU in this browser");
+      return;
+    }
+    ui.modelRow.textContent = "";
+    ui.modelRow.appendChild(el("span", "pounce-ask-note", "Checking for a usable GPU…"));
+
+    navigator.gpu
+      .requestAdapter()
+      .then(function (adapter) {
+        if (!adapter) {
+          noGpuNote("No usable GPU available to this browser");
+          return;
+        }
+        var f16 = !!(adapter.features && adapter.features.has("shader-f16"));
+        renderModelPicker(modelOptions(f16));
+      })
+      .catch(function (err) {
+        noGpuNote("WebGPU could not be initialized (" + (err && err.message ? err.message : err) + ")");
+      });
+  }
+
+  function renderModelPicker(opts) {
+    var row = ui.modelRow;
+    row.textContent = "";
+
+    var sel = el("select", "pounce-ask-select");
+    sel.setAttribute("aria-label", "Local model");
+
+    var remembered = null;
+    try {
+      remembered = localStorage.getItem(LS_MODEL);
+    } catch (e) {
+      /* private mode: fall through to the default (the first, smallest) */
+    }
+    opts.forEach(function (o) {
+      var opt = el("option", null, o.label);
+      opt.value = o.id;
+      if (o.id === remembered) opt.selected = true;
+      sel.appendChild(opt);
+    });
+
+    var btn = el("button", "pounce-ask-load", "Load model");
+    btn.type = "button";
+    btn.addEventListener("click", function () {
+      loadModel(sel.value, btn);
+    });
+
+    row.appendChild(sel);
+    row.appendChild(btn);
+    row.appendChild(
+      el(
+        "span",
+        "pounce-ask-note",
+        "Downloaded once, then cached by your browser. Until then you get passages, not prose."
+      )
+    );
+    ui.modelSelect = sel;
+  }
+
+  async function loadModel(modelId, btn) {
+    if (!modelId) return;
+    btn.disabled = true;
+    if (ui.modelSelect) ui.modelSelect.disabled = true;
+    setStatus("Fetching the WebLLM runtime…", "busy");
+    try {
+      var webllm = await import(/* webpackIgnore: true */ WEBLLM_URL);
+      state.engine = await webllm.CreateMLCEngine(modelId, {
+        initProgressCallback: function (p) {
+          setStatus(p && p.text ? p.text : "Loading model…", "busy");
+        }
+      });
+      state.engineModel = modelId;
+      try {
+        localStorage.setItem(LS_MODEL, modelId);
+      } catch (e) {
+        /* private mode: the model still works, it just is not remembered */
+      }
+      setStatus("Model ready — answers will be written, with citations.", "ok");
+      btn.textContent = "Model loaded";
+      if (ui.modelSelect) ui.modelSelect.disabled = false;
+    } catch (err) {
+      // Leave retrieval fully working; this is an enhancement that failed.
+      state.engine = null;
+      btn.disabled = false;
+      if (ui.modelSelect) ui.modelSelect.disabled = false;
+      setStatus(
+        "Could not load the model (" + (err && err.message ? err.message : err) + "). Passages still work.",
+        "error"
+      );
+    }
+  }
+
+  // --------------------------------------------------------------- answer --
+
+  function renderSources(hits) {
+    ui.sources.textContent = "";
+    if (!hits.length) return;
+    ui.sources.appendChild(el("h3", "pounce-ask-sources-title", "Passages"));
+    var ol = el("ol", "pounce-ask-source-list");
+    hits.forEach(function (hit) {
+      var li = el("li");
+      var a = el("a", "pounce-ask-source-link", hit.chunk.h);
+      a.href = hrefFor(hit.chunk);
+      if (hit.chunk.k === "wiki") {
+        a.rel = "noopener";
+        a.appendChild(el("span", "pounce-ask-badge", "wiki"));
+      }
+      li.appendChild(a);
+      li.appendChild(el("p", "pounce-ask-excerpt", excerpt(hit.chunk.x)));
+      ol.appendChild(li);
+    });
+    ui.sources.appendChild(ol);
+  }
+
+  // The index stores markdown, because that is what the model reads best —
+  // a fenced block and a bolded caveat are signal to it. A human skimming a
+  // 260-character preview gets the opposite: `**Have an analytic Hessian?**`
+  // and stray `*` bullets are noise. So the preview, and only the preview,
+  // is flattened to prose.
+  function excerpt(text, max) {
+    var flat = text
+      .replace(/^\s*(```+|~~~+).*$/gm, " ") // fence lines
+      .replace(/^\s{0,3}#{1,6}\s+/gm, "") // stray headings
+      .replace(/^\s{0,3}[-*+]\s+/gm, "· ") // bullets
+      .replace(/^\s{0,3}>\s?/gm, "") // block quotes
+      .replace(/\*\*([^*]+)\*\*/g, "$1")
+      .replace(/(^|\s)\*([^*\n]+)\*(?=\s|$|[.,;:)])/g, "$1$2")
+      .replace(/`+/g, "")
+      .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1") // links and images
+      .replace(/\s+/g, " ")
+      .trim();
+    max = max || 260;
+    return flat.length > max ? flat.slice(0, max) + "…" : flat;
+  }
+
+  function buildPrompt(question, hits) {
+    var context = hits
+      .map(function (hit, n) {
+        var body = hit.chunk.x;
+        if (body.length > MAX_CTX_CHARS) body = body.slice(0, MAX_CTX_CHARS) + "…";
+        return "[" + (n + 1) + "] " + hit.chunk.h + "\n" + body;
+      })
+      .join("\n\n");
+
+    return [
+      {
+        role: "system",
+        content:
+          "You are the POUNCE documentation assistant. POUNCE is a pure-Rust " +
+          "interior-point solver for nonlinear, conic and global optimization, " +
+          "drop-in compatible with Ipopt.\n\n" +
+          "Answer ONLY from the numbered excerpts the user provides. If they do " +
+          "not contain the answer, say so plainly and name the excerpt that looks " +
+          "closest — do not fill the gap from memory. Quote option names, values " +
+          "and status strings exactly as written. Cite every claim with the " +
+          "bracketed number of the excerpt it came from, like [2]. Be concise."
+      },
+      {
+        role: "user",
+        content: "Excerpts:\n\n" + context + "\n\nQuestion: " + question
+      }
+    ];
+  }
+
+  // Model output is rendered as text, never as HTML: inline `code` becomes a
+  // <code> element and everything else stays a text node, so a stray angle
+  // bracket in an answer cannot become markup.
+  function renderAnswer(text) {
+    ui.answer.textContent = "";
+    var para = el("p", "pounce-ask-answer-body");
+    var parts = text.split(/(`[^`]+`)/);
+    parts.forEach(function (part) {
+      if (part.length > 2 && part.charAt(0) === "`" && part.charAt(part.length - 1) === "`") {
+        para.appendChild(el("code", null, part.slice(1, -1)));
+      } else if (part) {
+        para.appendChild(document.createTextNode(part));
+      }
+    });
+    ui.answer.appendChild(para);
+  }
+
+  async function ask(question) {
+    if (!question || state.busy) return;
+    state.busy = true;
+    ui.askBtn.disabled = true;
+    ui.answer.textContent = "";
+    ui.sources.textContent = "";
+
+    try {
+      var idx = await loadIndex();
+      var hits = search(idx, question, TOP_SHOW);
+      state.lastHits = hits;
+
+      if (!hits.length) {
+        setStatus("");
+        renderAnswer("Nothing in the book or the wiki matched that. Try the option name or the exact status string.");
+        return;
+      }
+
+      renderSources(hits);
+
+      if (!state.engine) {
+        setStatus(
+          navigator.gpu
+            ? "Showing passages. Load a model above for a written answer."
+            : "Showing passages (no WebGPU in this browser)."
+        );
+        return;
+      }
+
+      setStatus("Thinking…", "busy");
+      var messages = buildPrompt(question, hits.slice(0, TOP_K));
+      var stream = await state.engine.chat.completions.create({
+        messages: messages,
+        stream: true,
+        temperature: 0.2,
+        max_tokens: 600
+      });
+
+      var acc = "";
+      for await (var part of stream) {
+        var delta = part && part.choices && part.choices[0] && part.choices[0].delta;
+        if (delta && delta.content) {
+          acc += delta.content;
+          renderAnswer(acc);
+        }
+      }
+      setStatus("Answered from the passages below.", "ok");
+    } catch (err) {
+      setStatus("Failed: " + (err && err.message ? err.message : err), "error");
+    } finally {
+      state.busy = false;
+      ui.askBtn.disabled = false;
+    }
+  }
+
+  // ----------------------------------------------------------------- init --
+
+  function init() {
+    injectStylesheet();
+    buildPanel();
+    if (!buildToggle()) {
+      // No mdBook chrome on this page (404, print view): drop the panel too
+      // rather than leave an unreachable dialog in the DOM.
+      if (ui.panel && ui.panel.parentNode) ui.panel.parentNode.removeChild(ui.panel);
+      return;
+    }
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && ui.panel && !ui.panel.hidden) closePanel();
+    });
+  }
+
+  // Test seam. The retrieval half — tokenizer, stemmer, index, scorer — is
+  // pure, and docs/tests/ask_retrieval.mjs exercises it under node against a
+  // freshly built index. Requiring THIS file rather than a copy of the
+  // scoring is the point: a test of a reimplementation would go green while
+  // the shipped ranker regressed. There is no `document` in node, so the DOM
+  // half is simply never reached.
+  if (typeof document === "undefined") {
+    if (typeof module !== "undefined" && module.exports) {
+      module.exports = {
+        STOPWORDS: STOPWORDS,
+        normTok: normTok,
+        tokenize: tokenize,
+        buildIndex: buildIndex,
+        queryTerms: queryTerms,
+        search: search,
+        buildPrompt: buildPrompt,
+        MAX_CTX_CHARS: MAX_CTX_CHARS
+      };
+    }
+  } else if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -65,6 +65,7 @@
 
 # Appendix
 
+- [Ask POUNCE: the Docs Assistant](ask.md)
 - [Color Theme](color-theme.md)
 
 ---

--- a/docs/src/ask.md
+++ b/docs/src/ask.md
@@ -1,0 +1,119 @@
+# Ask POUNCE: the in-browser docs assistant
+
+The **Ask** button in the menu bar opens a question box for these docs. It has
+two halves, and they work independently:
+
+| | What it does | What it costs |
+|---|---|---|
+| **Search** | Ranks passages from this book *and* the [project wiki](https://github.com/jkitchin/pounce/wiki), deep-linked to the exact heading | one ~1.3 MB index download, on first use |
+| **Answer** | Writes those passages up into prose, with citations | a language model download, hundreds of MB, only if you ask for it |
+
+Search always works. The answer half is strictly opt-in: nothing is downloaded
+until you pick a model and click **Load model**. If you never do, you still get
+ranked, linked passages, which is most of the value on a reference manual.
+
+Nothing you type leaves your browser. There is no API key, no server, and no
+telemetry — the assistant is a static JavaScript file, and the only third-party
+request it ever makes is fetching model weights from the WebLLM CDN after you
+click.
+
+## What it searches
+
+The index covers every page of this book **and** the five long-form wiki
+pages, which are not part of the book:
+
+- [Tuning POUNCE per problem](https://github.com/jkitchin/pounce/wiki/Tuning-POUNCE-per-problem)
+- [Recovering from a bad start](https://github.com/jkitchin/pounce/wiki/Recovering-from-a-bad-start)
+- [A hair's width times a cliff](https://github.com/jkitchin/pounce/wiki/A-hairs-width-times-a-cliff)
+- [Why multistart misses solutions](https://github.com/jkitchin/pounce/wiki/Why-multistart-misses-solutions)
+
+That inclusion is the point of the feature as much as the model is. The wiki
+carries the measured guidance — which of the 441 options are worth setting,
+what to do when a solve dies at its starting point, why bound relaxation
+costs what it costs — and a reader asking "why is my solve slow" wants those
+pages, not a reference entry. Wiki hits are marked `wiki` in the source list
+and link out to GitHub.
+
+Passages are cut at heading boundaries, so every citation lands on the section
+that answered rather than at the top of a long page.
+
+## Requirements for written answers
+
+| | |
+|---|---|
+| **Browser** | WebGPU: Chrome/Edge 113+, Safari 26+, Firefox with WebGPU enabled |
+| **Download** | 0.9–2.3 GB depending on the model, cached by the browser afterwards |
+| **Memory** | roughly the model's size in GPU memory while loaded |
+
+Without WebGPU the panel says so and stays in search-only mode.
+
+Three models are offered, smallest first — Llama 3.2 1B, Qwen 2.5 1.5B, and
+Llama 3.2 3B. The smallest is the default because a 0.9 GB download that
+answers beats a 2.3 GB one you abandon; the larger ones follow instructions
+and citation formatting more reliably. If your GPU reports `shader-f16` you
+get the half-precision builds, which are about a third smaller.
+
+## How much to trust it
+
+The model only ever sees the five passages your question retrieved, and it is
+told to answer from them alone and to cite each claim. That keeps it far
+closer to the docs than an unaided chatbot — but a 1B model reading correct
+passages can still summarize them wrongly.
+
+**Treat the answer as a routing device and the passages as the source.** Every
+answer is shown with the passages it was built from, in rank order, linked to
+the heading they came from. When the two disagree, the passage is right.
+
+The retrieval half is worth stating plainly too: it is
+[BM25](https://en.wikipedia.org/wiki/Okapi_BM25) over words, not embeddings.
+It is excellent at exact names — an option like `bound_relax_factor`, or a
+solver status string copied straight out of your log — and weaker at questions
+phrased with no term in common with the docs. If a question comes back empty,
+search for the option name or the exact status string.
+
+(Only one identifier is named in that sentence, on purpose. This page is in the
+index like any other, and an earlier draft that listed several real option and
+status names in one short paragraph became the top hit for each of them — ahead
+of the reference pages that actually define them. A short passage dense in rare
+terms is exactly what BM25 rewards.)
+
+## For maintainers
+
+| Piece | File |
+|---|---|
+| Index builder | `scripts/build-docs-index.py` |
+| Panel, retrieval, WebLLM glue | `docs/assets/ask.js`, `docs/assets/ask.css` |
+| Staging and injection | `scripts/build-versioned-docs.sh` |
+| Wiki clone | `.github/workflows/docs.yml` |
+
+Two details that are easy to get wrong:
+
+- **The assistant is injected, not configured in `book.toml`.** It reaches
+  every built book — including archived tag builds whose source predates it —
+  the same way the version selector does. Listing it under `additional-js`
+  instead would reach `dev/` and nothing else until the next release, because
+  the site root is built from the newest *tag*. A plain `mdbook build docs`
+  (`make book`) therefore has no **Ask** button; use
+  `scripts/build-versioned-docs.sh` to see it.
+- **There is one index, built from `main`, shared by every version.** So the
+  assistant inside an archived book answers about *current* docs and links to
+  the stable book. That is the deliberate trade: one 1.3 MB file rather than
+  one per archived tag, and answers that describe the software as it is now.
+
+To build the index locally, including the wiki:
+
+```console
+$ git clone --depth 1 https://github.com/jkitchin/pounce.wiki.git /tmp/pounce-wiki
+$ POUNCE_WIKI_DIR=/tmp/pounce-wiki scripts/build-versioned-docs.sh ./site
+$ mkdir -p _serve/pounce && cp -a site/. _serve/pounce/
+$ python3 -m http.server -d _serve 8000    # http://localhost:8000/pounce/
+```
+
+Serving under the real base path matters: the assistant resolves its own
+paths from the injected `data-p2r` / `data-index` attributes, and a bad
+relative path is only visible at a nesting depth greater than one.
+
+The wiki clone is optional. Without `POUNCE_WIKI_DIR` the index is book-only
+and the build still succeeds — in CI the clone step is `continue-on-error`
+for the same reason, so an unreachable wiki degrades the assistant instead of
+taking the docs site down.

--- a/docs/tests/ask_retrieval.mjs
+++ b/docs/tests/ask_retrieval.mjs
@@ -1,0 +1,250 @@
+// Guard for the docs assistant's retrieval half (docs/assets/ask.js).
+//
+// It loads the SHIPPED ask.js — not a copy of the scoring — through the test
+// seam at the bottom of that file, and runs it against an index built from the
+// live docs/src. A test of a reimplemented ranker would stay green while the
+// ranker readers actually use regressed, which is the whole failure mode here:
+// retrieval has no exception to throw. It returns the wrong thing, silently,
+// and the only symptom is a reader not finding the page.
+//
+// Two things are checked, and they fail for different reasons:
+//
+//   1. The stemmer, against known Porter step-1 outputs and against the
+//      specific pairs the corpus needs collapsed. This is a unit test: it
+//      does not depend on what the docs say.
+//   2. Ranking, against a labelled query set. This is a *corpus* test and it
+//      is deliberately loose — see THRESHOLDS below.
+//
+// Usage:
+//   python3 scripts/build-docs-index.py -o /tmp/ask-index.json --quiet
+//   node docs/tests/ask_retrieval.mjs /tmp/ask-index.json
+//
+// `make ask-check` does both steps; ci.yml runs the same two lines.
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const ask = require(resolve(here, "../assets/ask.js"));
+
+const indexPath = process.argv[2];
+if (!indexPath) {
+  console.error("usage: node docs/tests/ask_retrieval.mjs <ask-index.json>");
+  process.exit(2);
+}
+
+let failures = 0;
+function check(ok, msg) {
+  if (!ok) failures++;
+  console.log((ok ? "  ok   " : "  FAIL ") + msg);
+}
+
+// ---------------------------------------------------------------- stemmer --
+
+console.log("stemmer: pairs the corpus needs collapsed");
+for (const [a, b] of [
+  ["relaxing", "relax"],
+  ["relaxed", "relax"],
+  ["started", "start"],
+  ["starting", "start"],
+  // The +e restoration case: without it "scaling" stems to `scal` and stops
+  // matching the page called "Scaling".
+  ["scaling", "scale"],
+  ["iterations", "iteration"],
+  ["solves", "solve"],
+  ["tightening", "tighten"],
+  ["bounded", "bound"],
+  ["duals", "dual"]
+]) {
+  check(ask.normTok(a) === ask.normTok(b), a + " ≡ " + b + " → " + ask.normTok(a));
+}
+
+console.log("stemmer: canonical Porter step-1 outputs");
+for (const [w, want] of [
+  ["caresses", "caress"],
+  ["ponies", "poni"],
+  ["cats", "cat"],
+  ["feed", "feed"],
+  ["agreed", "agree"],
+  ["plastered", "plaster"],
+  ["motoring", "motor"],
+  ["hopping", "hop"],
+  ["failing", "fail"],
+  ["filing", "file"],
+  ["happy", "happi"],
+  ["sky", "sky"],
+  // Known and accepted: Porter step 1 does not restore the `e` here, because
+  // the cvc rule only fires at m == 1 and `converg` has m == 2. Pinned so the
+  // asymmetry is a decision on the record rather than a surprise.
+  ["converged", "converg"],
+  ["converge", "converge"]
+]) {
+  check(ask.normTok(w) === want, w + " → " + ask.normTok(w));
+}
+
+console.log("stemmer: identifiers and short tokens pass through untouched");
+for (const w of ["bound_relax_factor", "theta_max", "mu", "tol", "l1", "qp", "ipopt", "nlp"]) {
+  check(ask.normTok(w) === w, w + " unchanged");
+}
+
+console.log("distinct terms must not collide");
+for (const [a, b] of [
+  ["scaling", "scalar"],
+  ["convex", "converge"],
+  ["dual", "duel"],
+  ["bound", "bind"]
+]) {
+  check(ask.normTok(a) !== ask.normTok(b), a + " ≠ " + b);
+}
+
+// ---------------------------------------------------------------- ranking --
+
+const doc = JSON.parse(readFileSync(indexPath, "utf8"));
+const idx = ask.buildIndex(doc.chunks || []);
+console.log(
+  "\nindex: " + idx.N + " passages, avg " + idx.avgdl.toFixed(0) + " tokens"
+);
+check(idx.N > 500, "index is populated");
+
+// The wiki half is the reason this feature exists; an index that quietly
+// stopped carrying it would still answer, just worse, and nothing else here
+// would notice.
+const wikiChunks = (doc.chunks || []).filter((c) => c.k === "wiki").length;
+if (doc.counts && doc.counts.wiki > 0) {
+  check(wikiChunks > 0, "wiki passages present (" + wikiChunks + ")");
+} else {
+  console.log("  note  index was built without the wiki; skipping wiki checks");
+}
+
+console.log("\nquery-side compound handling");
+{
+  // An identifier the corpus contains is searched as itself, never split —
+  // splitting let a passage about `fix_relax` outrank the documentation of
+  // `bound_relax_factor` by matching three of its four parts.
+  const known = ask.queryTerms(idx, "bound_relax_factor");
+  check(
+    known.length === 1 && known[0] === "bound_relax_factor",
+    "known identifier stays whole: [" + known.join(", ") + "]"
+  );
+  const unknown = ask.queryTerms(idx, "no_such_option_here");
+  check(unknown.length > 1, "unknown identifier falls back to parts: [" + unknown.join(", ") + "]");
+  const stopped = ask.queryTerms(idx, "what does it do");
+  check(stopped.length === 0, "an all-stopword question yields no terms");
+}
+
+console.log("\nresult shaping");
+{
+  const hits = ask.search(idx, "scaling", 6);
+  const urls = hits.map((h) => h.chunk.u);
+  check(new Set(urls).size === urls.length, "no two hits share a URL");
+  const pages = urls.map((u) => u.split("#")[0]);
+  const worst = Math.max(...pages.map((p) => pages.filter((q) => q === p).length));
+  check(worst <= 2, "at most two hits per page (worst: " + worst + ")");
+  check(ask.search(idx, "", 6).length === 0, "empty query returns nothing");
+  check(ask.search(idx, "zzzqqqxxnotaword", 6).length === 0, "unmatched query returns nothing");
+}
+
+// Labelled set. `want` substrings are matched against the citation URL, and a
+// query lists every page that genuinely answers it — not one blessed page —
+// because several of these questions have more than one honest home in the
+// book.
+//
+// THRESHOLDS ARE DELIBERATELY BELOW THE MEASURED SCORE. This is a corpus
+// test: adding or retitling a page can legitimately move a ranking, and a
+// guard pinned to the exact current number would fail on honest doc edits and
+// get raised until it meant nothing. It is set to catch the shape of a real
+// regression — a scoring change that drops several queries at once — not
+// single-rank drift.
+//
+// Measured at the time of writing, in both configurations this runs in:
+//   with the wiki (production)  18/20 top-1, 20/20 top-5
+//   book only (CI, no clone)    17/20 top-1, 20/20 top-5
+// The floors are set under the lower of the two.
+const THRESHOLD_TOP1 = 14;
+const THRESHOLD_TOP5 = 18;
+
+const EVAL = [
+  { q: "why does relaxing the bounds cost iterations",
+    want: ["A-hairs-width", "qp-bound-relax", "options.html", "convex-solver"] },
+  { q: "bound_relax_factor", want: ["A-hairs-width", "options.html"] },
+  { q: "how do I warm start a solve",
+    want: ["initialization.html", "active-set-sqp", "warm-start-benchmark", "sessions.html"] },
+  { q: "what does MaximumIterationsExceeded mean",
+    want: ["troubleshooting", "solution-output", "solve-report-v1", "options.html"] },
+  { q: "what does hessian_approximation limited-memory do",
+    want: ["options.html", "casadi.html", "algorithm.html"] },
+  { q: "how do I install pounce",
+    want: ["installation.html", "docker.html", "quick-start", "python.html"] },
+  { q: "using pounce from pyomo", want: ["pyomo.html", "quick-start"] },
+  { q: "the JSON solve report schema", want: ["json-output", "solve-report-v1"] },
+  { q: "which solver options are actually worth setting",
+    want: ["Tuning-POUNCE-per-problem", "options.html", "troubleshooting"] },
+  { q: "my solve fails because of where it started",
+    want: ["Recovering-from-a-bad-start", "initialization.html"] },
+  { q: "run pounce in the browser with webassembly", want: ["wasm.html"] },
+  { q: "register pounce as a GAMS solver", want: ["gams.html"] },
+  { q: "finding multiple minima with deflation",
+    want: ["find-minima", "Why-multistart-misses-solutions"] },
+  { q: "how does crossover work", want: ["crossover.html"] },
+  { q: "sensitivity analysis of the solution to a parameter",
+    want: ["sensitivity.html", "path-following", "continuation"] },
+  { q: "what is feasibility based bound tightening", want: ["fbbt.html"] },
+  { q: "solving a boundary value problem", want: ["bvp.html", "ode.html", "dae.html"] },
+  { q: "why is my convex QP slow",
+    want: ["convex-solver", "lp-qp-routing", "Tuning-POUNCE-per-problem", "benchmarks.html",
+           "qp-bound-relax", "troubleshooting"] },
+  { q: "scaling the problem variables", want: ["scaling.html", "options.html"] },
+  { q: "debug a solve step by step", want: ["debugger.html", "troubleshooting", "options.html"] }
+];
+
+console.log("\nprompt construction (the RAG contract)");
+{
+  const hits = ask.search(idx, "bound_relax_factor", 5);
+  const msgs = ask.buildPrompt("what is bound_relax_factor?", hits);
+  check(msgs.length === 2 && msgs[0].role === "system" && msgs[1].role === "user",
+    "system + user message");
+  // The grounding instructions are the only thing keeping a 1B model from
+  // answering about Ipopt from memory; losing them would not fail loudly.
+  check(/ONLY from the numbered excerpts/.test(msgs[0].content), "system prompt grounds the model");
+  check(/Cite every claim/.test(msgs[0].content), "system prompt demands citations");
+  check(msgs[1].content.includes("what is bound_relax_factor?"), "question is in the user message");
+  for (let n = 1; n <= hits.length; n++) {
+    check(msgs[1].content.includes("[" + n + "] "), "excerpt [" + n + "] is numbered");
+  }
+  // Every passage must be reachable from the source list the reader sees, or
+  // a citation points at nothing.
+  check(hits.length <= 6, "no more passages than the panel lists");
+
+  // Truncation: a long passage must be cut, not sent whole, or five of them
+  // overflow a small model's context.
+  const long = [{ chunk: { h: "H", t: "T", u: "u.html", k: "book",
+                           x: "x".repeat(ask.MAX_CTX_CHARS * 3) } }];
+  const cut = ask.buildPrompt("q", long)[1].content;
+  check(cut.length < ask.MAX_CTX_CHARS * 2, "over-long passage is truncated (" + cut.length + " chars)");
+  check(cut.includes("\u2026"), "truncation is marked with an ellipsis");
+}
+
+console.log("\nranking over " + EVAL.length + " labelled queries");
+let top1 = 0;
+let top5 = 0;
+for (const c of EVAL) {
+  const urls = ask.search(idx, c.q, 6).map((h) => h.chunk.u);
+  const hit = (u) => c.want.some((w) => u.includes(w));
+  const at1 = urls.length > 0 && hit(urls[0]);
+  const at5 = urls.slice(0, 5).some(hit);
+  if (at1) top1++;
+  if (at5) top5++;
+  console.log("  " + (at1 ? "T1" : at5 ? ".5" : "XX") + "  " + c.q);
+  if (!at1) console.log("        got: " + (urls[0] || "(nothing)"));
+}
+
+console.log("\n  top-1 " + top1 + "/" + EVAL.length + " (floor " + THRESHOLD_TOP1 + ")");
+console.log("  top-5 " + top5 + "/" + EVAL.length + " (floor " + THRESHOLD_TOP5 + ")");
+check(top1 >= THRESHOLD_TOP1, "top-1 above the floor");
+check(top5 >= THRESHOLD_TOP5, "top-5 above the floor");
+
+console.log("\n" + (failures ? failures + " FAILURE(S)" : "ask_retrieval: OK"));
+process.exit(failures ? 1 : 0);

--- a/scripts/build-docs-index.py
+++ b/scripts/build-docs-index.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Build the retrieval index the in-browser docs assistant searches.
+
+The assistant (docs/assets/ask.js) is retrieval-augmented: it looks up
+passages in this index and hands them to a WebLLM model running in the
+reader's own browser. The model never sees the corpus, only the passages a
+question retrieves, so the index *is* the assistant's knowledge — a page
+missing here is a page the assistant cannot answer about.
+
+Two corpora, deliberately handled differently:
+
+  * ``docs/src/**/*.md`` — the rendered book. Citations are relative links
+    into the book itself (``options.html#barrier-parameter``).
+  * the GitHub wiki (``--wiki <dir>``, a clone of ``pounce.wiki``) — indexed
+    but **not** rendered into the book. Citations are absolute links back to
+    github.com/jkitchin/pounce/wiki. The wiki holds the longer-form measured
+    guidance (tuning, bad starts, bound relaxation, multistart), which is
+    exactly the material a reader asks a question about and exactly what a
+    reference manual does not carry, so leaving it out would make the
+    assistant blind to the best answers the project has.
+
+Chunking is by heading section, because a heading is the finest granularity
+that mdBook gives a stable anchor — so every retrieved passage can be
+deep-linked rather than dumping the reader at the top of a 900-line page.
+Sections longer than MAX_CHARS are split at paragraph boundaries and each
+piece re-carries the heading trail, so a passage is self-describing even
+when it is the fourth slice of one section.
+
+Usage:
+    scripts/build-docs-index.py [-o OUT] [--wiki DIR] [--book-src DIR]
+
+Output is JSON on the schema documented in ``docs/src/ask.md``. Keys are
+short (``t``/``h``/``u``/``k``/``x``) because this file is downloaded by
+every reader who opens the assistant.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+# Passage sizing. MAX_CHARS is a retrieval choice, not a model-context one:
+# short enough that a hit is specific, long enough that a worked example or a
+# full option description survives in one piece. MIN_CHARS drops the "### Foo"
+# heading-only stubs that would otherwise win on a title match and carry no
+# answer.
+MAX_CHARS = 1600
+MIN_CHARS = 40
+
+# A long fenced block is bad context — it crowds out prose in the model's
+# window and rarely contains the sentence that answers the question. Keep
+# enough to show the shape of the call.
+MAX_CODE_LINES = 40
+
+WIKI_BASE = "https://github.com/jkitchin/pounce/wiki/"
+
+# mdBook directives ({{#include ...}}, {{#playground ...}}) expand at render
+# time; the raw form is noise in an index.
+RE_MDBOOK_DIRECTIVE = re.compile(r"\{\{#[^}]*\}\}")
+RE_HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+RE_HTML_TAG = re.compile(r"<[^>\n]{1,200}>")
+RE_HEADING = re.compile(r"^(#{1,6})\s+(.*?)\s*#*\s*$")
+RE_FENCE = re.compile(r"^\s*(```+|~~~+)")
+
+
+def strip_inline_markup(text: str) -> str:
+    """Reduce heading markup to the text mdBook renders (and slugifies)."""
+    text = re.sub(r"!\[([^\]]*)\]\([^)]*\)", r"\1", text)  # images
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)  # links
+    text = re.sub(r"\[([^\]]*)\]\[[^\]]*\]", r"\1", text)  # ref links
+    text = text.replace("`", "")
+    text = re.sub(r"\*\*([^*]+)\*\*", r"\1", text)
+    text = re.sub(r"\*([^*]+)\*", r"\1", text)
+    text = re.sub(r"__([^_]+)__", r"\1", text)
+    return text.strip()
+
+
+def slugify(heading: str) -> str:
+    """mdBook's heading-anchor algorithm.
+
+    mdBook lowercases the rendered heading text, keeps only alphanumerics,
+    spaces, `-` and `_`, then turns spaces into `-`. Reimplemented rather
+    than guessed at: an anchor that does not match is a citation link that
+    silently lands at the top of the page, which looks like it worked.
+    """
+    slug = strip_inline_markup(heading).lower()
+    slug = "".join(c for c in slug if c.isalnum() or c in " -_")
+    slug = slug.replace(" ", "-")
+    return slug
+
+
+def uniquify(slug: str, seen: dict[str, int]) -> str:
+    """Match mdBook's duplicate-anchor suffixing (`foo`, `foo-1`, `foo-2`)."""
+    if slug not in seen:
+        seen[slug] = 0
+        return slug
+    seen[slug] += 1
+    return "%s-%d" % (slug, seen[slug])
+
+
+def clean_body(lines: list[str]) -> str:
+    """Normalize a section body for indexing.
+
+    Fenced code is kept (an option name or a CLI flag is often *only* in a
+    code block) but capped at MAX_CODE_LINES.
+    """
+    out: list[str] = []
+    fence: str | None = None
+    code_lines = 0
+    for line in lines:
+        m = RE_FENCE.match(line)
+        if m:
+            marker = m.group(1)
+            if fence is None:
+                fence = marker
+                code_lines = 0
+                out.append(line)
+            elif line.strip().startswith(fence):
+                fence = None
+                out.append(line)
+            else:
+                out.append(line)
+            continue
+        if fence is not None:
+            code_lines += 1
+            if code_lines <= MAX_CODE_LINES:
+                out.append(line)
+            elif code_lines == MAX_CODE_LINES + 1:
+                out.append("    … (%d more lines)" % (len(lines) - MAX_CODE_LINES))
+            continue
+        out.append(line)
+
+    text = "\n".join(out)
+    text = RE_HTML_COMMENT.sub(" ", text)
+    text = RE_MDBOOK_DIRECTIVE.sub(" ", text)
+    text = RE_HTML_TAG.sub(" ", text)
+    # Collapse runs of blank lines but keep paragraph breaks: the splitter
+    # below uses them as the only safe place to cut a long section.
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = "\n".join(ln.rstrip() for ln in text.split("\n"))
+    return text.strip()
+
+
+def _pack(units: list[str], sep: str, max_chars: int) -> list[str]:
+    """Greedily pack units into runs no longer than max_chars."""
+    parts: list[str] = []
+    buf = ""
+    for unit in units:
+        if not buf:
+            buf = unit
+        elif len(buf) + len(sep) + len(unit) <= max_chars:
+            buf += sep + unit
+        else:
+            parts.append(buf)
+            buf = unit
+    if buf:
+        parts.append(buf)
+    return parts
+
+
+def split_long(text: str, max_chars: int = MAX_CHARS) -> list[str]:
+    """Split an over-long section into passages.
+
+    Paragraph boundaries first. A markdown *table* is one paragraph — its
+    rows are single-newline separated — and the option tables in this book
+    run to eleven thousand characters, so a paragraph pass alone leaves
+    chunks that would swamp a small model's whole context window with one
+    hit. Over-long paragraphs therefore get a second, line-level pass.
+
+    A single line longer than max_chars is still emitted whole: cutting
+    mid-sentence costs more than the overrun.
+    """
+    if len(text) <= max_chars:
+        return [text]
+    parts: list[str] = []
+    for para in _pack(text.split("\n\n"), "\n\n", max_chars):
+        if len(para) <= max_chars:
+            parts.append(para)
+        else:
+            parts.extend(_pack(para.split("\n"), "\n", max_chars))
+    return parts
+
+
+def parse_sections(md: str) -> list[tuple[str, str, str]]:
+    """Split markdown into (heading_trail, anchor, body) triples.
+
+    The trail is the enclosing heading path ("Solver Options › Scaling"), so
+    a retrieved passage names its own context without the reader opening the
+    page. Content before the first heading is attributed to the page itself
+    with an empty anchor.
+    """
+    lines = md.split("\n")
+    sections: list[tuple[str, str, str]] = []
+    seen_slugs: dict[str, int] = {}
+    stack: list[tuple[int, str]] = []  # (level, text)
+    cur_trail = ""
+    cur_anchor = ""
+    buf: list[str] = []
+    fence: str | None = None
+
+    def flush() -> None:
+        body = clean_body(buf)
+        if body:
+            sections.append((cur_trail, cur_anchor, body))
+
+    for line in lines:
+        m = RE_FENCE.match(line)
+        if m:
+            marker = m.group(1)
+            if fence is None:
+                fence = marker
+            elif line.strip().startswith(fence):
+                fence = None
+        # A `#` inside a fence is a shell comment, not a heading.
+        h = None if fence is not None else RE_HEADING.match(line)
+        if h:
+            flush()
+            buf = []
+            level = len(h.group(1))
+            text = strip_inline_markup(h.group(2))
+            while stack and stack[-1][0] >= level:
+                stack.pop()
+            stack.append((level, text))
+            cur_trail = " › ".join(t for _lvl, t in stack)
+            cur_anchor = uniquify(slugify(h.group(2)), seen_slugs)
+        else:
+            buf.append(line)
+    flush()
+    return sections
+
+
+def chunks_for(md: str, title: str, url_base: str, kind: str) -> list[dict]:
+    """Turn one document into indexable chunks."""
+    out: list[dict] = []
+    for trail, anchor, body in parse_sections(md):
+        heading = trail or title
+        url = url_base + ("#" + anchor if anchor else "")
+        for piece in split_long(body):
+            if len(piece) < MIN_CHARS:
+                continue
+            out.append(
+                {
+                    "t": title,
+                    "h": heading,
+                    "u": url,
+                    "k": kind,
+                    "x": piece,
+                }
+            )
+    return out
+
+
+def page_title(md: str, fallback: str) -> str:
+    for line in md.split("\n"):
+        m = RE_HEADING.match(line)
+        if m and len(m.group(1)) == 1:
+            return strip_inline_markup(m.group(2))
+    return fallback
+
+
+def collect_book(src_dir: str) -> list[dict]:
+    chunks: list[dict] = []
+    paths = sorted(glob.glob(os.path.join(src_dir, "**", "*.md"), recursive=True))
+    for path in paths:
+        rel = os.path.relpath(path, src_dir)
+        if rel == "SUMMARY.md":
+            continue
+        with open(path, encoding="utf-8") as f:
+            md = f.read()
+        title = page_title(md, os.path.splitext(os.path.basename(rel))[0])
+        url_base = rel[: -len(".md")] + ".html"
+        chunks.extend(chunks_for(md, title, url_base.replace(os.sep, "/"), "book"))
+    return chunks
+
+
+def collect_wiki(wiki_dir: str) -> list[dict]:
+    """Index a `pounce.wiki` clone.
+
+    Wiki filenames are the page names with spaces as hyphens, which is also
+    the URL form — so the citation URL is the basename, no slugification.
+
+    `_Sidebar` / `_Footer` are navigation chrome. `Home` is too: it is a
+    one-paragraph blurb per wiki page, so it matches a term from every topic
+    at once and, being short, wins on BM25 length normalization — measured, it
+    was the top hit for "my solve fails because of where it started" ahead of
+    the page named "Recovering from a bad start". Everything it links to is
+    indexed on its own, so dropping it costs no content.
+    """
+    chunks: list[dict] = []
+    paths = sorted(glob.glob(os.path.join(wiki_dir, "*.md")))
+    for path in paths:
+        name = os.path.splitext(os.path.basename(path))[0]
+        if name.startswith("_") or name == "Home":
+            continue
+        with open(path, encoding="utf-8") as f:
+            md = f.read()
+        title = page_title(md, name.replace("-", " "))
+        chunks.extend(chunks_for(md, title, WIKI_BASE + name, "wiki"))
+    return chunks
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-o", "--out", default="ask-index.json", help="output JSON path")
+    ap.add_argument("--book-src", default="docs/src", help="mdBook src directory")
+    ap.add_argument(
+        "--wiki",
+        default=None,
+        help="path to a pounce.wiki clone; omitted means book-only (a local "
+        "build without network access still produces a usable index)",
+    )
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args(argv)
+
+    if not os.path.isdir(args.book_src):
+        print("build-docs-index: no such book src: %s" % args.book_src, file=sys.stderr)
+        return 1
+
+    chunks = collect_book(args.book_src)
+    n_book = len(chunks)
+
+    n_wiki = 0
+    if args.wiki:
+        if os.path.isdir(args.wiki):
+            wiki_chunks = collect_wiki(args.wiki)
+            n_wiki = len(wiki_chunks)
+            chunks.extend(wiki_chunks)
+        else:
+            # Not fatal: the wiki is a separate repository, and a docs build
+            # must not fail because that clone did not happen. The assistant
+            # degrades to book-only, and the count below says so out loud.
+            print(
+                "build-docs-index: WARNING wiki dir not found, indexing book only: %s"
+                % args.wiki,
+                file=sys.stderr,
+            )
+
+    for i, c in enumerate(chunks):
+        c["i"] = i
+
+    doc = {
+        "schema": 1,
+        "counts": {"book": n_book, "wiki": n_wiki, "total": len(chunks)},
+        "wiki_base": WIKI_BASE,
+        "chunks": chunks,
+    }
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(doc, f, ensure_ascii=False, separators=(",", ":"))
+        f.write("\n")
+
+    if not args.quiet:
+        size = os.path.getsize(args.out)
+        print(
+            "build-docs-index: %d chunks (%d book, %d wiki) -> %s (%.0f KB)"
+            % (len(chunks), n_book, n_wiki, args.out, size / 1024.0)
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-versioned-docs.sh
+++ b/scripts/build-versioned-docs.sh
@@ -7,10 +7,28 @@
 #   <out>/vX.Y.Z/        one archived build per v* release tag
 #   <out>/versions.json  manifest the selector reads (copied into every book)
 #   <out>/versions.js    the selector (copied into every book)
+#   <out>/ask.js         the docs assistant (copied into every book)
+#   <out>/ask.css        its styling (copied into every book)
+#   <out>/ask-index.json its retrieval corpus (ONE copy, at the site root)
 #
 # The version selector (docs/assets/versions.js) is injected into EVERY built
 # book — including archived tag builds whose source predates the selector — by
 # copying the current versions.js in and adding a <script> tag to every page.
+# The assistant (docs/assets/ask.js) rides exactly the same mechanism, and for
+# the same reason: shipped only via book.toml's `additional-js` it would reach
+# `dev/` and nothing else until the next release, because the site root is
+# built from the newest *tag*, whose source predates this change.
+#
+# The retrieval index is the one shared file. It is built from the working
+# tree's docs/src plus (optionally) a wiki clone, so it describes CURRENT
+# docs no matter which version's book is displaying it — which is why each
+# page gets an explicit `data-index` path back to the single root copy rather
+# than a per-book copy. One 1.3 MB file, not one per archived tag.
+# docs/src/ask.md tells readers that the assistant answers about current docs.
+#
+# Set POUNCE_WIKI_DIR to a `pounce.wiki` clone to index the wiki too; without
+# it the index is book-only and the build still succeeds (see docs.yml, which
+# clones the wiki, and scripts/build-docs-index.py).
 #
 # Requirements: git, mdbook, python3. Local runs need the tags present:
 #   git fetch --tags && scripts/build-versioned-docs.sh ./site
@@ -31,6 +49,12 @@ rm -rf "${OUT:?}"/*
 
 VERSIONS_JS="$PWD/docs/assets/versions.js"
 [[ -f "$VERSIONS_JS" ]] || { echo "missing $VERSIONS_JS" >&2; exit 1; }
+
+ASK_JS="$PWD/docs/assets/ask.js"
+ASK_CSS="$PWD/docs/assets/ask.css"
+for f in "$ASK_JS" "$ASK_CSS"; do
+  [[ -f "$f" ]] || { echo "missing $f" >&2; exit 1; }
+done
 
 # Release tags only: vX.Y.Z (excludes python-v* / pyomo-pounce-v*). sort -V so
 # the highest is last -> STABLE. A new release tag appears here automatically.
@@ -66,15 +90,31 @@ fi
 echo "[root] copying stable ($STABLE) to site root"
 cp -a "$OUT/$STABLE/." "$OUT/"
 
-# --- selector: manifest, versions.js, and per-page <script> injection ------
-echo "[selector] writing versions.json, copying versions.js, injecting tags"
-OUT="$OUT" STABLE="$STABLE" TAGS="$TAGS" VERSIONS_JS="$VERSIONS_JS" python3 - <<'PY'
+# --- assistant retrieval index (one copy, shared by every version) ---------
+# Built from the working tree, i.e. main: the assistant answers about current
+# docs even when displayed inside an archived book. Non-fatal if the wiki
+# clone is absent — the index is then book-only rather than the build failing
+# on a second repository being unreachable.
+echo "[ask] building retrieval index (wiki: ${POUNCE_WIKI_DIR:-none})"
+ASK_INDEX_ARGS=(-o "$OUT/ask-index.json" --book-src "$PWD/docs/src")
+if [[ -n "${POUNCE_WIKI_DIR:-}" ]]; then
+  ASK_INDEX_ARGS+=(--wiki "$POUNCE_WIKI_DIR")
+fi
+python3 scripts/build-docs-index.py "${ASK_INDEX_ARGS[@]}"
+
+# --- selector + assistant: assets, manifest, per-page <script> injection ---
+echo "[selector] writing versions.json, copying assets, injecting tags"
+OUT="$OUT" STABLE="$STABLE" TAGS="$TAGS" VERSIONS_JS="$VERSIONS_JS" \
+ASK_JS="$ASK_JS" ASK_CSS="$ASK_CSS" python3 - <<'PY'
 import os, re, json, shutil
 
 out = os.environ["OUT"]
 stable = os.environ["STABLE"]
 tags = os.environ["TAGS"].split()
 versions_js = os.environ["VERSIONS_JS"]
+ask_js = os.environ["ASK_JS"]
+ask_css = os.environ["ASK_CSS"]
+ask_index = os.path.join(out, "ask-index.json")
 
 # Manifest: dev first, then tags newest -> oldest.
 entries = [{"id": "dev", "label": "dev (unreleased)", "path": "dev", "kind": "dev"}]
@@ -95,13 +135,39 @@ P2R = re.compile(r'const\s+path_to_root\s*=\s*"([^"]*)"')
 def inject(html_path):
     with open(html_path, "r", encoding="utf-8") as f:
         html = f.read()
-    if 'id="pounce-versions"' in html or "</head>" not in html:
+    if "</head>" not in html:
         return
     m = P2R.search(html)
     p2r = m.group(1) if m else ""
-    tag = ('<script defer src="%sversions.js" id="pounce-versions" '
-           'data-p2r="%s"></script>\n</head>') % (p2r, p2r)
-    html = html.replace("</head>", tag, 1)
+    tags_html = ""
+    if 'id="pounce-versions"' not in html:
+        tags_html += ('<script defer src="%sversions.js" id="pounce-versions" '
+                      'data-p2r="%s"></script>\n') % (p2r, p2r)
+    if 'id="pounce-ask"' not in html:
+        # p2r only reaches this *version's* root, and two of the assistant's
+        # paths are site-root-relative, not version-relative:
+        #
+        #   data-index  one index file, shared by every version
+        #   data-root   where citations point — the stable book at the site
+        #               root, because the index describes current docs. An
+        #               archived book resolving them against its own root
+        #               yields 404s for pages and anchors added since.
+        #
+        # Both are computed from this page's real directory rather than
+        # derived from p2r, which cannot express "up out of this version".
+        page_dir = os.path.dirname(html_path)
+        rel_index = os.path.relpath(ask_index, page_dir).replace(os.sep, "/")
+        rel_root = os.path.relpath(out, page_dir).replace(os.sep, "/")
+        if rel_root == ".":
+            rel_root = ""
+        else:
+            rel_root += "/"
+        tags_html += ('<script defer src="%sask.js" id="pounce-ask" '
+                      'data-p2r="%s" data-index="%s" data-root="%s"></script>\n'
+                      ) % (p2r, p2r, rel_index, rel_root)
+    if not tags_html:
+        return
+    html = html.replace("</head>", tags_html + "</head>", 1)
     with open(html_path, "w", encoding="utf-8") as f:
         f.write(html)
 
@@ -109,6 +175,8 @@ for root in book_roots:
     with open(os.path.join(root, "versions.json"), "w", encoding="utf-8") as f:
         f.write(manifest)
     shutil.copyfile(versions_js, os.path.join(root, "versions.js"))
+    shutil.copyfile(ask_js, os.path.join(root, "ask.js"))
+    shutil.copyfile(ask_css, os.path.join(root, "ask.css"))
     for dirpath, _dirs, files in os.walk(root):
         for name in files:
             if name.endswith(".html"):


### PR DESCRIPTION
## Problem

The docs site has no way to ask a question. mdBook's built-in search is
whole-word over one book, and the material a reader most often actually wants
— the four long-form wiki pages on tuning, bad starts, bound relaxation and
multistart — is not searchable from the site at all, because the wiki is a
separate repository that the site never touches.

There is no oracle table here: this is a docs feature, not a solver change. The
measurable claim is retrieval quality, and it is measured below.

## Cause

n/a — new feature.

## Fix

An **Ask** panel in the menu bar of every page, built from two halves that work
independently:

| | | |
|---|---|---|
| **Retrieval** | BM25 over `ask-index.json` (the book **and** the wiki), each hit deep-linked to the heading that answers | always available |
| **Generation** | a small instruct model via [WebLLM](https://github.com/mlc-ai/web-llm) on WebGPU, handed **only** the retrieved passages | strictly opt-in |

Nothing leaves the browser: no API key, no server, no telemetry, and no
download at all until the reader picks a model and clicks. Without WebGPU,
without a model, or on a phone, a reader still gets ranked linked passages, and
the panel says which of those states it is in.

Three decisions worth arguing with:

**The wiki is indexed but not rendered into the book.** It carries the measured
guidance a question is usually really about, while the book stays the reference
manual. Wiki hits are badged `wiki` and link out to GitHub. `docs.yml` clones
`pounce.wiki` with `continue-on-error`, and the build treats a missing
`POUNCE_WIKI_DIR` as book-only — an unreachable wiki must degrade the
assistant, never take the docs site down.

**Delivery rides the version selector's per-page injection, not
`book.toml`'s `additional-js`.** Via `additional-js` this would reach `dev/` and
nothing else until the next release, because the site root is built from the
newest *tag*, whose source predates the change. The corollary is that `make
book` has **no** Ask button; `make book-site` is added for that.

**One index, built from `main`, shared by every version**, so citations resolve
against the site root (`data-root`, distinct from `data-p2r`). Resolving them
against an archived book 404s on every page and anchor added since that tag —
measured, four of six hits on one v0.2.0 page before this was fixed.

Rejected and removed: a coordination factor scaling by the fraction of query
terms a passage matched. It was added in the same step as the stopword list and
credited with part of their effect; ablated on its own it moved neither
configuration of the eval set, so it is gone rather than kept on the strength
of the argument for it. Also considered and not taken: vector embeddings, which
would mean a second model download for a corpus whose distinctive vocabulary is
option names that lexical search already handles well.

## Blast radius

No Rust changed — the diff is workflows, `docs/`, `scripts/` and the `Makefile`.
Nothing in the solver, no fixture sweep implicated.

The two live surfaces affected:

- **`docs.yml` gains an external dependency** on `jkitchin/pounce.wiki`. Gated
  `continue-on-error`, so the failure mode is an amber step and an assistant
  without wiki passages, not a red docs deploy. `CLAUDE.md` records this as the
  docs site's fourth input.
- **Every page of the deployed site gains two `<script>`/`<link>` tags and a
  menu-bar button**, including archived tag builds. The index (1.3 MB, ~450 KB
  gzipped) is fetched lazily — only when a reader opens the panel — and is a
  single copy at the site root rather than one per archived version.

`ci.yml` gains one step in the existing `test` job (python3 + node, both already
present on `ubuntu-latest`); it adds no toolchain.

## Tests

`docs/tests/ask_retrieval.mjs` (`make ask-check`, and `ci.yml`) runs the
**shipped** `ask.js` through a test seam — not a copy of the scoring. That is
the point of it: retrieval has no exception to throw, it returns the wrong
passage silently, and a test of a reimplemented ranker would stay green while
the real one regressed.

It checks the stemmer against known Porter step-1 outputs (a unit test, corpus
independent), query-side compound handling, result shaping, prompt
construction, and ranking against 20 labelled queries.

Measured, final state:

| | top-1 | top-5 |
|---|---|---|
| with the wiki (production) | 18/20 | 20/20 |
| book only (CI, no clone) | 17/20 | 20/20 |

Ablated against that final system, book-only top-1:

| component removed | top-1 |
|---|---|
| — (full system) | 17/20 |
| heading + title bonus | 13/20 |
| stopword list | 14/20 |
| stemming | 14/20 |
| compound-identifier rule | 17/20 (18 → 17 with the wiki) |
| coordination factor | 17/20 (18 → 18 with the wiki) — removed |

Four ranking defects were found by measuring rather than by inspection, and
every one of them looked fine on the page: function words swamping
natural-language questions, a compound identifier split so that `fix_relax`
outranked the documentation of `bound_relax_factor`, the heading bonus
rewarding nesting *depth* rather than specificity, and the wiki's link-farm
`Home` page winning multi-term queries.

**The ranking half of the guard does not "fail on the parent commit" in the
usual sense** — `docs/assets/ask.js` does not exist there, so the test cannot
run at all. What it bites on is future change: its thresholds sit deliberately
*below* the measured score, because it is a corpus test and honest doc edits
move rankings. It is built to catch a scoring change that drops several queries
at once, not single-rank drift.

Also verified in Chromium against a full 12-version build (49 checks) over the
stable root, `dev/`, a two-deep nested page and an archived v0.2.0 book:
injection at every depth, index load, retrieval, every citation link resolving,
`ask.css` applying in both themes, and the no-usable-GPU degradation. That last
one is a real finding, not a formality — `navigator.gpu` existing is not the
same as WebGPU working, `requestAdapter()` resolves *null* on machines with no
usable GPU, and offering the button there bought a wait and an error from
inside WebLLM.

**Deliberately not pinned, and the gap is known: the generation half was never
executed.** The sandbox this was built in blocks the WebLLM CDN and has no GPU,
so no model was ever loaded and no question was ever answered by one. What is
verified is the six model IDs against WebLLM's published `config.ts`, prompt
construction (grounding instructions, excerpt numbering, truncation), and the
adapter-null path. The load-and-answer path needs a real browser on real
hardware before it is trusted — please try it once when reviewing.

---

- [ ] ~~Tests fail on the parent commit for the stated reason~~ — see the
      paragraph above: the file under test does not exist on the parent, so
      the ranking guard cannot run there. Stated rather than ticked.
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
      (`docs/src/ask.md`; `scripts/check-docs-consistency.sh` passes)
- [ ] ~~`cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean~~ —
      not run, and not applicable: this diff touches no Rust.
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now. The ablation table above is why the second commit
      exists: two code comments credited the stopword list with a bundled
      11/20 → 15/20 measurement, and the coordination factor was justified by
      an argument no measurement supported. Both corrected against the final
      diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKa1xpjG3LK95pWozQ8VL8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKa1xpjG3LK95pWozQ8VL8)_