### PR TITLE
feat(sens): dlambda/dp for strictly active inequality constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,53 @@ changes.
 
 ### Added
 
+- **Multiplier sensitivities on inequality constraints
+  (`sens_jacobian(of=<inequality Constraint>)`, gh#910).** `dλ/dp` was
+  equality-only:
+  an inequality target raised, and the workaround was to rewrite a
+  known-active cap as an equality. It now answers wherever the row is
+  *strictly complementary* — active with a multiplier bounded away from
+  zero — which is the whole region where the multiplier is a
+  differentiable function of the parameters. New plumbing:
+  `Solver::d_multiplier_rows` (Rust and Python), backed by a `full_to_d`
+  map on `BoundClassification` that is the exact complement of the
+  existing `full_to_c`.
+
+  The other two regimes are **refused, each naming itself**, because they
+  need different things from the caller. An *inactive* row's multiplier is
+  pinned at zero over a neighbourhood, so its derivative genuinely is zero
+  — but there is no KKT row to differentiate, and a returned `0.0` would
+  be indistinguishable from a computed one. At a *kink* (`λ ≈ 0` and slack
+  `≈ 0` together) the two one-sided derivatives differ, so no two-sided
+  `dλ/dp` exists; `sens_solution()` and `Solver.parametric_step_full` still
+  give a one-sided step for a chosen direction.
+
+  The gate is `reduced_row_activity()`, not `classify_activity()`, and the
+  reason is not the one it looks like. Neither classifier can *admit* a
+  kink: a row's reduced curvature is never larger than its directional
+  one, so the reduced ratio is never below the directional ratio, and
+  `strongly_active` is the high-ratio tail of both. What the directional
+  normalizer gets wrong is the **refusal reason**. Swept over a genuine row
+  kink coupled to the rest of the free space at strength `ρ`,
+  `classify_activity()` reads `weakly_active` at `ρ = 1`, `ambiguous` by
+  `1e-2`, and `inactive` by `1e-6`, while `reduced_row_activity()` holds
+  `weakly_active` throughout. `inactive` is the one class a caller may
+  legitimately read as a structural zero — so the directional gate would
+  not decline to answer about a tight cap's shadow price, it would answer
+  "it does not move". Coupling that strong is routine on a collocation
+  model.
+
+  Covered by a third fixture in
+  `crates/pounce-sensitivity/tests/sens_invariance_legs.rs` — a strictly
+  active cap behind an equality pin and an inactive decoy, so the row's g
+  index, its d-block position and its (nonexistent) c-block position are
+  three different numbers — with a row in each of the three legs, its own
+  mutation table, and a liveness witness that does not go through the map
+  under test. Two mutations of the new map each fail exactly the six
+  multiplier tests and leave the witness green. End-to-end regime coverage,
+  including a coupled kink that `classify_activity` misreads as `inactive`,
+  is in `pyomo-pounce/tests/test_sens.py`.
+
 - **A phase-changing flash as a complementarity problem
   (`pounce.examples.flash_mpcc`, notebook 38).** A single vapour–liquid
   equilibrium stage solved across a temperature path that crosses

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -389,6 +389,21 @@ pub trait IpoptNlp: Nlp {
         Some(full_idx)
     }
 
+    /// Map a 0-based **full-g** index to a 0-based position in the
+    /// d-block (algorithm-side inequality multiplier vector `y_d`,
+    /// length `m_ineq()`). Returns `None` when the constraint is an
+    /// equality (lives in `c`, not `d`).
+    ///
+    /// The exact complement of [`Self::full_g_to_c_block`]: every row
+    /// is in one block or the other, so exactly one of the two returns
+    /// `Some` for an in-range index. Default impl matches
+    /// `full_g_to_c_block`'s (which assumes every row is an equality)
+    /// by returning `None` for all of them; `OrigIpoptNlp` overrides
+    /// via `BoundClassification::full_to_d`.
+    fn full_g_to_d_block(&self, _full_idx: Index) -> Option<Index> {
+        None
+    }
+
     /// Inverse of [`Self::full_x_to_var_x`]: map a 0-based var-x index
     /// (length `n()`) to the corresponding full-x index (length
     /// `n_full_x()`). Used when scattering a compressed step or

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -2780,6 +2780,17 @@ impl IpoptNlp for OrigIpoptNlp {
         if c < 0 { None } else { Some(c) }
     }
 
+    fn full_g_to_d_block(&self, full_idx: Index) -> Option<Index> {
+        let cls = self.adapter.borrow();
+        let cls = cls.classification();
+        let f = full_idx as usize;
+        if f >= cls.full_to_d.len() {
+            return None;
+        }
+        let d = cls.full_to_d[f];
+        if d < 0 { None } else { Some(d) }
+    }
+
     fn var_x_to_full_x(&self, var_idx: Index) -> Index {
         let cls = self.adapter.borrow();
         let cls = cls.classification();

--- a/crates/pounce-nlp/src/tnlp_adapter.rs
+++ b/crates/pounce-nlp/src/tnlp_adapter.rs
@@ -91,6 +91,15 @@ pub struct BoundClassification {
     /// Maps full-g index → c-block position, with `-1` for inequality
     /// rows: the O(1) inverse of `c_map`, mirroring `full_to_var`.
     pub full_to_c: Vec<Index>,
+    /// Maps full-g index → d-block position, with `-1` for equality
+    /// rows: the O(1) inverse of `d_map`, and the exact complement of
+    /// `full_to_c` — every row is in one block or the other, so
+    /// `(full_to_c[i] < 0) == (full_to_d[i] >= 0)` for every `i`.
+    ///
+    /// Added so a caller holding a user-space row index can find the
+    /// inequality multiplier `y_d` in the compound KKT vector, which
+    /// `full_to_c` alone could only refuse to do (pounce#910).
+    pub full_to_d: Vec<Index>,
 }
 
 impl BoundClassification {
@@ -560,6 +569,7 @@ fn classify_bounds(
     let mut d_l_map: Vec<Index> = Vec::new();
     let mut d_u_map: Vec<Index> = Vec::new();
     let mut full_to_c: Vec<Index> = vec![-1; ng];
+    let mut full_to_d: Vec<Index> = vec![-1; ng];
 
     for i in 0..ng {
         let lo = g_l[i];
@@ -589,6 +599,7 @@ fn classify_bounds(
             }
         }
         let d_idx = d_map.len() as Index;
+        full_to_d[i] = d_idx;
         d_map.push(i as Index);
         if lo_present {
             d_l_map.push(d_idx);
@@ -618,6 +629,7 @@ fn classify_bounds(
         d_l_map,
         d_u_map,
         full_to_c,
+        full_to_d,
     })
 }
 
@@ -1298,5 +1310,84 @@ mod tests {
 
         let adapter = adapter_for(NonlinVars::silent());
         assert!(adapter.quasi_newton_nonlinear_vars(99).is_err());
+    }
+
+    // ── the c/d split is a partition (jkitchin/pounce#910) ──────────
+    //
+    // `full_to_d` is documented as the exact complement of
+    // `full_to_c`, and `python/pounce/sensitivity/_session.py`'s
+    // `mult_entry` leans on it: it asks the equality block, then the
+    // inequality block, and treats both answering `None` as
+    // unreachable. That claim is about THIS function, so it is pinned
+    // here rather than asserted downstream.
+    //
+    // The row worth naming is the free one. A `-inf <= g <= inf` row
+    // is the shape a reader expects to fall through both blocks, and
+    // Pyomo cannot even construct one, so no end-to-end test can
+    // reach it -- which is exactly why the premise belongs at this
+    // level. It lands in `d` with empty bound-map entries, and the
+    // gate downstream then refuses it as inactive, which is the
+    // truth: a free row's multiplier is zero always.
+
+    fn split_of(g_l: &[Number], g_u: &[Number]) -> BoundClassification {
+        classify_bounds(
+            1,
+            g_l.len() as Index,
+            &[-1e19],
+            &[1e19],
+            g_l,
+            g_u,
+            -1e19,
+            1e19,
+            FixedVarTreatment::MakeParameter,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn every_constraint_row_lands_in_exactly_one_of_c_and_d() {
+        // equality, <=-only, >=-only, two-sided range, and free.
+        let cls = split_of(
+            &[2.0, -1e19, 0.0, -1.0, -1e19],
+            &[2.0, 5.0, 1e19, 1.0, 1e19],
+        );
+        for i in 0..5usize {
+            let in_c = cls.full_to_c[i] >= 0;
+            let in_d = cls.full_to_d[i] >= 0;
+            assert!(
+                in_c != in_d,
+                "row {i} is in c={in_c} and d={in_d}; the split must be a \
+                 partition, so `mult_entry`'s both-None branch stays \
+                 unreachable",
+            );
+        }
+        assert_eq!(cls.full_to_c, vec![0, -1, -1, -1, -1]);
+        assert_eq!(cls.full_to_d, vec![-1, 0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn a_free_row_gets_a_d_slot_with_no_bound_on_either_side() {
+        let cls = split_of(&[-1e19], &[1e19]);
+        assert_eq!(cls.full_to_c, vec![-1], "a free row is not an equality");
+        assert_eq!(cls.full_to_d[0], 0, "but it does get a d slot");
+        assert_eq!(cls.d_map, vec![0]);
+        assert!(
+            cls.d_l_map.is_empty() && cls.d_u_map.is_empty(),
+            "and no bound on either side, so nothing can be active",
+        );
+    }
+
+    #[test]
+    fn full_to_d_is_the_positional_inverse_of_d_map() {
+        // The accessor indexes the `y_d` block directly, so an
+        // off-by-one here is a neighbouring row's multiplier -- the
+        // silent failure the newtype work (gh#764 item 3) is about.
+        let cls = split_of(&[0.0, 1.0, 1.0, -1e19, 3.0], &[0.0, 2.0, 1.0, 4.0, 3.0]);
+        for (pos, &full) in cls.d_map.iter().enumerate() {
+            assert_eq!(cls.full_to_d[full as usize], pos as Index);
+        }
+        for (pos, &full) in cls.c_map.iter().enumerate() {
+            assert_eq!(cls.full_to_c[full as usize], pos as Index);
+        }
     }
 }

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -716,6 +716,39 @@ impl PySolver {
         Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
     }
 
+    /// Rows of the compound KKT vector holding the **inequality**
+    /// multipliers for the given 0-based constraint (`g`) indices;
+    /// `None` for equality constraints, whose multipliers
+    /// `multiplier_rows` finds instead. Between them the two cover
+    /// every row, and exactly one returns a row for any given index.
+    ///
+    /// This is a mapping and not a verdict: an inequality multiplier is
+    /// differentiable only where the row is STRICTLY active. On an
+    /// inactive row the derivative is structurally zero, and at a kink
+    /// (`lambda ~ 0` and slack `~ 0` together) the two-sided
+    /// derivative does not exist -- the entry then holds whichever
+    /// one-sided answer the factorization landed on. Gate on
+    /// `reduced_row_activity()` before showing a user a number from
+    /// here; `classify_activity()` is NOT sufficient for a row.
+    /// Neither classifier can *admit* a kink -- the reduced ratio is
+    /// never below the directional one and STRONGLY_ACTIVE is the
+    /// high-ratio tail of both -- but the directional ratio for a
+    /// genuine kink is `reduced/directional` (pounce#804), so a kink
+    /// whose coordinate is coupled to the rest of the free space
+    /// slides WEAKLY_ACTIVE -> AMBIGUOUS -> INACTIVE there while
+    /// `reduced_row_activity()` holds WEAKLY_ACTIVE. INACTIVE is the
+    /// one class a caller may legitimately read as a structural zero,
+    /// so the directional gate does not refuse a tight cap's shadow
+    /// price, it answers "it does not move" (pounce#910).
+    fn d_multiplier_rows(&self, g_indices: Vec<i64>) -> PyResult<Vec<Option<i64>>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("d_multiplier_rows: no converged factor (call solve() first)")
+        })?;
+        let gs = validate_pins(&g_indices, s.m)?;
+        let rows = s.inner.d_multiplier_rows(&gs).map_err(solver_error_to_py)?;
+        Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
+    }
+
     /// Rows of the compound KKT vector holding the primal values for
     /// the given 0-based **user-space** variable (`x`) indices; `None`
     /// where the solve removed the column as a fixed variable

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -1488,6 +1488,18 @@ impl PdSensBacksolver {
         self.nlp.borrow().full_g_to_c_block(full_idx)
     }
 
+    /// `None` when the constraint is an equality (it lives in the `c`
+    /// block, not `y_d`). Delegates to the held NLP's c/d-split map,
+    /// and is the exact complement of [`Self::full_g_to_c_block`].
+    ///
+    /// The flat KKT row of an inequality's multiplier is
+    /// `n_x + n_s + n_c + full_g_to_d_block(g)`; the same warning
+    /// applies as for the `c` side — it is NOT `n_x + n_s + n_c + g`,
+    /// which differs whenever any equality precedes the row in `g(x)`.
+    pub fn full_g_to_d_block(&self, full_idx: Index) -> Option<Index> {
+        self.nlp.borrow().full_g_to_d_block(full_idx)
+    }
+
     /// Map a 0-based **full-x** index (user-TNLP variable order) to its
     /// 0-based position in the algorithm-side `x` block, or `None` when
     /// the solve removed the column because `x_l == x_u` under

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -1876,9 +1876,10 @@ impl Solver {
 
     /// Flat rows of the compound KKT vector holding the equality
     /// multipliers `y_c` for the given 0-based **full-g** constraint
-    /// indices. `None` for inequalities (their multipliers live in the
-    /// `y_d` block; mapping those is not exposed here). Row `r` of a
-    /// [`Self::parametric_step_full`] result is then `∂λ_g/∂p · Δp`.
+    /// indices. `None` for inequalities, whose multipliers live in the
+    /// `y_d` block — [`Self::d_multiplier_rows`] maps those. Row `r`
+    /// of a [`Self::parametric_step_full`] result is then
+    /// `∂λ_g/∂p · Δp`.
     pub fn g_multiplier_rows(
         &self,
         g_indices: &[Index],
@@ -1894,6 +1895,89 @@ impl Solver {
                     .backsolver
                     .full_g_to_c_block(g)
                     .map(|pos| y_c_offset + pos)
+            })
+            .collect())
+    }
+
+    /// Flat rows of the compound KKT vector holding the **inequality**
+    /// multipliers `y_d` for the given 0-based full-g indices. `None`
+    /// for equalities, whose multipliers are in `y_c` — so this is the
+    /// exact complement of [`Self::g_multiplier_rows`] and the two
+    /// together cover every row. Row `r` of a
+    /// [`Self::parametric_step_full`] result is then `∂λ_d/∂p · Δp`.
+    ///
+    /// **This is a mapping, not a verdict, and `∂λ_d/∂p` is not always
+    /// a derivative.** An inequality's multiplier is only
+    /// differentiable where the row is *strictly* active, and the row
+    /// lands in one of three regimes:
+    ///
+    /// * strictly active (`λ > 0`, slack `0`) — well defined, and the
+    ///   same quantity an equality in that position would report;
+    /// * inactive (`λ = 0`, slack `> 0`) — `λ` stays `0` under a small
+    ///   perturbation, so the derivative is `0` for a structural
+    ///   reason rather than a measured one;
+    /// * weakly active — a kink, `λ ≈ 0` *and* slack `≈ 0`, where the
+    ///   two-sided derivative does not exist at all. Only one-sided
+    ///   ones do, and they differ; the number this row holds is
+    ///   whichever side the factorization happened to land on.
+    ///
+    /// Nothing here distinguishes them. A caller putting this in front
+    /// of a user must gate on the activity class first, and for a
+    /// *row* that means [`Self::reduced_row_activity`] rather than
+    /// [`Self::classify_activity`].
+    ///
+    /// Not because the directional classifier can *admit* a kink — it
+    /// cannot. A row's reduced curvature is never larger than its
+    /// directional one, so the reduced ratio is never smaller than the
+    /// directional ratio, and
+    /// [`STRONGLY_ACTIVE`](crate::activity::STRONGLY_ACTIVE) is the
+    /// high-ratio tail of both. What the directional normalizer gets
+    /// wrong is the *refusal reason*: the ratio it reports for a
+    /// genuine kink is `reduced/directional` (gh#804), so as the row's
+    /// coordinate couples to the remaining free space the class slides
+    /// [`WEAKLY_ACTIVE`](crate::activity::WEAKLY_ACTIVE) →
+    /// [`AMBIGUOUS`](crate::activity::AMBIGUOUS) →
+    /// [`INACTIVE`](crate::activity::INACTIVE) while
+    /// [`Self::reduced_row_activity`] holds `WEAKLY_ACTIVE`
+    /// throughout. `INACTIVE` is the one class whose derivative a
+    /// caller may legitimately treat as a structural zero, so the
+    /// directional gate does not decline to answer about a tight cap's
+    /// shadow price — it answers "it does not move", which is wrong.
+    /// `pounce.sensitivity`'s `mult_entry` is the gated caller
+    /// (pounce#910).
+    ///
+    /// An out-of-range index is an **error** here, where
+    /// [`Self::g_multiplier_rows`] returns `None` for it. The
+    /// asymmetry is deliberate and is what makes the fall-through
+    /// pattern — ask `g_multiplier_rows`, then ask this — safe: with
+    /// both accessors returning `None` a caller cannot tell "that row
+    /// is an equality" from "that row does not exist", and the second
+    /// call is where the question is finally settled. Same reasoning
+    /// as [`Self::x_primal_rows`], whose `None` means "removed as
+    /// fixed" and must not double as "out of range".
+    pub fn d_multiplier_rows(
+        &self,
+        g_indices: &[Index],
+    ) -> Result<Vec<Option<Index>>, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let n_full_g = state.backsolver.n_full_g();
+        if let Some(&bad) = g_indices.iter().find(|&&g| g < 0 || g >= n_full_g) {
+            return Err(SolverError::BadShape {
+                what: "d_multiplier_rows constraint index",
+                got: bad as usize,
+                expected: n_full_g as usize,
+            });
+        }
+        let dims = state.backsolver.block_dims();
+        let y_d_offset = (dims[0] + dims[1] + dims[2]) as Index;
+        Ok(g_indices
+            .iter()
+            .map(|&g| {
+                state
+                    .backsolver
+                    .full_g_to_d_block(g)
+                    .map(|pos| y_d_offset + pos)
             })
             .collect())
     }

--- a/crates/pounce-sensitivity/tests/sens_invariance_legs.rs
+++ b/crates/pounce-sensitivity/tests/sens_invariance_legs.rs
@@ -68,8 +68,8 @@ use pounce_nlp::tnlp::{
     BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, ScalingRequest, Solution, SparsityRequest,
     StartingPoint,
 };
-use pounce_sensitivity::Solver;
-use pounce_sensitivity::activity::{AMBIGUOUS, FIXED, INACTIVE, WEAKLY_ACTIVE};
+use pounce_sensitivity::activity::{AMBIGUOUS, FIXED, INACTIVE, STRONGLY_ACTIVE, WEAKLY_ACTIVE};
+use pounce_sensitivity::{Solver, SolverError};
 
 /// Coupling between the pin and the kink variable. The one-sided
 /// derivative on the leaving side is exactly this.
@@ -1281,4 +1281,658 @@ fn leg_release_all_is_the_releasing_sides_map_in_every_frame() {
             1e-6,
         );
     }
+}
+
+// ===================================================================
+// Fixture 3 -- a strictly active INEQUALITY row, for
+// `d_multiplier_rows` (pounce#910)
+// ===================================================================
+//
+// The two fixtures above have `m = 1`, and that one row is the pin
+// equality: neither of them has an inequality row at all, so neither
+// says anything about the `y_d` block. `d_multiplier_rows` maps a
+// user-space row to the KKT row of its inequality multiplier, and it
+// has a dimension in all three legs:
+//
+// 1. it is read through the frame conversions -- the multiplier it
+//    points at is scaled by the row's own factor and by the
+//    objective's, and the pin's delta is scaled too, so three factors
+//    meet in one number (the same shape as
+//    `leg_scaling_the_reduced_row_curvature_is_unmoved_by_a_row_scaling`);
+// 2. the step it is read out of is affine in `delta` like every other
+//    block, so the invariant is a slope;
+// 3. it is an index map, and the space it maps out of is not the space
+//    it maps into. `full_to_c` and `full_to_d` are complements, so the
+//    d-block position of a row is its g index MINUS the equalities
+//    ahead of it -- which is exactly the shape of the full-x/var-x
+//    hazard leg 3 exists for, one block over. The fixture puts the pin
+//    equality FIRST and an inactive inequality SECOND so that the
+//    active row's g index (2), its d-block position (1) and its
+//    c-block position (which does not exist) are three different
+//    things.
+//
+// ```text
+// min  0.5 x^2 + 0.5 y^2 - x - y     [+ 0.5 (xf - 0.7)^2]
+// s.t. g0:  p == 0                   (the pin)
+//      g1:  x - y <= SLACK_UB        (never active)
+//      g2:  x + y - p <= P_CAP       (strictly active)
+// ```
+//
+// With `p = delta` the cap reads `x + y <= P_CAP + delta`, and the
+// unconstrained optimum `x = y = 1` violates it for `P_CAP < 2`. On
+// the cap, `x = y = (P_CAP + delta)/2` and the multiplier is
+//
+//     lambda = 1 - (P_CAP + delta)/2,   d lambda / d delta = -1/2
+//
+// at `P_CAP = 1`, i.e. `lambda = 1/2`: bounded away from zero on both
+// sides, which is what makes the derivative two-sided and the row
+// answerable at all. `SLACK_UB` keeps `g1` slack by a wide margin so
+// its own multiplier stays at the barrier floor.
+//
+// Mutation table -- each row was introduced, the suite run, and the
+// mutation reverted:
+//
+// | mutation                                            | result |
+// |-----------------------------------------------------|--------|
+// | `full_g_to_d_block` returns `Some(full_idx)` instead | 18 passed, 6 failed |
+// | `d_multiplier_rows`' `y_d_offset` drops `dims[2]`    | 18 passed, 6 failed -- the same six |
+//
+// The six are every test in this section except
+// `the_scaled_arm_of_the_multiplier_leg_is_actually_scaled`, which is
+// the liveness witness and stays green under both.
+//
+// It stays green by construction: it reads `nlp_scaling()` and
+// `variable_scaling()`, which do not go through `full_to_d` at all, so
+// it can still testify that the scaled arm really was scaled while the
+// map under test is broken. A leg asserting "this number did not move"
+// passes identically when the mechanism never engaged, which is what
+// that separation is for.
+//
+// What this fixture is NOT evidence about, so that the next reader does
+// not over-read a green run:
+//
+// * **the gate.** Nothing here is weakly active, by design -- the cap's
+//   multiplier is `1/2`. The three-regime refusal lives in
+//   `python/pounce/sensitivity/_session.py`'s `mult_entry` and is
+//   covered by `pyomo-pounce/tests/test_sens.py`, including a coupled
+//   row kink that `classify_activity` misreads as INACTIVE. Per the
+//   branch rule in CLAUDE.md, a leg is evidence only about the branch
+//   its fixture reaches, and this one reaches the strictly complementary
+//   branch only.
+// * **more than one active inequality.** `m = 3` with exactly one
+//   active cap, so no leg here compares two live multiplier
+//   derivatives against each other. The ordering half of that gap is
+//   closed by hand -- the precondition test pins both d rows to their
+//   exact flat positions, so a permuted `d_map` fails even though only
+//   one of the two rows is active -- but a defect that needs two
+//   *simultaneously active* rows to appear would not show.
+// * **magnitude.** Three variables and three rows; nothing here says
+//   anything about the cost of the extra map at benchmark scale (it is
+//   an `O(1)` vector read, but that is an argument, not a measurement).
+
+/// The active cap's right-hand side. Below 2 so the cap binds, and far
+/// enough below that the multiplier `1 - P_CAP/2` is nowhere near the
+/// barrier floor: this fixture is the STRICTLY complementary branch,
+/// deliberately, since the kink branch is what the two fixtures above
+/// already carry.
+const P_CAP: Number = 1.0;
+/// Upper bound on the decoy inequality `x - y`. The solution has
+/// `x = y`, so the row sits this far inside its bound.
+const SLACK_UB: Number = 5.0;
+/// `d lambda / d delta` for the active cap, exactly.
+const EXACT_DLAMBDA: Number = -0.5;
+
+/// User-space g index of each row of [`IneqMultTnlp`]. Named because
+/// the whole point of the fixture is that these are not the block
+/// positions.
+const G_PIN: Index = 0;
+const G_SLACK: Index = 1;
+const G_CAP: Index = 2;
+
+struct IneqMultTnlp {
+    /// Per-variable factors under `user-scaling`, or `None` to decline
+    /// scaling. Length `3 + off`.
+    x_scaling: Option<Vec<Number>>,
+    /// Per-row factors, same convention. Length 3.
+    g_scaling: Option<Vec<Number>>,
+    leading_fixed: bool,
+}
+
+impl IneqMultTnlp {
+    fn off(&self) -> usize {
+        usize::from(self.leading_fixed)
+    }
+}
+
+impl TNLP for IneqMultTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: (3 + self.off()) as Index,
+            m: 3,
+            nnz_jac_g: 6,
+            nnz_h_lag: (2 + self.off()) as Index,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        if self.x_scaling.is_none() && self.g_scaling.is_none() {
+            return false;
+        }
+        *req.obj_scaling = 1.0;
+        if let Some(d) = self.x_scaling.as_ref() {
+            *req.use_x_scaling = true;
+            req.x_scaling.copy_from_slice(d);
+        } else {
+            *req.use_x_scaling = false;
+        }
+        if let Some(d) = self.g_scaling.as_ref() {
+            *req.use_g_scaling = true;
+            req.g_scaling.copy_from_slice(d);
+        } else {
+            *req.use_g_scaling = false;
+        }
+        true
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        let o = self.off();
+        if self.leading_fixed {
+            b.x_l[0] = FIXED_AT;
+            b.x_u[0] = FIXED_AT;
+        }
+        for j in 0..3 {
+            b.x_l[o + j] = -1.0e19;
+            b.x_u[o + j] = 1.0e19;
+        }
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        b.g_l[1] = -1.0e19;
+        b.g_u[1] = SLACK_UB;
+        b.g_l[2] = -1.0e19;
+        b.g_u[2] = P_CAP;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        let o = self.off();
+        if self.leading_fixed {
+            sp.x[0] = FIXED_AT;
+        }
+        sp.x[o] = 0.2;
+        sp.x[o + 1] = 0.2;
+        sp.x[o + 2] = 0.0;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let o = self.off();
+        let (a, b) = (x[o], x[o + 1]);
+        let mut f = 0.5 * a * a + 0.5 * b * b - a - b;
+        if self.leading_fixed {
+            f += 0.5 * (x[0] - 0.7) * (x[0] - 0.7);
+        }
+        Some(f)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let o = self.off();
+        if self.leading_fixed {
+            g[0] = x[0] - 0.7;
+        }
+        g[o] = x[o] - 1.0;
+        g[o + 1] = x[o + 1] - 1.0;
+        g[o + 2] = 0.0;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let o = self.off();
+        g[0] = x[o + 2];
+        g[1] = x[o] - x[o + 1];
+        g[2] = x[o] + x[o + 1] - x[o + 2];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        let o = self.off() as Index;
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0 as Index, 1, 1, 2, 2, 2]);
+                jcol.copy_from_slice(&[o + 2, o, o + 1, o, o + 1, o + 2]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, 1.0, -1.0, 1.0, 1.0, -1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        let o = self.off() as Index;
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                // lower triangle: (x,x), (y,y) [, (xf,xf)]. Both
+                // constraints are linear and `p` carries no curvature,
+                // so nothing else is nonzero.
+                let mut rs: Vec<Index> = vec![o, o + 1];
+                let mut cs: Vec<Index> = vec![o, o + 1];
+                if self.leading_fixed {
+                    rs.push(0);
+                    cs.push(0);
+                }
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = obj_factor;
+                values[1] = obj_factor;
+                if self.leading_fixed {
+                    values[2] = obj_factor;
+                }
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+/// As [`solved`], for [`IneqMultTnlp`]. Both arms of leg 1 run under
+/// `user-scaling`; only whether the TNLP hands factors back differs.
+fn solved_ineq(
+    x_scaling: Option<Vec<Number>>,
+    g_scaling: Option<Vec<Number>>,
+    leading_fixed: bool,
+) -> Solver {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", "user-scaling", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("tol", 1e-10, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("bound_relax_factor", 0.0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(IneqMultTnlp {
+        x_scaling,
+        g_scaling,
+        leading_fixed,
+    }));
+    let mut solver = Solver::new(app, tnlp);
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "inequality-multiplier base solve failed: {status:?}",
+    );
+    solver
+}
+
+/// The KKT row `d_multiplier_rows` gives for user row `g`, or a panic
+/// naming the row if it refuses.
+fn d_row(s: &Solver, g: Index) -> usize {
+    s.d_multiplier_rows(&[g])
+        .expect("d_multiplier_rows")
+        .into_iter()
+        .next()
+        .unwrap()
+        .unwrap_or_else(|| panic!("row {g} has no inequality multiplier")) as usize
+}
+
+/// `d lambda / d delta` for user row `g`, as a slope between two
+/// perturbations on the same side -- see the module docs on why this
+/// is not `step / delta`.
+fn mult_slope(s: &Solver, g: Index, d_hi: Number, d_lo: Number) -> Number {
+    let row = d_row(s, g);
+    let hi = s
+        .parametric_step_full(&[G_PIN], &[d_hi])
+        .unwrap_or_else(|e| panic!("full step at {d_hi:e}: {e:?}"));
+    let lo = s
+        .parametric_step_full(&[G_PIN], &[d_lo])
+        .unwrap_or_else(|e| panic!("full step at {d_lo:e}: {e:?}"));
+    (hi[row] - lo[row]) / (d_hi - d_lo)
+}
+
+// ---------------------------------------------------------------
+// Preconditions -- without these the three legs below are vacuous
+// ---------------------------------------------------------------
+
+/// The fixture has to carry a STRICTLY active inequality, an INACTIVE
+/// one, and an equality ahead of both. A leg that asserts "the row's
+/// multiplier derivative is unmoved" passes identically when the row
+/// stopped being active, so the branch each leg runs on is asserted
+/// here and named, exactly as
+/// [`the_fixture_carries_a_kink_and_an_untouchable_interior_variable`]
+/// does for fixture 1.
+#[test]
+fn the_ineq_fixture_carries_one_strictly_active_and_one_inactive_row() {
+    let s = solved_ineq(None, None, false);
+
+    // the pin is an equality: in the c block, not the d block
+    assert_eq!(
+        s.d_multiplier_rows(&[G_PIN]).unwrap()[0],
+        None,
+        "the pin row must have no inequality multiplier",
+    );
+    assert!(
+        s.g_multiplier_rows(&[G_PIN]).unwrap()[0].is_some(),
+        "the pin row must have an equality multiplier",
+    );
+    // and the two inequalities are the other way round
+    for g in [G_SLACK, G_CAP] {
+        assert_eq!(
+            s.g_multiplier_rows(&[g]).unwrap()[0],
+            None,
+            "row {g} must have no equality multiplier",
+        );
+        assert!(
+            s.d_multiplier_rows(&[g]).unwrap()[0].is_some(),
+            "row {g} must have an inequality multiplier",
+        );
+    }
+
+    // The two d rows must come back in g order, and adjacent: the
+    // fixture has n_x = 3, n_s = 2 and n_c = 1, so the `y_d` block
+    // starts at flat row 6 and the slack row (d position 0) precedes
+    // the cap row (d position 1). Spelled out rather than derived so a
+    // permuted `d_map` -- which every other test in this section would
+    // survive, since only one row is ever active -- fails here.
+    assert_eq!(
+        (d_row(&s, G_SLACK), d_row(&s, G_CAP)),
+        (6, 7),
+        "the d block must start at n_x + n_s + n_c = 6 and hold the          two inequalities in g order",
+    );
+
+    // the classifier -- the same gate `pounce.sensitivity`'s
+    // `mult_entry` uses -- has to agree about which is which
+    let rep = s
+        .reduced_row_activity(&[G_SLACK as usize, G_CAP as usize])
+        .unwrap();
+    assert_eq!(
+        rep.status[0], INACTIVE,
+        "g1 must be inactive, got status {}",
+        rep.status[0],
+    );
+    assert_eq!(
+        rep.status[1], STRONGLY_ACTIVE,
+        "g2 must be strictly active, got status {}",
+        rep.status[1],
+    );
+
+    // ... and the exact answer must be the one the legs then compare
+    // against, at unit scaling and with no fixed variable in front
+    let got = mult_slope(&s, G_CAP, 1.0e-3, 1.0e-6);
+    assert!(
+        (got - EXACT_DLAMBDA).abs() < 1e-6,
+        "d lambda/d delta = {got:e}, want {EXACT_DLAMBDA:e}",
+    );
+}
+
+/// An out-of-range g index is an ERROR from `d_multiplier_rows`, not a
+/// `None`.
+///
+/// With both accessors present, `None` from `g_multiplier_rows` means
+/// "ask the other one" -- which is exactly the fall-through
+/// `pounce.sensitivity`'s `mult_entry` performs. If the second call
+/// also answered `None` for a row that does not exist, a caller could
+/// not tell "no multiplier row" from "no such row", and the message it
+/// would print names the wrong reason. `g_multiplier_rows` keeps its
+/// historical `None` (nothing reads it as a complement), so the pair is
+/// asymmetric on purpose and the asymmetry is what closes the case.
+///
+/// The same shape as `x_primal_rows`, whose comment says it directly:
+/// out of range must not masquerade as "removed as fixed".
+#[test]
+fn an_out_of_range_row_is_an_error_not_an_equality() {
+    let s = solved_ineq(None, None, false);
+    let past_the_end = 3 as Index; // m = 3, so 0..=2 are the rows
+    assert_eq!(
+        s.g_multiplier_rows(&[past_the_end]).unwrap()[0],
+        None,
+        "g_multiplier_rows keeps its historical None for an unknown row",
+    );
+    let err = s
+        .d_multiplier_rows(&[past_the_end])
+        .expect_err("d_multiplier_rows must refuse an out-of-range row");
+    match err {
+        SolverError::BadShape { got, expected, .. } => {
+            assert_eq!((got, expected), (3, 3), "wrong BadShape payload: {err:?}");
+        }
+        other => panic!("wrong error for an out-of-range row: {other:?}"),
+    }
+    // and a negative index, which reaches the same guard by the other
+    // side of the comparison rather than by the `as usize` wrap
+    assert!(
+        s.d_multiplier_rows(&[-1]).is_err(),
+        "a negative row index must refuse too",
+    );
+}
+
+/// The `y_d` block is affine in `delta` for the same reason the primal
+/// block is, and by the same order of constant. The companion of
+/// [`the_step_is_affine_in_delta`] for the multiplier row: if the
+/// base-point term ever stops being negligible or stops being
+/// constant, this says so rather than leg 2 failing under a name that
+/// does not describe it.
+#[test]
+fn the_multiplier_step_is_affine_in_delta() {
+    let s = solved_ineq(None, None, false);
+    let row = d_row(&s, G_CAP);
+    let mut consts = Vec::new();
+    for d in [1.0e-3, 1.0e-5, 1.0e-7] {
+        let step = s.parametric_step_full(&[G_PIN], &[d]).unwrap();
+        consts.push(step[row] - EXACT_DLAMBDA * d);
+    }
+    let spread = consts.iter().fold(Number::NEG_INFINITY, |a, &b| a.max(b))
+        - consts.iter().fold(Number::INFINITY, |a, &b| a.min(b));
+    assert!(
+        consts.iter().all(|c| c.abs() < 1e-6),
+        "base-point term is not negligible: {consts:?}",
+    );
+    assert!(
+        spread < 1e-9,
+        "base-point term is not constant across delta: {consts:?}",
+    );
+}
+
+// ---------------------------------------------------------------
+// Leg 1 -- scaling
+// ---------------------------------------------------------------
+
+/// Leg 1 for `d_multiplier_rows`. The multiplier this row points at
+/// lives in the algorithm's frame: the row's own factor `dg` divides
+/// it, the objective factor multiplies it, and the pin's `delta` is
+/// scaled by the PIN row's factor -- three factors meeting in one
+/// ratio, the same shape as
+/// [`leg_scaling_the_reduced_row_curvature_is_unmoved_by_a_row_scaling`].
+/// The model's `d lambda / d delta` is a property of the model, so it
+/// must come out the same in either frame.
+///
+/// The factors are deliberately unequal across the three rows and the
+/// three columns: a conversion that used the wrong row's factor, or
+/// the pin's where the cap's belongs, is invisible when they agree.
+#[test]
+fn leg_scaling_the_multiplier_derivative_is_unmoved_by_the_change_of_variables() {
+    let base = solved_ineq(None, None, false);
+    let scaled = solved_ineq(
+        Some(vec![4.0, 0.25, 1.0e2]),
+        Some(vec![1.0e-1, 8.0, 5.0e1]),
+        false,
+    );
+
+    for (what, s) in [("base", &base), ("scaled", &scaled)] {
+        let got = mult_slope(s, G_CAP, 1.0e-3, 1.0e-6);
+        assert!(
+            (got - EXACT_DLAMBDA).abs() < 1e-6,
+            "{what}: d lambda/d delta = {got:e}, want {EXACT_DLAMBDA:e}",
+        );
+    }
+}
+
+/// The scaled arm has to be genuinely scaled, or the leg above is two
+/// runs of the same solve -- and nothing the sensitivity layer returns
+/// can show that, because every accessor on `Solver` already reports
+/// natural units. That is the property leg 1 asserts, so it cannot
+/// also be the evidence that leg 1 is live. Measured: `row_sigma`,
+/// documented as RAW, differs between the two arms by 4e-6 relative,
+/// which is floating-point divergence and not a factor of 50.
+///
+/// [`Solver::nlp_scaling`] is the honest witness: it reports the
+/// factors the IPM actually applied. It also cross-checks
+/// `full_to_d`'s ordering against a source that does not go through
+/// it -- the cap's factor has to land in the SECOND `d_scale` slot,
+/// the same position [`Solver::d_multiplier_rows`] claims for it.
+#[test]
+fn the_scaled_arm_of_the_multiplier_leg_is_actually_scaled() {
+    let base = solved_ineq(None, None, false);
+    let scaled = solved_ineq(
+        Some(vec![4.0, 0.25, 1.0e2]),
+        Some(vec![1.0e-1, 8.0, 5.0e1]),
+        false,
+    );
+
+    let (_, cb, db) = base.nlp_scaling().expect("nlp scaling");
+    assert!(
+        cb.is_none() && db.is_none() && base.variable_scaling().unwrap().is_none(),
+        "the base arm must run unscaled, got c={cb:?} d={db:?}",
+    );
+
+    let (_, cs, ds) = scaled.nlp_scaling().expect("nlp scaling");
+    let cs = cs.expect("scaled arm must carry equality row factors");
+    let ds = ds.expect("scaled arm must carry inequality row factors");
+    assert_eq!(cs, vec![1.0e-1], "the pin's factor, in the c block");
+    assert_eq!(
+        ds,
+        vec![8.0, 5.0e1],
+        "the two inequality factors in d-block order: the slack row \
+         first, the CAP second -- the position d_multiplier_rows claims \
+         for it, reached without going through full_to_d",
+    );
+    assert_eq!(
+        scaled.variable_scaling().unwrap(),
+        Some(vec![4.0, 0.25, 1.0e2]),
+        "the column factors must reach the algorithm too",
+    );
+}
+
+// ---------------------------------------------------------------
+// Leg 2 -- perturbation magnitude
+// ---------------------------------------------------------------
+
+/// Leg 2 for `d_multiplier_rows`, over eight orders on both sides.
+/// The cap is strictly active, so unlike a kink the two sides agree --
+/// which is the property that makes the row answerable at all, and is
+/// therefore the thing to assert rather than to assume.
+#[test]
+fn leg_magnitude_the_multiplier_derivative_does_not_depend_on_the_step_size() {
+    let s = solved_ineq(None, None, false);
+    for sign in [1.0, -1.0] {
+        for (hi, lo) in [
+            (1.0e-2, 1.0e-3),
+            (1.0e-4, 1.0e-5),
+            (1.0e-6, 1.0e-7),
+            (1.0e-8, 1.0e-9),
+        ] {
+            let got = mult_slope(&s, G_CAP, sign * hi, sign * lo);
+            assert!(
+                (got - EXACT_DLAMBDA).abs() < 1e-5,
+                "sign {sign:+}, delta {hi:e}..{lo:e}: d lambda/d delta = \
+                 {got:e}, want {EXACT_DLAMBDA:e}",
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------
+// Leg 3 -- a fixed variable ahead of the row
+// ---------------------------------------------------------------
+
+/// Leg 3 for `d_multiplier_rows`, and the leg the accessor is most
+/// exposed to. Its answer is `n_x + n_s + n_c + full_to_d[g]`, so it
+/// reads THREE block dimensions and one index map, and a fixed
+/// variable removed by `make_parameter` moves `n_x` under it. Getting
+/// `n_x` from the wrong place -- the user's variable count rather than
+/// the factor's -- returns a neighbouring block's row, which is
+/// gh#450's hazard one block over.
+///
+/// The map itself is checked in the same breath: `full_to_d` is the
+/// complement of `full_to_c`, so the cap's d-block position is its g
+/// index minus the one equality ahead of it. Asserting the row's
+/// numeric VALUE rather than its index is what makes that check bite
+/// -- an off-by-one lands in the slack row's multiplier, whose
+/// derivative is zero, not in an out-of-range panic.
+#[test]
+fn leg_fixed_the_multiplier_derivative_is_unmoved_by_a_fixed_variable_ahead() {
+    let plain = solved_ineq(None, None, false);
+    let fixed = solved_ineq(None, None, true);
+
+    // the index spaces really do diverge, or the leg is two runs of
+    // the same solve
+    let dims_plain = plain.block_dims().expect("block dims");
+    let dims_fixed = fixed.block_dims().expect("block dims");
+    assert_eq!(
+        dims_plain[0] + 1,
+        dims_fixed[0] + 1,
+        "sanity: both solves keep three free columns",
+    );
+    assert_eq!(
+        dims_plain[0], dims_fixed[0],
+        "make_parameter must remove the fixed column, leaving n_x equal",
+    );
+
+    for (what, s) in [("plain", &plain), ("fixed", &fixed)] {
+        // the cap's d-block position is 1, not its g index 2
+        let row = d_row(s, G_CAP);
+        let dims = s.block_dims().expect("block dims");
+        assert_eq!(
+            row,
+            dims[0] + dims[1] + dims[2] + 1,
+            "{what}: the cap's row must be the SECOND entry of the y_d \
+             block (one equality is ahead of it in g)",
+        );
+        let got = mult_slope(s, G_CAP, 1.0e-3, 1.0e-6);
+        assert!(
+            (got - EXACT_DLAMBDA).abs() < 1e-6,
+            "{what}: d lambda/d delta = {got:e}, want {EXACT_DLAMBDA:e}",
+        );
+    }
+}
+
+/// The three legs compose: scaled AND with a fixed variable in front.
+/// Each leg alone can pass while the two conversions cancel only in
+/// isolation; fixture 1 has [`the_legs_compose_at_the_fixed_and_scaled_corner`]
+/// for the same reason.
+#[test]
+fn the_multiplier_legs_compose_at_the_fixed_and_scaled_corner() {
+    let s = solved_ineq(
+        Some(vec![2.0, 4.0, 0.25, 1.0e2]),
+        Some(vec![1.0e-1, 8.0, 5.0e1]),
+        true,
+    );
+    let got = mult_slope(&s, G_CAP, 1.0e-3, 1.0e-6);
+    assert!(
+        (got - EXACT_DLAMBDA).abs() < 1e-6,
+        "corner: d lambda/d delta = {got:e}, want {EXACT_DLAMBDA:e}",
+    );
 }

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -280,12 +280,81 @@ below. There is one exception to the warning, a bound written on a declared Para
 [Declared Params in variable bounds](#declared-params-in-variable-bounds)
 below. `sens_solution_report()` measures the same step and reports where the
 active set changes along it, covered in
-[What the step did about the bounds](#what-the-step-did-about-the-bounds-sens_solution_report). Multiplier sensitivities are available for equality constraints.
+[What the step did about the bounds](#what-the-step-did-about-the-bounds-sens_solution_report). Multiplier sensitivities are available for equality constraints unconditionally and for
+strictly active inequalities, covered in
+[Multipliers](#multipliers-an-error-bar-on-a-shadow-price) below.
 Models without declarations solve through the ordinary AMPL/CLI path,
 unchanged. See
 [`python/notebooks/25_pyomo_sensitivity.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/25_pyomo_sensitivity.ipynb)
 for a worked optimal-control example (initial conditions as
 parameters; the first-move gradient IS the NMPC feedback gain).
+
+### Multipliers: an error bar on a shadow price
+
+`of=` a `Constraint` gives the derivative of that row's Lagrange
+multiplier — the error bar on a shadow price, once `Σ_θ` is in hand.
+
+An **equality** row answers unconditionally: its multiplier is a
+coordinate of the KKT system being differentiated, so `dλ/dp` is the
+same backsolve as `dx*/dp`, one block over.
+
+An **inequality** row answers only where its multiplier is a
+differentiable function of the parameters, which is where the row is
+*strictly complementary* — active with a multiplier bounded away from
+zero. There are three regimes and only one of them has a two-sided
+answer to give:
+
+| regime | slack, multiplier | `dλ/dp` |
+|---|---|---|
+| strictly active | `s ≈ 0`, `λ > 0` | the row behaves as an equality over a neighbourhood; **answered** |
+| inactive | `s > 0`, `λ ≈ 0` | `λ` is pinned at zero over a neighbourhood, so the derivative exists and is zero — but there is no KKT row to return, and returning `0.0` would be indistinguishable from a computed answer; **refused, naming the regime** |
+| weakly active (a kink) | `s ≈ 0` *and* `λ ≈ 0` | the two one-sided derivatives differ, so no two-sided `dλ/dp` exists; **refused** |
+
+```python
+sens_jacobian(m.cap, wrt=m.p)     # dλ_cap/dp, if the cap is strictly active
+```
+
+The refusal messages name which regime the row is in, because the three
+call for different things from the caller: an inactive row's answer is
+genuinely zero, a kink needs a *direction* (`sens_solution()` /
+`Solver.parametric_step_full` still report a one-sided step for a chosen
+perturbation), and only the strictly active case has an unqualified
+number.
+
+Before this (gh#910), an inequality target was refused outright, and the
+workaround was to rewrite a known-active cap as an equality `g(x) == b`. That still
+works and is still the right move when you *want* the row held; it is no
+longer necessary to get the derivative.
+
+**Which classifier gates it.** The gate is `Solver.reduced_row_activity()`,
+not `classify_activity()`. Not because the directional classifier could
+*admit* a kink — it cannot: a row's reduced curvature is never larger than
+its directional one, so the reduced ratio is never below the directional
+ratio, and `strongly_active` is the high-ratio tail of both. What the
+directional normalizer gets wrong is the *refusal reason*. The ratio it
+reports for a genuine kink is `reduced / directional`
+([`ambiguous` is not "probably not a kink"](#ambiguous-is-not-probably-not-a-kink)),
+so as the row's coordinate couples to the rest of the free space at
+strength `ρ` the class slides:
+
+| `ρ` | `classify_activity()` | `reduced_row_activity()` |
+|---|---|---|
+| `1` | `weakly_active` | `weakly_active` |
+| `1e-2` | `ambiguous` | `weakly_active` |
+| `1e-4` | `ambiguous` | `weakly_active` |
+| `1e-6` | **`inactive`** | `weakly_active` |
+
+`inactive` is the one class whose derivative a caller may legitimately
+read as a structural zero. Gating on the directional ratio would
+therefore not *decline* to answer about a tight cap's shadow price — it
+would answer "it does not move", which is wrong. Coupling this strong is
+routine on a collocation model.
+`reduced_row_activity()` costs one backsolve per row asked about and needs
+`bound_relax_factor = 0`, which the sensitivity session already sets.
+
+Sign convention is unchanged: Pyomo's `m.dual` holds the AMPL marginal
+`−λ`, and `sens_jacobian` negates so its answer finite-differences against
+`m.dual` (gh#271) — for inequality rows the same way as for equalities.
 
 ### Bending the estimate around a bound: `mode="fix_relax"`
 
@@ -1728,7 +1797,7 @@ replaces constraints even if they don't contain the parameters."*
 | Cost per query | model clone + full constraint rebuild + subprocess + file parse | declare once; the KKT factor is retained and each query is one backsolve |
 | Perturbation values | required **before** the solve | not required; ask for any `Δp` afterwards |
 | `dx*/dp` | ✅ `get_dsdp`, whole matrix | ✅ `sens_jacobian(of, wrt=…)`, scalar or `Jacobian` / DataFrame |
-| `dλ/dp`, multiplier sensitivity | ❌ | ✅ pass an equality `Constraint` as `of=` |
+| `dλ/dp`, multiplier sensitivity | ❌ | ✅ pass a `Constraint` as `of=` (equalities unconditionally; inequalities where strictly active) |
 | Total `df/dp` | ❌ | ✅ `sens_jacobian(m.obj, wrt=p)`, explicit partial plus the path through `x*` |
 | Declared `Param` in a variable **bound** | ❌ substitution walks constraints and the objective only, so the derivative reads exactly `0.0` | ✅ rewritten to a row at declaration — see [Declared Params in variable bounds](#declared-params-in-variable-bounds) |
 | Bound crossing (fix-relax) | sIPOPT implements `sens_boundcheck`, but the toolbox never sets it — only `run_sens=yes` | ✅ `mode="fix_relax"`, both the pin and the release half |

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1366,9 +1366,10 @@ def _param_pin(session, param_data):
 
 class Jacobian:
     """Derivatives d(target*)/d(param) for one or more targets/parameters.
-    Targets are variables (primal sensitivities), equality constraints
-    (multiplier sensitivities), or the objective (the total derivative
-    df/dp).
+    Targets are variables (primal sensitivities), constraints
+    (multiplier sensitivities -- an equality unconditionally, an
+    inequality only where it is STRICTLY active), or the objective
+    (the total derivative df/dp).
 
     Access with g[target_data, param_data] (either order); when one side is
     a single component, g[data] works. to_dataframe() gives the full
@@ -1469,11 +1470,20 @@ def sens_jacobian(of=None, *, wrt, max_pdpert=None):
     """d(of*)/d(wrt).
 
     of: what the derivative is about (the target rows) -- a Var
-    (primal sensitivity), an equality Constraint (its multiplier's
+    (primal sensitivity), a Constraint (its multiplier's
     sensitivity), or the model's Objective (the TOTAL derivative
     df/dp, gh#878); data object or container; omit for all model
     variables. wrt: the differentiation variable, a declared Param
     (data or container).
+
+    An INEQUALITY constraint target answers only where its multiplier
+    is a differentiable function of the parameters, which is where the
+    row is strictly complementary -- active with a multiplier bounded
+    away from zero (gh#910). An inactive row is refused (its
+    multiplier is zero over a neighbourhood, so every derivative of it
+    is structurally zero and there is no KKT row to differentiate) and
+    so is a kink, where the two one-sided derivatives differ. Both
+    refusals name the regime. Equality targets are unconditional.
 
     The objective target answers
 

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -68,6 +68,179 @@ def test_sens_jacobian_multiplier_matches_finite_difference(solved):
         "and pyomo duals")
 
 
+# ── inequality multipliers (jkitchin/pounce#910) ─────────────────────────────
+#
+# A multiplier sensitivity used to be equality-only, which forced a
+# user who knew a cap was active to rewrite it as an equality to get an
+# error bar on its shadow price. The mathematics never needed that: a
+# strictly active inequality behaves exactly like an equality over a
+# neighbourhood of the solved point, and its multiplier's derivative is
+# the same KKT back-solve. What was missing was the map from a
+# user-space row to the `y_d` block, and a gate saying when the number
+# means anything.
+#
+#     min 0.5 x^2 + 0.5 y^2 - x - y   s.t.   x + y <= cap
+#
+# has its unconstrained optimum at (1, 1), so the cap binds below 2.
+# On it, x = y = cap/2 and the multiplier is `1 - cap/2`, exactly:
+#
+#     d lambda / d cap = -1/2
+#
+# and Pyomo's `dual` is the AMPL marginal `-lambda` (gh#271), so the
+# number `sens_jacobian` reports is `+1/2`. At cap = 2 the multiplier
+# is zero with the row still tight -- a kink -- and above 2 the row is
+# inactive.
+
+CAP_EXACT = 0.5
+
+
+def build_cap(cap=1.0):
+    m = pyo.ConcreteModel()
+    m.cap = pyo.Param(initialize=cap, mutable=True)
+    m.x = pyo.Var(initialize=0.2)
+    m.y = pyo.Var(initialize=0.2)
+    m.c = pyo.Constraint(expr=m.x + m.y <= m.cap)
+    m.obj = pyo.Objective(expr=0.5 * m.x**2 + 0.5 * m.y**2 - m.x - m.y)
+    return m
+
+
+def solve_declared(m, **opts):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        declare_sens_param(m.cap)
+        pyo.SolverFactory("pounce").solve(
+            m, options=dict({"tol": 1e-10}, **opts))
+    return m
+
+
+def test_a_strictly_active_inequality_multiplier_matches_finite_difference():
+    m = solve_declared(build_cap(1.0))
+    g = sens_jacobian(m.c, wrt=m.cap)
+    assert g == pytest.approx(CAP_EXACT, abs=1e-6)
+
+    hi = solve_plain(build_cap(1.0 + FD_H))
+    lo = solve_plain(build_cap(1.0 - FD_H))
+    fd = (hi.dual[hi.c] - lo.dual[lo.c]) / (2 * FD_H)
+    assert g == pytest.approx(fd, abs=1e-4), (
+        "sign convention mismatch between parametric_step_full's y_d block "
+        "and pyomo duals -- the y_c block's convention has to carry over")
+
+
+def test_the_inequality_answer_is_the_one_the_equality_rewrite_gives():
+    """The workaround this replaces has to agree with it.
+
+    Rewriting a known-active cap as `x + y == cap` is what a user had
+    to do before, and it is a different KKT block reached by a
+    different map. Same model, same number.
+    """
+    mi = solve_declared(build_cap(1.0))
+    ineq = sens_jacobian(mi.c, wrt=mi.cap)
+
+    m = build_cap(1.0)
+    m.del_component(m.c)
+    m.c = pyo.Constraint(expr=m.x + m.y == m.cap)
+    me = solve_declared(m)
+    eq = sens_jacobian(me.c, wrt=me.cap)
+
+    assert ineq == pytest.approx(eq, abs=1e-6)
+
+
+def test_an_inactive_inequality_is_refused_as_structurally_zero():
+    """`lambda` is pinned at zero over a neighbourhood, so there is no
+    KKT row to differentiate -- the refusal has to say which of the
+    three regimes it is, not just that it declined."""
+    m = solve_declared(build_cap(9.0))
+    with pytest.raises(ValueError, match="structurally"):
+        sens_jacobian(m.c, wrt=m.cap)
+
+
+def test_a_row_kink_is_refused_because_no_two_sided_derivative_exists():
+    """cap = 2 puts the row exactly at the unconstrained optimum:
+    tight, with a multiplier at the barrier floor. Raising the cap
+    leaves `lambda` at zero, lowering it moves at -1/2, so the two
+    one-sided derivatives differ and no two-sided one exists."""
+    m = solve_declared(build_cap(2.0))
+    with pytest.raises(ValueError, match="two-sided"):
+        sens_jacobian(m.c, wrt=m.cap)
+
+
+def build_coupled_kink(rho):
+    """A row kink whose coordinate is coupled to the free space.
+
+    ``min 0.5 x^2 + c x y + 0.5 y^2 - p x / 2   s.t.  x <= 0`` with
+    ``c = sqrt(1 - rho)``. At ``p = 0`` the row is tight with a
+    vanishing multiplier -- a kink by construction -- and `rho` is the
+    curvature along the row's normal AFTER `y` re-optimizes, i.e. how
+    strongly the coordinate is coupled.
+    """
+    import math
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=0.0, mutable=True)
+    m.x = pyo.Var(initialize=0.3)
+    m.y = pyo.Var(initialize=0.0)
+    m.c = pyo.Constraint(expr=m.x <= 0.0)
+    m.obj = pyo.Objective(
+        expr=0.5 * m.x**2 + math.sqrt(1.0 - rho) * m.x * m.y
+        + 0.5 * m.y**2 - 0.5 * m.p * m.x)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        declare_sens_param(m.p)
+        pyo.SolverFactory("pounce").solve(m, options={"tol": 1e-9})
+    return m
+
+
+def _row_and_session(m):
+    session = m.__dict__["_pounce_sens"].session
+    name = session.con_alias.get("c", "c")
+    return session, session._con_row[name]
+
+
+def test_a_coupled_row_kink_is_refused_where_classify_reads_it_INACTIVE():
+    """Why the gate is `reduced_row_activity` and not `classify_activity`.
+
+    Neither can *admit* a kink: a row's reduced curvature is no larger
+    than the directional one `classify_activity` divides by, so the
+    reduced ratio is the larger of the two and STRONGLY_ACTIVE is the
+    high-ratio tail. What the directional normalizer gets wrong is the
+    refusal. A genuine kink's ratio there is `reduced/directional`,
+    which slides down as the row couples to the remaining free space:
+    AMBIGUOUS by `rho = 1e-2`, and INACTIVE by `1e-6`. Measured on this
+    fixture, both verdicts on the same solve.
+
+    INACTIVE is the one class whose derivative genuinely is zero, so
+    reading it off the directional normalizer would tell a user the
+    shadow price of a *tight* cap does not move -- a wrong answer, not
+    a refusal. The reduced normalizer puts a kink at ratio 1 whatever
+    the coupling.
+    """
+    m = build_coupled_kink(1e-6)
+    session, g = _row_and_session(m)
+
+    assert session.solver.classify_activity()["row_status"][g] == "inactive"
+    assert (session.solver.reduced_row_activity([g])["status"][0]
+            == "weakly_active")
+
+    with pytest.raises(ValueError, match="two-sided"):
+        sens_jacobian(m.c, wrt=m.p)
+
+
+def test_the_coupled_fixture_is_a_kink_at_every_coupling_it_is_asked_at():
+    """The premise of the test above, swept: `reduced_row_activity`
+    certifies the same kink at four couplings while
+    `classify_activity`'s verdict walks from WEAKLY_ACTIVE to INACTIVE.
+    Without this the test above could pass on a fixture that stopped
+    being a kink at all."""
+    seen = []
+    for rho in (1.0, 1e-2, 1e-4, 1e-6):
+        m = build_coupled_kink(rho)
+        session, g = _row_and_session(m)
+        assert (session.solver.reduced_row_activity([g])["status"][0]
+                == "weakly_active"), f"rho={rho:g} stopped being a kink"
+        seen.append(session.solver.classify_activity()["row_status"][g])
+    assert seen == ["weakly_active", "ambiguous", "ambiguous", "inactive"], (
+        f"the directional normalizer's walk moved: {seen}")
+
+
 def test_sens_solution_matches_resolve(solved):
     m = solved
     est = sens_solution(m, [(m.p, 2.2), (m.q, 0.9)])
@@ -534,12 +707,26 @@ def test_both_bounds_rewritten_are_both_recorded():
 # without needing the solver. The value-correctness of the fan-out path is
 # already covered by test_sens_jacobian_object_for_containers.
 
-def _fake_session(names, cons, row_offset=1000, **kw):
+def _fake_session(names, cons, row_offset=1000, d_row=None, status=None,
+                  **kw):
+    """A _Session over a stub solver.
+
+    `row_offset=None` makes every row read as an inequality, i.e. the
+    equality lookup refuses; `d_row` and `status` then say what the
+    inequality path finds -- the KKT row and the
+    `reduced_row_activity` verdict `mult_entry` gates on.
+    """
     from pyomo_pounce.sens import _Session
 
     class _Solver:
         def multiplier_rows(self, gs):
             return [None if row_offset is None else gs[0] + row_offset]
+
+        def d_multiplier_rows(self, gs):
+            return [None if d_row is None else gs[0] + d_row]
+
+        def reduced_row_activity(self, gs):
+            return {"status": [status], "ratio": [0.5]}
 
     return _Session(None, None, _Solver(), names, cons, {},
                     {"orig.c": cons[-1]}, **kw)
@@ -575,9 +762,87 @@ def test_unknown_name_raises_value_error_not_key_error():
         s.mult_entry("nope")
 
 
-def test_inequality_multiplier_error_is_unchanged():
-    s = _fake_session(["a"], ["c"], row_offset=None)
-    with pytest.raises(ValueError, match="equality constraints"):
+# ── the inequality multiplier gate (jkitchin/pounce#910) ─────────────────────
+#
+# An inequality's multiplier is differentiable only where the row is
+# STRICTLY active. `mult_entry` answers there and refuses in the other
+# two regimes, and the refusal has to name which one -- "inactive" and
+# "kink" are different facts about the model and a caller does
+# different things with them.
+#
+# The gate reads `reduced_row_activity`, not `classify_activity`, and
+# the reason is not the one it looks like. Neither classifier can
+# ADMIT a kink: a row's reduced curvature is never larger than its
+# directional one, so the reduced ratio is never below the directional
+# ratio, and `strongly_active` is the high-ratio tail of both. What
+# the directional normalizer gets wrong is the REFUSAL REASON. Its
+# ratio for a genuine kink is reduced/directional (gh#804), so as the
+# row couples to the rest of the free space at strength rho the class
+# slides -- measured, in
+# `test_a_coupled_row_kink_is_refused_where_classify_reads_it_INACTIVE`:
+#
+#     rho     classify_activity()   reduced_row_activity()
+#     1       weakly_active         weakly_active
+#     1e-2    ambiguous             weakly_active
+#     1e-4    ambiguous             weakly_active
+#     1e-6    INACTIVE              weakly_active
+#
+# `inactive` is the one class a caller may read as a structural zero,
+# so the directional gate would not decline to answer about a tight
+# cap -- it would answer "it does not move". Reading an activity class
+# as a proxy for kink-ness is the inference that shipped gh#756.
+
+def test_a_strictly_active_inequality_gets_its_multiplier_row():
+    s = _fake_session(["a"], ["c"], row_offset=None, d_row=500,
+                      status="strongly_active")
+    assert s.mult_entry("c") == 500
+
+
+def test_an_inactive_inequality_is_refused_as_structurally_zero():
+    s = _fake_session(["a"], ["c"], row_offset=None, d_row=500,
+                      status="inactive")
+    with pytest.raises(ValueError, match="structurally"):
+        s.mult_entry("c")
+
+
+@pytest.mark.parametrize("status", ["weakly_active", "ambiguous"])
+def test_a_kink_is_refused_because_no_two_sided_derivative_exists(status):
+    """AMBIGUOUS refuses too: it is not "probably not a kink"."""
+    s = _fake_session(["a"], ["c"], row_offset=None, d_row=500,
+                      status=status)
+    with pytest.raises(ValueError, match="two-sided"):
+        s.mult_entry("c")
+
+
+def test_a_row_in_neither_block_asserts_rather_than_indexing_a_None():
+    """Both accessors answering None is unreachable, and says so.
+
+    This test used to assert that such a row is "a free row, which has
+    no multiplier at all". That was false, and the message it pinned
+    said so out loud. `classify_bounds` puts every row in exactly one
+    of the two blocks -- a `-inf <= g <= inf` row included, which lands
+    in `d` with empty bound lists and is then refused by the gate below
+    as inactive, which is the truth: a free row's multiplier is zero
+    always. So there is no model that reaches this branch, and the stub
+    has to fabricate it.
+
+    It is kept because the two accessors are separately maintained: a
+    future split that grows a third case should land here loudly rather
+    than index the step vector with a None.
+
+    The premise -- that the split really is a partition -- cannot be
+    checked from here: Pyomo refuses to construct a free constraint at
+    all (`pyo.inequality(None, x, None)` raises), so no end-to-end
+    model reaches this branch to be tested against. It is pinned where
+    it is decided instead, in `crates/pounce-nlp/src/tnlp_adapter.rs`:
+    `every_constraint_row_lands_in_exactly_one_of_c_and_d`,
+    `a_free_row_gets_a_d_slot_with_no_bound_on_either_side`, and
+    `full_to_d_is_the_positional_inverse_of_d_map`. Without those this
+    stub is unfalsifiable -- it can only show what happens IF both
+    accessors answer None, never that nothing makes them.
+    """
+    s = _fake_session(["a"], ["c"], row_offset=None, d_row=None)
+    with pytest.raises(ValueError, match="should be impossible"):
         s.mult_entry("c")
 
 

--- a/python/pounce/sensitivity/_session.py
+++ b/python/pounce/sensitivity/_session.py
@@ -239,7 +239,46 @@ class SensSession:
                 f"{name}: not a variable of the solved model") from None
 
     def mult_entry(self, con_name):
-        """The KKT row of constraint `con_name`'s multiplier."""
+        """The KKT row of constraint `con_name`'s multiplier.
+
+        Equality rows answer unconditionally. An **inequality** row
+        (pounce#910) answers only where its multiplier is a
+        differentiable function of the parameters, which is where the
+        row is *strictly* complementary — active with a multiplier bounded away from
+        zero. The three regimes and why only one of them has an answer
+        to give:
+
+        * **strictly active** (`s ≈ 0`, `λ > 0`) — the row behaves
+          exactly like an equality over a neighbourhood of the solved
+          point, and `dλ/dp` is the same KKT back-solve. Answered.
+        * **inactive** (`s > 0`, `λ ≈ 0`) — `λ` is pinned at zero over
+          a neighbourhood, so the derivative exists and is *zero*.
+          Refused rather than returned as a row, because there is no
+          KKT row to return: an inactive row's multiplier is not a
+          free coordinate of the system being differentiated.
+        * **weakly active / kink** (`s ≈ 0` *and* `λ ≈ 0`) — the two
+          one-sided derivatives differ, so no two-sided `dλ/dp`
+          exists. Refused.
+
+        The gate is :meth:`Solver.reduced_row_activity`, not
+        `classify_activity`. Neither of them can *admit* a kink: a
+        row's reduced curvature is never larger than its directional
+        one, so the reduced ratio is never smaller than the
+        directional ratio, and `"strongly_active"` is the high-ratio
+        tail of both. What the directional normalizer gets wrong is
+        the **refusal reason**. Swept over a genuine row kink whose
+        coordinate is coupled to the rest of the free space at
+        strength `rho`, `classify_activity` reads it
+        `"weakly_active"` at `rho = 1`, `"ambiguous"` by `1e-2`, and
+        `"inactive"` by `1e-6`, while `reduced_row_activity` holds
+        `"weakly_active"` throughout (pounce#804). `"inactive"` is
+        the one class whose derivative a caller may legitimately
+        treat as a structural zero, so gating on the directional
+        ratio would tell the holder of a *tight* cap that its shadow
+        price does not move -- a wrong answer wearing a refusal's
+        clothes. Reading an activity class as a proxy for kink-ness
+        is the inference that shipped pounce#756.
+        """
         # a caller whose solve ran on a rewritten copy translates the
         # original name to the copy's row
         con_name = self.con_alias.get(con_name, con_name)
@@ -249,11 +288,64 @@ class SensSession:
             raise ValueError(
                 f"{con_name}: not a constraint of the solved model") from None
         row = self.solver.multiplier_rows([g])[0]
+        if row is not None:
+            return row
+        row = self.solver.d_multiplier_rows([g])[0]
         if row is None:
+            # Unreachable: the c/d split puts every row in exactly one
+            # block, a row with no finite bound on either side included
+            # (it lands in `d` with an empty bound list, and the gate
+            # below then refuses it as inactive, which is the truth --
+            # a free row's multiplier is zero always). Kept because the
+            # two accessors are separately maintained and a future
+            # split that grows a third case should say so here rather
+            # than index the step with a None.
             raise ValueError(
-                f"{con_name}: multiplier sensitivities are only available "
-                "for equality constraints")
+                f"{con_name}: neither the equality nor the inequality "
+                "multiplier block claims constraint row "
+                f"{g}, which should be impossible; please report this.")
+        self._require_strict_complementarity(con_name, g)
         return row
+
+    def _require_strict_complementarity(self, con_name, g):
+        """Raise unless inequality row `g` is strictly active.
+
+        Split out of :meth:`mult_entry` so the regime message is one
+        thing and the row lookup another; see that method for why the
+        gate reads the *reduced* classification.
+        """
+        try:
+            rep = self.solver.reduced_row_activity([g])
+        except Exception as exc:  # BadOptions, a failed back-solve
+            raise ValueError(
+                f"{con_name}: multiplier sensitivities on an inequality "
+                "need its activity classified, and that failed: "
+                f"{exc}") from None
+        status = rep["status"][0]
+        if status == "strongly_active":
+            return
+        if status == "inactive":
+            raise ValueError(
+                f"{con_name}: the constraint is inactive at the solved "
+                "point, so its multiplier is zero over a neighbourhood "
+                "and every parameter derivative of it is structurally "
+                "zero. There is no KKT row to differentiate.")
+        if status in ("weakly_active", "ambiguous"):
+            ratio = float(rep["ratio"][0])
+            what = ("a kink" if status == "weakly_active"
+                    else "possibly a kink")
+            raise ValueError(
+                f"{con_name}: the constraint is {what} at the solved point "
+                f"(reduced_row_activity says {status!r}, ratio {ratio:.3g}) "
+                "— active with a multiplier at the barrier floor. The two "
+                "one-sided derivatives of its multiplier differ, so no "
+                "two-sided dlambda/dp exists. Solver.parametric_step_full "
+                "still reports a one-sided step for a chosen "
+                "perturbation direction if that is the question.")
+        raise ValueError(
+            f"{con_name}: multiplier sensitivities on an inequality need "
+            "the row strictly active, and reduced_row_activity reports "
+            f"{status!r}.")
 
 
 def user_row_names(session):


### PR DESCRIPTION
`sens_jacobian(of=<Constraint>)` gave `dλ/dp` for equality rows only. An
inequality target was refused outright, even where the row is strictly active
at the solved point — the case where the multiplier is an ordinary
differentiable function of the parameters and the derivative is the same
backsolve an equality gets, one block over.

That is the case users reach for. The shadow price you want an error bar on is
usually a **cap**: a safety limit, a capacity, a purity spec. Those are written
as inequalities. The only workaround was to know the row was active and rewrite
it as `g(x) == b` before solving — which changes the model, and is only correct
if the row really does stay active over the perturbation being asked about.

Fixes #910

## What was actually missing

API surface, not mathematics. The compound KKT vector is
`(x, s, y_c, y_d, z_l, z_u, v_l, v_u)`, and `parametric_step_full` already
returns all of it, `y_d` included. What was missing was the **map**:
`BoundClassification::full_to_c` returns `-1` for an inequality and there was no
counterpart, so the only thing the layer could do with one was refuse.

| layer | added |
|---|---|
| `pounce-nlp` | `BoundClassification::full_to_d` — the O(1) inverse of `d_map`, the exact complement of `full_to_c` |
| `pounce-nlp` | `IpoptNlp::full_g_to_d_block` (default `None`), overridden by `OrigIpoptNlp` |
| `pounce-sensitivity` | `PdSensBacksolver::full_g_to_d_block`, `Solver::d_multiplier_rows` |
| `pounce-py` | the `d_multiplier_rows` PyO3 binding |
| `python/pounce/sensitivity` | the gate, in `_session.py`'s `mult_entry` |

**Not a trajectory change.** Nothing on the solve path reads `full_to_d`;
`classify_bounds` gains one `vec![-1; ng]` and one store per inequality row, and
no iterate moves. The only reader is the new accessor
(`grep -rn 'full_to_d\|full_g_to_d_block\|d_multiplier_rows' --include='*.rs'`
returns the definitions plus one call site in `_session.py`). No fixture sweep.

## The three regimes, and why two are refused

An inequality's multiplier is differentiable only where the row is *strictly
complementary*.

| regime | slack, multiplier | `dλ/dp` |
|---|---|---|
| strictly active | `s ≈ 0`, `λ > 0` | behaves as an equality over a neighbourhood; **answered** |
| inactive | `s > 0`, `λ ≈ 0` | zero over a neighbourhood — but there is no KKT row to differentiate, and a returned `0.0` would be indistinguishable from a computed one; **refused, naming the regime** |
| weakly active (kink) | `s ≈ 0` *and* `λ ≈ 0` | two one-sided derivatives that differ; **refused** |

The `y_d` entry holds a number in all three cases. In the third it is whichever
side the factorization happened to land on — the "silently wrong while reporting
success" class, with nothing to warn on. So the map ships with a gate, and the
refusals name the regime, because the three call for different things from the
caller: an inactive row's answer really is zero, and a kink needs a *direction*
(`sens_solution()` and `parametric_step_full` still give a one-sided step for
one).

## Which classifier gates it — measured, not argued

`reduced_row_activity()`, not `classify_activity()`. The reason is not the one
it looks like.

**Neither classifier can *admit* a kink.** A row's reduced curvature is never
larger than its directional one, so the reduced ratio is never below the
directional ratio, and `strongly_active` is the high-ratio tail of both.

What the directional normalizer gets wrong is the **refusal reason**. The ratio
it reports for a genuine kink is `reduced / directional` (#804), so as the row's
coordinate couples to the rest of the free space at strength `rho` the class
slides. Swept on a fixture whose row is a kink at every `rho`:

| `rho` | `classify_activity()` | `reduced_row_activity()` |
|---|---|---|
| `1` | `weakly_active` | `weakly_active` |
| `1e-2` | `ambiguous` | `weakly_active` |
| `1e-4` | `ambiguous` | `weakly_active` |
| `1e-6` | **`inactive`** | `weakly_active` |

`inactive` is the one class whose derivative a caller may legitimately read as a
structural zero. So gating on the directional ratio would not *decline* to
answer about a tight cap's shadow price — it would answer "it does not move",
which is a wrong answer wearing a refusal's clothes. Coupling that strong is
routine on a collocation model. Reading an activity class as a proxy for
kink-ness is the inference that shipped #756.

That sweep is `test_a_coupled_row_kink_is_refused_where_classify_reads_it_INACTIVE`,
with `test_the_coupled_fixture_is_a_kink_at_every_coupling_it_is_asked_at` as its
premise so it cannot pass on a fixture that stopped being a kink.

## One asymmetry, on purpose

`d_multiplier_rows` **errors** on an out-of-range index where
`g_multiplier_rows` returns `None`. With both accessors present, `None` from the
first means "ask the other", which is exactly the fall-through `mult_entry`
performs — so if the second also answered `None` for a row that does not exist,
a caller could not tell "that row is an equality" from "that row does not
exist", and the message it prints would name the wrong reason. Same shape as
`x_primal_rows`, whose comment already says it: out of range must not
masquerade as "removed as fixed". Pinned by
`an_out_of_range_row_is_an_error_not_an_equality`.

While there: `mult_entry`'s old both-`None` message claimed "the constraint has
no finite bound on either side". That is false — `classify_bounds` puts every
row in exactly one block, a free row included (it lands in `d`, and the gate
then refuses it as inactive, which is the truth: a free row's multiplier is zero
always). It now says what it is, an unreachable assertion.

That premise is pinned where it is decided, in `tnlp_adapter.rs`, not asserted
downstream: `every_constraint_row_lands_in_exactly_one_of_c_and_d` (over
equality / `<=`-only / `>=`-only / range / free rows),
`a_free_row_gets_a_d_slot_with_no_bound_on_either_side`, and
`full_to_d_is_the_positional_inverse_of_d_map`. It has to live there because
**Pyomo cannot construct a free constraint at all** — `pyo.inequality(None, x,
None)` raises — so no end-to-end model reaches the branch, and the stub covering
it can only show what happens *if* both accessors answer `None`, never that
nothing makes them.

## Tests

**A third fixture in `sens_invariance_legs.rs`**, per the "a new public accessor
gets a row in each leg" rule in `CLAUDE.md`:

```
min  0.5x² + 0.5y² − x − y     [+ 0.5(xf − 0.7)²]
s.t. g0:  p == 0                (the pin)
     g1:  x − y <= 5            (never active)
     g2:  x + y − p <= 1        (strictly active, λ = 1/2)
```

The pin equality goes **first** and an inactive decoy **second**, so the active
row's g index (2), its d-block position (1) and its c-block position (which does
not exist) are three different numbers. `dλ/dδ = −1/2` exactly, from the model —
an outside number, not one the machinery produced.

Seven tests: a precondition asserting the branch each leg runs on (and pinning
both d rows to their exact flat positions, so a permuted `d_map` fails even
though only one row is active), an affine-in-`delta` companion, a row in each of
the three legs, the corner where two compose, and a liveness witness.

**Mutation table** (in the fixture header, each introduced and reverted):

| mutation | result |
|---|---|
| `full_g_to_d_block` returns `Some(full_idx)` | 18 passed, 6 failed |
| `d_multiplier_rows`' `y_d_offset` drops `dims[2]` | 18 passed, 6 failed — the same six |

The six are every test in the section except the liveness witness, which stays
green under both by construction: it reads `nlp_scaling()` / `variable_scaling()`,
which do not go through the map under test, so it can still testify that the
scaled arm really was scaled while the map is broken. (That separation was
earned: the first two drafts of the witness compared the raw
`parametric_step_full` value — identical to 16 digits in both arms — and then
`row_sigma`, which differs by 3.6e-6 relative. Everything the sensitivity layer
returns is already frame-converted, so `nlp_scaling()` is the only honest
witness.)

**The Rust legs reach only the strictly complementary branch, by design** — the
fixture's multiplier is `1/2`. Per the branch rule, the other two branches are
covered end to end in `pyomo-pounce/tests/test_sens.py`: a strictly active
multiplier against a finite difference, the equality-rewrite agreeing with the
inequality answer, an inactive row refused, a decoupled kink refused, and the
coupled kink above. Five stub tests drive the regime dispatch directly.

## Verification

- `cargo test --workspace --exclude pounce-hsl` — green. (`pounce-hsl`'s
  `ma57_batched_backsolve` fails on this machine for want of a working MA57;
  confirmed identical on a stashed tree, and `pounce-hsl` does not depend on
  anything this PR touches.)
- `cargo clippy --workspace --all-targets` — exit 0, no new warnings.
- `cargo fmt --all -- --check` — clean.
- `python/tests` — 1446 passed. `pyomo-pounce/tests` — 511 passed, 11 skipped.
- **Which binary:** the in-tree `python/pounce/_pounce.abi3.so`, rebuilt with
  `maturin develop --release` after the last Rust edit. `conftest.py`'s
  staleness guard fired once (rustfmt bumped the source mtimes) and was
  **obeyed** — `POUNCE_SKIP_EXT_STALE_CHECK` was never set.

## `/sens-review`

| # | class | verdict | evidence |
|---|-------|---------|----------|
| 1 | index space | PASS | the whole diff is an index map, and all three new conversions feed direct array indexing. Fixture 3 makes g index, d position and c position three different numbers; `leg_fixed_*` puts a `make_parameter`-removed variable ahead so full-x/var-x diverge too; two mutations each fail exactly six tests |
| 2 | frame and scaling | PASS | three factors meet in the multiplier (row `dg`, objective `df`, the pin's `delta`); `leg_scaling_the_multiplier_derivative_is_unmoved_by_the_change_of_variables` plus a witness that reads `nlp_scaling()`. Nothing is compared against `Sigma` |
| 3 | absolute thresholds | PASS | no new constant in `src/`; the gate reuses `reduced_row_activity`'s `sqrt(mu)`-relative classification. Test side compares **slopes**, never `step/delta`, and a null predictor scores `0.0` against an exact `−0.5` — five orders outside the budget at every `delta` in the sweep |
| 4 | doc drift | PASS | `g_multiplier_rows`' doc said the `y_d` mapping "is not exposed here" — this PR makes that false, corrected. `mult_entry`'s both-`None` message was false, corrected. My own first draft of the gate rationale claimed a coupled kink reads `ambiguous` "at any tolerance"; measurement showed it slides to `inactive`, and all four copies now carry the sweep |
| 5 | silently wrong while reporting success | PASS, with the limit named | this is the class the diff creates — a `y_d` entry at a kink is one arbitrary side, with no residual to warn on. The gate is the mitigation, and the coupled-kink test asserts the refusal on the branch where the naive gate would answer wrongly. The fixture's `−1/2` is an outside number (closed form from the model), but it is a 3-variable model: **no row was added to `sens_resolve_oracle.rs`**, so nothing here is evidence about the multiplier step at scale |
| 6 | which branch does the fixture take | PASS | the rule branches three ways; the Rust fixture reaches one, and the other two are covered in `test_sens.py` — including a premise sweep asserting the coupled fixture is still a kink at every `rho` it is asked at |
| 7 | name the measured populations | PASS | the discriminator is *which classifier gates*, and the `rho` table above is the measurement, reproduced in #910, the CHANGELOG, the docs and the test |
| 8 | which binary | PASS | in-tree `.so`, rebuilt; staleness guard obeyed, never bypassed |

The one RISK-shaped item is entry 5's: a resolve-oracle row for the `y_d` block
is the natural follow-up, and I did not add one.

## Note for whoever merges second

Notebook 39 (`39_design_under_kinetic_uncertainty.ipynb`) lives on
#908's branch, not on `main`, and its section 10 says:

> **Multiplier sensitivities are available for equality constraints only.** A
> variable bound or an inequality has no dλ/dp row to read.

Half of that is now wrong: a **strictly active inequality** does have one; a
variable bound still does not. Whichever of the two PRs lands second should
update that bullet — the section's `m.T == T_cap` rewrite is still a fine
illustration of pinning a known-active row, it is just no longer the only way
to get the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bUD9V6h3GkS8E1PnBkz8p
