### PR TITLE
feat(sens): dλ/dp for a strictly active inequality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,61 @@ changes.
 
 ### Added
 
+- **`dλ/dp` for a strictly active inequality
+  ([#910](https://github.com/jkitchin/pounce/issues/910)).**
+  `sens_jacobian(of=<Constraint>)` gave multiplier sensitivities for
+  equality rows only; an inequality was refused outright, even where the
+  row is strictly active at the solved point and its multiplier is a
+  perfectly ordinary differentiable function of the parameters. The
+  shadow price a user wants an error bar on is usually a *cap* — a
+  safety limit, a capacity, a purity spec — and those are written as
+  inequalities, so the only route was to rewrite the row as an equality
+  before solving, which changes the model and is correct only if the row
+  really does stay active over the perturbation being asked about.
+
+  The restriction was API surface, not mathematics: the compound KKT
+  vector is `(x, s, y_c, y_d, z_l, z_u, v_l, v_u)` and
+  `parametric_step_full` already returned `y_d`; what was missing was the
+  map to it. Added as `BoundClassification::full_to_d`,
+  `IpoptNlp::full_g_to_d_block`, `Solver::d_multiplier_rows` and
+  `solver.inequality_multiplier_rows()` — the exact complement of the
+  existing `full_to_c` / `full_g_to_c_block` / `g_multiplier_rows` /
+  `multiplier_rows` chain.
+
+  The map is ungated, because a caller asking for a one-sided answer
+  still needs the row. `pounce.sensitivity`'s `mult_entry` is where the
+  gate lives: an inequality is answered only where the row is strictly
+  active, and the other two regimes are refused with messages that *name*
+  the regime, since they call for different things from the caller — an
+  inactive row's answer really is zero, and a kink needs a direction.
+
+  The gate reads `reduced_row_activity()`, not `classify_activity()`, and
+  the reason is not the obvious one: neither classifier can *admit* a
+  kink, but the directional normalizer gets the refusal REASON wrong. Its
+  ratio for a genuine kink is `reduced/directional`
+  ([#804](https://github.com/jkitchin/pounce/issues/804)), so the class
+  slides with the coupling — measured on a row that is a kink at every
+  coupling, `ambiguous` at `rho = 1e-2` and **`inactive`** by `1e-6`.
+  `inactive` is the one class whose derivative a caller may legitimately
+  read as a structural zero, so gating there would answer a tight cap's
+  kinked shadow price with a confident zero rather than declining it — a
+  wrong answer wearing a refusal's clothes. Coupling that strong is
+  routine on a collocation model, and reading an activity class as a
+  proxy for kink-ness is the inference that shipped
+  [#756](https://github.com/jkitchin/pounce/issues/756).
+
+  `sens_invariance_legs.rs` grows a third fixture, per CLAUDE.md's "a new
+  public accessor gets a row in each leg" rule: the pin equality first
+  and an inactive decoy second, so the active row's `g` index, its
+  d-block position and its flat KKT row are three different numbers, plus
+  a kink row so all three regimes are present. Mutation-checked — a
+  `y_c`-shaped offset, a `g`-index-as-d-position map, and an offset built
+  from the user's `n` instead of the factor's `x` width each turn legs
+  red, and the last of those turns *only* leg 3 red, which is what leg 3
+  is for.
+
+  Book page: `docs/src/sensitivity.md`, "The shadow price of a cap".
+
 - **A phase-changing flash as a complementarity problem
   (`pounce.examples.flash_mpcc`, notebook 38).** A single vapour–liquid
   equilibrium stage solved across a temperature path that crosses

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -389,6 +389,24 @@ pub trait IpoptNlp: Nlp {
         Some(full_idx)
     }
 
+    /// Map a 0-based **full-g** index to a 0-based position in the
+    /// d-block (algorithm-side inequality multiplier vector `y_d`,
+    /// length `m_ineq()`). Returns `None` when the constraint is an
+    /// equality (it lives in `c`, not `d`).
+    ///
+    /// The exact complement of [`Self::full_g_to_c_block`]: on
+    /// `OrigIpoptNlp` every row answers `Some` to exactly one of the
+    /// two. Added by gh#910 so a strictly active inequality's
+    /// multiplier sensitivity can be addressed at all — `y_d` was
+    /// already in the compound KKT vector, with no map to reach it.
+    ///
+    /// Default `None`, the complement of `full_g_to_c_block`'s
+    /// identity default: an impl that does not split c from d puts
+    /// every row in `c`, so it has no d-block to index.
+    fn full_g_to_d_block(&self, _full_idx: Index) -> Option<Index> {
+        None
+    }
+
     /// Inverse of [`Self::full_x_to_var_x`]: map a 0-based var-x index
     /// (length `n()`) to the corresponding full-x index (length
     /// `n_full_x()`). Used when scattering a compressed step or

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -2780,6 +2780,17 @@ impl IpoptNlp for OrigIpoptNlp {
         if c < 0 { None } else { Some(c) }
     }
 
+    fn full_g_to_d_block(&self, full_idx: Index) -> Option<Index> {
+        let cls = self.adapter.borrow();
+        let cls = cls.classification();
+        let f = full_idx as usize;
+        if f >= cls.full_to_d.len() {
+            return None;
+        }
+        let d = cls.full_to_d[f];
+        if d < 0 { None } else { Some(d) }
+    }
+
     fn var_x_to_full_x(&self, var_idx: Index) -> Index {
         let cls = self.adapter.borrow();
         let cls = cls.classification();
@@ -3471,6 +3482,12 @@ mod tests {
 
         // full_g_to_c_block: the one g is an equality → c-block 0.
         assert_eq!(nlp_dyn.full_g_to_c_block(0), Some(0));
+
+        // full_g_to_d_block is its complement: an equality has no
+        // d-block position, and an index past `m` is None in both
+        // (gh#910).
+        assert_eq!(nlp_dyn.full_g_to_d_block(0), None);
+        assert_eq!(nlp_dyn.full_g_to_d_block(1), None);
 
         // lift_x_to_full inflates a compressed [v_0] back to [7.0, v_0].
         let mut x_var = nlp.x_space().make_new_dense();

--- a/crates/pounce-nlp/src/tnlp_adapter.rs
+++ b/crates/pounce-nlp/src/tnlp_adapter.rs
@@ -91,6 +91,14 @@ pub struct BoundClassification {
     /// Maps full-g index → c-block position, with `-1` for inequality
     /// rows: the O(1) inverse of `c_map`, mirroring `full_to_var`.
     pub full_to_c: Vec<Index>,
+    /// Maps full-g index → d-block position, with `-1` for equality
+    /// rows: the O(1) inverse of `d_map`, and the exact complement of
+    /// [`Self::full_to_c`] — every row is `-1` in exactly one of the
+    /// two (gh#910). Wanted for the same reason `full_to_c` is: an
+    /// inequality's multiplier lives in `y_d` at THIS position, not at
+    /// its user-space `g` index, and the two coincide only on a model
+    /// with no equalities ahead of it.
+    pub full_to_d: Vec<Index>,
 }
 
 impl BoundClassification {
@@ -560,6 +568,7 @@ fn classify_bounds(
     let mut d_l_map: Vec<Index> = Vec::new();
     let mut d_u_map: Vec<Index> = Vec::new();
     let mut full_to_c: Vec<Index> = vec![-1; ng];
+    let mut full_to_d: Vec<Index> = vec![-1; ng];
 
     for i in 0..ng {
         let lo = g_l[i];
@@ -589,6 +598,7 @@ fn classify_bounds(
             }
         }
         let d_idx = d_map.len() as Index;
+        full_to_d[i] = d_idx;
         d_map.push(i as Index);
         if lo_present {
             d_l_map.push(d_idx);
@@ -618,6 +628,7 @@ fn classify_bounds(
         d_l_map,
         d_u_map,
         full_to_c,
+        full_to_d,
     })
 }
 
@@ -699,6 +710,13 @@ mod tests {
         assert_eq!(c.c_map, vec![1]);
         assert_eq!(c.n_d, 1);
         assert_eq!(c.d_map, vec![0]);
+        // The two inverse maps are exact complements: every row is
+        // -1 in exactly one of them (gh#910). This model is where a
+        // g index and a block position genuinely differ -- the
+        // equality is g1 but c-block 0, the inequality g0 but d-block
+        // 0 -- so neither map can pass by being an identity.
+        assert_eq!(c.full_to_c, vec![-1, 0]);
+        assert_eq!(c.full_to_d, vec![0, -1]);
         // The single inequality has a finite lower bound (25) and an
         // infinite upper bound (2e19 == nlp_upper_bound_inf).
         assert_eq!(c.d_l_map, vec![0]);
@@ -781,6 +799,10 @@ mod tests {
         // d[1] is fully free — neither bound finite.
         assert_eq!(c.d_l_map, vec![0]);
         assert_eq!(c.d_u_map, vec![0]);
+        // No equalities, so full_to_d is the identity here and
+        // full_to_c is empty of positions -- the complement again.
+        assert_eq!(c.full_to_c, vec![-1, -1]);
+        assert_eq!(c.full_to_d, vec![0, 1]);
     }
 
     /// Inconsistent bounds (lo > hi) should error.

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -706,13 +706,47 @@ impl PySolver {
 
     /// Rows of the compound KKT vector holding the equality
     /// multipliers for the given 0-based constraint (`g`) indices;
-    /// `None` for inequality constraints.
+    /// `None` for inequality constraints (see
+    /// `inequality_multiplier_rows`).
     fn multiplier_rows(&self, g_indices: Vec<i64>) -> PyResult<Vec<Option<i64>>> {
         let s = self.state.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err("multiplier_rows: no converged factor (call solve() first)")
         })?;
         let gs = validate_pins(&g_indices, s.m)?;
         let rows = s.inner.g_multiplier_rows(&gs).map_err(solver_error_to_py)?;
+        Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
+    }
+
+    /// Rows of the compound KKT vector holding the **inequality**
+    /// multipliers (`y_d`) for the given 0-based constraint (`g`)
+    /// indices; `None` for equality constraints, which are
+    /// `multiplier_rows`'. The complement of that accessor
+    /// (pounce#910).
+    ///
+    /// The row exists for every inequality. The **derivative** does
+    /// not: `y_d` holds a number in all three activity regimes, and
+    /// only a strictly active row (`s ≈ 0`, `λ > 0`) has a two-sided
+    /// `dλ/dp`. An inactive row's derivative is a structural zero the
+    /// KKT row does not carry, and a weakly active row — a kink, `s ≈
+    /// 0` *and* `λ ≈ 0` — has two one-sided derivatives that differ,
+    /// with the entry holding whichever side the factorization landed
+    /// on. Gate on the regime before reading these as sensitivities.
+    ///
+    /// The classifier that gates it is `reduced_row_activity`, NOT
+    /// `classify_activity`: on the directional normalizer a genuine
+    /// kink whose row couples to the remaining free space reports
+    /// `"inactive"` at strong enough coupling (pounce#804), and
+    /// `"inactive"` is the one verdict a caller may legitimately read
+    /// as "this shadow price does not move". Gating there would answer
+    /// a kink with a confident zero rather than declining it.
+    fn inequality_multiplier_rows(&self, g_indices: Vec<i64>) -> PyResult<Vec<Option<i64>>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "inequality_multiplier_rows: no converged factor (call solve() first)",
+            )
+        })?;
+        let gs = validate_pins(&g_indices, s.m)?;
+        let rows = s.inner.d_multiplier_rows(&gs).map_err(solver_error_to_py)?;
         Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
     }
 

--- a/crates/pounce-sensitivity/src/activity.rs
+++ b/crates/pounce-sensitivity/src/activity.rs
@@ -1084,29 +1084,30 @@ pub(crate) fn reduced_row_activity(
         (curr.x.dim() as usize, curr.s.dim() as usize)
     };
 
-    // full-g in, d-block rows out, through the same ascending scan the
-    // report's scatter uses: reading the user index as an inequality
-    // position returns a NEIGHBORING row's answer wherever an equality
-    // precedes it (the gh#450 hazard, one block over).
+    // full-g in, d-block rows out, through the NLP's own c/d map:
+    // reading the user index as an inequality position returns a
+    // NEIGHBORING row's answer wherever an equality precedes it (the
+    // gh#450 hazard, one block over). It is the same map
+    // `Solver::d_multiplier_rows` addresses the `y_d` block with
+    // (gh#910), deliberately rather than a second ascending scan that
+    // agrees with it today: the gate that accepts a strictly active
+    // inequality's `dλ/dp` classifies with THIS function and then
+    // reads THAT row, so a disagreement between the two would classify
+    // one row and answer about another.
     let n_full_g = bs.n_full_g() as usize;
     let d_index: Vec<Option<usize>> = {
         let nl = nlp.borrow();
-        let mut d_pos = 0usize;
-        let map = (0..n_full_g)
-            .map(|g| {
-                if nl.full_g_to_c_block(g as Index).is_some() {
-                    None
-                } else {
-                    let p = d_pos;
-                    d_pos += 1;
-                    Some(p)
-                }
-            })
+        let map: Vec<Option<usize>> = (0..n_full_g)
+            .map(|g| nl.full_g_to_d_block(g as Index).map(|p| p as usize))
             .collect();
         // the same invariant [`compute`] asserts after its own scan,
         // restated here because every `sigma_s` / `d_scale` index
         // below rests on it
-        assert_eq!(d_pos, m_d, "inequality count disagrees with the c/d split");
+        assert_eq!(
+            map.iter().filter(|p| p.is_some()).count(),
+            m_d,
+            "inequality count disagrees with the c/d split"
+        );
         map
     };
     let mut rows: Vec<Option<usize>> = Vec::with_capacity(user_rows.len());

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -1488,6 +1488,20 @@ impl PdSensBacksolver {
         self.nlp.borrow().full_g_to_c_block(full_idx)
     }
 
+    /// Map a 0-based **full-g** index to its 0-based position in the
+    /// inequality-multiplier `y_d` block, or `None` when the
+    /// constraint is an equality (it lives in `y_c`). The exact
+    /// complement of [`Self::full_g_to_c_block`], and the map gh#910
+    /// added so an inequality's multiplier row can be addressed.
+    ///
+    /// The flat KKT row is `n_x + n_s + n_y_c + full_g_to_d_block(g)`,
+    /// and the caveat is the same one `full_g_to_c_block` carries: it
+    /// is NOT `g`, and it is not `g` offset by a constant either —
+    /// each equality ahead of the row shifts it by one.
+    pub fn full_g_to_d_block(&self, full_idx: Index) -> Option<Index> {
+        self.nlp.borrow().full_g_to_d_block(full_idx)
+    }
+
     /// Map a 0-based **full-x** index (user-TNLP variable order) to its
     /// 0-based position in the algorithm-side `x` block, or `None` when
     /// the solve removed the column because `x_l == x_u` under

--- a/crates/pounce-sensitivity/src/lib.rs
+++ b/crates/pounce-sensitivity/src/lib.rs
@@ -26,8 +26,9 @@
 //!
 //! * **Fixed-variable lifting** ✔ — `pounce_sens` handles `n_x != n_full`
 //!   via the `IpoptNlp::full_x_to_var_x` / `var_x_to_full_x` /
-//!   `full_g_to_c_block` trait methods (which delegate to
-//!   `BoundClassification.x_not_fixed_map` / `c_map`).
+//!   `full_g_to_c_block` / `full_g_to_d_block` trait methods (which
+//!   delegate to `BoundClassification.x_not_fixed_map` / `full_to_c` /
+//!   `full_to_d`).
 //! * **Reduced-Hessian eigendecomposition** ✔ — pure-Rust cyclic Jacobi
 //!   in [`pounce_linalg::symmetric_eigen`] (shared with the convex QP
 //!   sensitivity path); surfaced via

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -1876,9 +1876,10 @@ impl Solver {
 
     /// Flat rows of the compound KKT vector holding the equality
     /// multipliers `y_c` for the given 0-based **full-g** constraint
-    /// indices. `None` for inequalities (their multipliers live in the
-    /// `y_d` block; mapping those is not exposed here). Row `r` of a
-    /// [`Self::parametric_step_full`] result is then `∂λ_g/∂p · Δp`.
+    /// indices. `None` for inequalities — their multipliers live in
+    /// the `y_d` block, which [`Self::d_multiplier_rows`] addresses.
+    /// Row `r` of a [`Self::parametric_step_full`] result is then
+    /// `∂λ_g/∂p · Δp`.
     pub fn g_multiplier_rows(
         &self,
         g_indices: &[Index],
@@ -1894,6 +1895,63 @@ impl Solver {
                     .backsolver
                     .full_g_to_c_block(g)
                     .map(|pos| y_c_offset + pos)
+            })
+            .collect())
+    }
+
+    /// Flat rows of the compound KKT vector holding the **inequality**
+    /// multipliers `y_d` for the given 0-based **full-g** constraint
+    /// indices. `None` for equalities (those are
+    /// [`Self::g_multiplier_rows`]'s). The `y_d` counterpart of that
+    /// accessor, added by gh#910: `parametric_step_full` already
+    /// returned the `y_d` block, and this is the map that says which
+    /// row of it belongs to which user constraint.
+    ///
+    /// **Reading the row is not the same as the row being a
+    /// derivative.** `y_d` holds a number for every inequality, in all
+    /// three activity regimes, and only one of them has a two-sided
+    /// `∂λ/∂p` at all:
+    ///
+    /// * **strictly active** (`s ≈ 0`, `λ > 0`): the row behaves as an
+    ///   equality over a neighbourhood of the solved point, and this
+    ///   row is the same back-solve an equality gets. Well defined.
+    /// * **inactive** (`s > 0`, `λ ≈ 0`): the derivative is a
+    ///   structural zero over a neighbourhood; the KKT row carries the
+    ///   barrier's residue rather than a derivative of anything.
+    /// * **weakly active** (a kink: `s ≈ 0` *and* `λ ≈ 0`): the two
+    ///   one-sided derivatives differ and no two-sided value exists.
+    ///   The entry holds whichever side the factorization landed on —
+    ///   the silently-wrong-while-reporting-success class.
+    ///   [`Self::parametric_step_directional`] is what answers a kink,
+    ///   and it needs a direction.
+    ///
+    /// So a caller reading these rows as `∂λ/∂p` must gate on the
+    /// regime first, and the classifier that answers it is
+    /// [`Self::reduced_row_activity`], **not**
+    /// [`Self::classify_activity`]: a genuine kink whose row couples
+    /// to the remaining free space reports `INACTIVE` on the
+    /// directional normalizer at strong enough coupling (gh#804), and
+    /// `INACTIVE` is the one class whose derivative a caller may
+    /// legitimately read as a structural zero. Gating on the cheap
+    /// classifier would therefore answer "it does not move" about a
+    /// kink — a wrong answer wearing a refusal's clothes. That
+    /// inference, reading an activity class as a proxy for kink-ness,
+    /// is what shipped gh#756.
+    pub fn d_multiplier_rows(
+        &self,
+        g_indices: &[Index],
+    ) -> Result<Vec<Option<Index>>, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let dims = state.backsolver.block_dims();
+        let y_d_offset = (dims[0] + dims[1] + dims[2]) as Index;
+        Ok(g_indices
+            .iter()
+            .map(|&g| {
+                state
+                    .backsolver
+                    .full_g_to_d_block(g)
+                    .map(|pos| y_d_offset + pos)
             })
             .collect())
     }

--- a/crates/pounce-sensitivity/tests/sens_invariance_legs.rs
+++ b/crates/pounce-sensitivity/tests/sens_invariance_legs.rs
@@ -69,7 +69,7 @@ use pounce_nlp::tnlp::{
     StartingPoint,
 };
 use pounce_sensitivity::Solver;
-use pounce_sensitivity::activity::{AMBIGUOUS, FIXED, INACTIVE, WEAKLY_ACTIVE};
+use pounce_sensitivity::activity::{AMBIGUOUS, FIXED, INACTIVE, STRONGLY_ACTIVE, WEAKLY_ACTIVE};
 
 /// Coupling between the pin and the kink variable. The one-sided
 /// derivative on the leaving side is exactly this.
@@ -1279,6 +1279,585 @@ fn leg_release_all_is_the_releasing_sides_map_in_every_frame() {
             &released_slope(&plain, hi, lo),
             &exact,
             1e-6,
+        );
+    }
+}
+
+// ---------------------------------------------------------------
+// Third fixture: the shadow price of a cap (gh#910)
+// ---------------------------------------------------------------
+//
+// `d_multiplier_rows` is the `y_d` counterpart of `g_multiplier_rows`,
+// and it is a *map*: it says which row of the compound KKT vector
+// carries a given inequality's multiplier. Two things can go wrong
+// with a map, and this fixture is built so neither can hide.
+//
+// 1. **It can address the wrong row.** The d-block position of a
+//    user constraint is neither its `g` index nor its `g` index minus
+//    a constant -- every equality ahead of it shifts it by one -- and
+//    the flat row is that position offset by three block widths. So
+//    the fixture puts the pin equality at `g0` and an INACTIVE decoy
+//    inequality at `g1`, which makes the cap's three coordinates three
+//    different numbers: `g` index 2, d-block position 1, and no
+//    c-block position at all. A `full_to_c`-shaped confusion, an
+//    off-by-one in the scan, and reading `g` as the d position each
+//    land somewhere else.
+//
+// 2. **It can address the right row of a number that is not a
+//    derivative.** `y_d` holds an entry for every inequality in all
+//    three activity regimes, and only the strictly active one has a
+//    two-sided `dlambda/dp`. So `g3` is a genuine row kink, and the
+//    fixture asserts that all three regimes are present and
+//    distinguishable -- which is what makes the gate in
+//    `pounce.sensitivity`'s `mult_entry` testable at all.
+//
+// The three legs then run on the cap's multiplier row: its position is
+// unmoved by a change of variables (leg 1), the derivative it carries
+// does not depend on the step size (leg 2), and neither moves when a
+// `make_parameter`-removed variable leads the model (leg 3). Leg 3 is
+// the one that would look vacuous -- a fixed variable is an `x`-block
+// question and this is a `y_d` row -- and it is exactly the leg that
+// fails if the offset is assembled from `n_full_x` instead of the
+// factor's own `x` width, which is the gh#450 hazard two blocks over.
+
+/// Where the cap sits, and the row's gradient scale. Not 1, so the
+/// multiplier carries a factor and an answer of `-1` cannot pass by
+/// coincidence.
+const CAP_SCALE: Number = 2.0;
+const CAP: Number = 2.0;
+/// The unconstrained optimum of `u`, comfortably past the cap so the
+/// row is held hard against it: `lambda = (U0 - u)/CAP_SCALE = 2`.
+const U0: Number = 5.0;
+/// The decoy row: `DECOY_SCALE * w <= DECOY_CAP`, with `w` sitting at
+/// `W_STAR`, decades of slack away.
+const DECOY_SCALE: Number = 3.0;
+const DECOY_CAP: Number = 30.0;
+/// The kink row `KINK_SCALE * z >= 0`, and the pin's coupling into
+/// `z`. At `p = 0` both `z` and the row's multiplier vanish.
+const KINK_SCALE: Number = 1.0;
+const A_KINK: Number = 0.6;
+
+/// ```text
+/// min  0.5 (u - U0)^2 + 0.5 (w - W_STAR)^2 + 0.5 z^2 - A_KINK p z
+///                                            [+ 0.5 (xf - 0.7)^2]
+/// s.t. g0:                    p == 0       (the pin; the whole c block)
+///      g1: DECOY_SCALE * w <= DECOY_CAP    (inactive decoy; d position 0)
+///      g2: CAP_SCALE (u - p) <= CAP        (strictly active; d position 1)
+///      g3: KINK_SCALE * z  >= 0            (weakly active; d position 2)
+/// ```
+///
+/// Every variable is free, so the ONLY activity in the model is in the
+/// rows -- a variable-bound answer cannot stand in for a row one.
+///
+/// The cap moves with the pin, which is what gives its shadow price a
+/// derivative: at the solution `CAP_SCALE (u - p) = CAP`, so
+/// `u = CAP/CAP_SCALE + p`, and stationarity in `u` gives
+/// `lambda_2 = (U0 - u)/CAP_SCALE`. Hence
+/// `dlambda_2/dp = -1/CAP_SCALE`, exactly, on both sides.
+///
+/// `leading_fixed` prepends `xf` exactly as [`KinkTnlp`] does, so
+/// full-x and var-x diverge in front of everything.
+struct CapTnlp {
+    x_scaling: Option<Vec<Number>>,
+    leading_fixed: bool,
+}
+
+impl CapTnlp {
+    fn off(&self) -> usize {
+        usize::from(self.leading_fixed)
+    }
+}
+
+impl TNLP for CapTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: (4 + self.off()) as Index,
+            m: 4,
+            nnz_jac_g: 5,
+            nnz_h_lag: (4 + self.off()) as Index,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        let Some(d) = self.x_scaling.as_ref() else {
+            return false;
+        };
+        *req.obj_scaling = 1.0;
+        *req.use_x_scaling = true;
+        req.x_scaling.copy_from_slice(d);
+        *req.use_g_scaling = false;
+        true
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        let o = self.off();
+        if self.leading_fixed {
+            b.x_l[0] = FIXED_AT;
+            b.x_u[0] = FIXED_AT;
+        }
+        for i in o..o + 4 {
+            b.x_l[i] = -1.0e19;
+            b.x_u[i] = 1.0e19;
+        }
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        b.g_l[1] = -1.0e19;
+        b.g_u[1] = DECOY_CAP;
+        b.g_l[2] = -1.0e19;
+        b.g_u[2] = CAP;
+        b.g_l[3] = 0.0;
+        b.g_u[3] = 1.0e19;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        let o = self.off();
+        if self.leading_fixed {
+            sp.x[0] = FIXED_AT;
+        }
+        sp.x[o] = 0.5;
+        sp.x[o + 1] = 0.5;
+        sp.x[o + 2] = 0.5;
+        sp.x[o + 3] = 0.0;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let o = self.off();
+        let (u, w, z, p) = (x[o], x[o + 1], x[o + 2], x[o + 3]);
+        let mut f = 0.5 * (u - U0) * (u - U0) + 0.5 * (w - W_STAR) * (w - W_STAR) + 0.5 * z * z
+            - A_KINK * p * z;
+        if self.leading_fixed {
+            f += 0.5 * (x[0] - 0.7) * (x[0] - 0.7);
+        }
+        Some(f)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let o = self.off();
+        let (u, w, z, p) = (x[o], x[o + 1], x[o + 2], x[o + 3]);
+        if self.leading_fixed {
+            g[0] = x[0] - 0.7;
+        }
+        g[o] = u - U0;
+        g[o + 1] = w - W_STAR;
+        g[o + 2] = z - A_KINK * p;
+        g[o + 3] = -A_KINK * z;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let o = self.off();
+        g[0] = x[o + 3];
+        g[1] = DECOY_SCALE * x[o + 1];
+        g[2] = CAP_SCALE * (x[o] - x[o + 3]);
+        g[3] = KINK_SCALE * x[o + 2];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        let o = self.off() as Index;
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 2, 2, 3]);
+                jcol.copy_from_slice(&[o + 3, o + 1, o, o + 3, o + 2]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, DECOY_SCALE, CAP_SCALE, -CAP_SCALE, KINK_SCALE]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // every row is linear, so the Lagrangian Hessian is the
+        // objective's alone and `lambda` never enters
+        let o = self.off() as Index;
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                // lower triangle: (u,u), (w,w), (z,z), (p,z) [, (xf,xf)]
+                let mut rs: Vec<Index> = vec![o, o + 1, o + 2, o + 3];
+                let mut cs: Vec<Index> = vec![o, o + 1, o + 2, o + 2];
+                if self.leading_fixed {
+                    rs.push(0);
+                    cs.push(0);
+                }
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = obj_factor;
+                values[1] = obj_factor;
+                values[2] = obj_factor;
+                values[3] = -obj_factor * A_KINK;
+                if self.leading_fixed {
+                    values[4] = obj_factor;
+                }
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+/// User-space `g` indices of the four rows, by role.
+const G_PIN: Index = 0;
+const G_DECOY: Index = 1;
+const G_CAP: Index = 2;
+const G_KINK: Index = 3;
+
+/// `d(lambda_cap)/dp`, exact and two-sided: see [`CapTnlp`].
+const CAP_MULT_SLOPE: Number = -1.0 / CAP_SCALE;
+
+/// Same option set the other two fixtures solve under, so the only
+/// difference between the arms of a leg is the fixture's own knob.
+fn solved_cap(x_scaling: Option<Vec<Number>>, leading_fixed: bool) -> Solver {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", "user-scaling", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("tol", 1e-8, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("bound_relax_factor", 0.0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(CapTnlp {
+        x_scaling,
+        leading_fixed,
+    }));
+    let mut solver = Solver::new(app, tnlp);
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "cap fixture base solve failed: {status:?}",
+    );
+    solver
+}
+
+/// The flat KKT row carrying `g`'s multiplier, through whichever block
+/// claims it. Panics if neither does, which the c/d split forbids.
+fn mult_row(s: &Solver, g: Index) -> usize {
+    let c = s.g_multiplier_rows(&[g]).expect("y_c rows")[0];
+    let d = s.d_multiplier_rows(&[g]).expect("y_d rows")[0];
+    assert!(
+        c.is_none() || d.is_none(),
+        "g{g} claimed by both multiplier blocks: y_c {c:?}, y_d {d:?}"
+    );
+    c.or(d)
+        .unwrap_or_else(|| panic!("g{g} claimed by neither multiplier block")) as usize
+}
+
+/// `reduced_row_activity`'s verdict for one user row.
+fn row_class(s: &Solver, g: Index) -> i8 {
+    s.reduced_row_activity(&[g as usize])
+        .expect("reduced row")
+        .status[0]
+}
+
+/// Slope of a flat KKT row of `parametric_step_full` in `delta`,
+/// between two perturbations on the same side. The step is affine in
+/// `delta` (see [`the_step_is_affine_in_delta`]), so a slope is the
+/// derivative and `row / delta` would not be.
+fn full_slope(s: &Solver, row: usize, d_hi: Number, d_lo: Number) -> Number {
+    let at = |d: Number| -> Number {
+        s.parametric_step_full(&[G_PIN], &[d])
+            .unwrap_or_else(|e| panic!("full step at delta={d:e}: {e:?}"))[row]
+    };
+    (at(d_hi) - at(d_lo)) / (d_hi - d_lo)
+}
+
+// ---------------- preconditions ----------------
+
+/// Without this every leg below is vacuous: the fixture has to put its
+/// three inequalities in three different regimes, and it has to make
+/// the cap's `g` index, its d-block position and its flat KKT row
+/// three genuinely different numbers.
+#[test]
+fn the_cap_fixture_carries_all_three_inequality_regimes_at_shifted_indices() {
+    let s = solved_cap(None, false);
+    let x = s.converged().expect("converged").x.clone();
+    assert!(
+        (x[0] - CAP / CAP_SCALE).abs() < 1e-6,
+        "u is held at the cap, got {}",
+        x[0]
+    );
+    assert!(
+        (x[1] - W_STAR).abs() < 1e-6,
+        "w sits at W_STAR, decades inside the decoy, got {}",
+        x[1]
+    );
+    assert!(x[2].abs() < 1e-3, "z sits at its kink row, got {}", x[2]);
+
+    assert_eq!(row_class(&s, G_CAP), STRONGLY_ACTIVE, "the cap");
+    assert_eq!(row_class(&s, G_DECOY), INACTIVE, "the decoy");
+    assert_eq!(row_class(&s, G_KINK), WEAKLY_ACTIVE, "the kink row");
+
+    // the pin is the whole c block; the three inequalities are the
+    // whole d block, in g order
+    assert_eq!(
+        s.g_multiplier_rows(&[G_PIN, G_DECOY, G_CAP, G_KINK])
+            .expect("y_c rows")
+            .iter()
+            .map(|r| r.is_some())
+            .collect::<Vec<_>>(),
+        vec![true, false, false, false],
+        "only the pin lives in y_c",
+    );
+    let d_rows = s
+        .d_multiplier_rows(&[G_PIN, G_DECOY, G_CAP, G_KINK])
+        .expect("y_d rows");
+    assert!(d_rows[0].is_none(), "the pin is an equality, not in y_d");
+    let dims = s.block_dims().expect("block dims");
+    let y_d_offset = (dims[0] + dims[1] + dims[2]) as Index;
+    assert_eq!(
+        d_rows[1..].to_vec(),
+        vec![Some(y_d_offset), Some(y_d_offset + 1), Some(y_d_offset + 2)],
+        "the d block is the three inequalities in g order",
+    );
+
+    // the three numbers the map exists to keep apart
+    let cap_row = mult_row(&s, G_CAP);
+    assert_ne!(
+        cap_row, G_CAP as usize,
+        "the cap's flat row must not equal its g index, or a raw g \
+         index would pass as a row",
+    );
+    assert_ne!(
+        d_rows[2].unwrap() - y_d_offset,
+        G_CAP,
+        "the cap's d-block position must differ from its g index, or an \
+         equality-blind scan would pass",
+    );
+
+    // and the derivative the whole fixture is about
+    assert!(
+        (full_slope(&s, cap_row, 1.0e-3, 1.0e-6) - CAP_MULT_SLOPE).abs() < 1e-6,
+        "d(lambda_cap)/dp should be {CAP_MULT_SLOPE}, got {}",
+        full_slope(&s, cap_row, 1.0e-3, 1.0e-6),
+    );
+}
+
+/// A kink row's `y_d` entry is addressable -- the map does not gate,
+/// and must not: a caller asking for a one-sided answer needs the row.
+/// What the entry holds there is not a two-sided derivative, which is
+/// the classifier's business and not the map's. Pinned so that a
+/// future "helpfully" gating map is a deliberate change.
+#[test]
+fn the_map_addresses_every_inequality_including_the_ones_with_no_derivative() {
+    let s = solved_cap(None, false);
+    for g in [G_DECOY, G_CAP, G_KINK] {
+        assert!(
+            s.d_multiplier_rows(&[g]).expect("y_d rows")[0].is_some(),
+            "g{g} ({}) must be addressable in y_d",
+            row_class(&s, g),
+        );
+    }
+    // and the classifier is what separates them, at classes the
+    // DIRECTIONAL normalizer would not have to agree with
+    assert_ne!(row_class(&s, G_CAP), row_class(&s, G_KINK));
+    assert_ne!(row_class(&s, G_DECOY), row_class(&s, G_KINK));
+}
+
+// ---------------- leg 1: scaling ----------------
+
+/// Per-variable factors for the cap fixture, spread over decades.
+const D_CAP: [Number; 4] = [1.0e-2, 5.0, 0.25, 1.0e3];
+const D_CAP_FIXED: [Number; 5] = [2.0, 1.0e-2, 5.0, 0.25, 1.0e3];
+
+/// The row a constraint's multiplier lives in is a property of the c/d
+/// split, not of the units the solve ran in -- and the derivative it
+/// carries is in natural units, so the change of variables must not
+/// reach it either.
+///
+/// `y_d`'s natural-units conversion is `E = dd`, `F = dd/df`, exactly
+/// `y_c`'s one block over. A conversion that used the `x` block's
+/// factors, or that dropped `df`, moves this number without moving any
+/// row index -- so the leg asserts the derivative, not just the row.
+#[test]
+fn leg_scaling_the_cap_multiplier_row_is_unmoved_by_the_change_of_variables() {
+    let plain = solved_cap(None, false);
+    let scaled = solved_cap(Some(D_CAP.to_vec()), false);
+
+    for g in [G_PIN, G_DECOY, G_CAP, G_KINK] {
+        assert_eq!(
+            plain.d_multiplier_rows(&[g]).expect("y_d rows"),
+            scaled.d_multiplier_rows(&[g]).expect("y_d rows"),
+            "g{g}: the y_d row moved under the change of variables",
+        );
+        assert_eq!(
+            row_class(&plain, g),
+            row_class(&scaled, g),
+            "g{g}: the activity regime moved under the change of variables",
+        );
+    }
+
+    for sign in [1.0, -1.0] {
+        let (hi, lo) = (sign * 1.0e-3, sign * 1.0e-6);
+        assert_close(
+            "scaled d(lambda_cap)/dp",
+            &[full_slope(&scaled, mult_row(&scaled, G_CAP), hi, lo)],
+            &[CAP_MULT_SLOPE],
+            1e-5,
+        );
+        assert_close(
+            "plain d(lambda_cap)/dp",
+            &[full_slope(&plain, mult_row(&plain, G_CAP), hi, lo)],
+            &[CAP_MULT_SLOPE],
+            1e-5,
+        );
+    }
+}
+
+// ---------------- leg 2: perturbation magnitude ----------------
+
+/// The cap is strictly active, so its multiplier derivative is
+/// two-sided and must be the same number over eight orders of `delta`
+/// and on either side -- unlike the kink's, which has no two-sided
+/// value at all. An absolute tolerance anywhere on the path to this
+/// number reads a `1e-10` step as no step, which is gh#672 finding 4.
+#[test]
+fn leg_magnitude_the_cap_multiplier_derivative_does_not_depend_on_the_step_size() {
+    let s = solved_cap(None, false);
+    let row = mult_row(&s, G_CAP);
+    for sign in [1.0, -1.0] {
+        for w in DELTAS.windows(2) {
+            let (hi, lo) = (sign * w[0], sign * w[1]);
+            assert_close(
+                &format!("d(lambda_cap)/dp over [{lo:e}, {hi:e}]"),
+                &[full_slope(&s, row, hi, lo)],
+                &[CAP_MULT_SLOPE],
+                1e-5,
+            );
+        }
+        let (hi, lo) = (sign * DELTAS[0], sign * DELTAS[DELTAS.len() - 1]);
+        assert_close(
+            &format!("d(lambda_cap)/dp over the full span [{lo:e}, {hi:e}]"),
+            &[full_slope(&s, row, hi, lo)],
+            &[CAP_MULT_SLOPE],
+            1e-5,
+        );
+    }
+}
+
+/// ...and the same sweep under the change of variables, so leg 2's
+/// answer is not an artifact of unit scaling.
+#[test]
+fn leg_magnitude_the_cap_multiplier_derivative_holds_under_scaling_too() {
+    let s = solved_cap(Some(D_CAP.to_vec()), false);
+    let row = mult_row(&s, G_CAP);
+    for sign in [1.0, -1.0] {
+        for w in DELTAS.windows(2) {
+            let (hi, lo) = (sign * w[0], sign * w[1]);
+            assert_close(
+                &format!("scaled d(lambda_cap)/dp over [{lo:e}, {hi:e}]"),
+                &[full_slope(&s, row, hi, lo)],
+                &[CAP_MULT_SLOPE],
+                1e-5,
+            );
+        }
+    }
+}
+
+// ---------------- leg 3: a fixed variable ahead of the rows ----------------
+
+/// A `make_parameter`-removed variable shortens the factor's `x`
+/// block, and the `y_d` block's offset is the sum of the `x`, `s` and
+/// `y_c` widths -- so an offset assembled from the USER's `n` instead
+/// of the factor's puts every `y_d` row one too far along. Nothing
+/// about the two lengths is distinguishable on a model without a fixed
+/// variable, which is the gh#450 hazard two blocks over.
+///
+/// The row itself is *expected* to move (the block ahead of it got
+/// shorter). What must not move is the answer it carries, or the
+/// d-block position within the block.
+#[test]
+fn leg_fixed_the_cap_multiplier_is_unmoved_by_a_fixed_variable_ahead_of_the_rows() {
+    let plain = solved_cap(None, false);
+    let fixed = solved_cap(None, true);
+
+    // precondition: the spaces genuinely diverge, or the leg is
+    // vacuous
+    let n_plain = plain.n_full_x().expect("n_full_x");
+    let n_fixed = fixed.n_full_x().expect("n_full_x");
+    assert_eq!((n_plain, n_fixed), (4, 5), "fixture drifted");
+    assert_eq!(
+        plain.block_dims().expect("block dims")[0],
+        fixed.block_dims().expect("block dims")[0],
+        "the fixed variable must be removed from the x block, or the \
+         leg tests nothing",
+    );
+
+    // the constraint side is untouched by a fixed VARIABLE, so the
+    // d-block positions and the regimes must be identical
+    let dims_p = plain.block_dims().expect("block dims");
+    let dims_f = fixed.block_dims().expect("block dims");
+    let off_p = (dims_p[0] + dims_p[1] + dims_p[2]) as Index;
+    let off_f = (dims_f[0] + dims_f[1] + dims_f[2]) as Index;
+    for g in [G_DECOY, G_CAP, G_KINK] {
+        let rp = plain.d_multiplier_rows(&[g]).expect("y_d rows")[0].unwrap();
+        let rf = fixed.d_multiplier_rows(&[g]).expect("y_d rows")[0].unwrap();
+        assert_eq!(
+            rp - off_p,
+            rf - off_f,
+            "g{g}: the d-block position moved with a fixed variable",
+        );
+        assert_eq!(
+            row_class(&plain, g),
+            row_class(&fixed, g),
+            "g{g}: the activity regime moved with a fixed variable",
+        );
+    }
+
+    for sign in [1.0, -1.0] {
+        let (hi, lo) = (sign * 1.0e-3, sign * 1.0e-6);
+        assert_close(
+            "d(lambda_cap)/dp with a fixed variable ahead of the rows",
+            &[full_slope(&fixed, mult_row(&fixed, G_CAP), hi, lo)],
+            &[CAP_MULT_SLOPE],
+            1e-5,
+        );
+    }
+}
+
+/// The corner: a fixed variable AND a change of variables, the same
+/// composition [`the_legs_compose_at_the_fixed_and_scaled_corner`]
+/// runs for the kink fixture.
+#[test]
+fn the_cap_legs_compose_at_the_fixed_and_scaled_corner() {
+    let s = solved_cap(Some(D_CAP_FIXED.to_vec()), true);
+    assert_eq!(row_class(&s, G_CAP), STRONGLY_ACTIVE);
+    assert_eq!(row_class(&s, G_DECOY), INACTIVE);
+    assert_eq!(row_class(&s, G_KINK), WEAKLY_ACTIVE);
+    let row = mult_row(&s, G_CAP);
+    for sign in [1.0, -1.0] {
+        assert_close(
+            "d(lambda_cap)/dp at the fixed-and-scaled corner",
+            &[full_slope(&s, row, sign * 1.0e-3, sign * 1.0e-6)],
+            &[CAP_MULT_SLOPE],
+            1e-5,
         );
     }
 }

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -293,12 +293,98 @@ below. There is one exception to the warning, a bound written on a declared Para
 [Declared Params in variable bounds](#declared-params-in-variable-bounds)
 below. `sens_solution_report()` measures the same step and reports where the
 active set changes along it, covered in
-[What the step did about the bounds](#what-the-step-did-about-the-bounds-sens_solution_report). Multiplier sensitivities are available for equality constraints.
+[What the step did about the bounds](#what-the-step-did-about-the-bounds-sens_solution_report). Multiplier
+sensitivities are available for every equality constraint, and for an
+inequality that is strictly active at the solved point, covered in
+[The shadow price of a cap](#the-shadow-price-of-a-cap) below.
 Models without declarations solve through the ordinary AMPL/CLI path,
 unchanged. See
 [`python/notebooks/25_pyomo_sensitivity.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/25_pyomo_sensitivity.ipynb)
 for a worked optimal-control example (initial conditions as
 parameters; the first-move gradient IS the NMPC feedback gain).
+
+### The shadow price of a cap
+
+`of=` a **Constraint** gives `d(dual)/dp`: how the row's shadow price
+moves with a declared parameter. Every equality has one. So does an
+inequality — but only where the row is **strictly active** at the
+solved point
+([#910](https://github.com/jkitchin/pounce/issues/910)).
+
+That restriction is the interesting half, because the shadow price a
+user actually wants an error bar on is usually a *cap*: a safety limit,
+a capacity, a purity spec. Those are written as inequalities.
+
+```python
+m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+declare_sens_param(m.theta)
+SolverFactory("pounce").solve(m)
+
+m.dual[m.cap]                       # the shadow price
+sens_jacobian(m.cap, wrt=m.theta)   # ...and how it moves with theta
+```
+
+An inequality multiplier is differentiable only where the row is
+strictly complementary, and there are three regimes:
+
+| regime | slack, multiplier | `dλ/dp` |
+|---|---|---|
+| strictly active | `s ≈ 0`, `λ > 0` | behaves as an equality over a neighbourhood; well defined, and it is the same back-solve an equality gets |
+| inactive | `s > 0`, `λ ≈ 0` | zero over a neighbourhood — but there is no KKT row to differentiate |
+| weakly active (a kink) | `s ≈ 0` *and* `λ ≈ 0` | two one-sided derivatives that differ; no two-sided value exists |
+
+The compound KKT vector holds a `y_d` entry in all three cases. In the
+third it is whichever side the factorization happened to land on. So
+the other two regimes are refused, and the message **names the
+regime**, because they call for different things from you: an inactive
+row's answer really is zero — but whether it stays inactive across the
+perturbation you mean is your question, not the factor's — and a kink
+needs a direction, which `sens_solution()` and
+`parametric_step_directional` take and `sens_jacobian` does not.
+
+Before #910 the only route to a cap's `dλ/dp` was to rewrite the row as
+an equality `g(x) == b` before solving. That changes the model, and is
+correct only if the row really does stay active over the perturbation
+being asked about — the assumption the gate above makes you state.
+
+#### Which classifier gates it
+
+`reduced_row_activity()`, not `classify_activity()`, and the reason is
+not the obvious one.
+
+Neither classifier can *admit* a kink. A row's reduced curvature is
+never larger than its directional one, so the reduced ratio is never
+below the directional ratio, and `strongly_active` is the high-ratio
+tail of both. What the directional normalizer gets wrong is the
+**refusal reason**. Its ratio for a genuine kink is
+`reduced / directional`
+([#804](https://github.com/jkitchin/pounce/issues/804)), so as the
+row's coordinate couples to the rest of the free space at strength
+`rho` the class slides. Measured, on a fixture whose row is a kink at
+every `rho`:
+
+| `rho` | `classify_activity()` | `reduced_row_activity()` |
+|---|---|---|
+| `1e-2` | `ambiguous` | `weakly_active` |
+| `1e-4` | `ambiguous` | `weakly_active` |
+| `1e-6` | **`inactive`** | `weakly_active` |
+
+`inactive` is the one class whose derivative you may legitimately read
+as a structural zero. So gating on the directional ratio would not
+decline to answer about a tight cap's shadow price — it would answer
+"it does not move", which is a wrong answer wearing a refusal's
+clothes. Coupling that strong is routine on a collocation model, and
+reading an activity class as a proxy for kink-ness is the inference
+that shipped
+[#756](https://github.com/jkitchin/pounce/issues/756). See
+[`ambiguous` is not "probably not a kink"](#ambiguous-is-not-probably-not-a-kink)
+below.
+
+The Rust and Python layers underneath expose the map itself, ungated,
+since a caller asking for a one-sided answer still needs the row:
+`Solver::d_multiplier_rows` / `solver.inequality_multiplier_rows()`,
+the `y_d` counterpart of `g_multiplier_rows` /
+`solver.multiplier_rows()`.
 
 ### Bending the estimate around a bound: `mode="fix_relax"`
 
@@ -1811,7 +1897,7 @@ replaces constraints even if they don't contain the parameters."*
 | Cost per query | model clone + full constraint rebuild + subprocess + file parse | declare once; the KKT factor is retained and each query is one backsolve |
 | Perturbation values | required **before** the solve | not required; ask for any `Δp` afterwards |
 | `dx*/dp` | ✅ `get_dsdp`, whole matrix | ✅ `sens_jacobian(of, wrt=…)`, scalar or `Jacobian` / DataFrame |
-| `dλ/dp`, multiplier sensitivity | ❌ | ✅ pass an equality `Constraint` as `of=` |
+| `dλ/dp`, multiplier sensitivity | ❌ | ✅ pass a `Constraint` as `of=` — every equality, and a strictly active inequality, gated on the regime ([The shadow price of a cap](#the-shadow-price-of-a-cap)) |
 | Total `df/dp` | ❌ | ✅ `sens_jacobian(m.obj, wrt=p)`, explicit partial plus the path through `x*` |
 | Declared `Param` in a variable **bound** | ❌ substitution walks constraints and the objective only, so the derivative reads exactly `0.0` | ✅ rewritten to a row at declaration — see [Declared Params in variable bounds](#declared-params-in-variable-bounds) |
 | Bound crossing (fix-relax) | sIPOPT implements `sens_boundcheck`, but the toolbox never sets it — only `run_sens=yes` | ✅ `mode="fix_relax"`, both the pin and the release half |

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1525,9 +1525,10 @@ def _param_pin(session, param_data):
 
 class Jacobian:
     """Derivatives d(target*)/d(param) for one or more targets/parameters.
-    Targets are variables (primal sensitivities), equality constraints
-    (multiplier sensitivities), or the objective (the total derivative
-    df/dp).
+    Targets are variables (primal sensitivities), constraints
+    (multiplier sensitivities -- every equality, and an inequality
+    that is strictly active at the solved point, gh#910), or the
+    objective (the total derivative df/dp).
 
     Access with g[target_data, param_data] (either order); when one side is
     a single component, g[data] works. to_dataframe() gives the full
@@ -1579,12 +1580,18 @@ class Jacobian:
         derivatives of primal values, which is what `m.x.value` holds.
 
         Constraint targets do. `mult_entry` rows come from
-        `parametric_step_full`'s y_c block, i.e. derivatives of POUNCE's
-        internal Lagrange multiplier, whereas `m.dual[con]` holds the AMPL
-        *marginal* `d obj / d b = -lambda` (gh #271). So d(dual)/d(param)
-        is the negation of the raw row -- without this, `sens_jacobian(m.con,
-        wrt=m.p)` disagrees in sign with a finite difference of
-        `m.dual[m.con]` taken across a re-solve.
+        `parametric_step_full`'s y_c block -- or, for a strictly active
+        inequality, its y_d block (gh#910) -- i.e. derivatives of
+        POUNCE's internal Lagrange multiplier, whereas `m.dual[con]`
+        holds the AMPL *marginal* `d obj / d b = -lambda` (gh #271). So
+        d(dual)/d(param) is the negation of the raw row -- without
+        this, `sens_jacobian(m.con, wrt=m.p)` disagrees in sign with a
+        finite difference of `m.dual[m.con]` taken across a re-solve.
+
+        The same sign serves both multiplier blocks: `pack_lambda_for_user`
+        scatters y_c and y_d into the one `lambda` array with no sign
+        change between them, so an inequality's dual is on the same
+        footing as an equality's.
         """
         return -1.0 if td.ctype is Constraint else 1.0
 

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -68,6 +68,85 @@ def test_sens_jacobian_multiplier_matches_finite_difference(solved):
         "and pyomo duals")
 
 
+# ── an inequality's shadow price (gh#910) ────────────────────────────────────
+#
+# The shadow price a user wants an error bar on is usually a *cap* -- a
+# safety limit, a capacity, a purity spec -- and those are written as
+# inequalities. `sens_jacobian(of=<Constraint>)` used to refuse every
+# one of them, so the only route was to rewrite the row as an equality
+# before solving, which changes the model and is correct only if the row
+# really does stay active across the perturbation being asked about.
+
+
+CAP_H = 1e-3
+
+
+def build_cap(p=0.0):
+    """min .5(u-5)^2 + .5(w-2)^2  s.t.  2(u - p) <= 2,  3w <= 30.
+
+    The cap is strictly active and moves with `p`: `u = 1 + p` at the
+    solution, and stationarity in `u` gives `lambda_cap = (5 - u)/2`, so
+    `d lambda_cap/dp = -1/2` and `d(dual)/dp = +1/2` in the AMPL
+    marginal convention pyomo reports. The decoy row is decades slack.
+    """
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=p, mutable=True)
+    m.u = pyo.Var(initialize=0.5)
+    m.w = pyo.Var(initialize=0.5)
+    m.cap = pyo.Constraint(expr=2.0 * (m.u - m.p) <= 2.0)
+    m.decoy = pyo.Constraint(expr=3.0 * m.w <= 30.0)
+    m.obj = pyo.Objective(
+        expr=0.5 * (m.u - 5.0) ** 2 + 0.5 * (m.w - 2.0) ** 2)
+    return m
+
+
+@pytest.fixture(scope="module")
+def solved_cap():
+    m = build_cap()
+    declare_sens_param(m.p)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+def test_a_strictly_active_inequalitys_shadow_price_has_a_derivative(
+        solved_cap):
+    """gh#910, end to end and against an outside number.
+
+    The closed form is `+1/2`, and the finite difference of
+    `m.dual[m.cap]` across a re-solve is what says the SIGN convention
+    survived the trip through the `y_d` block -- `pack_lambda_for_user`
+    scatters `y_c` and `y_d` into one `lambda` array with no sign change
+    between them, so an inequality's dual is on the same footing as an
+    equality's, and this is the assertion that would catch it if it
+    were not.
+    """
+    m = solved_cap
+    g = sens_jacobian(m.cap, wrt=m.p)
+    assert g == pytest.approx(0.5, abs=1e-6)
+
+    hi = solve_plain(build_cap(p=CAP_H))
+    lo = solve_plain(build_cap(p=-CAP_H))
+    fd = (hi.dual[hi.cap] - lo.dual[lo.cap]) / (2 * CAP_H)
+    assert g == pytest.approx(fd, abs=1e-4), (
+        "sign convention mismatch between parametric_step_full's y_d "
+        "block and pyomo duals")
+
+
+def test_an_inactive_inequality_is_refused_by_naming_its_regime(solved_cap):
+    """Refused, not answered `0`.
+
+    The derivative IS zero over a neighbourhood, but it is a structural
+    zero rather than something the KKT row carries -- and the caller who
+    asked is the one who has to decide whether the row stays inactive
+    across the perturbation they mean. So the refusal names the regime
+    instead of handing back a number that looks measured.
+    """
+    with pytest.raises(ValueError, match="inactive at the solved point"):
+        sens_jacobian(solved_cap.decoy, wrt=solved_cap.p)
+
+
 def test_sens_solution_matches_resolve(solved):
     m = solved
     est = sens_solution(m, [(m.p, 2.2), (m.q, 0.9)])
@@ -534,12 +613,26 @@ def test_both_bounds_rewritten_are_both_recorded():
 # without needing the solver. The value-correctness of the fan-out path is
 # already covered by test_sens_jacobian_object_for_containers.
 
-def _fake_session(names, cons, row_offset=1000, **kw):
+def _fake_session(names, cons, row_offset=1000, d_offset=None,
+                  row_class="strongly_active", **kw):
+    """A `_Session` over a stub solver, for the row-map contract alone.
+
+    `row_offset=None` makes every row an inequality, which sends
+    `mult_entry` down the `y_d` half added by gh#910: `d_offset` is
+    then the row it reports and `row_class` the regime the gate reads
+    off `reduced_row_activity`.
+    """
     from pyomo_pounce.sens import _Session
 
     class _Solver:
         def multiplier_rows(self, gs):
             return [None if row_offset is None else gs[0] + row_offset]
+
+        def inequality_multiplier_rows(self, gs):
+            return [None if d_offset is None else gs[0] + d_offset]
+
+        def reduced_row_activity(self, gs):
+            return {"status": [row_class] * len(gs)}
 
     return _Session(None, None, _Solver(), names, cons, {},
                     {"orig.c": cons[-1]}, **kw)
@@ -575,9 +668,26 @@ def test_unknown_name_raises_value_error_not_key_error():
         s.mult_entry("nope")
 
 
-def test_inequality_multiplier_error_is_unchanged():
-    s = _fake_session(["a"], ["c"], row_offset=None)
-    with pytest.raises(ValueError, match="equality constraints"):
+def test_a_strictly_active_inequality_is_answered_from_the_y_d_block():
+    """gh#910: the row exists, and the gate lets a strict one through."""
+    s = _fake_session(["a"], ["c"], row_offset=None, d_offset=2000)
+    assert s.mult_entry("c") == 2000
+
+
+@pytest.mark.parametrize("row_class,message", [
+    ("inactive", "inactive at the solved point"),
+    ("weakly_active", "weakly active at the solved point"),
+    ("ambiguous", "could not be resolved"),
+])
+def test_a_non_strict_inequality_is_refused_by_naming_its_regime(
+        row_class, message):
+    """The other two regimes hold a `y_d` entry and no derivative, and
+    the refusal names which -- an inactive row's answer really is zero,
+    while a kink needs a direction, so they call for different things
+    from the caller."""
+    s = _fake_session(["a"], ["c"], row_offset=None, d_offset=2000,
+                      row_class=row_class)
+    with pytest.raises(ValueError, match=message):
         s.mult_entry("c")
 
 

--- a/python/pounce/sensitivity/_session.py
+++ b/python/pounce/sensitivity/_session.py
@@ -275,7 +275,37 @@ class SensSession:
                 f"{name}: not a variable of the solved model") from None
 
     def mult_entry(self, con_name):
-        """The KKT row of constraint `con_name`'s multiplier."""
+        """The KKT row of constraint `con_name`'s multiplier.
+
+        An equality is answered from the `y_c` block unconditionally:
+        its multiplier is a differentiable function of the parameters
+        wherever the solve is regular, and the row is the whole answer.
+
+        An inequality is answered from `y_d`, but only where the row is
+        **strictly active** (gh#910). That is the regime in which the
+        row behaves as an equality over a neighbourhood of the solved
+        point, so `dlambda/dp` is the same back-solve an equality gets.
+        The other two regimes hold a number in `y_d` and no derivative:
+        an inactive row's answer is a structural zero the KKT row does
+        not carry, and a kink -- slack AND multiplier both vanishing --
+        has two one-sided derivatives that differ, with the entry
+        holding whichever side the factorization landed on. Both are
+        refused, and the message names the regime, because they call
+        for different things from the caller.
+
+        The gate reads `reduced_row_activity`, not the `row_status` of
+        `classify_activity`. The cheap classifier normalizes a row by
+        the curvature along its own gradient rather than by the reduced
+        curvature that generates its multiplier, so its ratio for a
+        genuine kink is `reduced/directional` and slides with the
+        coupling: at coupling `1e-6` a row that is a kink at every
+        coupling reports "inactive" there (gh#804). "inactive" is the
+        one verdict this method may pass through as "the shadow price
+        does not move", so gating on it would answer a tight cap's
+        kinked shadow price with a confident zero -- a wrong answer
+        wearing a refusal's clothes. Reading an activity class as a
+        proxy for kink-ness is the inference that shipped gh#756.
+        """
         # a caller whose solve ran on a rewritten copy translates the
         # original name to the copy's row
         con_name = self.con_alias.get(con_name, con_name)
@@ -285,11 +315,70 @@ class SensSession:
             raise ValueError(
                 f"{con_name}: not a constraint of the solved model") from None
         row = self.solver.multiplier_rows([g])[0]
+        if row is not None:
+            return row
+        return self._inequality_mult_entry(con_name, g)
+
+    #: What the strictly-active gate says about each regime it turns
+    #: away. Keyed by `reduced_row_activity` status; the value is the
+    #: sentence after the refusal, and it names the regime rather than
+    #: restating the rule, since the two regimes want different things.
+    _INEQUALITY_REFUSAL = {
+        "inactive": (
+            "the row is inactive at the solved point (slack > 0, "
+            "multiplier ~ 0), so its multiplier is zero over a "
+            "neighbourhood of the parameters and d(dual)/dp is a "
+            "structural zero -- there is no KKT row to differentiate"),
+        "weakly_active": (
+            "the row is weakly active at the solved point -- a kink, "
+            "with slack AND multiplier both vanishing -- so the "
+            "multiplier has two one-sided derivatives that differ and "
+            "no two-sided value exists. Ask for a direction instead: "
+            "`solution()` / `parametric_step_directional` report the "
+            "one-sided step for a signed perturbation"),
+        "ambiguous": (
+            "the row's activity regime could not be resolved: its "
+            "barrier-to-curvature ratio sits between the strictly "
+            "active and the inactive thresholds, so whether its "
+            "multiplier is differentiable here is undecided. A tighter "
+            "solve (smaller `tol`) is what moves this ratio"),
+        "unidentified": (
+            "the row's reduced curvature is below the identification "
+            "floor, so its activity regime cannot be measured"),
+        "unbounded": (
+            "the row has no finite bound, so it has no multiplier to "
+            "differentiate"),
+    }
+
+    def _inequality_mult_entry(self, con_name, g):
+        """`mult_entry`'s `y_d` half: the strictly-active gate."""
+        row = self.solver.inequality_multiplier_rows([g])[0]
         if row is None:
+            # neither block claims it, which the c/d split makes
+            # impossible for a row of the solved model -- so this is a
+            # map disagreement, not a user error
             raise ValueError(
-                f"{con_name}: multiplier sensitivities are only available "
-                "for equality constraints")
-        return row
+                f"{con_name}: constraint row {g} is in neither the "
+                "equality nor the inequality multiplier block")
+        try:
+            status = self.solver.reduced_row_activity([g])["status"][0]
+        except Exception as exc:
+            # the classifier's own refusals name the option they are
+            # about -- a relaxed solve is the one a caller actually
+            # meets -- and not the question that reached it, so the
+            # constraint gets attached here
+            raise ValueError(
+                f"{con_name}: an inequality's multiplier sensitivity is "
+                "gated on the row's activity regime, which could not be "
+                f"classified: {exc}") from exc
+        if status == "strongly_active":
+            return row
+        why = self._INEQUALITY_REFUSAL.get(
+            status, f"the row classified as {status!r}")
+        raise ValueError(
+            f"{con_name}: multiplier sensitivities for an inequality "
+            f"are available only where the row is strictly active, and "
+            f"{why}.")
 
 
 def user_row_names(session):

--- a/python/tests/test_sensitivity_core.py
+++ b/python/tests/test_sensitivity_core.py
@@ -582,3 +582,221 @@ def test_refinement_can_only_lengthen_alpha_never_shorten_it():
     assert (a_amb, first_amb) == (2.0, "r")
     assert (a_ref, first_ref) == (float("inf"), None)
     assert a_ref >= a_amb, "refining a coordinate onto its bound cannot shorten alpha"
+
+
+# ── an inequality's shadow price (gh#910) ────────────────────────────────────
+#
+# `mult_entry` used to refuse every inequality outright, which made the
+# one shadow price a user most often wants an error bar on -- a cap: a
+# safety limit, a capacity, a purity spec -- reachable only by rewriting
+# the row as an equality before solving. That rewrite changes the model,
+# and is correct only if the row really does stay active across the
+# perturbation being asked about.
+#
+# The restriction was API surface, not mathematics: `parametric_step_full`
+# has always returned the `y_d` block, and what was missing was the map
+# from a user row to its position in it. But the lift needs a gate, since
+# `y_d` holds a number in all three activity regimes and only one of them
+# has a two-sided derivative.
+
+U0, W_STAR, CAP_SCALE, CAP, A_KINK = 5.0, 2.0, 2.0, 2.0, 0.6
+
+
+def cap_model():
+    """min .5(u-U0)^2 + .5(w-W_STAR)^2 + .5 z^2 - A_KINK p z
+
+        s.t.  pin_p:            p == 0
+              decoy:      3 * w <= 30      (inactive)
+              cap:   2 * (u - p) <= 2      (strictly active)
+              kink:            z >= 0      (weakly active)
+
+    One row in each of the three regimes, with the pin equality first
+    and the inactive decoy second -- so the cap's `g` index (2), its
+    d-block position (1) and its flat KKT row are three different
+    numbers and no index confusion can pass by coincidence.
+
+    Every variable is free: the only activity in the model is in the
+    rows, so a variable-bound answer cannot stand in for a row one.
+
+    At the solution `2(u - p) = 2`, so `u = 1 + p`, and stationarity in
+    `u` gives `lambda_cap = (U0 - u)/2`. Hence `d lambda_cap/dp = -1/2`
+    exactly, on both sides.
+    """
+    v = pounce.NlExpr.vars(4)                       # u, w, z, p
+    return pounce.build_nl_problem(
+        n=4,
+        objective=(0.5 * (v[0] - U0) ** 2 + 0.5 * (v[1] - W_STAR) ** 2
+                   + 0.5 * v[2] ** 2 - A_KINK * v[3] * v[2]),
+        constraints=[v[3], 3.0 * v[1], CAP_SCALE * (v[0] - v[3]), v[2]],
+        g_l=[0.0, -1e19, -1e19, 0.0],
+        g_u=[0.0, 30.0, CAP, 1e19],
+        x_l=[-1e19] * 4, x_u=[1e19] * 4,
+        x0=[0.5, 0.5, 0.5, 0.0],
+        var_names=["u", "w", "z", "p"],
+        con_names=["pin_p", "decoy", "cap", "kink"],
+    )
+
+
+def cap_session():
+    return solve_for_sensitivity(cap_model(), pins={"p": 0},
+                                 options={"print_level": 0})
+
+
+def test_the_cap_fixture_puts_one_row_in_each_activity_regime():
+    """Precondition: without this every assertion below is vacuous."""
+    sess = cap_session()
+    np.testing.assert_allclose(sess.base_x[:2], [CAP / CAP_SCALE, W_STAR],
+                               atol=1e-6)
+    assert abs(sess.base_x[2]) < 1e-3, "z sits at its kink row"
+
+    status = sess.solver.reduced_row_activity([0, 1, 2, 3])["status"]
+    assert status == ["equality", "inactive", "strongly_active",
+                      "weakly_active"]
+
+
+def test_a_strictly_active_inequality_gets_the_derivative_an_equality_gets():
+    """The whole point of gh#910: `d lambda_cap/dp = -1/CAP_SCALE`.
+
+    Read off the `y_d` block, which needs the row map the layer did not
+    have. `-0.5` and not `-1`, because the row's gradient scale is 2 --
+    a right answer here cannot be a coincidence of unit coefficients.
+    """
+    sess = cap_session()
+    row = sess.mult_entry("cap")
+    assert sess.column(0)[row] == pytest.approx(-1.0 / CAP_SCALE, abs=1e-7)
+
+
+def test_the_cap_row_is_not_its_g_index_nor_its_c_block_position():
+    """The map is the feature; addressing the wrong row is how it fails.
+
+    The cap is `g` index 2, d-block position 1, and has no c-block
+    position at all. An equality-blind scan, a `full_to_c`-shaped
+    confusion, and a raw `g` index each land somewhere else.
+    """
+    sess = cap_session()
+    s = sess.solver
+    assert s.multiplier_rows([0, 1, 2, 3]) == [
+        s.multiplier_rows([0])[0], None, None, None], "only the pin is y_c"
+
+    d_rows = s.inequality_multiplier_rows([0, 1, 2, 3])
+    assert d_rows[0] is None, "the pin is an equality, not in y_d"
+    # the three inequalities are consecutive in g order, and the cap is
+    # the SECOND of them -- not the third, which its g index would make it
+    assert d_rows[2] - d_rows[1] == 1 and d_rows[3] - d_rows[2] == 1
+    assert sess.mult_entry("cap") == d_rows[2]
+    assert d_rows[2] != 2, "a raw g index must not pass as a KKT row"
+
+
+def test_an_inactive_row_is_refused_by_naming_its_regime():
+    """Its derivative is a structural zero, not this row's to report.
+
+    Refused rather than answered `0`, and the message says which of the
+    three regimes it is, because the two refusals want different things
+    from the caller: an inactive row's answer really is zero, and a
+    kink needs a direction.
+    """
+    sess = cap_session()
+    with pytest.raises(ValueError, match="inactive at the solved point"):
+        sess.mult_entry("decoy")
+
+
+def test_a_weakly_active_row_is_refused_by_naming_its_regime():
+    sess = cap_session()
+    with pytest.raises(ValueError, match="weakly active at the solved point"):
+        sess.mult_entry("kink")
+    # ...and the row IS addressable: the map does not gate, so a caller
+    # asking for a one-sided answer can still reach it
+    assert sess.solver.inequality_multiplier_rows([3])[0] is not None
+
+
+def test_an_equality_is_still_answered_from_the_y_c_block():
+    """The lift must not reroute the case that already worked."""
+    sess = cap_session()
+    assert sess.mult_entry("pin_p") == sess.solver.multiplier_rows([0])[0]
+
+
+def test_an_unknown_constraint_name_still_raises_before_any_classification():
+    sess = cap_session()
+    with pytest.raises(ValueError, match="not a constraint"):
+        sess.mult_entry("no_such_row")
+
+
+def test_a_relaxed_solve_is_refused_by_naming_the_constraint():
+    """The classifier's own refusals reach the caller as this question.
+
+    `reduced_row_activity` declines a solve with `bound_relax_factor != 0`
+    -- relaxed bounds shift the slacks it reads -- and its message names
+    the option, not the thing that asked. An equality is unaffected: it
+    never reaches the classifier at all.
+    """
+    sess = solve_for_sensitivity(cap_model(), pins={"p": 0},
+                                 options={"print_level": 0,
+                                          "bound_relax_factor": 1e-8})
+    assert sess.mult_entry("pin_p") is not None, "the y_c half is ungated"
+    with pytest.raises(ValueError, match="cap: an inequality's multiplier"):
+        sess.mult_entry("cap")
+
+
+# ── which classifier gates it, and why it is not the cheap one ───────────────
+
+def coupled_kink_model(rho):
+    """min .5 k^2 + c k y + .5 y^2 - A p k  s.t.  p == 0,  2k >= 0.
+
+    `c = sqrt(1 - rho)` makes the curvature REDUCED along the row's
+    direction exactly `rho`, while the curvature along the row's own
+    gradient stays 1. The row is a genuine kink at every `rho`: at
+    `p = 0` both its slack and its multiplier vanish.
+
+    `classify_activity` normalizes by the directional curvature, so its
+    ratio here is `rho/1` and its verdict slides with the coupling --
+    "ambiguous" at `1e-2`, and "inactive" by `1e-6` (gh#804).
+    `reduced_row_activity` divides by `rho` itself and says
+    "weakly_active" throughout.
+    """
+    import math
+    c = math.sqrt(1.0 - rho)
+    v = pounce.NlExpr.vars(3)                       # k, y, p
+    return pounce.build_nl_problem(
+        n=3,
+        objective=(0.5 * v[0] ** 2 + c * v[0] * v[1] + 0.5 * v[1] ** 2
+                   - 0.25 * v[2] * v[0]),
+        constraints=[v[2], 2.0 * v[0]],
+        g_l=[0.0, 0.0], g_u=[0.0, 1e19],
+        x_l=[-1e19] * 3, x_u=[1e19] * 3,
+        x0=[0.3, 0.0, 0.0],
+        var_names=["k", "y", "p"], con_names=["pin_p", "kink"],
+    )
+
+
+@pytest.mark.parametrize("rho,cheap", [(1e-2, "ambiguous"),
+                                       (1e-4, "ambiguous"),
+                                       (1e-6, "inactive")])
+def test_the_gate_reads_the_reduced_classifier_not_the_cheap_one(rho, cheap):
+    """The refusal REASON is what the cheap classifier gets wrong.
+
+    Neither classifier can *admit* a kink -- a row's reduced curvature
+    is never larger than its directional one, so the reduced ratio is
+    never below the directional one and `strongly_active` is the
+    high-ratio tail of both. What slides with the coupling is the
+    class the kink lands in when it is turned away, and by `rho = 1e-6`
+    the cheap classifier calls it **inactive**.
+
+    "inactive" is the one verdict a caller may legitimately read as
+    "this shadow price does not move". So gating there would not
+    decline to answer about a tight cap's kinked shadow price -- it
+    would answer "it does not move", which is a wrong answer wearing a
+    refusal's clothes. Coupling that strong is routine on a collocation
+    model, and reading an activity class as a proxy for kink-ness is
+    the inference that shipped gh#756.
+
+    This is a three-`rho` sweep and not one case because the cheap
+    classifier's verdict is the thing that moves: a single `rho` cannot
+    distinguish "the gate reads the reduced classifier" from "the two
+    classifiers happen to agree here".
+    """
+    sess = solve_for_sensitivity(coupled_kink_model(rho), pins={"p": 0},
+                                 options={"print_level": 0})
+    assert sess.solver.classify_activity()["row_status"][1] == cheap
+    assert sess.solver.reduced_row_activity([1])["status"][0] == "weakly_active"
+    with pytest.raises(ValueError, match="weakly active at the solved point"):
+        sess.mult_entry("kink")


### PR DESCRIPTION
Fixes #910

## Problem

`sens_jacobian(of=<Constraint>)` gave multiplier sensitivities for equality rows only. An inequality was refused outright — including the one case where the multiplier is a perfectly ordinary differentiable function of the parameters, a row that is strictly active at the solved point.

That is the case a user actually asks about. The shadow price someone wants an error bar on is usually a *cap* — a safety limit, a capacity, a purity spec — and those are written as inequalities. The only route was to rewrite the row as an equality `g(x) == b` before solving: a change to the model, correct only if the row really does stay active over the perturbation being asked about.

Closed form on the fixture this PR adds (`min .5(u-5)² + .5(w-2)²` s.t. `2(u - p) <= 2`, `3w <= 30`), where `u = 1 + p` and `λ_cap = (5 - u)/2`:

| | `sens_jacobian(m.cap, wrt=m.p)` |
|---|---|
| before | `ValueError: multiplier sensitivities are only available for equality constraints` |
| after | `+0.500000000` |
| oracle — finite difference of `m.dual[m.cap]` across a re-solve | `+0.499999999` |

## Cause

API surface, not mathematics. The compound KKT vector is `(x, s, y_c, y_d, z_l, z_u, v_l, v_u)` and `parametric_step_full` has always returned the whole thing, `y_d` included. What was missing was the *map*: `g_multiplier_rows` finds an equality's `y_c` row through `BoundClassification::full_to_c`, and there was no counterpart for `y_d`. `full_to_c` returns `-1` for an inequality, so the only thing the layer could do with one was refuse.

## Fix

The exact complement of the existing chain, at every layer it already exists in:

```
BoundClassification::full_to_d       <- the O(1) inverse of d_map
IpoptNlp::full_g_to_d_block          <- default None (complement of full_g_to_c_block's identity)
PdSensBacksolver::full_g_to_d_block
Solver::d_multiplier_rows            <- n_x + n_s + n_y_c + d position
solver.inequality_multiplier_rows()  <- the PyO3 binding
```

**The map is ungated, and deliberately so** — a caller asking for a one-sided answer at a kink still needs the row. The gate lives one layer up, in `pounce.sensitivity`'s `mult_entry`: an inequality is answered only where the row is strictly active. The other two regimes are refused with messages that *name the regime*, because they call for different things from the caller — an inactive row's answer really is zero (but whether it stays inactive across the perturbation you mean is your question, not the factor's), and a kink needs a direction, which `sens_solution()` / `parametric_step_directional` take and `sens_jacobian` does not.

### Which classifier gates it, and the approach that was rejected

`reduced_row_activity()`, not `classify_activity()` — and the obvious reason is the wrong one.

Neither classifier can *admit* a kink. A row's reduced curvature is never larger than its directional one, so the reduced ratio is never below the directional ratio, and `strongly_active` is the high-ratio tail of both. Gating on the cheap classifier would not let a kink through. What it gets wrong is the **refusal reason**: its ratio for a genuine kink is `reduced/directional` (#804), so the class slides with the coupling. Measured here, on a fixture whose row is a kink at every `rho` (`min .5k² + c·k·y + .5y² - .25·p·k` s.t. `p == 0`, `2k >= 0`, with `c = sqrt(1 - rho)` fixing the reduced curvature at `rho`):

| `rho` | `classify_activity()` | `reduced_row_activity()` |
|---|---|---|
| `1e-2` | `ambiguous` | `weakly_active` |
| `1e-4` | `ambiguous` | `weakly_active` |
| `1e-6` | **`inactive`** | `weakly_active` |

`inactive` is the one class whose derivative a caller may legitimately read as a structural zero. So gating on the directional ratio would not decline to answer about a tight cap's kinked shadow price — it would answer "it does not move", which is a wrong answer wearing a refusal's clothes. Coupling that strong is routine on a collocation model, and reading an activity class as a proxy for kink-ness is the inference that shipped #756.

That is a three-`rho` sweep and not one case on purpose: a single `rho` cannot distinguish "the gate reads the reduced classifier" from "the two classifiers happen to agree here".

### One thing beyond the issue's list

`reduced_row_activity`'s own full-g → d-block scan now goes through the new map rather than the second ascending scan it carried, which agrees with it today. The gate classifies with *that* function and then reads *this* row, so a drift between the two would classify one row and answer about another — exactly the failure the map exists to prevent. The invariant the old scan asserted (`d_pos == m_d`) is kept, restated as a count.

## Blast radius

Additive. No existing call changes its answer:

- `g_multiplier_rows` / `multiplier_rows` are untouched; an equality still returns the same `y_c` row, and `mult_entry` returns before reaching any new code for one. `test_an_equality_is_still_answered_from_the_y_c_block` pins that, and it is the one new test that passes on the parent commit.
- `full_to_d` is a new field populated in the existing classification loop; nothing but the new method reads it. `BoundClassification` has exactly one construction site.
- `IpoptNlp::full_g_to_d_block` defaults to `None`, and only `OrigIpoptNlp` overrides it — the same set of impls that override `full_g_to_c_block` (which is: only that one).
- The `reduced_row_activity` reroute is behaviour-preserving on `OrigIpoptNlp` (the two maps are complements by construction) and on every default impl (both scans return all-`None`).

**No trajectory change**, so no fixture sweep: nothing here is reachable from a solve. The only touched code on any solve path is a struct field that is written and never read during a solve.

The user-visible behaviour change is that a call which used to raise can now return a number, and two calls which used to raise one message now raise a more specific one. `pyomo-pounce/tests/test_sens.py::test_inequality_multiplier_error_is_unchanged` asserted the old message and is replaced by tests for the new gate.

## Tests

**Verified failing on the parent commit, for the stated reason.** Checking out `HEAD~1`'s `_session.py` against the built extension (the parent's gate never calls the new binding, so this faithfully reproduces it): 8 of the 9 new core tests and all 6 new pyomo tests fail, each with `multiplier sensitivities are only available for equality constraints`. The 9th is the equality no-regression test above, which is *supposed* to pass pre-fix.

**`sens_invariance_legs.rs` grows a third fixture**, per CLAUDE.md's "a new public accessor gets a row in each leg" rule. The pin equality is `g0` and an **inactive decoy** is `g1`, which makes the cap's coordinates three different numbers — `g` index 2, d-block position 1, no c-block position at all — so a `full_to_c`-shaped confusion, an equality-blind scan, and a raw `g` index each land somewhere else. A kink row at `g3` puts all three regimes in one model. Rows in legs 1 (scaling), 2 (magnitude), 3 (fixed variable) and at the fixed-and-scaled corner.

The legs bite. Mutation-checked, each reverted:

| mutation | result |
|---|---|
| `y_d` offset built as `dims[0]+dims[1]` (the `y_c` offset) | 6 legs red |
| `full_to_d[i] = i` (g index read as d position) | 7 red, incl. the map-addressability test |
| offset from `n_full_x` instead of the factor's `x` width | **only leg 3 and the corner** red |

That last row is the point of leg 3, and it is the leg that looks vacuous — a fixed variable is an `x`-block question and this is a `y_d` row. It is the gh#450 hazard two blocks over.

**One outside number.** Every other guard here compares a number the sensitivity layer produced against another one it produced. `pyomo-pounce/tests/test_sens.py::test_a_strictly_active_inequalitys_shadow_price_has_a_derivative` checks `sens_jacobian(m.cap, wrt=m.p)` against a finite difference of `m.dual[m.cap]` across a re-solve — `+0.5` both ways. That is what pins the *sign* convention through the `y_d` block (`pack_lambda_for_user` scatters `y_c` and `y_d` into one `lambda` array with no sign change between them, so an inequality's dual is on the same footing as an equality's, and this is the assertion that would catch it if it were not).

**Deliberately not pinned.** The re-solve oracle in `sens_resolve_oracle.rs` gets no new row: this PR reroutes no correction and changes no step, only which row of an existing step is addressable. The pyomo FD test is the outside number for the quantity that is new.

**CI, all 8 checks green on `4a8bb73`.** `Test (ubuntu-latest)` covers `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude pounce-hsl --all-targets -D clippy::correctness -D clippy::suspicious`, and `cargo test --workspace --exclude pounce-hsl`; plus Python tests (jax) and (torch), both wheel smokes, both CasADi jobs, and the WebAssembly smoke.

Locally: `pounce-nlp` + `pounce-sensitivity` + `pounce-sens-core` **433 passed, 0 failed** (legs file 24/24); `cargo check --workspace --all-targets` clean; `cargo fmt --all -- --check` clean; pyomo-pounce **461 passed**; python **1117 passed**; `make ask-check` **17/20 top-1 (floor 14), 20/20 top-5 (floor 18)** — run because #911's new docs-retrieval guard indexes `docs/src`, which this PR edits.

## Note on the merge commit

`4a8bb73` merges `origin/main` into the branch: #911 landed after this branched, and GitHub reported the PR `dirty`. Resolved as a merge (no rebase or force-push), clean, with this PR's CHANGELOG entry above #911's. The merge brought in no code outside `docs/`, `scripts/` and the `Makefile`.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`sensitivity.md`, "The shadow price of a cap"; existing page, no `SUMMARY.md` change)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

**On the fourth box**, which I first submitted unticked: I could not complete `cargo test --workspace` locally — the workspace debug build exhausts my container's disk allowance — and had substituted `cargo check --workspace --all-targets` plus full test runs of the three crates the diff touches. CI has now run the real thing green, so the box is ticked on CI's authority rather than mine. One correction to what I originally wrote: I listed `pounce-hsl` failing to link without `COINHSL_DIR` as a gap, but CI **excludes `pounce-hsl` from build, test and clippy by design** for that same reason, so it was never a gap — just the repo's own policy showing up locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpDSkKHHKVTMMv2i2QRkRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpDSkKHHKVTMMv2i2QRkRj)_