### PR TITLE
docs: make the Ask button a floating widget in the lower-right corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@ changes.
 ### Added
 
 - **An in-browser docs assistant on the rendered site (`Ask`).** A question
-  box in the menu bar of every page of <https://jkitchin.github.io/pounce/>,
-  built from two halves that work independently. Retrieval is BM25 over an
-  index of the whole book *and* the GitHub wiki, deep-linked to the heading
-  that answers; generation is optional, a small instruct model
-  ([WebLLM](https://github.com/mlc-ai/web-llm) on WebGPU) that is handed only
-  the retrieved passages. Nothing leaves the browser: no API key, no server,
-  no telemetry, and no download at all until the reader clicks "Load model".
+  box behind a floating button in the lower-right corner of every page of
+  <https://jkitchin.github.io/pounce/>, built from two halves that work
+  independently. Retrieval is BM25 over an index of the whole book *and* the
+  GitHub wiki, deep-linked to the heading that answers; generation is
+  optional, a small instruct model ([WebLLM](https://github.com/mlc-ai/web-llm)
+  on WebGPU) that is handed only the retrieved passages. Nothing leaves the
+  browser: no API key, no server, no telemetry, and no download at all until
+  the reader clicks "Load model".
 
   **The wiki is the reason it exists as much as the model is.** The four
   long-form wiki pages carry the measured guidance — which of the 441 options

--- a/docs/assets/ask.css
+++ b/docs/assets/ask.css
@@ -11,24 +11,82 @@
    necessarily POUNCE's brand tokens (--pounce-tiger), which were added later.
    ========================================================================== */
 
-/* ---- Menu-bar toggle, sitting with the version selector ----------------- */
+/* ---- Floating toggle, lower-right ---------------------------------------
+   It used to sit inline in the menu bar's .right-buttons, next to the print /
+   repo / edit icons. At 0.8rem, transparent, in the --icons colour, between
+   the version selector and a row of glyphs, it read as one more piece of
+   chrome and readers did not find it. A filled pill pinned to the viewport is
+   the shape a reader already recognises as "ask something here", and it stays
+   on screen when the menu bar scrolls away.
+
+   z-index sits just under .pounce-ask-panel (1000) and above mdBook's menu bar
+   and sidebar, so the panel covers the button rather than the reverse; the
+   button is hidden outright while the panel is open (see below), because the
+   panel is right-aligned and would otherwise swallow the click target.
+   ------------------------------------------------------------------------ */
 .pounce-ask-toggle {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 999;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
   appearance: none;
   -webkit-appearance: none;
-  background: transparent;
-  color: var(--icons, #a88a5e);
-  border: 1px solid var(--icons, #a88a5e);
-  border-radius: 4px;
+  background: var(--pounce-tiger, #e87a1e);
+  color: #1a1411;
+  border: 1px solid var(--pounce-tiger, #e87a1e);
+  border-radius: 999px;
   font: inherit;
-  font-size: 0.8rem;
+  font-size: 0.9rem;
+  font-weight: 600;
   line-height: 1.2;
-  padding: 0.15em 0.7em;
-  margin-right: 0.4rem;
+  padding: 0.6em 1.15em;
   cursor: pointer;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3), 0 8px 28px rgba(0, 0, 0, 0.22);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 .pounce-ask-toggle:hover {
-  color: var(--pounce-tiger, #e87a1e);
-  border-color: var(--pounce-tiger, #e87a1e);
+  background: var(--pounce-amber, #b56a12);
+  border-color: var(--pounce-amber, #b56a12);
+  color: #fdf6e8;
+  transform: translateY(-1px);
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.34), 0 10px 32px rgba(0, 0, 0, 0.26);
+}
+.pounce-ask-toggle:active {
+  transform: translateY(0);
+}
+.pounce-ask-toggle:focus-visible {
+  outline: 2px solid var(--fg, #f1e4cb);
+  outline-offset: 2px;
+}
+.pounce-ask-toggle-icon {
+  display: block;
+  width: 1.15em;
+  height: 1.15em;
+  flex: none;
+}
+.pounce-ask-toggle-icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
+/* Open panel is right-aligned and full height: it lies over the button, so
+   take the button out rather than leave an unclickable one underneath. */
+body.pounce-ask-open .pounce-ask-toggle {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pounce-ask-toggle {
+    transition: none;
+  }
+  .pounce-ask-toggle:hover {
+    transform: none;
+  }
 }
 
 /* ---- Panel -------------------------------------------------------------- */
@@ -252,6 +310,30 @@
   .pounce-ask-panel {
     width: 100vw;
     border-left: none;
+  }
+  /* Icon-only circle: at this width the label costs more page than it buys,
+     and the button still carries its aria-label and title. */
+  .pounce-ask-toggle {
+    right: 1rem;
+    bottom: 1rem;
+    padding: 0;
+    width: 2.9rem;
+    height: 2.9rem;
+    justify-content: center;
+  }
+  .pounce-ask-toggle-label {
+    display: none;
+  }
+  .pounce-ask-toggle-icon {
+    width: 1.35rem;
+    height: 1.35rem;
+  }
+  /* mdBook stacks its previous/next chapter buttons at the foot of the page at
+     this width (the wide layout uses .nav-wide-wrapper outside the content and
+     hides this one), and the circle lands on the "next" one at the bottom of
+     the scroll. Give them room. */
+  .nav-wrapper {
+    margin-bottom: 3.25rem;
   }
 }
 

--- a/docs/assets/ask.js
+++ b/docs/assets/ask.js
@@ -481,19 +481,39 @@
     ui.toggle.focus();
   }
 
+  // A speech bubble, inline rather than a font glyph or an image: the button is
+  // injected into archived books whose CSS has no icon font, and an <img>
+  // would be a second request resolved against a path this file would have to
+  // compute. 16x16 viewBox, currentColor fill, so it inherits the pill.
+  var TOGGLE_ICON =
+    '<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" ' +
+    'aria-hidden="true" focusable="false">' +
+    '<path d="M8 1.5c-3.9 0-7 2.4-7 5.4 0 1.7 1 3.2 2.6 4.2-.1.8-.5 1.8-1.3 2.6' +
+    '-.2.2 0 .5.2.5 1.6-.1 3-.7 4-1.5.5.1 1 .1 1.5.1 3.9 0 7-2.4 7-5.4S11.9 1.5 8 1.5z"/>' +
+    "</svg>";
+
   function buildToggle() {
-    var bar = document.querySelector(".right-buttons");
-    if (!bar || document.getElementById("pounce-ask-toggle")) return false;
-    var btn = el("button", "pounce-ask-toggle", "Ask");
+    // .right-buttons is not the mount point any more — the button is fixed to
+    // the viewport — but it stays the test for "this page has mdBook chrome".
+    // A 404 or print view has none, and there the panel is unreachable, so
+    // init() drops it rather than leaving a dialog in the DOM.
+    var chrome = document.querySelector(".right-buttons");
+    if (!chrome || document.getElementById("pounce-ask-toggle")) return false;
+    var btn = el("button", "pounce-ask-toggle");
     btn.id = "pounce-ask-toggle";
     btn.type = "button";
     btn.title = "Ask a question about the POUNCE docs (runs in your browser)";
     btn.setAttribute("aria-label", "Ask the docs assistant");
+    var icon = el("span", "pounce-ask-toggle-icon");
+    icon.setAttribute("aria-hidden", "true");
+    icon.innerHTML = TOGGLE_ICON;
+    btn.appendChild(icon);
+    btn.appendChild(el("span", "pounce-ask-toggle-label", "Ask"));
     btn.addEventListener("click", function () {
       if (ui.panel.hidden) openPanel();
       else closePanel();
     });
-    bar.insertBefore(btn, bar.firstChild);
+    document.body.appendChild(btn);
     ui.toggle = btn;
     return true;
   }

--- a/docs/src/ask.md
+++ b/docs/src/ask.md
@@ -1,7 +1,7 @@
 # Ask POUNCE: the in-browser docs assistant
 
-The **Ask** button in the menu bar opens a question box for these docs. It has
-two halves, and they work independently:
+The floating **Ask** button in the lower-right corner of every page opens a
+question box for these docs. It has two halves, and they work independently:
 
 | | What it does | What it costs |
 |---|---|---|


### PR DESCRIPTION
## Problem

The **Ask** button was invisible in practice. Inline in the menu bar's
`.right-buttons`, it rendered at `0.8rem`, transparent background, `--icons`
colour, wedged between the version selector and the print / repo / edit glyphs.

Everything about that placement says "chrome". A reader scanning the page for a
way to ask a question has no reason to read a small outlined word sitting in a
row of icons as the entry point to the feature — and did not.

No numbers here; this is a visual-affordance problem, not a numerical one.

## Cause

The button inherited its position from the version selector, which is genuinely
chrome and belongs in the menu bar. The assistant is not chrome — it is the
feature the page is offering — and it was styled to match its neighbours rather
than to be found. Being in the menu bar also means it scrolls away.

## Fix

A filled pill fixed to the viewport at the lower right: speech bubble + "Ask",
brand tiger, shadowed. This is the shape readers already recognise as "ask
something here", and it stays on screen down a long page. At ≤700px it collapses
to a 2.9rem circle, and while the panel is open the button is taken out
entirely.

Decisions worth recording, because each had a wrong-looking-but-tempting
alternative:

- **`.right-buttons` is still queried, but only as a probe.** It is no longer
  the mount point — the button goes on `<body>` — but it remains the test for
  "this page has mdBook chrome". A 404 or print view has none, and `init()`
  still drops the panel there rather than leaving an unreachable dialog in the
  DOM. Dropping the query entirely was the obvious simplification and would
  have put an orphan panel on those pages.
- **The button is `display: none` while the panel is open.** The panel is
  right-aligned, full height, `z-index` 1000; the button at 999 sits directly
  underneath it. Leaving it there means an unclickable target under an opaque
  panel, which is worse than no button. `closePanel()` removes the body class
  before calling `focus()`, so focus return still works.
- **The icon is inline SVG with `currentColor`,** not a font glyph and not an
  `<img>`. `ask.js` is injected into archived books whose CSS predates the
  assistant and defines no icon font, and an image would be a second request
  against a path this file would have to compute — the same class of
  site-root-vs-version-root problem the `data-root` / `data-p2r` split exists
  to solve.
- **`.nav-wrapper` gets bottom clearance under 700px.** mdBook stacks its
  prev/next chapter buttons at the foot of the content at that width (the wide
  layout hides that one in favour of `.nav-wide-wrapper`), and the circle lands
  on "next" at the bottom of the scroll without it. Scoped inside the media
  query so the wide layout is untouched.
- `prefers-reduced-motion` drops the hover transition and lift.

## Blast radius

Presentation only, confined to the assistant's own toggle. Retrieval, ranking,
the index, WebLLM, and the panel's internals are untouched — the `ask.js` diff
is `buildToggle()` and a string constant.

It does reach **every** built book, including archived tags, because `ask.js` /
`ask.css` are injected per page by `scripts/build-versioned-docs.sh` rather than
configured in `book.toml`. That is the intended delivery path for this file and
the reason the CSS falls back to a literal for every colour: an archived book's
theme defines mdBook's variables but not necessarily POUNCE's brand tokens. The
new rules keep that discipline (`var(--pounce-tiger, #e87a1e)` etc.), and the
one rule that reaches into mdBook's own DOM, `.nav-wrapper`, sets a margin only.

No Rust, no solver, no fixtures — the corpus sweep is not applicable.

## Tests

`make ask-check` passes. It is not a test of this change — retrieval is
untouched — but it is what loads `ask.js` under node, so it would catch a
syntax error in the edited file.

The change is verified by **direct measurement in Chromium**, against a harness
carrying the real `ask.js` and `ask.css`, an index freshly built by
`scripts/build-docs-index.py`, and an mdBook-shaped page with a `.right-buttons`
menu bar. Checked in dark and light palettes, at 1100×620 and 390×700:

| | result |
|---|---|
| mounts on `<body>`, not in `.right-buttons` | ✅ |
| pinned across scroll | ✅ box unmoved after `scrollTo(0, 400)` |
| hit-tests to itself (`elementFromPoint` at its centre) | ✅ |
| hidden while the panel is open | ✅ |
| visible again after `Escape` | ✅ |
| focus returns to the toggle after `Escape` | ✅ `activeElement === #pounce-ask-toggle` |
| accessible name survives the icon | ✅ `aria-label="Ask the docs assistant"` |
| no page errors | ✅ |

Screenshots of the before and after are in the session, not inlined here —
they were taken in a sandbox with no way to upload an attachment to this repo,
and a body full of broken image links is worse than a description.

**Deliberately not pinned, and why:** there is no browser-driven test
infrastructure in this repo, and adding Playwright to CI for one button is not
proportionate. `docs/tests/ask_retrieval.mjs` runs under node precisely because
the retrieval half is pure and the DOM half is never reached there. So the
placement is a known unpinned surface — a future edit that moves the button back
into the menu bar, or breaks focus return, will not go red.

**Also not exercised end to end:** `make book-site` needs `mdbook`, which is not
available in this environment, so the injected-into-a-real-archived-book path
was not run. The harness reproduces the injected `<script>` tag and its
`data-*` attributes, but a local `make book-site` before merge would close that
gap.

## Docs

- `docs/src/ask.md` said "The **Ask** button in the menu bar"; it now says where
  the button is.
- `CHANGELOG.md` `[Unreleased]` made the same stale claim. The assistant has not
  shipped in a release yet, so that entry is the record to correct rather than a
  second entry to add.

---

- [x] Tests fail on the parent commit for the stated reason — n/a, no new
      automated test; see **Tests** for what was measured instead and for the
      gap that is deliberately left unpinned
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — n/a,
      no Rust in this diff (`docs/assets/*`, `docs/src/ask.md`, `CHANGELOG.md`)
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxpQNZjJVEy4Dsy5TniuGG
