### PR TITLE
docs(sens): the two loose ends #913 left, and a fixture for the other branch

### DIFF
--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -134,6 +134,66 @@ def test_a_strictly_active_inequalitys_shadow_price_has_a_derivative(
         "block and pyomo duals")
 
 
+def build_floor(p=0.0):
+    """The mirror of [`build_cap`], with the active row a floor.
+
+    `min .5(u+5)^2 + .5(w-2)^2  s.t.  2(u - p) >= 2,  3w <= 30.`
+
+    The objective centre moves to -5 so the unconstrained optimum sits
+    BELOW the row and the `>=` binds; `u = 1 + p` at the solution and
+    stationarity in `u` gives `lambda_floor = (u + 5)/2`, so
+    `d lambda_floor/dp = +1/2` and the AMPL marginal pyomo reports moves
+    by `+1/2` as well.
+    """
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=p, mutable=True)
+    m.u = pyo.Var(initialize=0.5)
+    m.w = pyo.Var(initialize=0.5)
+    m.floor = pyo.Constraint(expr=2.0 * (m.u - m.p) >= 2.0)
+    m.decoy = pyo.Constraint(expr=3.0 * m.w <= 30.0)
+    m.obj = pyo.Objective(
+        expr=0.5 * (m.u + 5.0) ** 2 + 0.5 * (m.w - 2.0) ** 2)
+    return m
+
+
+@pytest.fixture(scope="module")
+def solved_floor():
+    m = build_floor()
+    declare_sens_param(m.p)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+def test_a_lower_bounded_rows_shadow_price_has_a_derivative_too(solved_floor):
+    """The other branch of the c/d split, against the same outside number.
+
+    Every strictly-active fixture that arrived with gh#910 is a `<=`
+    row, and a row's finite bounds land in `d_l_map` or `d_u_map` — so
+    `>=` is a branch nothing reached, and CLAUDE.md's rule about that is
+    blunt. `full_to_d` is bound-side-agnostic, but the GATE is not: it
+    wants `strongly_active` out of `reduced_row_activity`, which reads
+    `v_l/(s - d_l)` on this side rather than `v_u/(d_u - s)`.
+
+    The finite difference is the part that matters. A sign convention
+    that happened to be right for a ceiling and wrong for a floor would
+    pass every internal check in the crate and show up only here.
+    """
+    m = solved_floor
+    assert pyo.value(m.u) == pytest.approx(1.0, abs=1e-6), (
+        "precondition: the floor must bind, or this is the inactive case")
+
+    g = sens_jacobian(m.floor, wrt=m.p)
+
+    hi = solve_plain(build_floor(p=CAP_H))
+    lo = solve_plain(build_floor(p=-CAP_H))
+    fd = (hi.dual[hi.floor] - lo.dual[lo.floor]) / (2 * CAP_H)
+    assert g == pytest.approx(fd, abs=1e-4), (
+        "sign convention differs between an active floor and an active "
+        "ceiling in the y_d block")
+
+
 def test_an_inactive_inequality_is_refused_by_naming_its_regime(solved_cap):
     """Refused, not answered `0`.
 

--- a/python/notebooks/39_design_under_kinetic_uncertainty.ipynb
+++ b/python/notebooks/39_design_under_kinetic_uncertainty.ipynb
@@ -49,10 +49,10 @@
    "id": "f1737133",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:03.046551Z",
-     "iopub.status.busy": "2026-09-05T15:03:03.046415Z",
-     "iopub.status.idle": "2026-09-05T15:03:03.888429Z",
-     "shell.execute_reply": "2026-09-05T15:03:03.887149Z"
+     "iopub.execute_input": "2026-09-05T21:10:25.018571Z",
+     "iopub.status.busy": "2026-09-05T21:10:25.018348Z",
+     "iopub.status.idle": "2026-09-05T21:10:25.849377Z",
+     "shell.execute_reply": "2026-09-05T21:10:25.849014Z"
     }
    },
    "outputs": [
@@ -63,7 +63,7 @@
       "python        3.12.11\n",
       "pounce-solver 0.11.0\n",
       "pyomo-pounce  0.1.0\n",
-      "commit        1369f570f3f7\n"
+      "commit        6ce7ccff58c5\n"
      ]
     }
    ],
@@ -132,10 +132,10 @@
    "id": "33390ca5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:03.891421Z",
-     "iopub.status.busy": "2026-09-05T15:03:03.890941Z",
-     "iopub.status.idle": "2026-09-05T15:03:03.895890Z",
-     "shell.execute_reply": "2026-09-05T15:03:03.895395Z"
+     "iopub.execute_input": "2026-09-05T21:10:25.850917Z",
+     "iopub.status.busy": "2026-09-05T21:10:25.850597Z",
+     "iopub.status.idle": "2026-09-05T21:10:25.853712Z",
+     "shell.execute_reply": "2026-09-05T21:10:25.853444Z"
     }
    },
    "outputs": [
@@ -201,10 +201,10 @@
    "id": "01bbb422",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:03.898078Z",
-     "iopub.status.busy": "2026-09-05T15:03:03.897946Z",
-     "iopub.status.idle": "2026-09-05T15:03:03.910673Z",
-     "shell.execute_reply": "2026-09-05T15:03:03.910103Z"
+     "iopub.execute_input": "2026-09-05T21:10:25.854904Z",
+     "iopub.status.busy": "2026-09-05T21:10:25.854833Z",
+     "iopub.status.idle": "2026-09-05T21:10:25.865290Z",
+     "shell.execute_reply": "2026-09-05T21:10:25.864962Z"
     }
    },
    "outputs": [
@@ -271,10 +271,10 @@
    "id": "05a03bf1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:03.912873Z",
-     "iopub.status.busy": "2026-09-05T15:03:03.912731Z",
-     "iopub.status.idle": "2026-09-05T15:03:04.145988Z",
-     "shell.execute_reply": "2026-09-05T15:03:04.144638Z"
+     "iopub.execute_input": "2026-09-05T21:10:25.866366Z",
+     "iopub.status.busy": "2026-09-05T21:10:25.866308Z",
+     "iopub.status.idle": "2026-09-05T21:10:26.074026Z",
+     "shell.execute_reply": "2026-09-05T21:10:26.073732Z"
     }
    },
    "outputs": [
@@ -324,10 +324,10 @@
    "id": "0fbf7bba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:04.150588Z",
-     "iopub.status.busy": "2026-09-05T15:03:04.149962Z",
-     "iopub.status.idle": "2026-09-05T15:03:04.156796Z",
-     "shell.execute_reply": "2026-09-05T15:03:04.155559Z"
+     "iopub.execute_input": "2026-09-05T21:10:26.075213Z",
+     "iopub.status.busy": "2026-09-05T21:10:26.075134Z",
+     "iopub.status.idle": "2026-09-05T21:10:26.078078Z",
+     "shell.execute_reply": "2026-09-05T21:10:26.077781Z"
     }
    },
    "outputs": [
@@ -393,10 +393,10 @@
    "id": "f7d27bce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:04.160472Z",
-     "iopub.status.busy": "2026-09-05T15:03:04.160068Z",
-     "iopub.status.idle": "2026-09-05T15:03:04.286714Z",
-     "shell.execute_reply": "2026-09-05T15:03:04.285345Z"
+     "iopub.execute_input": "2026-09-05T21:10:26.079212Z",
+     "iopub.status.busy": "2026-09-05T21:10:26.079138Z",
+     "iopub.status.idle": "2026-09-05T21:10:26.191502Z",
+     "shell.execute_reply": "2026-09-05T21:10:26.191143Z"
     }
    },
    "outputs": [
@@ -499,10 +499,10 @@
    "id": "c1230d05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:04.290593Z",
-     "iopub.status.busy": "2026-09-05T15:03:04.289945Z",
-     "iopub.status.idle": "2026-09-05T15:03:04.302265Z",
-     "shell.execute_reply": "2026-09-05T15:03:04.300975Z"
+     "iopub.execute_input": "2026-09-05T21:10:26.192735Z",
+     "iopub.status.busy": "2026-09-05T21:10:26.192671Z",
+     "iopub.status.idle": "2026-09-05T21:10:26.200605Z",
+     "shell.execute_reply": "2026-09-05T21:10:26.200276Z"
     }
    },
    "outputs": [
@@ -579,10 +579,10 @@
    "id": "a8aff190",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:04.305384Z",
-     "iopub.status.busy": "2026-09-05T15:03:04.305269Z",
-     "iopub.status.idle": "2026-09-05T15:03:04.383257Z",
-     "shell.execute_reply": "2026-09-05T15:03:04.381831Z"
+     "iopub.execute_input": "2026-09-05T21:10:26.201602Z",
+     "iopub.status.busy": "2026-09-05T21:10:26.201537Z",
+     "iopub.status.idle": "2026-09-05T21:10:26.274104Z",
+     "shell.execute_reply": "2026-09-05T21:10:26.273755Z"
     }
    },
    "outputs": [
@@ -647,10 +647,10 @@
    "id": "5fbdf14f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:04.386487Z",
-     "iopub.status.busy": "2026-09-05T15:03:04.386363Z",
-     "iopub.status.idle": "2026-09-05T15:03:04.392790Z",
-     "shell.execute_reply": "2026-09-05T15:03:04.391549Z"
+     "iopub.execute_input": "2026-09-05T21:10:26.275310Z",
+     "iopub.status.busy": "2026-09-05T21:10:26.275234Z",
+     "iopub.status.idle": "2026-09-05T21:10:26.278317Z",
+     "shell.execute_reply": "2026-09-05T21:10:26.278035Z"
     }
    },
    "outputs": [
@@ -685,10 +685,10 @@
    "id": "cbc30d18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:04.395361Z",
-     "iopub.status.busy": "2026-09-05T15:03:04.395271Z",
-     "iopub.status.idle": "2026-09-05T15:03:04.513168Z",
-     "shell.execute_reply": "2026-09-05T15:03:04.512611Z"
+     "iopub.execute_input": "2026-09-05T21:10:26.279357Z",
+     "iopub.status.busy": "2026-09-05T21:10:26.279292Z",
+     "iopub.status.idle": "2026-09-05T21:10:26.374414Z",
+     "shell.execute_reply": "2026-09-05T21:10:26.374035Z"
     }
    },
    "outputs": [
@@ -773,10 +773,10 @@
    "id": "d534868c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:04.514966Z",
-     "iopub.status.busy": "2026-09-05T15:03:04.514874Z",
-     "iopub.status.idle": "2026-09-05T15:03:04.518824Z",
-     "shell.execute_reply": "2026-09-05T15:03:04.518223Z"
+     "iopub.execute_input": "2026-09-05T21:10:26.375545Z",
+     "iopub.status.busy": "2026-09-05T21:10:26.375464Z",
+     "iopub.status.idle": "2026-09-05T21:10:26.378103Z",
+     "shell.execute_reply": "2026-09-05T21:10:26.377801Z"
     }
    },
    "outputs": [
@@ -854,10 +854,10 @@
    "id": "497bae19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:04.520739Z",
-     "iopub.status.busy": "2026-09-05T15:03:04.520629Z",
-     "iopub.status.idle": "2026-09-05T15:03:09.988108Z",
-     "shell.execute_reply": "2026-09-05T15:03:09.986800Z"
+     "iopub.execute_input": "2026-09-05T21:10:26.379091Z",
+     "iopub.status.busy": "2026-09-05T21:10:26.379013Z",
+     "iopub.status.idle": "2026-09-05T21:10:29.988683Z",
+     "shell.execute_reply": "2026-09-05T21:10:29.988271Z"
     }
    },
    "outputs": [
@@ -897,10 +897,10 @@
    "id": "da1aa9c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:09.990611Z",
-     "iopub.status.busy": "2026-09-05T15:03:09.990484Z",
-     "iopub.status.idle": "2026-09-05T15:03:10.100250Z",
-     "shell.execute_reply": "2026-09-05T15:03:10.099386Z"
+     "iopub.execute_input": "2026-09-05T21:10:29.990059Z",
+     "iopub.status.busy": "2026-09-05T21:10:29.989954Z",
+     "iopub.status.idle": "2026-09-05T21:10:30.090419Z",
+     "shell.execute_reply": "2026-09-05T21:10:30.089901Z"
     }
    },
    "outputs": [
@@ -978,10 +978,10 @@
    "id": "8e91a64e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:10.101954Z",
-     "iopub.status.busy": "2026-09-05T15:03:10.101864Z",
-     "iopub.status.idle": "2026-09-05T15:03:42.459752Z",
-     "shell.execute_reply": "2026-09-05T15:03:42.459105Z"
+     "iopub.execute_input": "2026-09-05T21:10:30.092099Z",
+     "iopub.status.busy": "2026-09-05T21:10:30.092002Z",
+     "iopub.status.idle": "2026-09-05T21:10:53.766830Z",
+     "shell.execute_reply": "2026-09-05T21:10:53.766390Z"
     }
    },
    "outputs": [
@@ -1094,10 +1094,10 @@
    "id": "333cd82b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:42.461688Z",
-     "iopub.status.busy": "2026-09-05T15:03:42.461548Z",
-     "iopub.status.idle": "2026-09-05T15:03:42.467333Z",
-     "shell.execute_reply": "2026-09-05T15:03:42.465834Z"
+     "iopub.execute_input": "2026-09-05T21:10:53.768242Z",
+     "iopub.status.busy": "2026-09-05T21:10:53.768164Z",
+     "iopub.status.idle": "2026-09-05T21:10:53.771783Z",
+     "shell.execute_reply": "2026-09-05T21:10:53.771480Z"
     }
    },
    "outputs": [
@@ -1157,10 +1157,10 @@
    "id": "9b5bc547",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:42.468610Z",
-     "iopub.status.busy": "2026-09-05T15:03:42.468517Z",
-     "iopub.status.idle": "2026-09-05T15:03:42.561926Z",
-     "shell.execute_reply": "2026-09-05T15:03:42.560510Z"
+     "iopub.execute_input": "2026-09-05T21:10:53.772794Z",
+     "iopub.status.busy": "2026-09-05T21:10:53.772733Z",
+     "iopub.status.idle": "2026-09-05T21:10:53.844579Z",
+     "shell.execute_reply": "2026-09-05T21:10:53.844257Z"
     }
    },
    "outputs": [
@@ -1262,10 +1262,10 @@
    "id": "4f5245f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:42.563799Z",
-     "iopub.status.busy": "2026-09-05T15:03:42.563674Z",
-     "iopub.status.idle": "2026-09-05T15:03:42.575837Z",
-     "shell.execute_reply": "2026-09-05T15:03:42.575390Z"
+     "iopub.execute_input": "2026-09-05T21:10:53.845797Z",
+     "iopub.status.busy": "2026-09-05T21:10:53.845735Z",
+     "iopub.status.idle": "2026-09-05T21:10:53.854144Z",
+     "shell.execute_reply": "2026-09-05T21:10:53.853793Z"
     }
    },
    "outputs": [
@@ -1328,10 +1328,10 @@
    "id": "27f65b39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:42.577745Z",
-     "iopub.status.busy": "2026-09-05T15:03:42.577658Z",
-     "iopub.status.idle": "2026-09-05T15:03:48.174255Z",
-     "shell.execute_reply": "2026-09-05T15:03:48.173567Z"
+     "iopub.execute_input": "2026-09-05T21:10:53.855273Z",
+     "iopub.status.busy": "2026-09-05T21:10:53.855195Z",
+     "iopub.status.idle": "2026-09-05T21:10:59.149082Z",
+     "shell.execute_reply": "2026-09-05T21:10:59.148514Z"
     }
    },
    "outputs": [
@@ -1401,10 +1401,23 @@
     "Two API facts shape this section, and both are worth knowing before you plan\n",
     "around them:\n",
     "\n",
-    "* **Multiplier sensitivities are available for equality constraints only.** A\n",
-    "  variable bound or an inequality has no $\\mathrm d\\lambda/\\mathrm dp$ row to\n",
-    "  read. So once the cap is known to be active we write it as\n",
-    "  `m.T == T_cap`, which is what makes the question answerable.\n",
+    "* **A constraint's multiplier sensitivity needs the row to be active.** Every\n",
+    "  equality has a $\\mathrm d\\lambda/\\mathrm dp$ row. So does an inequality —\n",
+    "  but only where it is **strictly active** at the solved point (gh#910), which\n",
+    "  is why we write the cap the natural way, `m.T <= T_cap`, and ask about it\n",
+    "  directly. The gate is not bureaucracy: an *inactive* row's multiplier is zero\n",
+    "  over a neighbourhood, so its derivative is a structural zero rather than\n",
+    "  something the factor carries, and a *weakly active* row — slack and\n",
+    "  multiplier both vanishing — has two one-sided derivatives that differ and no\n",
+    "  two-sided value at all. `sens_jacobian` refuses both and names which one it\n",
+    "  met. A **variable bound** still has no $\\mathrm d\\lambda/\\mathrm dp$ row,\n",
+    "  which is why the cap here is a constraint on `m.T` rather than a bound on it.\n",
+    "\n",
+    "  Before gh#910 the only route was to rewrite the row as `m.T == T_cap` before\n",
+    "  solving. That is a change to the *model*, and it is correct only if the cap\n",
+    "  really does stay active across the perturbation you are asking about — an\n",
+    "  assumption you had to make silently. Asking the inequality directly makes the\n",
+    "  solver check it for you.\n",
     "* **The `dual` Suffix comes back from a declared solve too**, so one solve\n",
     "  answers both halves: the multiplier from `m.dual`, its derivative from\n",
     "  `sens_jacobian`. The declared path solves in process rather than exchanging a\n",
@@ -1424,10 +1437,10 @@
    "id": "ab5c1191",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:48.176023Z",
-     "iopub.status.busy": "2026-09-05T15:03:48.175903Z",
-     "iopub.status.idle": "2026-09-05T15:03:48.185728Z",
-     "shell.execute_reply": "2026-09-05T15:03:48.185354Z"
+     "iopub.execute_input": "2026-09-05T21:10:59.150460Z",
+     "iopub.status.busy": "2026-09-05T21:10:59.150349Z",
+     "iopub.status.idle": "2026-09-05T21:10:59.159421Z",
+     "shell.execute_reply": "2026-09-05T21:10:59.158982Z"
     }
    },
    "outputs": [
@@ -1453,7 +1466,7 @@
     "\n",
     "def build_capped(theta, T_cap=T_CAP_BIND):\n",
     "    m = build_design_model(theta, T_max=400.0)        # bound well clear of the cap\n",
-    "    m.cap = pyo.Constraint(expr=m.T == T_cap)\n",
+    "    m.cap = pyo.Constraint(expr=m.T <= T_cap)   # an inequality, asked directly\n",
     "    return m\n",
     "\n",
     "\n",
@@ -1520,8 +1533,11 @@
     "  `sens_active_set_changes` detect that from the base factorization; here the\n",
     "  step crossed at 62 % of one standard deviation in one direction and never in\n",
     "  the other.\n",
-    "* **Multiplier sensitivities are equality-only**, which is what lets a *known\n",
-    "  active* cap carry an error bar on its shadow price.\n",
+    "* **A multiplier sensitivity needs an active row**, not an equality. An\n",
+    "  inequality answers wherever it is strictly active (gh#910); an inactive one\n",
+    "  is a structural zero and a weakly active one has no two-sided derivative, and\n",
+    "  `sens_jacobian` refuses each by name. Rewriting a known-active cap as an\n",
+    "  equality was the old route and it changed the model to ask the question.\n",
     "\n",
     "Related: notebook 26 (covariance and identifiability), 31 (the information\n",
     "matrix), 32 (`of=` blocks and holding the factor), 36 (active-set-aware\n",
@@ -1534,10 +1550,10 @@
    "id": "13e80ecb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T15:03:48.187207Z",
-     "iopub.status.busy": "2026-09-05T15:03:48.187095Z",
-     "iopub.status.idle": "2026-09-05T15:03:48.190419Z",
-     "shell.execute_reply": "2026-09-05T15:03:48.190030Z"
+     "iopub.execute_input": "2026-09-05T21:10:59.160782Z",
+     "iopub.status.busy": "2026-09-05T21:10:59.160696Z",
+     "iopub.status.idle": "2026-09-05T21:10:59.165013Z",
+     "shell.execute_reply": "2026-09-05T21:10:59.163605Z"
     }
    },
    "outputs": [

--- a/python/tests/test_sensitivity_core.py
+++ b/python/tests/test_sensitivity_core.py
@@ -800,3 +800,118 @@ def test_the_gate_reads_the_reduced_classifier_not_the_cheap_one(rho, cheap):
     assert sess.solver.reduced_row_activity([1])["status"][0] == "weakly_active"
     with pytest.raises(ValueError, match="weakly active at the solved point"):
         sess.mult_entry("kink")
+
+
+# ── the same cap, bound on the other side ────────────────────────────────────
+#
+# Every strictly-active fixture that arrived with gh#910 -- here, in
+# `sens_invariance_legs.rs`, and in `pyomo-pounce` -- is a `<=` row. The
+# c/d split puts a row's finite bounds in `d_l_map` or `d_u_map`, so
+# `>=` is the other branch of that split, and CLAUDE.md's rule about it
+# is blunt: a fixture that always takes one branch says nothing about
+# the other, and stays green while the other is broken.
+#
+# It is not an idle branch either. `full_to_d` is bound-side-agnostic
+# (set unconditionally for every inequality), but the GATE is not: it
+# asks `reduced_row_activity` for `strongly_active`, and that
+# classifier reads the barrier term of the row's slack, which is
+# `v_l/(s - d_l)` on this side and `v_u/(d_u - s)` on the other. A
+# strictly active `>=` row is a combination no fixture reached.
+#
+# Measured, and it is fine -- which is the point of writing it down
+# rather than assuming it. Recorded here so a future change to the
+# classifier or to the split cannot quietly break the half of the
+# feature users reach with a floor rather than a ceiling.
+
+U0_GE = -5.0            # pulls u DOWN, so a `>=` floor is what binds
+
+
+def floor_model():
+    """The mirror of [`cap_model`]: the active row is a floor, not a cap.
+
+        min .5(u-U0_GE)^2 + .5(w-W_STAR)^2 + .5 z^2 - A_KINK p z
+
+        s.t.  pin_p:            p == 0
+              decoy:      3 * w <= 30      (inactive, still `<=`)
+              floor: 2 * (u - p) >= 2      (strictly active, `>=`)
+              kink:            z >= 0      (weakly active)
+
+    Same shape, same index shifts, one bound moved from `g_u` to `g_l`.
+    The objective's centre moves to -5 so that the unconstrained
+    optimum sits BELOW the floor and the row binds; at the solution
+    `2(u - p) = 2` again, so `u = 1 + p`, and stationarity in `u` gives
+    `|d lambda_floor/dp| = 1/2` exactly, as on the `<=` side.
+    """
+    v = pounce.NlExpr.vars(4)                       # u, w, z, p
+    return pounce.build_nl_problem(
+        n=4,
+        objective=(0.5 * (v[0] - U0_GE) ** 2 + 0.5 * (v[1] - W_STAR) ** 2
+                   + 0.5 * v[2] ** 2 - A_KINK * v[3] * v[2]),
+        constraints=[v[3], 3.0 * v[1], CAP_SCALE * (v[0] - v[3]), v[2]],
+        g_l=[0.0, -1e19, CAP, 0.0],
+        g_u=[0.0, 30.0, 1e19, 1e19],
+        x_l=[-1e19] * 4, x_u=[1e19] * 4,
+        x0=[0.5, 0.5, 0.5, 0.0],
+        var_names=["u", "w", "z", "p"],
+        con_names=["pin_p", "decoy", "floor", "kink"],
+    )
+
+
+def floor_session():
+    return solve_for_sensitivity(floor_model(), pins={"p": 0},
+                                 options={"print_level": 0})
+
+
+def test_the_floor_fixture_binds_from_below():
+    """Precondition: without this the assertions below are vacuous.
+
+    A `>=` row that does not bind is just `cap_model`'s decoy, and
+    would exercise the inactive branch it already covers.
+    """
+    sess = floor_session()
+    np.testing.assert_allclose(sess.base_x[:2], [CAP / CAP_SCALE, W_STAR],
+                               atol=1e-6)
+
+
+def test_a_strictly_active_lower_bounded_row_classifies_the_same():
+    """The gate's branch: `v_l/(s - d_l)`, not `v_u/(d_u - s)`.
+
+    If `reduced_row_activity` read only the upper side of a row's
+    barrier term, a binding floor would come back `inactive` -- the one
+    verdict `mult_entry` passes through as "this shadow price does not
+    move" -- and the feature would answer a live constraint with a
+    confident zero.
+    """
+    sess = floor_session()
+    assert sess.solver.reduced_row_activity([0, 1, 2, 3])["status"] == [
+        "equality", "inactive", "strongly_active", "weakly_active"]
+
+
+def test_a_floors_shadow_price_has_the_same_derivative_a_caps_does():
+    """`|d lambda/dp| = 1/CAP_SCALE`, read off `y_d` as on the other side.
+
+    The magnitude matches `cap_model`'s because the two models differ
+    only in which side of the row is finite; the internal `y_d` entry
+    is signed by the active side, and both come back `-1/CAP_SCALE`
+    here because the objective centre moved with the bound.
+    """
+    sess = floor_session()
+    row = sess.mult_entry("floor")
+    assert sess.column(0)[row] == pytest.approx(-1.0 / CAP_SCALE, abs=1e-7)
+
+
+def test_the_floor_row_is_addressed_through_the_same_d_block_map():
+    """Index shifts are unchanged by which bound is finite.
+
+    `full_to_d` is set for every inequality regardless of side, and
+    this is the assertion that would fail if it were ever made
+    conditional on a bound being present -- a free row (neither bound
+    finite) still takes a `d` slot, which `classify_bounds`' own unit
+    tests pin one layer down.
+    """
+    sess = floor_session()
+    d_rows = sess.solver.inequality_multiplier_rows([0, 1, 2, 3])
+    assert d_rows[0] is None, "the pin is an equality, not in y_d"
+    assert d_rows[2] - d_rows[1] == 1 and d_rows[3] - d_rows[2] == 1
+    assert sess.mult_entry("floor") == d_rows[2]
+    assert d_rows[2] != 2, "a raw g index must not pass as a KKT row"


### PR DESCRIPTION
The two follow-ups #913 left behind, now that gh#910 is merged.

## 1. Notebook 39 was still telling readers the opposite

Section 10 opened with **"Multiplier sensitivities are available for equality
constraints only"**, the summary repeated it, and the code rewrote the safety
cap as `m.T == T_cap` before solving — a workaround for a restriction that no
longer exists. #913 updated `docs/src/sensitivity.md` but not the notebook.

Both bullets now state the actual rule: the row must be **active**; an
inequality qualifies where it is **strictly** active; an *inactive* row's
multiplier is a structural zero and a *weakly active* row has two differing
one-sided derivatives, and `sens_jacobian` refuses each by name; a variable
bound still has no `dλ/dp` row. The cap is written the natural way, `m.T <=
T_cap`, and asked about directly.

Leaving the equality rewrite in the code while the prose said "you no longer
need to rewrite" would have been exactly the doc drift `/sens-review` entry 4
is about, so the code moved with the prose.

**The notebook was re-executed, and every number in section 10 is
bit-identical to the `==` version** — same profit, same shadow price, same
39 % relative uncertainty, same four `d(shadow)/dθ` entries. That is what
should happen when the cap binds, and it is also the check: a sign or frame
error on the inequality path would have moved them. The only non-timestamp
output diff in the whole notebook is `SOURCE_COMMIT`.

## 2. The new gate had no `>=` fixture

Every strictly-active fixture that arrived with gh#910 is a `<=` row. The
reroute itself is bound-side-agnostic — `full_to_d` is set unconditionally in
the inequality branch — but **the gate is not**: `reduced_row_activity` reads
the row's slack barrier term, which is `v_l/(s − d_l)` on the lower side and
`v_u/(d_u − s)` on the upper. CLAUDE.md is blunt that a leg is only evidence
about the branch its fixture reaches, so both corpora get the mirror image.

**`python/tests/test_sensitivity_core.py`** — a floor fixture whose objective
centre sits below the row, so a `>=` binds. Four tests: that it binds from
below, that it classifies `strongly_active` alongside the existing three
regimes, that its shadow price carries the same derivative a cap's does, and
that it is addressed through the same `d`-block map.

**`pyomo-pounce/tests/test_sens.py`** — the same row against an *outside*
number: a central difference of `m.dual`. Everything inside the crate compares
one number the sensitivity layer produced against another; a sign convention
that happened to be right for a ceiling and wrong for a floor would pass all
of it and fail only here.

## Mutation check

Making the floor non-binding (`U0_GE` flipped positive in the core file, the
row's RHS pushed to `-100` in the Pyomo one) reddens all four core tests and
the FD oracle, and nothing else in either file moves. Restored: 40/40 core,
51/51 Pyomo.

No Rust changes, so no fixture sweep and no invariance legs.

Refs #910, #913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bUD9V6h3GkS8E1PnBkz8p
