### PR TITLE
Add notebook 42: mixing equation-based and JAX blocks in one model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,51 @@ changes.
   `IpoptApplication::set_presolve_already_applied(true)`, because
   `optimize_tnlp` applies `wrap_from_options` itself when `presolve=yes`.
 
+- **Notebook 42, `python/notebooks/42_mixing_equations_and_jax.ipynb`.** One
+  model, two front ends. POUNCE's equation surface (`NlExpr` /
+  `build_nl_problem`) has exact tape AD and exact sparsity but no callback
+  node, so a trained network has nowhere to live; the JAX surface takes the
+  network but pays a Python round trip and, by default, probes for sparsity.
+  Real models want both — a flowsheet that is algebra except for one unit, a
+  reactor train that is mass balances except for the rate law. The notebook
+  builds exactly that (three CSTRs in series; balances as `NlExpr`, kinetics
+  as a tanh network fitted in-notebook to sampled data) and shows the mixing
+  needs no changes to POUNCE: `pounce.Problem` accepts any object carrying the
+  cyipopt method set, and both surfaces already produce one, so the work is
+  stacking rather than bridging.
+
+  The recipe is to give the black box's output its own variable and one
+  residual row, which keeps the balances pure algebra. Stacking is then four
+  rules — objectives add, constraint rows stack, Jacobian rows offset, and
+  Hessian triplets simply *concatenate*, because the triplet→CSR converter is
+  a port of Ipopt's and compresses repeated `(row, col)` entries "with
+  repeated entries summed" (`crates/pounce-linalg/src/triplet_convert.rs`).
+  Two blocks' second derivatives at a shared entry should add, so the
+  duplicate is the wanted behaviour rather than a hazard. The one piece of
+  friction is naming: `NlProblem` spells its structure methods
+  `jacobian_structure` / `hessian_structure` where the bridge wants cyipopt's
+  `jacobianstructure` / `hessianstructure`, which is a six-line adapter.
+
+  Verified against an all-JAX twin of the same model — `max |dx*| = 1.8e-14`,
+  and the gradient and full Lagrangian Hessian at an *off-solution* probe
+  point (`6.2e-15` / `5.7e-14`), which is where an index-scatter bug shows
+  even when both solves happen to land in the same place. A second check
+  substitutes the withheld truth kinetics into the converged balances and
+  recovers residuals at the ~1% level the fit itself carries, isolating
+  surrogate error from solver error. `pounce.Solver` takes a `Problem`, so
+  the sensitivity layer needs no plumbing to work on the result: a feed-rate
+  `parametric_step` reproduces a re-solve and moves `T` by 0.199 (re-solve
+  0.198) even though the perturbed balance rows never mention `T` — the
+  coupling arrives through the JAX block's rows, which is the argument for
+  mixing rather than solving the halves separately.
+
+  Also records where stacking is the wrong tool: `trf_minimize` (notebook 29)
+  when the non-equation half is genuinely expensive or has no usable
+  derivatives, `pounce.jax.solve` needing a fully traced `f(x, p)` / `g(x, p)`
+  so a mixed model cannot ride it directly, `pyomo-pounce`'s `.nl` round trip
+  admitting no Python callback at all, and the AMPL imported-function route
+  that does reach inside an expression but wants a compiled shared library.
+
 - **Notebook 41, `python/notebooks/41_delta_planning_vectors.ipynb`.** The
   sequel to 40, and the other half of the question: a shadow price says what
   a disruption *costs*, and `dx*/dp` says what to *change*. A nonlinear

--- a/python/notebooks/42_mixing_equations_and_jax.ipynb
+++ b/python/notebooks/42_mixing_equations_and_jax.ipynb
@@ -1,0 +1,1000 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ccfc830c",
+   "metadata": {},
+   "source": [
+    "# Mixing equation-based and JAX blocks in one model\n",
+    "\n",
+    "POUNCE has two ways to hand the solver a nonlinear model, and they are good at\n",
+    "opposite things.\n",
+    "\n",
+    "**Equation-based** — `pounce.NlExpr` / `build_nl_problem` (or `read_nl` /\n",
+    "`parse_nl_text` for a `.nl` file). You write algebra; POUNCE tapes it and\n",
+    "differentiates it in Rust with exact reverse-mode AD. The sparsity pattern is\n",
+    "*read off the tape*, so it is exact rather than probed, and evaluation never\n",
+    "crosses back into Python. What it cannot do is call anything: an `NlExpr` tree\n",
+    "has no callback node, so a trained network, a table lookup, or a fitted closure\n",
+    "has nowhere to live.\n",
+    "\n",
+    "**JAX** — `pounce.jax.from_jax`. Anything JAX can trace, POUNCE can solve:\n",
+    "gradient, Jacobian, and Lagrangian Hessian all come from `jax.grad` /\n",
+    "`jacrev` / `hessian`. That includes the trained network the equation surface\n",
+    "cannot express. The costs are a Python round trip per evaluation and, unless\n",
+    "you supply the pattern yourself, sparsity detected by random probing.\n",
+    "\n",
+    "Real models often want both at once. A flowsheet is algebra except for one\n",
+    "unit; a reactor train is mass balances except for the rate law, which came out\n",
+    "of a fit. **This notebook builds exactly that model** — three CSTRs in series,\n",
+    "balances as equations and kinetics as a fitted network — and shows that mixing\n",
+    "the two surfaces takes about fifty lines of glue and no changes to POUNCE.\n",
+    "\n",
+    "The meeting point is `pounce.Problem`. It does not want an `NlProblem` or a\n",
+    "JAX function; it wants *any Python object* carrying the cyipopt method set\n",
+    "(`crates/pounce-py/src/tnlp_bridge.rs`):\n",
+    "\n",
+    "```python\n",
+    "def objective(self, x)            -> float\n",
+    "def gradient(self, x)             -> array(n)\n",
+    "def constraints(self, x)          -> array(m)\n",
+    "def jacobian(self, x)             -> array(nnz_jac)\n",
+    "def jacobianstructure(self)       -> (rows, cols)\n",
+    "def hessian(self, x, lam, obj_f)  -> array(nnz_hess)\n",
+    "def hessianstructure(self)        -> (rows, cols)\n",
+    "```\n",
+    "\n",
+    "Both surfaces already produce such an object. So the job is not to bridge two\n",
+    "foreign things — it is to *stack* two objects that already speak the same\n",
+    "protocol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "abe5bd0c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:39.440676Z",
+     "iopub.status.busy": "2026-09-06T20:03:39.440433Z",
+     "iopub.status.idle": "2026-09-06T20:03:40.370960Z",
+     "shell.execute_reply": "2026-09-06T20:03:40.369770Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pounce 0.11.0 | jax 0.10.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import pounce\n",
+    "from pounce.jax import from_jax    # `pounce.jax` is imported on demand, not by `import pounce`\n",
+    "\n",
+    "jax.config.update(\"jax_enable_x64\", True)   # pounce is a double-precision solver\n",
+    "print(\"pounce\", pounce.__version__, \"| jax\", jax.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e1714f5",
+   "metadata": {},
+   "source": [
+    "## 1. The model\n",
+    "\n",
+    "Three isothermal CSTRs in series, all at one temperature $T$ and all of one\n",
+    "volume $V$ (the design variables). Feed is $q = 10$ L/min of $C_{A0} = 2$\n",
+    "mol/L, and the outlet of the last stage must reach $C_A \\le 0.25$ mol/L.\n",
+    "\n",
+    "Two kinds of statement describe it:\n",
+    "\n",
+    "**Mass balances** — algebra, known exactly, one per stage:\n",
+    "\n",
+    "$$q\\,(C_{A,i-1} - C_{A,i}) - V r_i = 0, \\qquad C_{A,0} \\equiv C_{A0}$$\n",
+    "\n",
+    "**The rate law** — *not* known as an equation. We have a fitted surrogate:\n",
+    "\n",
+    "$$r_i = \\widehat{r}(C_{A,i}, T)$$\n",
+    "\n",
+    "Writing $r_i$ as its own variable is what makes the split clean: the balances\n",
+    "stay pure algebra referring to $r_i$, and the surrogate gets one residual row\n",
+    "of its own. That is the general recipe — **give the black-box output a\n",
+    "variable and let one constraint row define it**.\n",
+    "\n",
+    "The variable vector, $n = 8$:\n",
+    "\n",
+    "| slot | meaning |\n",
+    "|---|---|\n",
+    "| `x[0:3]` | $C_{A,1}, C_{A,2}, C_{A,3}$ |\n",
+    "| `x[3:6]` | $r_1, r_2, r_3$ |\n",
+    "| `x[6]`   | $V$ |\n",
+    "| `x[7]`   | $T$ |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5deace9b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:40.373706Z",
+     "iopub.status.busy": "2026-09-06T20:03:40.373383Z",
+     "iopub.status.idle": "2026-09-06T20:03:40.377406Z",
+     "shell.execute_reply": "2026-09-06T20:03:40.376515Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "N = 3                       # stages\n",
+    "n = 2 * N + 2               # CA(N), r(N), V, T\n",
+    "iCA = slice(0, N)\n",
+    "iR  = slice(N, 2 * N)\n",
+    "iV, iT = 2 * N, 2 * N + 1\n",
+    "\n",
+    "q, CA0, T0 = 10.0, 2.0, 320.0          # L/min, mol/L, K (base temperature)\n",
+    "cost_V, cost_T = 0.5, 2.0e-2           # $/L per stage, $/K^2 of heating\n",
+    "CA_target = 0.25                       # mol/L, outlet spec\n",
+    "w_trust = 200.0                        # weight on the surrogate trust penalty"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75cf5127",
+   "metadata": {},
+   "source": [
+    "## 2. The surrogate\n",
+    "\n",
+    "The premise is that we only ever saw *data*. So: sample a truth model we then\n",
+    "put away, and fit a small tanh network to it with plain JAX. `rate_nn` is the\n",
+    "thing that cannot be written as an `NlExpr` — the whole reason this notebook\n",
+    "exists.\n",
+    "\n",
+    "We keep `true_rate` around only to audit the answer in §7."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dd127082",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:40.379396Z",
+     "iopub.status.busy": "2026-09-06T20:03:40.379223Z",
+     "iopub.status.idle": "2026-09-06T20:03:43.633211Z",
+     "shell.execute_reply": "2026-09-06T20:03:43.632003Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fit rmse = 0.0059 mol/L/min (1.4% of the rate scale)\n",
+      "\n",
+      "    CA       T   surrogate      truth\n",
+      "  1.50   340.0      0.3653     0.3621\n",
+      "  0.90   360.0      0.4026     0.4009\n",
+      "  0.25   360.0      0.0626     0.0667\n"
+     ]
+    }
+   ],
+   "source": [
+    "def true_rate(CA, T):\n",
+    "    \"\"\"Arrhenius truth model. Used to generate data and, in section 6, to\n",
+    "    audit the optimum. It never enters the optimization problem.\"\"\"\n",
+    "    return 5.0e5 * np.exp(-5000.0 / T) * CA ** 1.4\n",
+    "\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "CA_s = rng.uniform(0.05, 2.0, 600)\n",
+    "T_s = rng.uniform(300.0, 380.0, 600)\n",
+    "r_s = true_rate(CA_s, T_s)\n",
+    "\n",
+    "# Normalize inputs and outputs so the fit is well conditioned.\n",
+    "mu = np.array([1.0, 340.0])\n",
+    "sd = np.array([0.6, 25.0])\n",
+    "r_sd = r_s.std()\n",
+    "\n",
+    "Xn = jnp.asarray(np.stack([(CA_s - mu[0]) / sd[0], (T_s - mu[1]) / sd[1]], axis=1))\n",
+    "Yn = jnp.asarray(r_s / r_sd)\n",
+    "\n",
+    "H = 16\n",
+    "k1, k2 = jax.random.split(jax.random.PRNGKey(0))\n",
+    "params = [jax.random.normal(k1, (2, H)) * 0.8, jnp.zeros(H),\n",
+    "          jax.random.normal(k2, (H, 1)) * 0.5, jnp.zeros(1)]\n",
+    "\n",
+    "\n",
+    "def net(p, xn):\n",
+    "    W1, b1, W2, b2 = p\n",
+    "    return (jnp.tanh(xn @ W1 + b1) @ W2 + b2).squeeze(-1)\n",
+    "\n",
+    "\n",
+    "value_and_grad = jax.jit(jax.value_and_grad(\n",
+    "    lambda p: jnp.mean((net(p, Xn) - Yn) ** 2)))\n",
+    "\n",
+    "momentum = [jnp.zeros_like(p) for p in params]\n",
+    "for _ in range(6000):                      # plain momentum SGD; no extra deps\n",
+    "    loss, grads = value_and_grad(params)\n",
+    "    momentum = [0.9 * m + g for m, g in zip(momentum, grads)]\n",
+    "    params = [p - 2e-2 * m for p, m in zip(params, momentum)]\n",
+    "\n",
+    "\n",
+    "@jax.jit\n",
+    "def rate_nn(CA, T):\n",
+    "    xn = jnp.stack([(CA - mu[0]) / sd[0], (T - mu[1]) / sd[1]], axis=-1)\n",
+    "    return net(params, xn) * r_sd\n",
+    "\n",
+    "\n",
+    "print(f\"fit rmse = {float(jnp.sqrt(loss)) * r_sd:.4f} mol/L/min \"\n",
+    "      f\"({100 * float(jnp.sqrt(loss)):.1f}% of the rate scale)\\n\")\n",
+    "print(f\"{'CA':>6} {'T':>7} {'surrogate':>11} {'truth':>10}\")\n",
+    "for CA, T in [(1.5, 340.0), (0.9, 360.0), (0.25, 360.0)]:\n",
+    "    got = float(rate_nn(jnp.array(CA), jnp.array(T)))\n",
+    "    print(f\"{CA:6.2f} {T:7.1f} {got:11.4f} {true_rate(CA, T):10.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fea8416c",
+   "metadata": {},
+   "source": [
+    "## 3. The equation block\n",
+    "\n",
+    "Everything POUNCE can be told exactly: the three balances, plus the objective\n",
+    "(capital cost proportional to total volume, heating cost quadratic in the\n",
+    "temperature rise).\n",
+    "\n",
+    "`build_nl_problem` returns an `NlProblem` whose derivatives come off the Rust\n",
+    "tape. Note it is built at the **full** `n = 8` — the block does not know or\n",
+    "care that another block will supply rows later. That is the contract for the\n",
+    "stacker in §5: *every block is a function of the whole `x`*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "42507d11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:43.635572Z",
+     "iopub.status.busy": "2026-09-06T20:03:43.635356Z",
+     "iopub.status.idle": "2026-09-06T20:03:43.641533Z",
+     "shell.execute_reply": "2026-09-06T20:03:43.640304Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NlProblem(n=8, m=3, nnz_jac=11, nnz_hess=4, minimize=true)\n",
+      "jacobian_structure nnz: 11\n",
+      "hessian_structure  nnz: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "v = pounce.NlExpr.vars(n)\n",
+    "\n",
+    "CA_in = [pounce.NlExpr.const_(CA0)] + [v[i - 1] for i in range(1, N)]\n",
+    "balances = [q * (CA_in[i] - v[i]) - v[iV] * v[N + i] for i in range(N)]\n",
+    "\n",
+    "algebraic_cost = N * cost_V * v[iV] + cost_T * (v[iT] - T0) ** 2\n",
+    "\n",
+    "eqn_problem = pounce.build_nl_problem(\n",
+    "    n=n,\n",
+    "    objective=algebraic_cost,\n",
+    "    constraints=balances,\n",
+    "    g_l=[0.0] * N, g_u=[0.0] * N,\n",
+    ")\n",
+    "print(eqn_problem)\n",
+    "print(\"jacobian_structure nnz:\", eqn_problem.jacobian_structure()[0].size)\n",
+    "print(\"hessian_structure  nnz:\", eqn_problem.hessian_structure()[0].size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7385a20c",
+   "metadata": {},
+   "source": [
+    "## 4. The JAX block\n",
+    "\n",
+    "Two contributions:\n",
+    "\n",
+    "* **Three constraint rows**, $r_i - \\widehat r(C_{A,i}, T) = 0$ — the surrogate\n",
+    "  wired into the model.\n",
+    "* **One objective term**, a soft penalty that grows as the operating point\n",
+    "  leaves the box the surrogate was fitted on. Optimizing against a surrogate\n",
+    "  without a term like this is how you end up at an optimum that only exists in\n",
+    "  the fit. It is written in the network's own normalized coordinates, which is\n",
+    "  why it belongs to this block rather than the algebraic one.\n",
+    "\n",
+    "We write the seven methods out by hand rather than calling `from_jax`, for two\n",
+    "reasons: `from_jax` returns a finished `Problem` (we need the *object*, not the\n",
+    "problem), and writing it out shows there is nothing privileged about what\n",
+    "`from_jax` builds.\n",
+    "\n",
+    "**The sparsity patterns are supplied, not probed.** They are known in closed\n",
+    "form here — row $i$ of this block touches only $C_{A,i}$, $r_i$, and $T$ — and\n",
+    "the docs are emphatic that a supplied pattern is both cheaper and safer than a\n",
+    "probed one. It must be a *superset* of the truth; a missing entry is silently\n",
+    "wrong. (If you would rather not derive it by hand, notebook 33 does it from the\n",
+    "jaxpr with `asdex`.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4d49edce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:43.643917Z",
+     "iopub.status.busy": "2026-09-06T20:03:43.643620Z",
+     "iopub.status.idle": "2026-09-06T20:03:43.717659Z",
+     "shell.execute_reply": "2026-09-06T20:03:43.715874Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jax block: m = 3 | nnz jac = 9 | nnz hess = 7\n"
+     ]
+    }
+   ],
+   "source": [
+    "def rate_residuals(x):\n",
+    "    \"\"\"r_i - surrogate(CA_i, T), one row per stage.\"\"\"\n",
+    "    return x[iR] - rate_nn(x[iCA], jnp.full((N,), x[iT]))\n",
+    "\n",
+    "\n",
+    "def trust_penalty(x):\n",
+    "    \"\"\"Soft guard keeping the optimizer inside the surrogate's training box.\n",
+    "    Separable in each input, and smooth everywhere (no abs / max kink).\"\"\"\n",
+    "    dCA = (x[iCA] - mu[0]) / sd[0]\n",
+    "    dT = (x[iT] - mu[1]) / sd[1]\n",
+    "    return w_trust * (jnp.sum(jnp.exp(2 * (dCA ** 2 - 4.0)))\n",
+    "                      + jnp.exp(2 * (dT ** 2 - 4.0)))\n",
+    "\n",
+    "\n",
+    "def lagrangian(x, lam, obj_factor):\n",
+    "    return obj_factor * trust_penalty(x) + jnp.dot(lam, rate_residuals(x))\n",
+    "\n",
+    "\n",
+    "# --- structure, known in closed form --------------------------------------\n",
+    "# Jacobian row i touches CA_i (col i), r_i (col N+i), T (col iT).\n",
+    "_jr = np.repeat(np.arange(N), 3)\n",
+    "_jc = np.concatenate([[i, N + i, iT] for i in range(N)])\n",
+    "\n",
+    "# Lagrangian Hessian lower triangle: r enters linearly, the penalty is\n",
+    "# separable, and the surrogate couples each CA_i with T.\n",
+    "_hr = np.concatenate([np.arange(N), np.full(N, iT), [iT]])\n",
+    "_hc = np.concatenate([np.arange(N), np.arange(N), [iT]])\n",
+    "\n",
+    "\n",
+    "class JaxBlock:\n",
+    "    \"\"\"The cyipopt method set, backed by JAX AD.\"\"\"\n",
+    "\n",
+    "    m = N\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self._f = jax.jit(trust_penalty)\n",
+    "        self._grad = jax.jit(jax.grad(trust_penalty))\n",
+    "        self._g = jax.jit(rate_residuals)\n",
+    "        self._jac = jax.jit(jax.jacrev(rate_residuals))\n",
+    "        self._hess = jax.jit(jax.hessian(lagrangian))\n",
+    "\n",
+    "    def objective(self, x):      return float(self._f(jnp.asarray(x)))\n",
+    "    def gradient(self, x):       return np.asarray(self._grad(jnp.asarray(x)))\n",
+    "    def constraints(self, x):    return np.asarray(self._g(jnp.asarray(x)))\n",
+    "    def jacobianstructure(self): return _jr, _jc\n",
+    "    def hessianstructure(self):  return _hr, _hc\n",
+    "\n",
+    "    def jacobian(self, x):\n",
+    "        return np.asarray(self._jac(jnp.asarray(x)))[_jr, _jc]\n",
+    "\n",
+    "    def hessian(self, x, lam, obj_factor):\n",
+    "        Hs = self._hess(jnp.asarray(x), jnp.asarray(lam), float(obj_factor))\n",
+    "        return np.asarray(Hs)[_hr, _hc]\n",
+    "\n",
+    "\n",
+    "jax_block = JaxBlock()\n",
+    "print(\"jax block: m =\", jax_block.m,\n",
+    "      \"| nnz jac =\", _jr.size, \"| nnz hess =\", _hr.size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca75e5ef",
+   "metadata": {},
+   "source": [
+    "## 5. The stacker\n",
+    "\n",
+    "Two blocks, both functions of the same `x`, both already speaking the cyipopt\n",
+    "protocol. Stacking them is four rules:\n",
+    "\n",
+    "| piece | rule |\n",
+    "|---|---|\n",
+    "| objective, gradient | **add** — both blocks contribute to one $f$ |\n",
+    "| constraints | **stack** — blocks own disjoint row ranges |\n",
+    "| Jacobian | **concatenate**, with each block's rows offset by where it starts |\n",
+    "| Hessian | **concatenate** — see below |\n",
+    "\n",
+    "The Hessian is the only one that needs an argument. Both blocks touch the same\n",
+    "variables, so their lower triangles *overlap*: here both declare an entry at\n",
+    "$(T, T)$. Concatenating the two structure arrays therefore declares that entry\n",
+    "twice.\n",
+    "\n",
+    "That is fine, and it is the documented contract rather than an accident.\n",
+    "POUNCE's triplet→CSR converter is a port of Ipopt's, and\n",
+    "`crates/pounce-linalg/src/triplet_convert.rs` states it outright: matrices\n",
+    "\"arrive in triplet (COO) form with possibly repeated `(row, col)` entries\" and\n",
+    "are compressed **\"with repeated entries summed.\"** A duplicated entry is\n",
+    "exactly what we want — the two blocks' second derivatives *should* add.\n",
+    "\n",
+    "One caveat on the naming: `NlProblem` spells its structure methods\n",
+    "`jacobian_structure` / `hessian_structure`, while the bridge wants cyipopt's\n",
+    "run-together `jacobianstructure` / `hessianstructure`. That is the entire\n",
+    "reason `NlBlock` below exists — six lines of renaming, nothing more.\n",
+    "\n",
+    "So the whole stacker is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bdfef895",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:43.720035Z",
+     "iopub.status.busy": "2026-09-06T20:03:43.719818Z",
+     "iopub.status.idle": "2026-09-06T20:03:43.730560Z",
+     "shell.execute_reply": "2026-09-06T20:03:43.729590Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mixed problem: n = 8  m = 6\n",
+      "declared nnz  jac = 20  hess = 11\n"
+     ]
+    }
+   ],
+   "source": [
+    "class NlBlock:\n",
+    "    \"\"\"cyipopt-shaped view of an NlProblem (renames the two structure\n",
+    "    methods; every other method already matches).\"\"\"\n",
+    "\n",
+    "    def __init__(self, p):\n",
+    "        self.p = p\n",
+    "        self.m = p.m\n",
+    "\n",
+    "    def objective(self, x):      return self.p.objective(x)\n",
+    "    def gradient(self, x):       return np.asarray(self.p.gradient(x))\n",
+    "    def constraints(self, x):    return np.asarray(self.p.constraints(x))\n",
+    "    def jacobianstructure(self): return self.p.jacobian_structure()\n",
+    "    def jacobian(self, x):       return np.asarray(self.p.jacobian(x))\n",
+    "    def hessianstructure(self):  return self.p.hessian_structure()\n",
+    "\n",
+    "    def hessian(self, x, lam, obj_factor):\n",
+    "        return np.asarray(self.p.hessian(x, lam if self.m else None, obj_factor))\n",
+    "\n",
+    "\n",
+    "class Mixed:\n",
+    "    \"\"\"Stack cyipopt-shaped blocks defined over a shared x into one\n",
+    "    problem_obj. Objectives add; constraint rows concatenate.\"\"\"\n",
+    "\n",
+    "    def __init__(self, blocks, n):\n",
+    "        self.blocks, self.n = list(blocks), n\n",
+    "        self.m_each = [b.m for b in self.blocks]\n",
+    "        self.m = sum(self.m_each)\n",
+    "        self.offsets = np.cumsum([0] + self.m_each)[:-1]\n",
+    "\n",
+    "        jr, jc, hr, hc = [], [], [], []\n",
+    "        for b, off in zip(self.blocks, self.offsets):\n",
+    "            r, c = b.jacobianstructure()\n",
+    "            jr.append(np.asarray(r, np.int64) + off)      # rows are disjoint\n",
+    "            jc.append(np.asarray(c, np.int64))\n",
+    "            r, c = b.hessianstructure()\n",
+    "            r, c = np.asarray(r, np.int64), np.asarray(c, np.int64)\n",
+    "            hr.append(np.maximum(r, c))                   # fold to lower\n",
+    "            hc.append(np.minimum(r, c))\n",
+    "        self._jac_s = (np.concatenate(jr), np.concatenate(jc))\n",
+    "        self._hes_s = (np.concatenate(hr), np.concatenate(hc))\n",
+    "\n",
+    "    def objective(self, x):\n",
+    "        return float(sum(b.objective(x) for b in self.blocks))\n",
+    "\n",
+    "    def gradient(self, x):\n",
+    "        return sum(np.asarray(b.gradient(x), float) for b in self.blocks)\n",
+    "\n",
+    "    def constraints(self, x):\n",
+    "        return np.concatenate([np.asarray(b.constraints(x), float)\n",
+    "                               for b in self.blocks])\n",
+    "\n",
+    "    def jacobianstructure(self):\n",
+    "        return self._jac_s\n",
+    "\n",
+    "    def jacobian(self, x):\n",
+    "        return np.concatenate([np.asarray(b.jacobian(x), float)\n",
+    "                               for b in self.blocks])\n",
+    "\n",
+    "    def hessianstructure(self):\n",
+    "        return self._hes_s\n",
+    "\n",
+    "    def hessian(self, x, lam, obj_factor):\n",
+    "        lam = np.asarray(lam, float)\n",
+    "        return np.concatenate([\n",
+    "            np.asarray(b.hessian(x, lam[o:o + mi], obj_factor), float)\n",
+    "            for b, o, mi in zip(self.blocks, self.offsets, self.m_each)])\n",
+    "\n",
+    "\n",
+    "mixed = Mixed([NlBlock(eqn_problem), jax_block], n=n)\n",
+    "print(\"mixed problem: n =\", n, \" m =\", mixed.m)\n",
+    "print(\"declared nnz  jac =\", mixed.jacobianstructure()[0].size,\n",
+    "      \" hess =\", mixed.hessianstructure()[0].size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7605f709",
+   "metadata": {},
+   "source": [
+    "## 6. Solve it\n",
+    "\n",
+    "Bounds carry the design limits and the outlet spec: `CA[2] <= 0.25` is the\n",
+    "conversion requirement, and `T <= 380` keeps the temperature inside the range\n",
+    "the surrogate saw. Both blocks' rows are equalities, so `cl = cu = 0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bfd8a685",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:43.732643Z",
+     "iopub.status.busy": "2026-09-06T20:03:43.732443Z",
+     "iopub.status.idle": "2026-09-06T20:03:44.608305Z",
+     "shell.execute_reply": "2026-09-06T20:03:44.607042Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solve_Succeeded  objective = 78.519981 $/min\n",
+      "\n",
+      "  V =   29.547 L per stage   (tau = 2.95 min)\n",
+      "  T =  359.977 K\n",
+      "\n",
+      " stage   CA (mol/L)       rate\n",
+      "     1       0.8684     0.3830\n",
+      "     2       0.4347     0.1468\n",
+      "     3       0.2500     0.0625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  capital  44.320   heating  31.962   trust   2.237\n"
+     ]
+    }
+   ],
+   "source": [
+    "lb = [0.01] * N + [0.0] * N + [1.0, 300.0]\n",
+    "ub = [2.0] * (N - 1) + [CA_target] + [50.0] * N + [500.0, 380.0]\n",
+    "x0 = [1.2, 0.7, 0.25] + [0.5, 0.3, 0.15] + [30.0, 350.0]\n",
+    "\n",
+    "prob = pounce.Problem(\n",
+    "    n=n, m=mixed.m, problem_obj=mixed,\n",
+    "    lb=lb, ub=ub,\n",
+    "    cl=[0.0] * mixed.m, cu=[0.0] * mixed.m,\n",
+    ")\n",
+    "prob.add_option(\"print_level\", 0)\n",
+    "prob.add_option(\"tol\", 1e-10)\n",
+    "\n",
+    "x, info = prob.solve(x0=x0)\n",
+    "x = np.asarray(x)\n",
+    "\n",
+    "print(info[\"status_msg\"], \" objective =\", round(info[\"obj_val\"], 6), \"$/min\\n\")\n",
+    "print(f\"  V = {x[iV]:8.3f} L per stage   (tau = {x[iV] / q:.2f} min)\")\n",
+    "print(f\"  T = {x[iT]:8.3f} K\\n\")\n",
+    "print(f\"{'stage':>6} {'CA (mol/L)':>12} {'rate':>10}\")\n",
+    "for i in range(N):\n",
+    "    print(f\"{i + 1:6d} {x[i]:12.4f} {x[N + i]:10.4f}\")\n",
+    "print(f\"\\n  capital {N * cost_V * x[iV]:7.3f}   heating \"\n",
+    "      f\"{cost_T * (x[iT] - T0) ** 2:7.3f}   trust \"\n",
+    "      f\"{float(trust_penalty(jnp.asarray(x))):7.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bdf0dfd",
+   "metadata": {},
+   "source": [
+    "## 7. Is it right?\n",
+    "\n",
+    "Two independent checks, because \"it converged\" is not evidence.\n",
+    "\n",
+    "**Against an all-JAX twin.** Write the *same* model entirely in JAX — balances\n",
+    "included — and hand it to `from_jax`. The twin re-derives the balances and\n",
+    "every derivative through JAX, sharing nothing with the mixed build but the\n",
+    "surrogate and the cost constants, so agreement means the stacker's index\n",
+    "bookkeeping is right. We compare the optimum, and also the gradient and the full Lagrangian\n",
+    "Hessian at an off-solution probe point, which is where a scatter bug would\n",
+    "show even if the solve happened to land in the same place.\n",
+    "\n",
+    "**Against the truth model.** Substitute `true_rate` into the balances at the\n",
+    "converged point. The mixed model is *exactly* consistent with the surrogate,\n",
+    "so what is left is the surrogate's own error — a statement about the fit, not\n",
+    "about the solver."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1a7b05be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:44.610827Z",
+     "iopub.status.busy": "2026-09-06T20:03:44.610468Z",
+     "iopub.status.idle": "2026-09-06T20:03:48.944464Z",
+     "shell.execute_reply": "2026-09-06T20:03:48.943233Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vs all-JAX twin\n",
+      "  max |dx*|       1.776e-14\n",
+      "  |df*|           1.421e-14\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  max |dgrad|     6.217e-15\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  max |dHess|     5.684e-14\n",
+      "\n",
+      "vs the truth model (surrogate error, not solver error)\n",
+      "  balance residual [ 0.0594  0.064  -0.1223]\n",
+      "  as % of q*dCA    [0.52 1.48 6.62]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def f_all_jax(x):\n",
+    "    return N * cost_V * x[iV] + cost_T * (x[iT] - T0) ** 2 + trust_penalty(x)\n",
+    "\n",
+    "\n",
+    "def g_all_jax(x):\n",
+    "    CAin = jnp.concatenate([jnp.array([CA0]), x[iCA][:N - 1]])\n",
+    "    return jnp.concatenate([q * (CAin - x[iCA]) - x[iV] * x[iR],\n",
+    "                            rate_residuals(x)])\n",
+    "\n",
+    "\n",
+    "reference = from_jax(\n",
+    "    f_all_jax, g_all_jax, n=n, m=2 * N, lb=lb, ub=ub,\n",
+    "    cl=[0.0] * (2 * N), cu=[0.0] * (2 * N),\n",
+    ")\n",
+    "reference.add_option(\"print_level\", 0)\n",
+    "reference.add_option(\"tol\", 1e-10)\n",
+    "x_ref, info_ref = reference.solve(x0=x0)\n",
+    "x_ref = np.asarray(x_ref)\n",
+    "\n",
+    "print(\"vs all-JAX twin\")\n",
+    "print(\"  max |dx*|      \", f\"{np.max(np.abs(x - x_ref)):.3e}\")\n",
+    "print(\"  |df*|          \", f\"{abs(info['obj_val'] - info_ref['obj_val']):.3e}\")\n",
+    "\n",
+    "# Derivatives at an off-solution probe point.\n",
+    "xp = np.array([1.1, 0.6, 0.3, 0.4, 0.2, 0.1, 25.0, 355.0])\n",
+    "lp = np.array([0.3, -0.2, 0.5, 1.1, -0.7, 0.4])\n",
+    "\n",
+    "g_mix = mixed.gradient(xp)\n",
+    "g_ref = np.asarray(jax.grad(f_all_jax)(jnp.asarray(xp)))\n",
+    "print(\"  max |dgrad|    \", f\"{np.max(np.abs(g_mix - g_ref)):.3e}\")\n",
+    "\n",
+    "Hm = np.zeros((n, n))\n",
+    "hr, hc = mixed.hessianstructure()\n",
+    "np.add.at(Hm, (hr, hc), mixed.hessian(xp, lp, 1.0))   # duplicates sum, as the solver does\n",
+    "Hm = Hm + Hm.T - np.diag(np.diag(Hm))\n",
+    "Hr = np.asarray(jax.hessian(\n",
+    "    lambda z: f_all_jax(z) + jnp.dot(jnp.asarray(lp), g_all_jax(z)))(jnp.asarray(xp)))\n",
+    "print(\"  max |dHess|    \", f\"{np.max(np.abs(Hm - Hr)):.3e}\")\n",
+    "\n",
+    "CA_in_star = np.concatenate([[CA0], x[iCA][:N - 1]])\n",
+    "resid = q * (CA_in_star - x[iCA]) - x[iV] * true_rate(x[iCA], x[iT])\n",
+    "print(\"\\nvs the truth model (surrogate error, not solver error)\")\n",
+    "print(\"  balance residual\", np.array2string(resid, precision=4))\n",
+    "print(\"  as % of q*dCA   \",\n",
+    "      np.array2string(100 * np.abs(resid) / (q * (CA_in_star - x[iCA])), precision=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da66d124",
+   "metadata": {},
+   "source": [
+    "Machine precision against the twin, and residuals against the truth model at\n",
+    "the ~1% level the fit itself carries. Note the second number is *not* a\n",
+    "verification of the mixing — it is the honest cost of having used a surrogate\n",
+    "at all, and it would be the same for the all-JAX build.\n",
+    "\n",
+    "## 8. Sparsity survives the mix\n",
+    "\n",
+    "Each block declares its own structure and the stacker keeps both, so the mixed\n",
+    "model is as sparse as its parts. The one thing to know is that concatenation\n",
+    "declares the *overlap* twice — `(T, T)` here — so the declared triplet count is\n",
+    "slightly above the true number of distinct entries. The converter coalesces\n",
+    "them, so this costs a little memory in the triplet array and nothing in the\n",
+    "factorization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0e54b1f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:48.946809Z",
+     "iopub.status.busy": "2026-09-06T20:03:48.946565Z",
+     "iopub.status.idle": "2026-09-06T20:03:49.144029Z",
+     "shell.execute_reply": "2026-09-06T20:03:49.142713Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jacobian :  20 nnz of 48 dense\n",
+      "Hessian  :  11 declared,  10 distinct, of 36 dense lower triangle\n",
+      "declared by both blocks: [(7, 7)]\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6wAAAF5CAYAAACbV6fxAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAnUpJREFUeJzs3Xd8E/X/B/DXpSPdpYUySguUqexRhsyypIAsEaFsUIYiQ0QZooDwA1QcDGULoixFcYBs2Uum7FGgQJktXelKm9zn90dtvk2TtunK4vV8PKrkxufe77tLcu/c3eckIYQAERERERERkZVRWDoAIiIiIiIiImNYsBIREREREZFVYsFKREREREREVokFKxEREREREVklFqxERERERERklViwEhERERERkVViwUpERERERERWiQUrERERERERWSUWrER26vLly9i8ebNZlnX79m18//33Rdrm9evX8eOPPxZpm/n1999/4+DBg0XS1rZt23Dy5Mkiacte7Nq1C0eOHLF0GPm2YcMGPH782KzL/O2333D79u1cpzHX+rSFfVmj0WDZsmV4+vSppUMpNFNzWbZsGR48eGD25RIRFTdJCCEsHQQRGRcbG4vNmzejV69eKFOmjG74oUOHcOXKFQwfPhzOzs664X/88Qfc3d3Rvn17LFmyBEuWLMG1a9eKPc4tW7Zg9OjRiI6OLrI2165di+nTpyMyMrLI2syvgQMHwsXFBatWrSp0Wx06dEBwcDDmz59fqHZ27NgBb29vNG/evNAxJSQk4NChQ3j69ClKly6NVq1awdvbu9Dtmqpnz54ICAjAkiVLzLbMnJi6Xnfu3Il3330X58+fx5o1a3KdtlatWmjVqlWO4zUaTZ77VmYby5cvx+bNm/H333/nOK251mdR7ctFRQiB5cuXo3v37vD39wcAJCYmwtPTE8ePH0ezZs2KdVnFzdRcJEnCnj170KFDB7Mu1xZYYrsRUdFxtHQARJQzd3d3TJw4EQqFAiNHjtQNnzx5Mk6cOIGaNWuidevWADK+kIcNG4b3338f7du3t1TIVMy++eYbVK1atdAF67Jly/DBBx+gbt26qF69Om7duoX+/fvjs88+w+jRo4soWtth6nqdNm0aJk2aBAA4f/68bvjly5dx/PhxvPnmm7phXl5eubal1WpNbmP48OGYPn069uzZg44dOxptLzQ0FD4+Prku0x5ptVq89dZbeOGFF4q9GDHnsqjocLsR2TYWrERWzNnZGc2bN8f+/ft1BWtiYiJOnz6NLl26YP/+/bqC9d9//0VMTAzatWun10ZqaiqOHTuGR48eITg4GDVq1NAbL4TA4cOHER4ejnLlyqF9+/Z6Z22N0Wg02L17N+Lj49GgQYMcp7t48SLOnj2LkiVLokWLFkYPpi9fvowzZ86gTJkyCAkJgVKpNNrW/fv3sX37dgCAq6sratSoYfCr/+XLl3Hp0iV0794de/fuxaNHjzB06FA4OztDo9HgwIEDiIyMROXKldGyZUsoFPp3RURHR2P37t3w9PTM84zCzZs3ceLECQwaNAgAoFarsWbNGjRs2BBNmjQBAFy4cAE3b95E7969dfM9fvwYJ06cgFarRdu2beHr66sbd/jwYVy+fBkAULJkSQQHByMoKEg3fv/+/bh37x5SUlKwbNkyAEC/fv1QokSJXGPN7qeffsJbb72FTZs2oW/fvrrhv/32G1599VX4+Pigb9++OH36NO7cuYM+ffrozX/ixAk8ePBAl1de63bbtm3w8/ND+fLlcejQIXh6eqJbt24GceWVf9a2AgICcPLkSWi1WoSGhsLT0zPHfItqvR47dgxXr15F3759oVQqddMCwJIlS3Dq1Cm9YXnJTxtOTk7o27cvli5dmmPBGhQUBHd3d71hp06dwrVr1+Dv74+WLVsafX8Vx74MFG6/ePbsGfbv34+0tDQ0aNAAL774Yo7rMfN2hD/++APXrl2Dj48Punbtqht/6dIlXLhwAaVLl0a7du0M3veFXZavry9cXV3RsmVLABm3M+zfvx+9e/eGn5+fbvry5cujUaNGAIC7d+/i8OHDUCgUCAkJMbmIOn/+PC5duoRy5cqhXbt2kCQp1+lNWU5sbCwOHDiA1NRUtG7dGuXLl8+xvYcPH+KPP/5A+/btUa1aNajVavz999+Ijo5GnTp1UL9+faPzZV5N8Oqrr+LRo0e4dOkSSpcujfbt20OhUODEiRO4fv06qlevjpdeeslgflO2UW7TGNtuWT/7iMjKCSKyanPmzBFly5bVvd6xY4eoXr26+OGHH0RISIhu+FdffSW8vLyERqMRQgixePFi4efnJ+rVqyd69OghevToIZydncXGjRt186Smpop27dqJcuXKibCwMFG9enVRo0YN8eDBgxzjSU5OFs2aNROBgYEiLCxMVK5cWbRo0UKULFlSN41WqxWDBw8W5cqVE/379xcvv/yy8PPzEwcPHtRNo9FoxKBBg4Snp6fo2bOnCA0NFcHBwSI2NlYIIcSaNWtE+fLlddNfvnxZjBo1SowaNUoMHDhQ+Pv7iy5dugitVqubJjPn2rVri27duolRo0aJ5ORkcffuXVGzZk3RoEEDMWjQIFGrVi3RuHFj3bKEEOLMmTPCx8dHNGnSRLz22muiQoUKombNmuKNN94wuh7Onz8vJEkS0dHRQgghDhw4IACIbt266aYZOnSoGDx4sBBCiPbt24tGjRqJatWqif79+4tGjRqJsmXLivv37+umX79+vS7Hnj17Cnd3d7F48WLd+LVr14oKFSqIOnXq6KZ7/PhxjtsqJ9WqVdOLM6s+ffqIypUrCyGE+Pvvv4Wjo6N48uSJ3jTBwcHivffeE0IIk9Zt+/btRcOGDUXlypXFgAEDxBdffCGEEKJHjx5izJgxJuefta3AwEDRt29fUbt2bREQECDu3LmTY75FtV4//PBD0aJFC6PLWLx4sVAqlTnGYIq82tiyZYvw8PAQaWlpRsdnX59hYWGiXLlyYtCgQaJTp06iYcOG4tGjRwbzFce+XJj9YuvWraJEiRKiS5cuon///qJUqVJi0qRJOa6X8ePH6+IdNWqUmDFjhlCpVAKAaNOmjWjYsKEYOHCgKFeunOjatavevEWxrJkzZ4pWrVrpppkwYYIAIFavXi2EEEKWZVGyZEnx66+/CiGEWLp0qVAqleKVV14RoaGhwsXFRaxfvz7HZWbm0rJlS1GzZk3Rr18/4efnJ7p166b3+QdA7NmzR/falOX88ssvwsPDQzRv3lz069dPVKtWTfzxxx96yz1+/LgQQoibN2+KSpUqibfeektotVrx+PFjERQUJIKDg8WQIUNEcHCwGDZsWK45NGzYUAQHB4v+/fsLb29v8eqrr4r+/fuLpk2biv79+wsPDw/xySef5Hsb5TWNse1GRLaDBSuRlTt27JgAIK5evSqEEOKDDz4QI0eOFPfv3xdKpVKkpKQIIYTo3r27eOWVV3TzLV68WAAQu3bt0g376KOPRM2aNXWvFyxYIMqUKaMrSFJSUkTjxo3FwIEDc4zns88+EwEBASImJkYIIURCQoKoVq2aXsG6cOFC8eKLLwqVSqUb9vXXX4ugoCC9ZXt5eYmbN2/qhl24cEF30Jy9YM0uISFBVKhQQWzYsMEg5y1btuhN27ZtWzF27Fjda41GI9q3by8mTJigG9a8eXMxYMAA3evM9Z5TwZp5EPrLL78IIYSYOXOmaNmypShRooTuILJSpUriu+++E0JkHJyXL19et960Wq2oV6+emDZtWo45HjhwQLi6uopnz57phnXt2lWMHz8+x3nycvfuXQFArFixwuj477//XgAQd+7cEVqtVgQEBIhFixbpxl+/fl0AEOfOnRNCmLZu27dvL3x9fQ0K3+wFVnbG8m/fvr1wdXUVt27dEkIIkZ6eLkJCQsTrr79u8joo6Hrt2rWrePPNN42OM0fBeuXKFQFAXL582ej4rOvz3r17AoAIDw/Xjb927ZqIjIw0mK849uWC7hePHj0Sbm5uYu/evbph9+7dE56enuLAgQNG805PTxcAxP79+3XDMguk/v37C1mWhRAZBZckSeKff/4p0mUdOHBAODs7i+TkZCGEEPXr1xctW7YUgwYNEkLo/yBw//594erqKtauXaub/4svvhAlSpTQffZll7VgzfyxIiIiQri7u+t9/mUtWE1ZTmRkpHBxcRGfffaZbpqkpCRx8uRJveUeP35cnDt3TpQpU0ZMnz5dN+2iRYtEnTp1dOtXCCH27duXaw5Zv1v+/PNPAUDvPbVx40bh6uqq++HVlG1kyjTGthsR2Q72Ekxk5Ro3bgwPDw/s378fQMbliyEhIQgICED58uVx/PhxyLKMQ4cOGVwOXLZsWbz88su6182aNUN4eLju9a+//ooBAwagdOnSAAAXFxeMGTMGv/32W47xbN26FQMGDNBd3uvp6Ylhw4bpTbN+/XpUrlwZmzZtwsqVK7FixQqoVCrcuXNH14nSxo0bMWTIEFStWlU3X506dVCyZMkcl52UlISdO3fiu+++w/r161GqVCmcOXNGb5oSJUroXbb46NEj7N+/H97e3li1ahVWrlyJ1atXw8fHB4cPHwYAPH36FMeOHcM777yjm++ll17SXQ5pjCRJaNWqlW67HDhwAKNGjYKrqyvOnTuHe/fuISIiAiEhIbp5unXrpltvCoUCTZo00dseAHDv3j38+uuvWLFiBa5evYq0tDRcuXIlxzjyKyoqCgAQGBhodHzm8KdPn0KhUCAsLAzr16/XjV+/fj1q1aqF+vXrm7RuM3Xv3l23n+XGlPy7dOmCypUrAwAcHR3x9ttv448//oDIpQ/BolivMTExZu2UKrvMS5SfPXuW57Tu7u5wcnLCvn37oNFoAAA1atQwerlnUe/Lhdkvtm7dCmdnZ9y5cwcrV67EypUrsWPHDpQpU8ZgXlMMHjxYd9ls1apVUapUKV2cRbWsZs2aQaFQ4NixY4iLi8Ply5fx0Ucf6a3PzM+2HTt2wN3dXXf5NQCMGTMGKSkpuulzMmrUKDg5OQEAKlasiB49euT4WW3KcrZu3QoXFxdMnDhRN42bm5vB596hQ4fQtm1bTJ06FbNnz9YNL1GiBJ48eYJz587phmX/Dspu4MCBun9nXh6dNcZGjRohJSVF19uxKduoqPcZIrI+vIeVyMo5OjqiZcuW2L9/PwYMGICzZ8/qDhzbtGmD/fv3w8vLC3FxcWjbtq3evNkPrp2dnZGWlqZ7ff/+fbz++ut601SsWBGJiYmIiYkxuCctc57sxU6FChX0Xt+7dw9OTk44ffq03vBRo0bp/v3gwQNd0WGKf/75B507d0aVKlVQo0YNuLu7Q6VSGRy8Z+1NOTMWAIiIiNAVa0DGvYzVq1fX5QQYFnHZ88ouJCQEK1euhFqtxokTJ/DDDz/otomfnx8qVKigd6+kse2hVqt1rz/99FPMmTMHLVu2hL+/P5ycnCBJkkkFiqkyO/HJ6VEVmcMzpxswYAA+//xzhIeHo2rVqtiwYQPeeOMNAKat20zZt4sxpuZvbDulpqYiKirKaFFcVOvV09MTiYmJ+ZqnKGUuO6/OnADA19cX69evx8cff4z3338frVq1wqBBg3K8b68o9+XC7Bf37t2Do6OjwWdH+/btDe6/N0VecRbFspRKJZo1a4b9+/cjMTERdevWRfv27REfH4/w8HAcOHBA95l9//59BAQE6N1Hq1QqUbZsWd16y4mx/T6nx26ZspwHDx6gYsWKcHBwyHW5s2fPRu3atfV+0AOAsLAwXLhwAS+//DLc3d3RoUMHjB8/HnXr1s2xrazbI7P4zro/Zw7L/J4yZRsV9T5DRNaHBSuRDWjbti0WLFiAgwcPokqVKihXrhyAjIJ11apV8PLygq+vL+rVq5evdkuXLm3wKJqoqCgolcocO/IpXbq0wYF+9jZ8fHzQpEkTfPnllzku29fXF0+ePDE51pkzZ+K1117D8uXLdcNefvnlXM+qZcYCACNGjNB1UJVdZpHz7NkzvTNQ0dHRuZ5RCwkJwbvvvos///wTAQEBCAgIQEhICP7880/4+fnpnZHKS0pKCj788EP8+eef6Ny5M4CMM8rLly/PM8f8qFq1Kvz8/HDo0CEMHjzYYPzhw4dRqlQpXWFRr1491K5dGxs2bECnTp10vQkDpq1bU+Unf2P7n6Ojo9EfWIpyvb744ou6zpss4datW3ByctK7KiE3ffr0QZ8+fRAZGYk///wTw4cPh1qtNrrdi3JfLsx+4ePjA1mW89V5VUEV5bJCQkKwZ88eJCUloW3btnBwcECLFi3w999/4/Dhw1i5ciUA45+5Qgg8e/Yszx91jO33OV21YMpyTP0MXrNmDaZMmYJBgwbhhx9+0BW4jo6O+Pzzz/Hpp5/iwoULWLZsGV566SVdB35FwZRtZM59hogsg5cEE9mAtm3bIioqCkuWLNE7cGzTpg3++ecfbN++HSEhIXn2GGms3S1btiA9PV03bP369WjdurVBT5qZQkJC8Msvv0Cr1QIAZFnG5s2b9abp1q0bfvzxR4MDrBs3buj+3aVLF2zYsAFJSUm6YbGxsTmewYqJidErJu/evYsjR47kmWP16tVRvXp1LFy4UK9AEULoLg0MCAhA1apV9fK4d+8ejh49mmvbdevWha+vLz755BPd2e2QkBAcPnxYd+m2qeLj46HVavVyzHopbiYvLy8kJyfrDTt9+nSezwTNJEkSJk2ahHXr1uldygdk9Ka6atUqTJo0SW/7DxgwAOvXr9ftG5lnnk1Zt6YyNX8A+Ouvv6BSqXSvN27ciBYtWsDR0fA32MKs1+w6duyIkydP6r1fTHHz5k0sW7YMqamp+ZovuyNHjqBFixYGPQEbEx0djZiYGAAZ+/dbb72FJk2a4N9//zU6fVHuy4XZL7p27YrY2FisW7dOb3h8fHyOVwU4OjrC1dU1z+1XnMsKCQnBP//8gx07duitvyVLliAmJkZXuLdp0wYPHz7Uu1T1999/h1qtRosWLXKNN+vnU1JSEv74448ct4spy+ncuTOePHmCP//8U2/ezCtOMgUEBGD//v04efIkBg0apPvsv3XrFmRZhkKhQP369fHpp58iOTk53+/93JiyjUyZJqfttmXLljwvxSYiy+MZViIb0LBhQ3h7e2P37t3YsGGDbnilSpVQtmxZHDhwAEuWLMl3u1OnTsWWLVsQEhKCHj164Pjx4/j7779zLQQnT56MjRs3on379ujSpQv27dtncIAzffp0HDx4EA0aNMCQIUPg5uaGkydPIikpCXv27NFNs3fvXjRq1Aj9+/dHamoqtm3bhj179sDDw8NguX379sWMGTOg0Wjg6OiIlStX5vook6zWrVuHzp07o23btujSpQtiY2Oxa9cuDBkyBOPHj4ckSViwYAFee+01REdHo2LFilizZk2u99MC/7v377fffsOUKVMAQHe58t27d/N1kF+2bFm0adMGAwYMwNChQ3H79m388ssvBkXYSy+9hDlz5qB69erw8PBAv379sG3bNnz99dcG9xLnZNKkSbh16xZatWqFYcOG6Z7D+t1332HIkCF4//339aYfMGAApk2bhnv37mHx4sV64/Jat0WdP5Bxr3WrVq0QFhaG8+fPY+vWrThw4ECh2jW2XrNfZZD5nNM///wTr776qsm5HT16FO+88w769+8PFxcXk+fLbtOmTfjkk09MmvbZs2fo2rUrOnbsiBo1auDatWs4efIkPv30U6PTF+W+DBR8v6hVqxbmzZuHN954AwcPHkTNmjVx+/Zt7N69G7/++muOZxRfeuklzJ8/H7dv34afn5/eY22Ke1l9+/ZFs2bN4ODggPDwcN3jbUJCQjBlyhTUrVtX91lSp04dvPPOO+jZsyfGjBkDjUaDxYsXY9q0aahUqVKu8R47dgyvv/46GjVqhM2bN8PX11fvNousTFlO7dq1MXPmTPTp0wdvvvkmAgMDsXv3bvTr1w8jRozQay8wMFB3afPgwYOxbt067N27F99++y26dOmC0qVL4/fff0fNmjURHByc57o3lSnbyNTtaGy7zZkzB/Xr1ze4nYaIrAsLViIb4ODggBkzZuD69eto37693rhp06bh3LlzBgdotWvXRr9+/fSGBQQE6B3g+Pr64vz58/j+++8RHh6Oxo0bY9GiRTl2yANkXGp29uxZrFq1CtHR0Rg+fDiqVq2KjRs36qbx9PTEkSNHsHXrVpw8eRJCCLz55pt6MXp7e+PEiRPYtGkTzp8/D39/f+zcuVN3uVqNGjX0OuN49913UaVKFRw8eBBKpRKbNm3CjRs39M4EGssZAJo2bYobN25g48aNCA8Ph7+/P77//nvUqVNHN02PHj1w5MgRbNmyBRqNBuvXr8fly5d191TlZOTIkShTpozedpk+fTpu3bqld89ft27dULFiRb15W7VqhdjYWN3rv/76C6tXr0Z4eDgCAwNx5swZfP7553rtvP322/Dx8cG5c+eQlJSEXr16ITg4GMOHD881zqwUCgWWL1+OUaNGYfv27bhx4wb8/Pywf/9+XUcoWQUGBmLWrFl48OABXnvtNb1xpqxbY7kD/ysA85M/kNFxy8svv4wDBw4gKCgIZ86cQa1atXLMt6DrNTsHBwdMnz4dX331lUHBWrt2bYOD/ExHjhzByJEj87z3NLc2tm3bBicnJ4Nn4maVdX3WqFEDp0+f1r1PgoKCcPnyZYN1mVVR7suF2S8mT56MTp064Y8//kBkZCTq1KmD2bNnG73kO9PmzZuxZs0aXL9+HdHR0ejZsydGjRplcJntoEGD9O5rLIplARn3h86YMQNqtVq3nYODg/HWW28ZPNN54cKFePnll7F//34oFAps3boVHTp0yHF5Tk5OGDVqFCZOnIijR4/i8uXL6N+/P0aMGAFXV1fddKNGjUJAQEC+lvPxxx+jY8eO2LZtG+Li4vDxxx+jTZs2esvNXIeBgYHYv38/5s+fj/3792PUqFFo1aoVfv/9d0RGRmLgwIEICwvTiyl7Dlm3h6urK0aNGoVSpUrphnl6emLUqFF6t2KYso1MmcbYduvTp4/eOiMi6ySJorw5ioiIqBh16NABwcHBmD9/vkWWL8sypkyZgnHjxpl8oDtr1iy8/fbb8PPzK/ByFy9ejIYNG+Z52SgREZG9YcFKREQ2w9IFKxEREZkXLwkmIiKbkdNlpERERGSfeIaViIiIiIiIrBIfa0NERERERERWiQUrERERERERWSUWrERERERERGSVWLASERERERGRVWLBSkRERERERFaJBSsRERERERFZJRasREREREREZJVYsBIREREREZFVYsFKREREREREVokFKxEREREREVklFqxERERERERklViwEhERERERkVViwUpERERERERWiQUrERERERERWSUWrERERERERGSVWLASERERERGRVWLBSkRERERERFaJBSsRERERERFZJRasREREREREZJVYsBIREREREZFVYsFKREREREREVokFK5ENioyMRL9+/XD8+HFLh2JW169fR79+/XDu3Lk8p31e1xERUX4MHToU69ats3QYVssa1s+UKVOwceNGvWHWEJelWeM6KGhMycnJGDRoEE6fPl0MUdk+FqxExeD27dvo168fTp48WSztx8XFYfPmzbh7926B5s9vfDExMejXr5/FvxiioqKwefNmPHjwIM9pC7uOiMj+jBkzBh999JGlw7AqW7ZswdmzZy2y7Ny2R1RUFPr164f169ebOSp9llw/ALBz5058+eWXaNasmd5wS8dVlAYMGFCg7WyN66CgMbm5uUGpVGLcuHHFEJXtY8FKVAxiYmKwefNm3L9/v1jaDwwMxMaNG9G8efMCzZ/f+JKTk7F582ar+2LITWHXERHZn99//x179uyxdBhW5fvvv8eQIUMssuzctkdSUhI2b95s0hU1xcmS6wcApk2bhr59+yIoKMhiMRS3gm5nS2+bojZ58mQcP34cf/zxh6VDsTqOlg6AiPLP29sb/fr1s3QYVo3riIgob71797Z0CFbNkuvn+PHjOHfuHD7//HOLxWDN7G3frVatGpo1a4Zvv/0W3bt3t3Q4VoUFK9m8ixcv4pdffkFERATKli2L7t27G5xV27t3L7Zv345nz56hfPnyeP3119GgQQPd+OvXr2PGjBmYPHkySpYsieXLl+PBgweoW7cuRo0aBXd3d732rl27hk2bNuHevXsoWbIkWrZsiR49egAATp48iY8//hgA8PXXX2PLli0AgL59+6JXr156yypRogRWr16NO3fuYPbs2fDz88OIESN0y1EqlahUqRJef/111KpVSzc8MjISkyZNwvjx4/HSSy/lK4e84jOVSqUyKdai3E5ZhYeHY+XKlXj69Cnq16+PESNGwM3NLdd1ZGrM+d0fiMh+TJgwAY8fPwYAODo6omzZsujcuTPat29vMO2BAwfwyy+/IDU1FW3btkVYWBgmTZoEf39/vPfeewAAWZbRv39/vPrqq3j55ZexatUqXLx4EQMGDMDLL79s0vKythEaGooVK1bg0qVLCAgIwOjRoxEQEFCg2ICMe+7atWuHwYMH52sdFCSmovLw4UP8+OOPuHr1KpycnNCqVSuEhYXB0fF/h7VRUVFYt24dbty4AWdnZ9SvXx8DBw6EUqnM1zSWXD8bN26Ep6cn2rZta/K6uXjxIjZv3ox79+7Bx8cHoaGh6Ny5s278J598AiEEZsyYoRu2cuVK7Nu3D6NHj0ZISAgAQKvVYujQoejSpQvCwsJ00+a17vPa37OKiYnB22+/DVmWsW3bNkRGRgIAGjZsiA8++CDPtsy5bUx9P+XElH0WALp3744PP/wQ0dHRKFWqVJ7tPi94STDZtNmzZ6NevXq4dOkSmjRpAl9fX0yePBlLly7VTfPGG28gNDQUGo0GLVu2REREBBo1aoQvvvhCN03mvZH79u3D8OHDUbp0abz44ouYPXs2unbtqrfMv/76C7Vr18adO3fQokULlC9fHuvWrdN9YJYvXx5t2rQBADRu3Bg9e/ZEz549UaNGDb1l7dixA0OHDkXJkiVRokQJxMTEQKlU6qbv2bMnmjVrhkuXLqFevXrYtm2bLgZj92eamkNe8ZnK1FiLcjtl+vfffzF8+HCUL18e1atXx/z589G0aVPExcXluo5MjTk/+wMR2ZeOHTvqPiPatWuH5ORkdO3aFTNnztSb7tNPP0Xbtm0RHx+PJk2a4OjRoxg/fjy2b9+Ow4cP66aTZRmbN2/GkSNH0KNHD6SmpqJGjRq6WzJMWV5mG8ePH8drr70GtVqNxo0bY8uWLWjcuLHeZ19+YgOM33NXHDEVlW3btqF69erYuXMnGjVqhOrVq2P69Olo06YNUlJSAGT00/Diiy9i27ZtqF+/PmrXro1//vkHwcHBunZMmcbS6+fAgQMIDg6GQmHa4fqyZctQv359XLlyBS1atICDgwN69OiBfv36QZZlABm3+Hz22WdQq9W6+RYuXIjNmzfjxx9/1A07deoUfvzxR70fgk1Z93nt71m5urqiZ8+ekCQJ1apV063TzB+Z82rLXNsmP+8nY0xZb5leeuklCCFw8ODBPNt9rggiG7Vjxw4BQPzf//2fwbiHDx8KIYTYtGmTACCWLVumN37s2LFCoVCI8+fPCyGEOHz4sAAg6tWrJ1JSUnTTbdy4UQAQf//9t25Yly5dRIsWLQyWGRkZqfv3qVOnBADx888/G0yXuayaNWuKxMRE3fDk5OQcc+3fv7+oWrWq7vXFixcFALFx40aDdk3JIbf4jLl//74AIMaPH5/ntNljLY7tVKtWLZGUlKSb7saNG8LJyUm88847umHG1pGpMednXRKR7Shfvrxo2rRpvudbtGiRcHBwEE+ePBFCCHH9+nXh4OAgJk6cqDfdl19+KVxcXESPHj10w9LT0wUA4enpKa5fv64bnttnfvblZbbh4+Mjbt26pZvu1q1bQqFQiLlz5+qG5Sc2IYRwd3c36bO9MDHlpHz58qJkyZKib9++Bn+vvPKKACDee+893fSPHz8W7u7uok+fPnrtPHjwQLi7u4vp06cLIYT45JNPhKurq0hLS9ObLuv3tCnTCGG59SPLsnB0dBRvvvmm0fHZ4woPDxeOjo5i6NChetOtX79eABArVqwQQgixZ88eAUDs3btXCJHxPQxAdO7cWVSoUEE33yeffCIcHBxEXFycEML0dV+Q/d3BwUFvO2fKqy1zbJvCvp9MXW+Z7t27JwCIWbNm5ZnX84SXBJPNWr16NTw8PDBp0iSDceXKlQOQcTmNt7c33njjDb3xkyZNwuLFi7Fp0ybUq1dPN3zAgAFwcXHRvc68fOX8+fO6S3KcnZ0RHh6Oy5cv611GWr58+XzF369fP71LS11dXQEAsbGx2LRpE/79918kJCRAlmVcv34dt27dQlJSUp6Xo5qSQ1ExJdbi2E79+/fX+9W3WrVq6NKlCzZt2oTFixcXOuZM5lyXRGQd0tPTsWXLFhw/fhzPnj2DVqtFdHQ0tFotLl++jNKlS+OXX36BVqvFO++8ozfv6NGj8f777xttt1WrVqhevbrudeZnvinLy9S2bVtUrlxZ97py5cqoUqUKzp8/rxtWkNgKsg7yE1NufHx80LNnT4PhUVFRBlfrbNy4EUlJSZg8ebLecH9/f3Tt2hU///wzZs+eDWdnZ6SmpmLnzp3o1q2bbrqs39OmTJMTc6yf+Ph4aDQa+Pj45BkPAPz888/QaDSYOHGi3vCwsDB88MEH2LBhA0aMGIGWLVvC1dUVu3fvRvv27bFnzx54eHhgxowZaNasGa5fv44aNWpgz549aNKkCby9vQGYvu4z5bS/F0R+2rK291N+11vJkiUBZOz/9D8sWMlm3bx5E1WqVIGzs3OO09y5cwdBQUEG9whUqFABLi4uuHPnjt7wKlWq6L329fWFQqHAo0ePdMNmzZqFnj17onbt2qhVqxbatGmDLl26oEuXLpAkyeT4q1atajDsxo0baNWqFcqWLYt+/fohICAATk5O2L59O86fPw+VSpVnwWpKDkXB1FiLYzsZW3fVqlXD77//DpVKBU9Pz0LFnMlc65KIrENycjJatWqFhw8f4o033kCDBg3g6uqKGzduYN++fYiPjweQ8Znl4OCAihUr6s3v6uqq+yEuO2OfW6YuL1P2zyQA8PPz0/tMKkhsxR1TbkqWLGm0g7yIiAiDR3xcu3YNAPD555/D0dERQggIIQBk3Cpy7949AMCoUaPw559/onv37ggICEBISAg6duyIPn366IodU6ax5PrJ/M5MS0vLdbpMmd+TWQs7ALrLbTPHu7i4oGXLlti9ezc+/fRT7NmzByEhIWjSpAn8/PywZ88elC9fHidOnMDUqVN17Zi67jMZ298LytS2rPH9lN/1lnmpdm7HTM8jFqxks5ydnfO8B8TJyQlJSUkGwzUaDdLT0w0+EIx9QEiSpLv3AwDq1q2LGzdu4NixYzh48CD27t2Lb7/9Fp06dcJff/1l8r0mxoqq+fPnIy0tDYcPH4aXl5dueH4eJG1KDkXB1FiLYztlv+cj6zAnJ6dCx5w19uyKY10SkXX48ccfcfbsWZw8eRJNmjTRDc/snC6Ts7MztFot0tLS9K7CAIx/PgHGP/NNXV7W5WaX/TOpILEVd0xFJfPzvXPnznodIwEZndVkfv+WKFECR44cwb///ou///4bhw4dwsiRIzFz5kycPHkSfn5+Jk1jjLnWj5ubGzw9PfHs2bNcp8uUuW5SU1MN1k1ycrJeHB07dsTkyZPx5MkT7N27F1OnToUkSWjfvj12796NSpUqIT09HR07djRoP691nymnH44LwtS2rPH9lN/1lrm9y5Ytm2fbzxMWrGSzmjZtimXLluHBgwc5XsJTv359/PDDDwa9rZ05cwZarRb169cv0LIdHR3RunVrtG7dGh999BFmzZqFmTNn4tKlS6hbt65eb3n5cf/+fVSqVEmvmAJQ5DffFzS+rEyNtTi205kzZwyevXb69Gm8+OKLBl8oBYmZiJ5PmZ25ZL0FAcjo/CarzPHnz59Hs2bN9OY3tcDIz/Lyo7CxFUdMRSWzCKlYsaKuN9vc1KtXD/Xq1cO7776LXbt2ITQ0FFu3bsXIkSPzNU1W5lw/wcHBuHjxoknTZn5P/vPPP3qFpkqlwtWrVxEaGqob1rFjR3zwwQf46quv8PjxY930HTt2xIQJExAQEABPT0+9/Se/6z4/HB0di+QHDmt8P+V3vf37779681EG9hJMNmvChAlwcXHByJEjkZCQoBseGRmJv//+GwAwZswYyLKMSZMmQavVAsj48H7//ffh6+ur1xW6qVauXGnwIaVWq6FQKFCiRAkA0HWJnv1Sj7zUq1cP165dQ3h4uG7YokWLiry3xYLGl5WpsRbHdjp48KDePSbr16/HyZMnMXbs2CKJmYieT5kHp3/++adu2MGDBw1+1Hr99dfh5+eHadOmITk5GUDGFSGzZs3K8cxcYZaXH4WNrThiKip9+/ZFzZo1MXbsWL0e4IGM24R++eUXABn3Hd68eVNvfOallr6+viZPY4w510+HDh1w6dIlqFSqPKft27cvypYtiw8//BCxsbEAACEEpkyZgqSkJIwfP143bb169VC6dGksXLgQAQEBePHFFwFk9NOgUqmwZs0ahISE6N2mY+q6L4iAgIBCHY9kssb3U37X27Fjx+Dh4aFXHBPPsJINq1KlCnbu3ImhQ4eicuXKaNSoERITExEdHY3ly5cDABo0aID169fj7bffRrVq1fDiiy/izJkzcHNzw/bt2wv0jKu4uDg0bNgQfn5+CAwMxL1793Dnzh188803qFChAgCgVKlSGDhwIGbMmIGDBw/C3d3dpOecfvjhhzhw4AAaNmyI1q1b4/79+6hbty5Gjx5ttNOigspvfJm/fGa9dMXUWItjO73//vt49913IUkSkpOTcerUKYwbNw6jR4/ONW9zrV8isl7h4eFG75msVKkS5s2bh/79+6Nfv34ICQnRXfI3d+5cdO/eXTett7c3fvvtN/Tu3RvVqlVD/fr1ERERgU8++QSHDx+Gg4ODSbH07t3bpOXlR2FjK46YioqzszP27NmDESNG4IUXXkCjRo3g6+uL27dvQwiBuXPnAsg4Y5f5uJQqVaogPj4ep0+fxpgxY/Dqq6+aPI0x5lw/Q4YMwYwZM7BlyxYMGzYs12k9PT3x119/oV+/fqhevToaN26M8PBwPH36FGvWrEGLFi1002Ze/rtx40a9s7EBAQF44YUXcO3aNb3hgOnrviDeffddjBs3Du3atUPp0qV1z2HNL2t8P+VnvQkh8PPPPxs8C5gASWTe+Utko2RZxtmzZ3H//n34+/ujfv36Bm/0lJQUnDx5Es+ePUP58uURHBys98thdHQ09u7di9atW8Pf319v3p9++gnVq1fXuyw1LS0NFy9exP379+Hn54eGDRsa7aTh3LlzuH37NtLT01G3bl3UrFkz12Vl5nP69Gk8evQIL7zwAmrUqIEbN27g7Nmz6NmzJ1xcXBAfH48dO3agefPmuiI5vznkFJ8x586dQ8OGDTF79mxMnz49X7EW13YqV64cjh8/jqdPn6JevXoICgrSa8vYOjI15oKsSyKyfn/88YfuLEl2Pj4+6NSpEwDg6tWruHHjBsqVK4fGjRsjJiYGe/bsQatWrfRubUhJScHRo0eRmpqKZs2aoVSpUvD29sZrr72G1atXA8g4CN28eTNq1aqFOnXqGF12XsvLrY19+/YBANq3b6833JTYgIwzjZUrV0aDBg2KPabs/vjjD7i5uaFDhw4G45KSkvDnn3/ihRdeMPp5e//+fVy4cAFCCFStWhU1atTQ6/hQCIGrV68iPDwcnp6eqFOnjsGPn6ZMY8n1A2T08nv//n0cOXLEpLi0Wq3uu7ZEiRJo2rSp0c4ar169in///RcNGzbU66jp+PHjuHv3Ltq3b5/jGcTc1r0p+7sxt2/fxsWLF5Gamgp/f3+0atUqz7bMuW0K+37Ka70BwO7du9G5c2dcuHBB7ykUxIKViEzw0UcfYc6cOThw4ADatGlj6XCIiKzS9evX8cILL2DRokV53qJgbtYcG+Xszp07ePHFF7Ft2zajhT1ZRnG8n1q0aIFatWphxYoVRdKePeE9rESUo0WLFqFly5b4v//7P4wZM4bFKhHRfw4dOoSnT5/qXicmJmLChAnw8vJC3759LRiZdcdG+RMUFIRdu3bpnodK5meO91NycjLGjh2LefPmFUl79ob3sBJRjho3boyKFSuibt26BpfcEhE9z7RaLZo2bQp/f394enri7NmzcHBwwC+//ILSpUszNioy/LHYsszxfnJzczN6bz1l4CXBRERERAWgVqtx4cIFREZGonTp0mjcuLHRZztagjXHRmRr+H6yLBasREREREREZJV4DysRERERERFZJRasREREREREZJVsutMlWZbx8OFDeHp66j3HiIiIqDgIIaBSqeDv7w+Fwn5+8+X3KRERmVN+vk9tumB9+PAhAgMDLR0GERE9Z+7fv4+AgABLh1Fk+H1KRESWYMr3qU0XrJ6engAyEvXy8iq25ciyjNjYWPj4+NjFL+rMx3rZUy4A87F29pSPuXJJSEhAYGCg7vvHXvD7tGDsKR97ygVgPtbOnvKxp1wA6/w+temCNfOyJS8vr2L/gtVoNPDy8rKbHZH5WCd7ygVgPtbOnvIxdy72dtksv08Lxp7ysadcAOZj7ewpH3vKBbDO71PbX6tERERERERkl2z6DCsREREREdkuIQQ0Gg20Wq2lQykQWZaRnp6O1NRUuznDWpT5ODk5wcHBoVBtsGAlIiIiIiKzS0tLw5MnT5CcnGzpUApMCKG779Mebhcp6nwkSUJAQAA8PDwK3AYLViIiIiIiMishBCIiIuDo6Ah/f384OzvbZMGXeYbY0dHRJuPPrijzEUIgKioKkZGRqFatWoHPtLJgJSIiIiIis9JoNJBlGf7+/nBzc7N0OAXGgjV3fn5+iIiIQHp6eoELVtu/0JqIiIiIiGySPdz3STkriqKXZ1iJiIioyGmioiCr1XrDZCGQnpiItJQUKLIdxCiUSjj6+ZkzRCKyEU9VqVCnyyZPr3RSoLSnSzFGZFu2bNmC1157zei4rVu3okePHgX+4SC3tosKC1YiIiI7kZKSAldXV0uHAU1UFB5Onw5Zlag3XEgSkkqVQmp0NCQh9MYpPD3gP2cOi1Yi0vNUlYrJWy5AlaoxeR5PF0d8+lpdmyhaf/31V/Tq1Ut3JrKwBaQxffr0gcj2mZspLCwMcXFxcHEp2LrKre2iwnPwRERENu7PP/9E5cqV4enpCV9fX8yZM8ei8chqNWRVIiSlEg7e3np/Cg93g2GSUglZlWhwRpaISJ0uQ5WqgdJJAW9Xpzz/lE4KqFI1+Toja0mvv/663iN9fv75Z5t9xE9xYcFKRERkwy5fvozevXtj3LhxSElJwZYtWzBv3jysXLnS0qFB4eIChZvb//5cXSEpXaBwddUfXsBf9ono+eHi6AB3pWOefy6OhXvmJwBERERgx44duHLlisG406dP4+jRo0hLS8Ovv/4KAEhPT8eff/6pm0YIga1bt+peb9u2DVu2bMGuXbsQFRWlG3706FEIIfDrr79iy5Yt0Gq16NOnj17nRFeuXMGuXbvw6NEjvTi2bNmC9PR0HDt2DMePH88zp7S0NBw9ehRnzpzJdborV65g9+7dBssDgLt372L79u3YsmUL7t27ZzA+KioKv/32GzQa08+Gm4KXBBMREdmwb7/9FtWqVcOECRMAAO3atcPAgQOxcOFCjBgxwrLBERHZmNmzZ2P9+vWoXr06rly5gldeeQVff/01AODNN9/E7t278cILL0AIgf379yM9PR1JSUkYPnw4oqOjAQBarRZhYWFITU0FAPz++++IjY1FUlISzp8/j19++QXNmzfH4cOHIYTA5s2bIUkSXnnlFb1LdMeOHYtff/0VtWvXxqlTp7B06VL07dsXQMaluKGhoRBC4Nq1a+jRowcWLlyYY15du3aFQqHAlStX0LVrVyxbtsxgmszl1apVC6dPn9Zb3syZM7FkyRI0bdoUrq6uKFOmDCpUqKCbNzw8HL1798acOXPg6Fi0JSYL1mzuRCchSa3/q4AQMlJViXiU6gBJ0j8p7a50RFApd3OGSHaC+xqZE/c3+3Xy5Em0atVKb1ibNm2wYsUKJCYmFuph7UREz5Pr169j5cqVWLBgARQKBdLT0zF69GhMmzYNjx49ws6dO3Ht2jV4eHjgt99+w/79+01qd9myZfjnn3/w+PFjHDp0CEuXLkXz5s0xZcoUTJ8+HZs3bzYo8i5cuICff/4Z169fh7e3N/bv349+/frpCkgAmDp1Klq3bo2nT5+iSpUquRasY8eORffu3aFSqVCjRg2MHTsWtWrVMljetWvX4O7ujsOHDyMsLAx9+/bFlStX8M033+DixYsoV66cQdsnT57E8OHDsWbNGjRp0sSkdZIfLFizuBOdhLYLDhgMV0CgspfA7QQJMgy7Zt4/KYQHdpQv3NfInLi/2benT5+iVKlSesNKly4NIOPyLGMFq1qthjrL/aIJCQkAAFmWIcuFv+9LFgJCkjL+sgwXWf6yypxWFqJIlm8usixD2FjMObGnXADmY+0y8wEyLp/NrdOe/40z9ulhdA6T2jXm3LlzkGUZP/30k25Yx44dkZSUhEuXLqFFixZwd3eHEAIdO3bMMdas/09MTETLli2hUChQsWJFxMbGwtnZWS+27LEKIXDp0iU0bdoUXl5eEEIgJCQEiYmJePr0Kfz+65yuRYsWEELAz88PQgikpqZCqVQaza1Dhw4QQsDDwwPNmjXD5cuXUbNmTYPleXt7Q6PRoG3btrrl/fvvv2jWrBnKli1rdJ127doV69atQ+PGjQ3GZ+aW/fslP/uyRQvW9PR0LF26FPv27YOLiwv69u2LV1991WLxZD/7UNzz0fOL+xqZE/c3+5f9iz/z/qGcnn83b948zJo1y2B4bGxskdx7lJ6YiKRSpaDwcIek1L8/NcXd3eDnEeGihOzkhNjERDjFxBR6+eYiyzJUKhWEEDb/LEl7ygVgPtZOlmUkJiZClmVoNJpcP3c0Wk2WoifvAjRzWo0293aNKVmyJNzc3PDjjz/q3UcKAL6+vrhz546uzVu3bmXEp9HA2dkZqampSE9PhyRJuvs7NRoNDhw4AF9fX+zevRsA8N133+Gnn37StZN5JlcvZ40Gvr6+iIiI0E33+PFjpKenw8PDQzcsexGYnp5uEHem27dvo0aNGgAy7tH18fHRtZN9eVqtVm95pUqVwq1bt3T5Zbdp0ya89dZb8Pf31ztrm9m2LMuIj49HcnKybrhKpTK+EYywaME6aNAgnDx5EjNmzEBsbCwGDBiA+fPnY/z48ZYMi4iIyGaUL18eT5480Rv29OlTKBQKlClTxug8U6dOxcSJE3WvExISEBgYCB8fH3h5eRU6prSUFKRGR8MhPR2KLI/ZyTw/4hEfr1e0yikp0MbHw8fDA86+voVevrnIsgxJkuDj42PzRYQ95QIwH2uXWajGxcXB0dEx13seHR0cIUkSJEmCQmH8R7isMqd1dMi9XWPatm2LkiVL4rXXXkOfPn3g5uYGR0dH9OzZE+3atcO4ceMwbtw4NG7cGD/88ENGfI6OcHNzQ/Xq1TFhwgQ0btwYmzdv1o0LCgrChQsXsHLlSqSmpmLRokWoWrWqLraKFSti4cKFqFq1Knr16qWbr127dlCr1Rg9ejRatmyJVatWYejQoXqPLsueX27rcty4cRg4cCBOnjyJ5ORkhISE6KbNvrzmzZvju+++0y2vbdu2cHd3x4ABA9C9e3e4uLigSZMmuntY27dvj++//x6vvfYaNm/ejIYNG+rFpFAo4O3trffonPxsG4sVrKdPn8bmzZtx9OhRNG/eHEBGBf7xxx9j5MiRVvEcOSIiImvXsmVLbNmyRW/Ynj170KhRoxy/S5VKpdHLxhQKRZEcDCskCZIQGX/ZxklZ/nTD/ptWIUk2dzAu/RezrcVtjD3lAjAfa5d5pi6zwMxrOsNPjhznMKldYxwdHfH3339jxYoV+Pvvv5GUlARXV1f06tULSqUShw4dwhdffIFz587h66+/RqNGjXTzbtmyBV999RXOnz+PBQsWYO7cuZAkCbVr18aqVavw+++/IzAwEKtXr8bRo0d1sa1btw6rV6/GmTNn0K1bN7z66qtwdHSEk5MTjhw5gkWLFuHgwYMYMGAARo0apZuvd+/eevn16tULjo6ORnPu3bs3pk+fjlWrVsHT0xMHDhyAk5MTABgsb+HChTh48CD69++P0aNHZxT/jo44cOAAlixZgp07d0KtVqNs2bKoWLGiLo7mzZvjp59+wtKlS/HFF1/ofvz8348N+vtufvZjSRT3k15zMHfuXCxcuFDvV+Hw8HBUq1YNf//9N9q2bZtnGwkJCfD29kZ8fHyR/CJ86UE8Xll8xGB4Xvd5bRvbErXLexd6+eYiyzJiYmLg6+trFx96tpgP9zXbZKv5PA/7m7m2TVF/7xSFu3fvok6dOnjjjTcwbtw4HDhwACNHjsRPP/2k+7U+L0WdV1pkJB5+MDnjuatubrrhAoDK2xue2c+wJidDGx8P/88+hXNAQKGXby62+plgjD3lAjAfayfLMp48eYLY2FhUrlxZ78xbdvdjkvHu5vPwdnWCuzLvc21Jag3iU9LxVd/6CPR1y3P6wnB0dER6ejo0Gk2OxaKtEUIUaT6pqam4c+cOgoKC9LZzfr53LHaGNSIiAuXLl9cbFhgYqBtnTHF3EiGEDIWRm7kVEJAgcnxorRBFs3xzsdcb920pH+5rtslW83ke9jdzbRtrXB8VK1bE3r17MWXKFDRr1gzlypXDd999Z3KxSkREBdO7d29Lh/BcsFjBmpaWZnCpkrOzMxQKBdLS0ozOU9ydRKSqElHZy/CgTgLg/98PNMLIQV+qKh4xMdpCL99c7PHGfVvLh/uabbLVfJ6H/c1c2yY/nUSYU5MmTfD3339bOgwD8n/PIMwkJCmjg6WUFEhZLvDKPh0RUXapGtO+j0ydrihs3rw53z0RU/5ZrGD18fFBTLaeAOPi4iDLMnx8fIzOU9ydRDxKdcDtBMNT35lnJu4kwOhlcy6e3vD1tY3L5gD7vHHf1vLhvmabbDWf52F/M9e2KeqHodsrhVIJhacHZFUitFmujBKSBNnJCdr4eL2CFQAUnh5Q5PA4BiJ6fimdFPB0cYQqVQN1umlXuXi6OELpZDvf05Q7i33z1q9fH99++y3i4+Ph7Z1xQHT27FndOGOKu5MISVIYPWgDMu67kWH8Pi9Jsr0b4O3xxn1byof7mu2yxXyel/3NHNvGltaHJTn6+cF/zhzIWYpVIOP5rLGJifDx8IAi271RCqUSjv89W5CIKFNpTxd8+lpdk4tVIKPILe2Z832xZFssVrD26NED7777LhYsWIDZs2dDq9Xis88+w0svvYTq1atbKiwiIiIqAsaKT1mW4RQTA2c76TiGiMyDxefzzWIFa4kSJbBx40b0798fW7ZsQUJCAjw9PbF9+3ZLhURERERERERWxKI343Tq1AmRkZE4f/48lEol6tevz19ciYiIiIhIRxMVZXCLQW6s7RaDyMhIBOTwyK4HDx4YPDmlqNq2FxbvPcLV1RUvvfSSpcMAAJOe7VSU89Hzi/samRP3NyIislWaqCg8nD4dsirR5HkUnh7wnzOnQEVrYQtIYwIDA3PsTbhKlSqIi4vL9Vm0BW3bXvBoJIugUu7YPykESWr9R+QIISNVFQ8XT29Ikv4ZYHelI4JKuZszTLID3NfInLi/ERGRrZLVasiqREhKJRQmFHVyaipkVWK+zshm1aZNG1y+fNloR69kGSxYszF2gCbLMmJitPD19eYly1RkuK+ROXF/IyIiW6ZwcYHCzc2kabUFLFYB4ODBg7pi9dGjR9BqtfD09NQ91QQAEhMTkZqailKlSgEANBoNnjx5kueluampqXBwcICTk1OO0wghkJCQoLe8rJ49e4aUlBT4+vrCLdv60Gq1ePToEcqVKwcHBweT8rUFPEIhIiIiIiJCxiW6qampAICuXbuiWbNmCAoKQr169RAREQEAiIuLQ8OGDXHx4kUAwHvvvYf58+fn2u64ceMQEBCAEiVKYMWKFUanWbNmDXx9fVGhQgVUr14dZ86c0Y377bffUL58eVSvXh3NmjXDrl279OZNSkpCjx49sHz5crsqVgEWrERERERERAbOnj2LO3fu4NKlS+jevTs+++wzAEBAQACWL1+Ofv36Yd26dTh+/DgWLFiQa1v+/v6Ijo7GqVOnMGXKFERGRuqNv3v3Lt59910cPHgQ8fHxGDt2LAYPHgwg477aYcOGYf369Xj27BkiIyPRq1cv3bxPnjxBhw4d0KNHD8yePbuI14LlsWAlIiIiIiLKQpZlvPHGG/Dy8kLDhg2xbNky3Lp1Sze+c+fOaNu2LUaNGoUNGzbkec/rmDFjAAA1a9ZEy5YtcerUKb3x//zzD5o3b466devqpr916xbi4uJw4sQJNG3aFCEhIUbbbt68OSZMmIARI0YUImPrxYKViIiIiIgoi4MHD+Ls2bOIiorC48ePsWzZMmi1Wt14lUqFffv2oVKlSjh+/Hie7SUnJ+v+nZSUZNArsIuLi940arUaWq0Wzs7OcHFxQWJizr0kjxs3DgsXLkRcXFw+MrQdLFiJiIiIiIiycHJyQkJCAm7evInjx4/jk08+0Rs/atQovPbaa9i1axdmzpyJq1ev5trepEmTcPXqVaxduxYXLlxA8+bN9ca3bNkSly9fxsqVK3Ht2jWMGzcObdu2hZubG1q1aoU7d+7g888/R3h4OCIjI/WK2/Hjx2PYsGHo0KEDoqOji24lWAkWrERERERERMjopVehUKBly5Z4/fXXERYWho8//hhDhw6F33/Pdd26dSvi4uIwc+ZMVKhQAV999RXee+89aDQao22WL18enTp1wqBBg7Bq1Sr89ttvul6AAwICIEkSfHx8sH37dvz888/o2bMn1Go1fvjhBwCAl5cX9u7di2PHjqFTp056nS5lPjN2xIgRmDBhAgYMGICEhITiXk1mxcfaEBERERHRcy09PR3Hjx+Ht7c3nJ2dAQDz5s3DvHnzDKbt1auXrtMjIQS6d++OV199FZIkGW07s4OlgQMHGowLDw/X/btJkybYvXu30TZefPFFbN26Nce2M9s3tgxbxzOsRERERET0XLt69SpGjx6NL774wtKhUDY8w0pERERERFZN/u/ZqEU1XXZ169bFlStXCjQvFS8WrEREREREZJUUSiUUnh6QVYnQqtWmzePpAUUej5kh28GClYiIiIiIrJKjnx/858yBbGKxCmQUuY7/dZBEto8FKxEREVEeNFFRBgfMshBIT0xEWkoKFNk6W+EBM5FpZFnOcxq+l2yXEKLQbbBgJSIishNPnz6Fm5sbPDw8LB2KXdFEReHh9OmQVYl6w4UkIalUKaRGR0PKdlCm8PSA/5w5PNAmyoGjoyMUCgUePnwIPz8/ODs759jLrjUTQkCj0cDR0dEm48+uKPMRQiAqKgqSJMHJyanA7bBgJSIismFJSUlYu3Ytli5diqtXr+L999/H/PnzLR2WXZHVasiqREhKJRQuLrrhQpKg8HCHQ3q6XsEqp6ZCViXm6xJGoueNJEmoVKkSnjx5gocPH1o6nAITQkCWZSgUCrspWIsyH0mSEBAQAAcHhwK3wYKViIjIhp06dQqXL1/Gxo0bERYWZulw7JrCxQUKNzfdawFAUrpA4eqK7Id1pnYOQ/Q8c3Z2RoUKFaDRaKDVai0dToHIsoz4+Hh4e3tDobD9J4YWdT5OTk6FKlYBFqxEREQ2LSQkBCEhIZYOg4ioQDIvFy3MJaOWJMsykpOT4eLiYjcFq7XlYx1REBEREREREWXDM6xERETPGbVaDXWWS1YTEhIAZPyybkqPnQUly7Lu/ihbIgsBIUkZf1mGiyx/WWVOK9tQrra6bXLCfKybPeVjT7kA5ssnP+2zYCUiInrOzJs3D7NmzTIYHhsbC41GU2zLlWUZKpUKQgirudTMFOmJiUgqVQoKD3dIShe9cSnu7gb3rwoXJWQnJ8QmJsIpJsZ8gRaCrW6bnDAf62ZP+dhTLoD58lGpVCZPy4KViIjoOTN16lRMnDhR9zohIQGBgYHw8fGBl5dXsS1XlmVIkgQfHx+bOrBLS0lBanQ0HNLToXB11Q3PPLvqER+vV7TKKSnQxsfDx8MDzr6+5g63QGx12+SE+Vg3e8rHnnIBzJePo6PpZSgLViIioueMUqmEUqk0GK5QKIr9gEuSJLMspygpJAmSEBl/2cZJWf50w/6bVvFfrrbCFrdNbpiPdbOnfOwpF8A8+eSnbRasRERENkyWZTx9+hQAoNFokJSUhMePH8PZ2Rm+NnJ2j4iIKCf28TMAERHRc+rZs2eoX78+6tevj7i4OPz888+oX78+Bg0aZOnQiIiICo1nWImIiGyYn58fHj9+bOkwngtyaqreayFJGR0spaRAEiLH6YiIqOBYsBIRERHlQqFUQuHpAVmVCG2WxwEJSYLs5ARtfLxewQoACk8PKIzcJ0xERPnDgpWIiIgoF45+fvCfMwdylmIVyHg+a2xiInw8PKCQ9LtjUiiVcPTzM2eYRER2iQUrERERUR6MFZ+yLMMpJgbOvr520zsoEZG1YcGazZ3oJCSp9R+aLoSMVFUiHqU6QJL0v5DclY4IKuVuzhDzxd7yIevFfc26cfsQERGRLbKKgjU2NhayLKNkyZIWjeNOdBLaLjhgMFwBgcpeArcTJMgGT2AD9k8KscoDO3vLh6wX9zXrxu1DREREtsqi16/8/vvvCA0NRenSpdGpUydLhgIABmcfinu+4mZv+ZD14r5m3bh9iIiIyFZZ7AyrWq3Gd999h3HjxqF69eo4duyYpUIhIiIiIiIiK2SxglWpVOL3338HAOzevdtSYRAREREREZGVYpd2REREREREZJWsotMlU6nVaqizPAMtISEBQEa38rIsF7p9IWQoIAyGKyAgQeRY3QtRNMsvavaWT05kWYYQwqZizomt5sJ9zbo9D9vHXNvGVtYHERGRvbCpgnXevHmYNWuWwfDY2FhoNIXvHCRVlYjKXoYHdRIAf7eMfwsjB32pqnjExGgLvfyiZm/55ESWZahUKgghbP45eLaaC/c16/Y8bB9zbRuVSlVsbRMREZEhmypYp06diokTJ+peJyQkIDAwED4+PvDy8ip0+49SHXA7wfDRDplnJu4kwOijH1w8veHr613o5Rc1e8snJ7IsQ5Ik+Pj42FQRYYyt5sJ9zbo9D9vHXNvG0dGmvjaJiIhsnk198yqVSiiVSoPhCoWiSA5QJElh9KANAAQyDuiMjZekoll+UbO3fHIjSVKR7QeWZou5cF+zbs/L9jHHtrGl9UFERGQPLFqwPnv2DOnp6UhOToZGo8Hjx48BAGXKlIEkGT+4IiIiIiIioueDRQvW3r1749q1a7rX9evXBwDcvn0bbm5uFoqKiIiIiIiIrIFFC9YDBw5YcvFERERERERkxXgzThbuyoLV7wWdr7jZWz5kvbivWTduHyIiIrJVPBrJIqiUO/ZPCkGSWv8ROULISFXFw8XTG5KkX+O7Kx0RVMrdnGGazN7yIevFfc26cfsQERGRrWLBmo2xAzRZlhETo4Wvr7fN9RBpb/mQ9eK+Zt24fYiIiMgWsWAlIiIieo5ooqIgq9V6w2QhkJ6YiLSUFCiyPalBoVTC0c/PnCESEemwYCUiIrIDGo0GycnJ8PLysnQoZMU0UVF4OH06ZFWi3nAhSUgqVQqp0dGQhNAbp/D0gP+cOSxaicgieA0YERGRDTt16hS6desGHx8fBAQEIDAwEGvWrLF0WGSlZLUasioRklIJB29vvT+Fh7vBMEmphKxKNDgjS0RkLixYiYiIbNhvv/2Gt956C9HR0UhISMD8+fPx5ptvYteuXZYOjayYwsUFCje3//25ukJSukDh6qo/3MXF0qES0XOOBSsREZEN+7//+z906dIFSqUSADBgwADUqlULO3futHBkREREhceClYiIyI6kpKTg4cOHKFu2rKVDISIiKjR2ukRERGRHPvjgAwghMGTIkBynUavVUGe5JzEhIQFAxqOOZFkutthkWYYQoliXYU62mI8sBIQkZfxlGS6y/GWVOa1sa3na4LbJDfOxXvaUC2C+fPLTPgtWIiIiO7FgwQKsWrUK27Zty/UM67x58zBr1iyD4bGxsdBoNMUWnyzLUKlUEELYxbN/bTGf9MREJJUqBYWHOySl/v2pKe7ukLJNL1yUkJ2cEJuYCKeYGPMFWki2uG1yw3yslz3lApgvH5VKZfK0LFiJiIjswNdff42PPvoIW7duRfv27XOddurUqZg4caLudUJCAgIDA+Hj41Osj8WRZRmSJMHHx8duDuxsLZ+0lBSkRkfDIT0dCldX3fDMs6se8fF6RauckgJtfDx8PDzg7Otr7nALzBa3TW6Yj/Wyp1wA8+Xj6Gh6GcqClYiIyMYtXLgQU6dOxa+//orQ0NA8p1cqlbpOmrJSKBTFfsAlSZJZlmMutpaPQpIgCZHxl22clOVPN+y/aRX/5WlLbG3b5IX5WC97ygUwTz75aZsFKxERkQ1bunQp3nvvPSxbtgx16tRBZGQkAMDNzQ2+NnRGjIiIyBj7+BmAiIjoOZV5v+rMmTPRrFkz3d/UqVMtHRoREVGh8QwrERGRDdu+fbulQyAbJKem6r0WkpTRwVJKCiQhcpyOiMjcWLASERERPScUSiUUnh6QVYnQZnm0kZAkyE5O0MbH6xWsAKDw9IDCyD3PRETmwIKViIiI6Dnh6OcH/zlzIGcpVoGM57PGJibCx8MDCkm/OyaFUglHPz9zhklEpMOClYiIiOg5Yqz4lGUZTjExcPb1tZueTonIPvATiYiIiIiIiKwSC1YiIiIiIiKySixYiYiIiIiIyCqxYCUiIiIiIiKrxIKViIiIiIiIrBILViIiIiIiIrJKLFiJiIiIiIjIKrFgJSIiIiIiIqvEgpWIiIiIiIisEgtWIiIiIiIiskqOlg6Aited6CQkqTV6w4SQkapKxKNUB0iS/m8W7kpHBJVyN2eI+WJv+ZD1srd9zd7ysSePHj3C1atXUadOHfj5+Vk6HCIiIqvCgtWO3YlOQtsFBwyGKyBQ2UvgdoIEGZLB+P2TQqzyQNXe8iHrZW/7mr3lY0/GjRuHJUuWQAiBHTt2IDQ0FF9++SUePXqEzz//3NLhERERWZxFLwlWq9XYtWsXli5dim3btkGtVlsyHLuT/WxKcc9X3OwtH7Je9rav2Vs+9uLHH3/Erl27cOnSJXTq1Ek3/J133sEPP/yA+Ph4C0ZHRERkHSxWsO7btw81a9bEV199hQsXLuDDDz9EjRo1cOvWLUuFREREZDa7d+/G1KlTUbNmTUjS/85wOzs7o3Llyjh//rzlgiMiIrISFrsk2NvbG4cPH4a/vz8AQKvVolWrVpg4cSJ+//13S4VFRERkFomJiXB1dQUAvYIVAJ49ewalUmmJsIiIiKyKxc6wBgcH64pVAHBwcEDLli1x8+ZNS4VERERkNs2bN8eGDRsghNArWNeuXYvHjx+jXr16FoyOiIjIOlhNp0vp6en4888/0bRp0xynUavVeve5JiQkAABkWYYsy8UWmyzLEEIU6zKKgxAyFBAGwxUQkCBy/LVCiOJdnwVlb/kYY6v7Wk5sNR9729fsLR9jzLWvFWX7o0ePxo8//ojGjRsjOjoay5cvx7x583Do0CEsW7ZMd/aViIjoeWY1Beu4cePw5MkTzJo1K8dp5s2bZ3R8bGwsNJri6xxElmWoVCoIIaBQ2M6ja1NViajsZXiQKgHwd8v4tzByEJuqikdMjLaYo8s/e8vHGFvd13Jiq/nY275mb/kYY659TaVSFVlbHh4eOHr0KBYvXoy9e/ciMjISQUFB2LNnDzp06JDv9mRZRnR0NEqVKmVT7zciIqLcWEXBOm3aNKxfvx67d+9GxYoVc5xu6tSpmDhxou51QkICAgMD4ePjAy8vr2KLT5ZlSJIEHx8fmzoIeJTqgNsJho+qyDzTcicBRh9l4eLpDV9f72KPL7/sLR9jbHVfy4mt5mNv+5q95WOMufY1R8ei/dp0d3fHlClTMGXKlAK38eDBA8yYMQNbtmyBs7MzkpKSMHjwYHz99de8D5aIiGyexQvWjz76CEuWLMHOnTvRrFmzXKdVKpVGv3wVCkWxHwxLkmSW5RQlSVIYPQgFAIGMA1Rj4yXJOvO0t3xyYov7Wm5sMR9729fsLZ+cmGNfs8b1cezYMXTs2BFLliyBi4sLrly5gpCQEPj5+eGTTz6xdHhERESFYtFv3hkzZmDhwoXYsWMHmjdvbslQiIiIil1oaCgkSTLpb+fOnSa12adPH/Tt2xcuLi4AgJo1ayI4OBjXrl0rzlSIiIjMwmJnWL/77jt88skneO2113D8+HEcP34cAODi4oJ33nnHUmEREREVm/nz52PSpEkmTdugQYN8tR0REQG1Wo0jR47g+PHj+PnnnwsSIhERkVWxWMFatmxZvPfeewCAx48f64azV0QiIrJX9evXL7a2Q0JCkJycjGfPnmHy5Mlo165djtOy1/2iYU/52FMuAPOxdvaUjz3lAlhnr/sWK1i7dOmCLl26WGrxzwV3ZcE2b0HnK272lg9ZL3vb1+wtH3tz/PhxnDx5ErGxsahUqRJ69OgBX1/ffLcTEREBALh06RJCQ0ORmpqKL7/80ui07HW/aNhTPvaUC8B8rJ095WNPuQDW2eu+JIQwfJaBjUhISIC3tzfi4+OLvZfgmJgY+Pr62tyOeCc6CUlq/YMPIWSkquLh4ukNSdLPx13piKBS7uYMMV/sLZ/sbHlfM8aW87G3fc3e8snOXPtaUX7vJCcno2/fvti+fTuqVKkCLy8vREREQKPRYPny5ejXr1+B2549ezaWLl2Khw8fGh1v7AxrYGAgYmNji/37NDY21uZ6Ds+JPeVjT7kAzMfa2VM+9pQLYL58EhIS4OPjY9L3ab5/Pler1ewm34YYO+DMOLDTwtfX2+beWPaWD1kve9vX7C0fe/Dll1/i2rVruHLlCl544QUAgEajwZIlSzB8+HB06NABpUqVyrMdrVYLBwcHvWFPnjyBu3vOPziw1/2iY0/52FMuAPOxdvaUjz3lAlhfr/v5jmLx4sWoUKECBg8ejO+++w63b9/ObxNERETPvdOnT2P69Om6YhXIeM7rhAkTUKNGDVy+fNmkdgYMGIBvvvkGZ8+exfnz5/HZZ59hxYoVePfdd4srdCIiIrPJ9xnWIUOGoHTp0jhw4ADmzJmDN954A4GBgQgJCUFISAhCQ0Ph7+9fHLESERHZjYoVKxq9h0cIAZVKhYoVK5rUzjfffIPPP/8c69atg1qtRtWqVbF9+3Z07NixqEMmIiIyu3wXrH5+fhg8eDAGDx4MALh//z527dqFL774Aj/88APee+89LFiwoMgDJSIisicjR45Ep06dULZsWXTp0gWurq64d+8eZs+ejTp16qBSpUomtVOyZEnMnz+/eIMlIiKykAJ1AZmeno7Tp09j//792L9/P44dOwY/Pz8MGTIEPXv2LOIQiYiI7EOvXr2wZ88e3evU1FT06dMHQMblwJk99Lq4uGDv3r3o0KGDReIkIiKyFvkuWNevX49Ro0ahVKlSCAkJwYABA7Bq1SqTL10iIiJ6Xn3wwQcYMmSISdPWrVu3mKMhIiKyfvkuWDMfKq5QKODg4KD7IyIioty99NJLlg6BiIjIpuS7l+BBgwYhLi4Oa9euRcWKFbFmzRpUr14d1apVw4gRI3D8+PHiiJOIiIiIiIieMwW6h9XZ2RmtW7dG69at8cYbb2DXrl34/PPPsWrVKnh7e/MXZCIiIhPcunUL3377LcLDw5GUlKQ3bv78+QgODrZQZERERNYh3wXrs2fPsHv3bhw4cAD79+/HzZs3Ua5cObRu3Rrjx49H165diyNOIiIiu3Lz5k3Ur18fnTt3xsWLF9GgQQPIsoxt27ahWbNm8PLysnSIREREFpfvgnXNmjX48ssv0bp1a0ycOBEhISF6Dz0nIiKivC1duhQjR47EV199hdDQUIwYMQKhoaE4fPgwXn/9dVSoUMHSIRIREVlcvgvWMWPGYNKkScURCxER0XMjPDwcw4cPBwAolUrdJcGtWrVCYGAgzp8/j2bNmlkyRCIiIovLd6dLrq6ueq/VanWRBUNERPS8SEtLg4uLCwAgICAAFy9eBAAIIRAXFwchhCXDIyIisgr5LlgB4NGjR3jjjTdQunRpuLi4oGTJkujbty/u3LlT1PERERHZvb59++Kzzz7DW2+9hdDQUCQmJqJevXqWDouIiMji8l2wpqamonXr1jh37hw++eQTbNu2DZ999hkePnyIl156CTExMcURJxERkV1Zvnw5WrZsCQBo3bo1NmzYgJiYGPj7+2Pfvn1wc3OzcIRERESWl+97WLdv3w4XFxccP34cSqVSN3zYsGFo27YtNm3ahLfffrtIgyQiIrI3FStW1Hvds2dP9OzZ0zLBEBERWal8n2F98OABmjdvrlesAoBCoUCbNm0QGRlZZMERERERERHR8yvfBWtQUBD279+PxMREveFpaWnYsWMHgoKCiiw4IiIiexIaGgpJkrBz507dv3P627lzp6XDJSIisrh8XxLcuXNnzJgxAw0aNMCgQYNQvnx5PHnyBBs3bkRSUhLCwsKKI04iIiKbN3/+fEyaNAkNGjTQ/TsnDRo0MGNkRERE1infBaujoyMOHDiA+fPn4+eff0ZkZCTKlSuHjh074qOPPoKHh0dxxElERGTz6tevr/t3YmIiqlatyu9NIiKiXOS7YL1x4wbUajXmzp2LuXPnFkdMREREdu/tt9/G2LFjERoaaulQiIiIrFa+72HdsWMH1qxZUxyxEBERPTcCAgL4/HIiIqI85LtgrVatGi5dulQcsRARET033n33XXz99dc4ePAgNBqNpcMhIiKySvkuWFu2bInY2FhMmjQJ586dQ2RkpN5ffHx8ccRJRERkV6ZOnYpbt24hJCQELi4u8PDw0Pvbu3evpUMkIiKyuHzfw7pixQqcPn0ap0+fxhdffGEw/r333sOCBQuKJDgiIiJ79cEHH2DIkCE5jq9bt26B2r158yYcHR35mDkiIrIL+S5Yhw8fjldeeSXH8SVLlixUQERERM+Dl156qcjbXLt2LYYNG4YaNWrg2rVrRd4+ERGRueW7YPX19YWvr29xxEJEREQFdOPGDUyfPh1hYWE4e/aspcMhIiIqEvkuWImIiKho3Lp1C99++y3Cw8ORlJSkN27+/PkIDg42qR21Wo2+ffvis88+w4ULF1iwEhGR3WDBmk1aRAS02Q4aZCGgTklByuPHUEiS3jgHd3c4V6pkxgjJXnBfIyoYe3nv3Lx5E/Xr10fnzp1x8eJFNGjQALIsY9u2bWjWrBm8vLxMbmvSpEmoVasW+vfvjwsXLhRj1ERERObFgjWLtIgI3ArtbDBcKBRIqVQJ8RERkGTZYHyVnTus8mCIrBf3NaKCsaf3ztKlSzFy5Eh89dVXCA0NxYgRIxAaGorDhw/j9ddfR4UKFUxq548//sC2bdtw/vx5k5etVquhVqt1rxMSEgAAsixDNrL+ioosyxBCFOsyzMme8rGnXADmY+3sKR97ygUwXz75ad+iBeu///6LJUuW4OLFiyhRogS6du2KUaNGwdnZ2SLxZP/Fvrjno+cX9zWigrGn9054eDiGDx8OAFAqlbpLglu1aoXAwECcP38ezZo1y7WNuLg4DBs2DJ9++ikePXqER48eISYmBmlpabh27RoCAwPh7u5uMN+8efMwa9Ysg+GxsbHF+kxYWZahUqkghIBCke8n61kde8rHnnIBmI+1s6d87CkXwHz5qFQqk6e1WMF65coVjBkzBiNGjMDIkSMRHh6O999/H+fPn8fq1astFRYREZFZpKWlwcXFBQAQEBCAixcvonfv3hBCIC4uDkKIPNtISEiAn58fFixYoHukXFRUFBITE9GzZ08sW7YMISEhBvNNnToVEydO1GsnMDAQPj4++boUOb9kWYYkSfDx8bGbAzt7yceecgGYj7Wzp3zsKRfAfPk4OppehlqsYK1WrRqOHDmie924cWM8ePAA8+bNY8FKRETPlb59+yI0NBRPnjzB7du3kZiYiHr16uU5X4UKFQweXzNlyhT89ttvuT7WRqlUQqlUGgxXKBTFfsAlSZJZlmMu9pSPPeUCMB9rZ0/52FMugHnyyU/bFlurTk5Oeq9TUlKwf/9+NG3a1EIRERERmc/y5cvRsmVLAEDr1q2xYcMGxMTEwN/fH/v27YObm5uFIyQiIrI8i3e6NGLECBw9ehT3799HixYt8PPPP+c4bXF3EiELAWGk2hcKBYQkGR2XOZ8t3WjNm8Mtj/uabWI+lmfp905RritJkuDh4aF73bNnT/Ts2bPQ7ZYuXRqVK1cudDtERETWwOIF64cffojY2FhcunQJ06ZNwwcffIClS5canba4O4lQp6QgxUgvkkKSoC5bFgAgGbmnKC4lBSkxMYVevrnw5nDL475mm5iP5Vn6vZOfTiLyMnLkSNy+fRsDBgzAwIEDUaVKlSJpd+LEiXr3pxIREdkyixeslSpVQqVKldCgQQN4e3ujR48emDZtGgIDAw2mLe5OIlIeP0Z8RITB8Mxf7F3v3jX6uIQSrq5w9fUt9PLNhTeHWx73NdvEfCzP0u+d/HQSkZdly5Zh/fr1WL9+PWbOnIlmzZph4MCB6Nu3L0qVKlVkyyEiIrJlFi9YsypZsiQAID4+3mjBWtydRCgkyeiBDpDxi70ky0bHK/67MdmW8OZwy+K+ZruYj2VZ+r1TlOupUqVK+PDDD/Hhhx/i3LlzWL9+PebOnYt3330XnTp1wqJFixAUFFRkyyMiIrJFFjtC+emnn3D48GHd6+joaMyePRtVq1ZFzZo1LRUWERGR2TVo0AALFizApUuX8Prrr2Pbtm24fv26pcMiIiKyOIsVrPXq1cO8efPg4+ODypUrIyAgAE5OTtixY4fN/NJPRERUWGlpafjtt9/Qp08f+Pv7Y/fu3RgzZoxJj7UhIiKydxa7JLhGjRr466+/kJSUhKdPn8Lf39/o5b5ERET26J9//sGqVavw888/Iy0tDT169MCWLVvQqVOnIr1XloiIyJZZ/BvR3d3dau7RcXB3N+t89PzivkZUMPb03vnkk0+Qnp6ORYsWoVevXnqPuCEiIqIMFi9YrYlzpUqosnMHtElJesNlIRCXkoISrq5QSJLeOAd3dzgbecQCUW64rxEVjD29d7Zs2QIXFxdLh0FERGTVWLBmY+ygRpZlpMTEwNXXl/fXUpHhvkZUMPby3mGxSkRElDfb+FYnIiIiIiKi5w4LViIiIiIiIrJKLFiJiIiIiIjIKrFgJSIiIiIiIqvEgpWIiIiIiIisEgtWIiIiIiIiskosWImIiIiIiMgqsWAlIiIiIiIiq8SClYiIiIiIiKwSC1YiIiIiIiKySixYiYiIiIiIyCqxYCUiIiIiIiKr5GjpAIiIiKjgVCoV7t69azD8hRdegKMjv+aJiMi28ZuMiIjIhu3btw+9e/fGiy++aDC8TJkyFoqKiIioaLBgJSIisnGurq64dOmSpcMgIiIqcryHlYiIyA48evQI9+/fhxDC0qEQEREVGRasRERENi4pKQl169ZFgwYN4Ovri8WLF1s6JCIioiLBS4KJiIhsWNmyZbF37160b98eALBx40YMHDgQpUuXRt++fY3Oo1aroVarda8TEhIAALIsQ5blYotVlmUIIYp1GeZkT/nYUy4A87F29pSPPeUCmC+f/LTPgpWIiMiGNWvWTO91WFgYNm/ejLVr1+ZYsM6bNw+zZs0yGB4bGwuNRlMscQIZBygqlQpCCCgUtn+Rlz3lY0+5AMzH2tlTPvaUC2C+fFQqlcnTsmAlIiKyMwEBAThw4ECO46dOnYqJEyfqXickJCAwMBA+Pj7w8vIqtrhkWYYkSfDx8bGbAzt7yceecgGYj7Wzp3zsKRfAfPnk57FrLFiJiIhsWFpaGpydnXWvZVnGkSNHUKNGjRznUSqVUCqVBsMVCkWxH3BJkmSW5ZiLPeVjT7kAzMfa2VM+9pQLYJ588tM2C1YiIiIbNnjwYNStWxctW7ZEeno6vv32W9y8eRPfffedpUMjIiIqNBasRERENmzlypVYuHAhZs6cCVmWUbt2bVy5cgUVK1a0dGhERESFxoKViIjIhnl6emL69OmYPn26pUMhIiIqcvZxoTURERERERHZHRasREREREREZJVYsBIREREREZFV4j2sdi4tIgLapCS9YbIQUKekIOXxYygkSW+cg7s7nCtVMmOEZC+4r5G5cF8jIiJ6flhNwXrnzh3Ex8ejVq1acHJysnQ4diEtIgK3QjsbDBcKBVIqVUJ8RAQkWTYYX2XnDh7cUb5wXyNz4b5GRET0fLGKS4KvXLmC2rVro0GDBnjy5Imlw7Eb2c9AFPd89Pzivkbmwn2NiIjo+WLxgjUlJQX9+vXDG2+8YelQiIiIiIiIyIpYvGCdMGECWrRoge7du1s6FCIiIiIiIrIiFr2HdcuWLTh48CDOnj2LY8eOWTIUIiIiIiIisjIWK1gjIiLw9ttvY8eOHXBzczNpHrVaDbVarXudkJAAAJBlGbKRTjaKiizLEEIU6zKKgywEhMLwJLpQKCAkyei4zPlsKVdb3T7G2Gou3Ndsky3mY+l9zZbWFRERkT2wWMH6xhtvoGvXrnBwcMD58+dx69YtABkdMEmShPLlyxvMM2/ePMyaNctgeGxsLDQaTbHFKssyVCoVhBBQ5HAwZI3UKSlIMdIrppAkqMuWBQBIQhiMj0tJQUpMTHGHV2RsdfsYY6u5cF+zTbaYj6X3NZVKVeg2iIiIyHQWK1iVSiXOnTuHoUOHAgASExMBAO+++y6GDh2K999/32CeqVOnYuLEibrXCQkJCAwMhI+PD7y8vIotVlmWIUkSfHx8bOagDgBSHj9GfESEwfDMMxCud+8affxDCVdXuPr6Fnd4RcZWt48xtpoL9zXbZIv5WHpfc3S0mqfBERERPRcs9s37119/6b3eu3cvOnbsiF27diEgIMDoPEqlEkql0mC4QqEo9oMtSZLMspyipJAkowduQMYZCEmWjY5X/JerLbHF7ZMTW8yF+5rtsrV8LL2v2cp6IiIishf85iUiIiIiIiKrZDUFq6enJ+rVqwdnZ2dLh0JERERERERWwGpuxmnatCnOnz9v6TCIiIiIiIjISljNGVYqeg7u7madj55f3NfIXLivERERPV+s5gwrFT3nSpVQZecOaJOS9IbLQiAuJQUlXF2hkCS9cQ7u7nA28sgIotxwXyNz4b5GRET0fGHBaueMHaTJsoyUmBi4+vqyx0sqMtzXyFy4rxERET0/WLASERERkc16qkqFOl3/cVZCyEhMSEWylAxJ0v8RS+mkQGlPF3OGmC/Mx7rzIfNjwUpERGQnoqKikJiYiKCgIEuHQmQWT1WpmLzlAlSpGr3hEgRKO6fjaZoTBPRvE/B0ccSnr9W1yqKI+Vh3PmQZLFiJiIhsXEREBIYPH47Tp0+jfPnycHR0xLp169CgQQNLh0ZUrNTpMlSpGiidFHBxdNANlyDg7ijg7aBfEKVqtFClagzO+FkL5mPd+ZBlsGAlIiKyYYmJiWjXrh0aNmyIR48ewd3dHeHh4Th37hwLVnpuuDg6wF35v8NaCQIuCi3cHRwNzuDZQjHEfIj+hwUrERGRDVu5ciWePHmCVatWwf2/x/dUrVoVVatWtXBkREREhceuFImIiGzY7t270bp1a5QoUQLh4eF4/PixpUMiIiIqMjzDSkREZMMePHiAoKAgBAcHIyYmBnFxcShfvnyu97Cq1Wqo1Wrd64SEBAAZjweS5eK7HE+WZQghinUZ5mRP+dhqLkLIkCB0f5ky/q0/LHO4BAEhindfLyjmY935GGOr752cmCuf/LTPgpWIiMiGOTg44M8//8S2bdvQpUsXpKWlYeDAgXj11Vdx69Yto8+lnTdvHmbNmmUwPDY2FhqNxmB4UZFlGSqVCkIIu3herj3lY6u5JCakorRzOtwdM+6JzCRBwF2RDgnQu0dS6aiF0lmDxPg4xIhUC0ScO+Zj3fkYY6vvnZyYKx+VSmXytCxYiYiIbFiFChWgVqvRpUsXAICzszPeeecdtGnTBnfu3EGVKlUM5pk6dSomTpyoe52QkIDAwED4+PjAy8ur2GKVZRmSJMHHx8duDuzsJR9bzSVZSsbTNCd4OzjB3UG/Ux8BIEFW6hVESRoN4tMkeHiXgK+PmwUizh3zse58jLHV905OzJWPo6PpZSgLViIiIhvWsWNHnDx5EhqNRncA8PTpUwCAj4+P0XmUSiWUSqXBcIVCUewHXJIkmWU55mJP+dhiLpKkyHLBqZR9rMHwzNeSZJ15Mh/rzicntvjeyY058slP23ZdsGq1WqSnpxe6HVmWkZ6ejtTUVLvYEe0lHycnJzg4OOQ9IRGRHRs+fDgWL16MIUOGYPTo0Xjy5AkmTZqEwYMHw9fX19LhERERFYrdFqyJiYmIjIyEECLvifOQeeNxbGwsJCn7r0O2x17ykSQJAQEBcHOzjUtGiIiKg5ubGw4fPow5c+bggw8+gI+PD9577z2MHj3a0qEREREVml0WrFqtFpGRkXBzc4Ofn1+hizIhhO5SK1su8DLZQz5CCERFRSEyMtLo/VlERM+T0qVLY9GiRZYOg8hiUjVavdcSBJSOWiRpNHqXnGafzloxH6L/scuCNT09HUII+Pn5wdXVtdDt2UOBl5W95OPn54eIiIgiueybiIiIbI/SSQFPF0eoUjVQp//vMRkSBJTOGR34ZL930tPFEUon67wlivlYdz5kGXZZsGay5WKM8sbtS0RE9Hwr7emCT1+rq1cMARnP/0yMj4OHdwlIkn7xo3RSoLSniznDNBnzse58yDLsumDNy53oJCSp837enBACWq0WXm5KVPbzMENktmHXrl2oVasWAgICDMbt3bsX1apVQ8WKFYu8bSIiIqJMxoobWZYRI1Lh6+Nmcx1MMh8ifc9twXonOgltFxzI93z7J4UgqJR70QdUxHbv3o0XX3wRgYGBAApfQBrz1VdfYcKECUaLyiVLlmDo0KEFXl5ubRMRERER0fPhuf1Jw5Qzq0U5n7ktWrQI//77r+719evXERsba8GIiIiIiIiI8ue5PcNqCQ8ePMCJEyfg4uKC9u3bw8Xlf5dIXLx4EdevX0fz5s1x8eJF1KlTB/7+/vjjjz/QvHlzlCpVCgCwY8cO1K9fH+XKlcOhQ4dw48YNODs7o2bNmggODgYAXLlyBffv38fu3bvx+PFjdOjQATVq1NB7gPzNmzdx4cIFBAYGokWLFrrhmZfi3r9/Hw8ePED79u1zfPB8pqNHj+Lp06do164dvL29jU5z8+ZNnD17FgEBAXrLA4CHDx/ixIkTiImJQdWqVRESEqI3Pj09HRs3bkSHDh3g7++f94omIiIiIiK78NyeYTW3P/74A+3atcPWrVuxZMkSNGzYEPHx8QCAVatWoV27dtiyZQteeeUVvP3227hy5QoAYO7cuYiIiNC188UXX+D69esAgFu3buHEiRPYt28fBg0ahA8//BAA8OTJE8TGxuL69es4ceIEnj17hiVLluDcuXMAgO+//x6tW7fG1q1bMXToUISFhena/+qrr9C7d2/MmTMHK1asQHBwMFJTU3PM68MPP8T//d//YfHixWjYsKHRs7jff/89XnrpJfz6668Gy9u6dStq166NH3/8ESdOnMCtW7f05k1ISECXLl1w//59FqtERERERM8ZnmE1kzFjxmDcuHG6s5WrVq3Cr7/+imHDhmHq1KnYu3cv6tWrh7i4OFSuXNmkNocNG4YXX3wRN2/eROPGjTFz5kz83//9H9q2bYu6deti9OjReOWVVwzme//99/H777+jefPmSE5ORo0aNXDy5Ek0bdoUANC1a1d8/PHHAIBmzZrhn3/+QevWrY3G0LZtWyxYsAAAMGjQIKxYsQKTJ0/Wm2bSpEnYvn07mjZtiqSkJL3ljRkzBj///DPat29v0HbmGd5x48Zh0KBBJq0TIiIiIiKyHyxYzSAuLg6PHj3SnRkFgNq1a6Ns2bKIiYlBeno66tWrBwAoUaIE6tSpY1K7AwYMwNmzZ9GoUSO4uLggNjYWWq0WDg4OOc4TExMDlUqFJk2aAADc3d3RtGlTXL9+XVewNm7cWDd9QEBArve+tmzZUvfv1q1b4/jx40aXl9l21uVVr14dz549M1qsAsCUKVMQFhbGYpWIiIiI6DnFgtUMvL294erqigkTJqB27dp642RZRnp6Oh4/foyyZctCo9Hgzp07uvHu7u5ISEgAkPF4nXv37gHIuK/zl19+QXx8PJRKJW7fvo3Vq1dDCAEAcHBwgCzrP/MKyCiIJUnCvXv3ULlyZQghcOPGDZQrV043Tfbnm2a2aUx4eLju39nbyb68ChUq6C2vRIkScHJyws2bN1GtWjWDthctWoSFCxdiyZIleOedd3KMgYiIiIiI7BMLVjOQJAkff/wxunbtilGjRqF06dIAgG7duqFMmTIYNWoUXnnlFQwcOBD79+9HUlKSbt7WrVtj8uTJGDx4MI4cOYJnz54BAJycnFChQgWMHz8eNWrUwObNm/WeY1WlShWsWrUKT548QceOHXXDFQoF3nnnHfTq1QvDhg3DsWPHoFAo0LZt2wLl9u233yI5ORmpqalYvXo1Tp06pTdeoVBg7Nix6NatG4YNG4ajR4/qlidJEqZNm4bOnTtj5MiR8PX11et0ycfHB3v27EHXrl2RlJRkcKkxERERERHZN3a6ZCbvv/8+1qxZg4SEBJw4cQInTpyASqUCACxYsACjR4/G/fv3MXbsWL1LcqdNm4bBgwfj7t27GDNmDD788EPdWcxdu3ahRIkSiI2NxapVqzBy5Ehd0Tp9+nQEBwfj1KlTePbsGTp27IhKlSoBAD777DO8//77iIiIQLNmzXDkyBE4Omb8dhEaGqp7disAdOjQQTdfdqGhodi4cSPc3Nyg0Whw4MABVKlSBQAMljdlyhSjy5s2bRoWLVqEJ0+e6HW6lBmHp6cndu7ciadPn+o9poeIiIiIiOyfJHK73tPKJSQkwNvbG/Hx8fDy8tINT01NxZ07dxAUFKT36JisLj2IxyuLj+R7mdvGtkTt8sYf3VJUQkNDMWnSJHTo0KFY2hdCQKPRwNHR0eDyX1uSuZ0rVqyI5ORk+Pr66p1ltkWyLCMmJsYucgGYj7Wzp3zMlUtO3zu2zlx52dM+B9hXPvaUC8B8rJ095WMPuaSlpeHy5cs4e/YsHj9+jKSkJJQrVw7169dHgwYN4OHhUeTLzM/3Di8JtkKhoaEoX768pcOwSrJaDfx3b66sVkOkpyM1PBxqtRopjx9Dka0Ad3B3h3MOZ4iJcpMWEQFtlsvzAUAWAuqUFO5rFsZtQ0REVHhnzpzBt99+i02bNiE5OdnoNAqFAp06dcLbb7+Nzp0759q5a3FhwWqFJkyYYOkQrJKsVkN986budZosQxMVhYdz50GtVCI+IgKSkY6mquzcwYNVype0iAjcCu1sMFwoFEipVIn7mgVx2xARERVOVFQU3nnnHfz0008AMjprDQ4ORqNGjVChQgWkpKQgKSkJ586dw6lTp7Bjxw7s2LEDDRs2xNq1a01+oklRsVjBmpaWhmnTphkM79evH4KDg4t9+e7KgqVe0PmoCBg5CDVF9jMxRHkp6D7Dfa34cdsQEREV3P79+9G3b19ERUXB19cX48aNw4gRI+Dv7w/A8BLnpKQkbNiwAV988YXucZoLFizAuHHjzBazRQvWL774AmPHjkWFChV0w11dXc2y/KBS7tg/KQRJak2e0wohoNVq4eWmRFApdzNER0REREREVHR2796N7t27Q61Wo1evXli6dCnKlCmT6zzu7u4YMWIEBg8ejFmzZuHTTz/F+PHjoVKp8OGHH5olboufLuzfvz+aNWtmkWWbWnxm7aSIiIiIiIjIlly7dg29evWCWq3G9OnT8cknn+Sr81WlUom5c+eiadOm6NOnD6ZPn47KlSsjLCysGKPOYPGurDZs2ICPPvoIa9euRVxcnKXDISIiIiIishtarRZDhw5FcnIy3n777XwXq1n16NED33//PQBgzJgxePToUVGGapRFTxl6e3sjOTkZ3t7e+PbbbzFlyhT89ddfaNiwodHp1Wo11Gq17nVCQgKAjGut5Sz3N8qyDCGE7i8naRERkJOM94iVnUargbOXl1V12nH37l2ULFnSaFfT9+7dg4+PDzw9PXNtI6f1k1vblpLTlhQKBYQkQeTQlbgshN7+Yc0y911biTcvtpqPLITR/cme9jXANrePpbeNLa0rS9NERWX07J6FLATSExORlpJi0JuzQqmEo5+fOUPMF3vKx55yIaK8rVixAidPnkT16tWxYMECXbH6+E4k1EkpetMKIZCYmozERzEGRa3S3RVlgwIQFhaGP/74A5s2bcL777+PH3/8sVjjt1jBqlQqcenSJQQEBAAAPvnkE3Tt2hVvvvkmzp49a3SeefPmYdasWQbDY2NjodH8717U9PR0yLIMjUajNzyrtLt3ce+VbvmOu8K2P+FcsWK+5zO1gMyPUaNGYezYsejUqZPBuLFjx2Lw4MHo0aOH0Xm1Wm2B27YUIcuQlUrda1mrhXB0RJq/P9T/Xa4tGSnA41JSkBITY7Y4C0OWZahUKgghbPZZXlnZaj7qlBSkGPlxSkgS1GXLArD9fQ2wze1j6W2jUqkK3UZRu3nzJp49e2YwXKlUokGDBhaIKKMgejh9OmRVot5wIUlIKlUKqdHRBttJ4ekB/zlzrLIwsqd87CkXIsqbEAKLFi0CACxcuFDXX9DjO5E4PeY9OKTon7wTkgRRviykB48NPgu0rm4I/uYLlA0KwKJFi/Dbb79h8+bNWLBgAcr+9x1cHCxWsDo5OemKVQCQJAlDhgxBWFgYEhMTjZ7Zmzp1KiZOnKh7nZCQgMDAQPj4+Og9cDY1NRWxsbFwdHTM8b5TTara6PC8KFLVBbqXdeHChejRowfatWtXoOUaI0kSHBwcjMajUChyHJcpt3G5tW0pskYDbZZfhBWyDEmjgfLhQ8DZGa537xp9nEUJV1e4+vqaM9QCk2UZkiTBx8fHZgqI3NhqPimPHyM+IsJgeObZO3vY1wDb3D6W3jbW9JmYac2aNfj777/1hl24cAE1atTAuXPnLBKTrFZDViVCUiqhcHHRDReSBIWHOxzS0/UOhOTUVMiqRIOzftbCnvKxp1yIKG+HDh3CtWvXUL16dbz88su64eqkFDikJEN2cobs7KwbLiQJcHEF3D30PgsUaWlwSEnWnZH18/NDv379sHbtWqxevbpYO2Cyqm9ejUYDIQTS0tKMjlcqlVBmOcOWSaFQ6B1sKRQKSJKk+zOqYJdtAxIKdM33pEmT4OPjA0mS8ODBA8TGxsLZ2RkVKlSAy39fGGlpabh58yZq1qypW8b169cRGBgINzc34+FIElJTUxEXF4dy5coZjMtsR5Zl3L9/H2XKlNFbh5njHz58iJiYGJQoUUL3Q0LW+W/cuAE/Pz/4+PjkO/eiktNal2QZkhAZ/zdyoKqQJJs5GAcy1nv2fdqW2WI+Ckkyui8BsKt9DbC97WPpbWON62nu3Ll6r6OiolC+fHkMGTLEQhH9j8LFBYos318CgKR0gcLV1eAzXWsDBZE95WNPuRBRzjJ/0Ozfv7/R7zDZ2RnCJctngSQBzkrAxQ3I+uMVAEW6fo02aNAgrF27Fvv37y/WgtVi37znzp3T3YMKZNyfumzZMjRs2BC+NnSGwlTjxo3Dvn37AABLly5Fv3790K1bN/j7+2Pjxo0AMs46T506FZ999hkAYNOmTRg0aBCcnJxybHfdunWoWrUqatWqhVdeeQXp6ekG0xw7dgyBgYFo3bo1/Pz88OWXX+rG/fvvv3jxxRcRHByMfv364ZtvvtGbVwiByZMnY/LkybrCmoiIrNcPP/wAhUKBQYMGWToUIiKysDNnzgAAmjZtWuRtN2rUCABw9uzZXPsNKiyLnWF98uQJ+vfvjzp16qBEiRLYt28fnJyc8PPPP1sqJLOZM2cOPvzwQ0RGRiI8PByjR49GWFgYJEnC2rVr0bhxY5QtWxYfffQRDh48mGvBmpKSgnv37iE9PR2dOnXC999/jzfffFNvmuHDh2PevHkYPHgwwsPDERwcjNDQUNSsWRODBw/GqFGjMGHCBIO209LSMGDAAPj6+uKXX36xyjMLRESkb/Xq1Xj11VdRsmRJS4dCREQWdvPmTQBArVq1irxtb29vVKhQAffu3UN0dDT8iuk+d4sVrKGhoXjppZewb98+REVFoU+fPmjbtq1V3h9U1L788kvMnDkTpUuXhouLCyIjI6HVauHg4ABfX18sXboUnTp1wtq1axEUFJRrWwMHDoSDgwMcHBwQFhaGf/75R69gTUhIwJ07dzBw4EAAQNWqVdGmTRucOXMGgYGBuHr1KsaOHWu07bfffhtdu3bFkiVLii55IiIqNsePH8eVK1fy/Nw2tdf9gpKFyOi4Q5L0engXWf6yypzWWnvatqd87CmX3NhiL+i5YT7Wy9pzyfysd3V11YtRZP0syHq7oyRl3IeX7TMCmdNmyzXztsWUlJR8rYP8TGvxx9q8+uqrlgzB7LRaLT7++GNcv34d5cuXR1xcHHx8fPROo69atQqNGzfGr7/+muc9SFmfXRsbGwt3d3e98S4uLpBlGYmJibqOqWJjY+Hh4QEXFxdIkoT4+Hijl2GPHz8eK1aswKFDh9C6detCZF1ECniG1yHbOiHKS0H3Ge5rxY/bJnerV69G1apVERISkut0pva6X1DpiYlIKlUKCg93SEr920lS3N0N7pEULkrITk6ITUyEkxX2tG1P+dhTLrmxxV7Qc8N8rJe155J5MvDhw4d6wxNTkyHKl83oYMk5Sx9BkgSU8AQg6d3DijR3iFQPJKYmIybLZ0FiYkaP48nJ+sPzkp9e9+3/dKaVUSgUUCqV2LNnD2rUqIHPP/9crxOnb7/9Fs+ePcOxY8fQrVs3fPXVV3j33XdzbO+zzz5DYGAgUlNTsXDhQoNLqp2dndGtWzeMGDEC7777Lo4cOYJr166hdevWcHJyQt++fTFgwABMnToVvr6+ep0u1alTB9u2bUO3bt2wZMkSvZ7FLEGhVEJZrRrw3y8yQq2GI4CyX32JFLUaJVxdDZ4d5+DublXPziXb4FypEqrs3AFtUpLecFkIxKWkcF+zIG6bnCUlJWHz5s2YPn16np0DmtrrfkGlpaQgNToaDunpUPz3CAXgf2fwPOLj9QojOSUF2vh4+Hh4wNkK+7Gwp3zsKZfc2GIv6LlhPtbL2nOpXr06bt26hcjISNSuXVs3PPFRDKQHjwF3j4wOljJJEgABPI3VL1hTkyElJcLDxU13ois+Ph6RkZEoUaIEqlWrlq+OafNzVS0LVjMRQsDBwQGSJGHjxo2YO3cunJ2dMWzYMNy9exeSJCEyMhKbNm3C5s2b4ejoiHXr1qF3797o1asXKhk52KpUqRLCwsKwYsUKPH36FAsWLECrVq0AABUrVtQddKxZswYff/wxJkyYgMDAQOzduxfe3t4AgOXLl2Pu3LmYOnUq4uPj0a1bN8ybNw+VKlWCp6cnatSogV27duGNN95AmTJlUK9ePbOtM2MUWXo4VkgSJCcnuFSsCDk5Ga6+vlb5QUG2yViBI8syUmJiuK9ZGLeNcZs3b4ZarcbQoUPznNbUXvcLSiFJGb02C2Fwxk7K8qcb9t+01trTtj3lY0+55MXWekHPC/OxXtacS3BwMHbs2IHTp0+jS5cuuuFSls+CrIWpyPxP5rjM6TM/N7J8FmQ+Oq1hw4ZwcHDIV1z5WVcsWM3g3LlzuHjxIipWrAgAePnll/XOVoaFhQEAAgICcOjQId1wPz8/vdfZLVu2DACMXja8cOFC3b+9vb31XgshdJd8ubq6Yvbs2Zg9e7bRtgEgKCjI4Bl/RERkXVavXo3u3bujTJkylg6FiIisRLt27TB79mxs2LABH330UYEez5mT9evXAwDatm1bZG0aY30/A9ihSZMmISwsDHXr1rV0KEREZIeePHkCWZbxzjvvWDoUIiKyIm3atEGNGjVw/fp17Nmzp8jajY6OxoYNG+Do6Ijhw4cXWbvG8AyrGWQ+f5WIiKg4lClTBsePH7d0GAbk1FS910KSMjrxSUnRu9Qs+3TWyp7ysadciChnkiRh7NixeOeddzBu3DicO3cOrlnuX1ekpUHWnwFIc8+4ZzXLZ4EiLU2v3QkTJiA1NRVhYWHw9/cv1hye24KVPU0SEREVD4VSCYWnB2RVIrRZHp8jJAmykxO08fF6B0IAoPD00OunwJrYUz72lAsRmWbUqFH4/vvvcerUKUyePBmLFi2C0t0VWlc3OKQkQ5H+v2JUSBJEqgekpESDzwKtqxuU7q746aefsH79epQoUQILFiwo9vif24I1p54mjRKARquBs5fXc9HTJBERUWE4+vnBf84cyFkKIiCjN+fYxET4eHgY9OasUCrhWEwPnS8se8rHnnIhItM4Ojpi7dq1CA4OxuLFi1GyZEl8/PHHCP7mC6iTUvSmFUIgMTUZHi5uBve7Kt1dcebKvxg0aBAAYPHixcV+dhWw84JVZPtVIDtTi8/MTory0/0yFb+8ti8REVmOsQJHlmU4xcTA2QZ7c7anfOwpFyIyTc2aNfHLL7+gZ8+emDlzJi5duoRvvvkGFYMC9KaTZRkxMTHwzfZZkJaWhtmzZ2PevHnQarWYNWsWBg4caJbY7bICc3JygiRJiIqKgp+fX6F7w8pasBZlz1qWYg/5CCEQFRUFSZLg5ORk6XCIiIiIiKxa586dsX37dvTr1w9btmzBgQMHMH78eLz55psoW7as0XmSk5OxceNGfPnll7hy5QocHR3xxRdf6D3Lu7jZZcHq4OCAgIAAREZGIiIiotDtCSEgyzIUCoXNFnhZ2Us+kiQhICAg3899IiIiIiJ6HnXo0AGXL1/G22+/jV9//RUfffQRZs2ahYYNG6JRo0aoWLEiUlNTkZiYiLNnz+LUqVNQqVQAgHr16mHt2rWoX7++WWO2y4IVADw8PFCtWjWkp6cXui1ZlhEfHw9vb2+7uEzGXvJxcnKCg4MDZFnOe2IiIiIiIkKZMmXwyy+/4J9//sG3336LzZs3459//sE///xjdPqXX34Zb7/9Nrp27WqRWyTttmAFMs60FsXZN1mWkZycDBcXF5su8DLZWz5ERERERJQ/TZo0QZMmTbB8+XJcvHgRZ8+exePHj5GUlIRy5cqhfv36aNCgAby9vS0ap10XrERERERERJQzpVKJ4OBgBAcH59jpkiXZdMGa2UtsQkJCsS5HlmWoVCo4OjpazYYrDOZjvewpF4D5WDt7ysdcuWR+39hbL+X8Pi0Ye8rHnnIBmI+1s6d87CkXwDq/T226YM28ATgwMNDCkRAR0fNEpVJZ/BKposTvUyIisgRTvk8lYcM/E8uyjIcPH8LT07NYe7tNSEhAYGAg7t+/Dy8vr2JbjrkwH+tlT7kAzMfa2VM+5spFCAGVSgV/f3+7+CU9E79PC8ae8rGnXADmY+3sKR97ygWwzu9Tmz7DqlAoEBAQkPeERcTLy8sudsRMzMd62VMuAPOxdvaUjzlysaczq5n4fVo49pSPPeUCMB9rZ0/52FMugHV9n9rPz8NERERERERkV1iwEhERERERkVViwWoCpVKJGTNmQKlUWjqUIsF8rJc95QIwH2tnT/nYUy72zN62kz3lY0+5AMzH2tlTPvaUC2Cd+dh0p0tERERERERkv3iGlYiIiIiIiKwSC1YiIiIiIiKySixYiYiIiIiIyCrZ9HNYzUGWZVy+fBkAUKtWLZt/ULxGo8GZM2fg7e2NF154wdLhFNqdO3eQnJyMypUrw9XV1dLhFIoQArdv30ZKSgoqV64MNzc3S4dUJCIiIhAZGYnatWujRIkSlg4n39RqNU6dOmUwvFatWvDx8bFAREXn1q1bSElJQc2aNW32s+348ePQarUGw8uWLYuqVataICLKSWJiIq5du4ZSpUqhUqVKlg6n0OLi4nDp0iVUq1YNZcqUsXQ4hZKeno7r16/Dzc0NFStWhIODg6VDKpS0tDRcu3YNbm5uCAoKsvl8Mp07dw5JSUlo2bKlpUMpkCdPnuDmzZsGw1u0aAFJkiwQUdHQaDS4evUqPD09bfazTaVS4d9//zU67oUXXkCpUqXMHFE2gnJ0/vx5ERQUJMqVKyf8/f1FUFCQOH/+vKXDKpCkpCQxY8YMUaFCBeHp6Sl69+5t6ZAK5ccffxRVq1YVlSpVEjVr1hReXl5i4cKFlg6rwDZv3iyqVKkiatSoIV544QXh4eEh5s6da+mwCu3JkyfC399fABA7duywdDgFcufOHQFANGrUSLRo0UL3d/ToUUuHVmAXLlwQ9erVE6VLlxaNGjUSNWvWFGfPnrV0WAXSsWNHve3SuHFjAUBMnTrV0qFRFmvWrBHu7u6iRo0awt3dXXTq1EmoVCpLh1UgN2/eFMOHDxflypUTkiSJlStXWjqkAktNTRVTpkwRJUuWFLVq1RL+/v6iatWq4tChQ5YOrUDS09PFtGnTRKlSpUT9+vWFv7+/qFixotizZ4+lQyu0nTt3CgcHB2HLh+4rV64USqVS7zO7RYsWQq1WWzq0Atu0aZPw8/MTVapUEbVq1RKdO3cWMTExlg4r3y5fvmywXapVqyYAiH379lk6PGG7e30xS09PF9WqVRMDBgwQsiwLWZZFv379RLVq1YRGo7F0ePl27949MWPGDHH//n3Ro0cPmy9Y58+fL27duqV7/euvvwoA4sCBAxaMquC++eYb8eDBA93r33//XQAQx48ft2BUhSPLsggNDRWTJ0+2i4L15s2blg6lSDx9+lT4+fmJkSNHivT0dCGEELdv3xbbt2+3cGRFY8OGDQKAuHbtmqVDof9cvnxZODg4iHXr1gkhhIiOjhZVqlQRb731loUjK5ht27aJVatWiaSkJKFUKm26YI2KihLz5s0TCQkJQgghtFqteOutt0TJkiVFcnKyhaPLv8TERPHVV1/pYpdlWYwZM0b4+PgIrVZr4egK7tGjRyIwMFBMmDDB5gvWihUrWjqMIrN7926hUCjEjz/+qBu2Z88e8f/t3XlUVPX/BvBHNhcYU9kpRDFFQE0itRQ3UMEMVDY1EZcyND1WVuaSdeLkSdQUzePSyQ0PJiAqSlJ0RIsrKAaYYKQRiogxyKKTAirM5/eHx/k5CV9hpO6MPq//5nPvvO8zF51733eb8+fPy5iq9cyaNUs4OTnpxf8dw/1X/y9LS0t7aKcnPz9fABDHjh2TL1greBIa1sbY2dmJFStWyB2jVahUKgFA7Nu3T+4oOouKihKjR48WV69efSIa1h9//FHk5ORoduwM1fLly4WlpaWora2VO8q/wsfHRwwbNkzuGPSARYsWiW7dummNrVmzRlhYWIg7d+7IlKp1GHrD2pgzZ84IACI7O1vuKK0iPj5etGnTxmC/u9VqtRg1apRYs2aN2LFjh8E3rI6OjiIvL0+cO3fOoM+sCiHEK6+8IgICAuSO8a/4+++/hYWFhYiMjJQ7ihBCCMO8aek/kJubC3Nzc7i4uGjG3N3d0aFDB+Tm5sqYjBpTXFyMa9euGfQ9a5WVlZAkCcnJyZgyZQqGDBmCcePGyR1LJ1lZWVi3bh127txp0PelPCg8PBxhYWGwtLTEm2++iZqaGrkj6eTo0aMYNWoUTExMkJubi6KiIqjVarljtYpLly4hLS0Ns2fPljsKPSA3Nxeenp5aYwMHDsTNmzdRWFgoUypqyunTp2FsbGyw9+IBQGFhIdLT0xEbG4uPP/4YS5YsgUKhkDuWTlauXAkhBBYuXCh3lFZx5coVBAcHY9y4cbC0tMSGDRvkjqSTmzdv4tSpU/D394dKpUJ2djbKysrkjtVq4uLiUFtbi5kzZ8odBQAfutSkqqoqWFpaPjRuaWmJqqoqGRJRU+7evYsZM2bAzc0NEyZMkDuOzvLy8vDxxx+jvLwc1dXV2LBhA9q1ayd3rBZTqVSYMmUKNm3aBAcHB4P/Am/fvj0OHDig+bd17tw5jBw5Eubm5li/fr284XRw9epVWFtbo0+fPmjbti2USiU6d+6MPXv2wMPDQ+54j2X79u3o1KkTgoOD5Y5CD6iqqkL37t21xu5vX7k91S+XLl3CkiVLMG/ePHTp0kXuODpLTExEUlISioqK8NxzzyEkJETuSDrJzMxEdHQ0cnJynoiDvy4uLjh37hxcXV0BAHv27EFYWBi6d+8Of39/mdO1jFKphFqtRnZ2NpYvXw57e3v88ccfGDZsGGJjYw3yIZMP2rZtG8aOHYvnnntO7igA+LM2TTI1NUVdXd1D47W1tTAzM5MhETWmoaEB06ZNQ2FhIZKSkgz6bzNixAhIkoQLFy4gJiYG4eHh+O677+SO1WKLFy+Gg4MDrK2tIUkSsrKyANxr9PLz82VO13K2trZaB0Lc3d2xYMEC7N27V75Qj8HU1BRHjhzBrl278Ouvv6KkpATu7u4IDQ2VO9pjUavV2LlzJ8LCwgzyQM+TrLHtaW1tLQAY9Hf2k+avv/7CmDFjMGDAAKxevVruOI/lo48+QkZGBkpLS+Hj44MRI0agsrJS7lgtNnXqVEybNg0XL16EJEmaJ+xKkoTS0lKZ07Xc0KFDNc0qALz++usYNmyYQW5PTU1NAdy7aik/Px85OTn4888/8dtvv2HJkiUyp3s8BQUFyMzM1KurlXiGtQlOTk6orKxEXV2dZuentrYW1dXV6Nq1q8zpCLjXrIaHh0OSJBw/fvyhI/iGbOzYsejTpw9SUlIM7rJghUIBIQQWL14M4N4ZcADYsWMHrly5gnXr1skZr1XY2tqivLwc9fX1MDExrK/Rbt26oXPnzhg0aBCAexvdN954A6+++irKyspgZ2cnc0LdpKamoqSkRK82sHSPk5PTQzvX919ze6ofysrK4O3tDWdnZxw4cOCJOZBgbGyMhQsXYtWqVcjMzMRrr70md6QW6dq1K06ePImTJ08CAMrLywHcOzA8f/58TJ48Wc54rcLW1tYgm297e3uYmZkhJCREc8WIjY0NAgMD8cMPP8ic7vFs27YNDg4OerX/aVh7Wv8hHx8fCCFw5MgRBAYGAgCSk5MhhIC3t7fM6UitVmPGjBn46aefcOzYMYO+d7W+vh5qtVprB6G2thalpaWNXpau76KiorRel5WVwd7eHmvWrIGfn59MqXR369YtmJuba42lpqbCxcXF4JpVAPD19cWGDRvQ0NCg+W3CK1euwMTExKAvYfrmm28waNAg9O3bV+4o9A+jR4/GvHnzUF1drfnt4qSkJPTt29fgf7/0SaBUKuHt7Y2uXbvi4MGDaNu2rdyRdNbY9/X9+6QNcXt6/Phxrdc7d+7EzJkzIUmSPIEe0z//PjU1NcjIyMD48eNlTKUbU1NTeHt7P9RsX7lyBdbW1jKlenx3797F7t27MXv2bL36/WLD29v6jzg6OmLevHmYO3cubt68CQD44IMPMH/+fDg6OsqcTjeZmZloaGhAVVUVjI2NIUkSTE1NNWdaDMmcOXMQHx+PrVu3QqlUQqlUAgAcHBzg7Owsc7qWUalUGDlyJN5880307t0bFRUV2Lx5M0xMTBARESF3vKfeqlWrcPnyZfj5+cHc3Fxzb1RCQoLc0XQSERGBrVu3IiwsDNOnT0dJSQmWLVuGd955x2Avpa2oqMDhw4exadMmuaNQI8LCwhAdHY2AgAC8//77+PXXX7Fr1y4cPHhQ7mg6UalUOHv2LABACIHCwkJIkgQbGxv06tVL5nQto1Kp4OPjg7q6Onz44Yf45ZdfNNPc3d01BxgMxffff4/t27cjNDQUzz77LM6fP4+oqCj4+fnh5ZdfljveUy8oKAgDBgzAoEGDcOvWLURHR6O+vh6LFi2SO5pOPv/8c4wYMQI9evTAoEGDcOLECSQmJuLw4cNyR9PZoUOHcO3aNbzxxhtyR9HSRggh5A6hr9RqNbZs2YLk5GQAwGuvvYY5c+bAyMgwb/0dM2bMQ0827dSpk+bzGZLAwEDNpTEPCgoKwnvvvSdDosdz+fJlbNy4EWfPnkXHjh3h6emJiIgIgz7jdV9VVRUCAgLw5ZdfGuTBESEE4uPjkZSUhOvXr6NXr16YO3eu1hPEDU1FRQVWrVqFnJwcWFlZwd/fH6+//rrBPtTj0KFDWLt2LZKTk2FhYSF3HGpEVVUVVq5ciezsbFhaWiIiIgI+Pj5yx9JJXl4e5s6d+9C4r68vli9fLkMi3V28eBHTpk1rdNqqVaswePDg/zjR40tPT0dMTAyKi4thZ2eHsWPHIjQ0VK/OFukqJSUFK1asMOgzrJs3b8bPP/8MExMTeHh4YMGCBXjmmWfkjqazM2fOYP369SgpKYGTkxMiIiIwcOBAuWPp7JNPPsG1a9ewefNmuaNoYcNKREREREREeskwTxUSERERERHRE48NKxEREREREeklNqxERERERESkl9iwEhERERERkV5iw0pERERERER6iQ0rERERERER6SU2rERERERERKSX2LASPQUKCgqQmpraovfk5eUhLS2t1esSEREZqrS0NOTl5bXoPampqSgoKGj1ukRPCzasRE+BpKQkLF26tEXviYuLQ2RkZKvXJSIiMlSRkZGIi4tr0XuWLl2KpKSkVq9L9LQwkTsAEf373Nzc4OvrK3cMIiIig+bt7Y3evXvLHYPoqcKGlUgPXL16Fenp6QgJCYGR0f9f+FBaWgpJkhAcHIzLly/j1KlTAAALCwu4ubnB2dlZq05eXh6uXbuGwYMHIyMjA1VVVQgODkbPnj3Rrl07zXwXL158ZK376urqkJubi4qKCgwZMgRdunR55Oe5cOECfvvtN9jZ2cHDwwNt27Zt8TohIiJqqezsbKhUKowcOVJr/JdffoFKpYK3tzcyMzNRXFyMNm3awMrKCv3794elpaXW/KmpqXB0dISVlRVOnTqFTp06wcvLC15eXrC2ttbM15xa91VUVODMmTMwMjLC0KFDYWpq+j8/i1qtRlZWFpRKJZ5//nm4u7vruFaIDBsbViI9YGZmhmnTpsHS0hKjRo3SjK9duxbp6emYNGkSLl++jIMHDwIAVCoVJEnCrFmzEB0drZk/Li4OcXFxaNeuHWxsbPDss88iODgYSUlJ2LdvH8aMGQMAzaoF3GuYPTw8YGdnhxs3bqCoqAjJycnw8vJq9HPcvXsXs2bNQmpqKgYOHIiSkhLU1dUhKSkJLi4urba+iIiIGlNYWIjZs2dDqVSiffv2mvHp06cjKCgI3t7eOH36NDIyMgDc286dPXsW27dvR1BQkGb+pUuXwsLCApcuXUK/fv0wfPhweHl5ITIyEl5eXujbty8ANKsWAKSkpGDjxo3o27cv8vPz0aVLF6SlpTXZ3BYXFyMgIAB37txBz549kZOTA09PTyQkJMDMzKxV1xmR3hNEpBfGjRsnZsyYoXnd0NAgHBwcxPr16xud/+LFi0KhUAhJkjRjy5YtEwBESkqK1rxffPGF8PT0bHLZ/6vW7t27NWMRERHC1dVVNDQ0NFo3MjJSeHp6ir///lszNn/+fDF8+PBHfHoiIqLHV1NTIxQKhdi7d69mLDc3VwAQ58+fb/Q9sbGxwsrKStTV1WnGPD09ha2trSgrK9Oad/jw4WLZsmVNLr+pWhYWFqKoqEgIIYRKpRJ9+vQRCxYsaLLu4MGDxbvvvivUarUQQohbt26Jfv36iS+++KI5q4HoicKHLhHpibCwMOzfvx91dXUAgGPHjqG8vByTJ0/WzFNbWwtJkrBv3z6cPHkSDg4OyMrK0qrTs2dP+Pn5PXJ5zallb2+PqVOnal5/9NFHKCgoaPJJhjt27EC/fv3w/fffIyEhAfHx8bC2tsaJEydw586dZq8LIiIiXbRv3x6BgYGIjY3VjMXGxmLAgAHo1auXZkypVOLo0aOIi4vDnTt3UFFRgaKiIq1aoaGhsLW1feQym1MrODgY3bt3BwAoFAq8/fbbiI+Pb7TehQsXkJGRAWdnZyQmJiIhIQHJycno0aMHjh071ux1QfSk4CXBRHpi/PjxeOutt3D48GGEhIQgNjYWo0ePho2NDQDg559/RnBwMGxsbODs7IwOHTrg+vXrKC8v16pjb2//yGU1t5aTkxPatGmj9drIyAjFxcV44YUXHqpbXFyMCxcuoKamRms8KCgItbW1vIyJiIj+dVOnTsW4ceNQWVmJzp0749tvv8WiRYs006OiohAZGQkPDw/Y2trCxOTe7nB5eTlcXV018zVne9rcWt26ddN6X/fu3VFWVobbt28/9JyHS5cuAbi3rTY2NtaMm5mZaTXdRE8LNqxEeqJ9+/aYOHEiYmNj4e/vj/3792PTpk2a6R988AFmzpyJqKgozVj//v0hhNCq82CD2ZTm1qqurtZ6fePGDajValhZWTVaV6FQIDAwEAsXLnxkBiIion+Dj48PrKyskJCQABcXFyiVSs3VSpWVlViyZAmOHj2qeTBTWVkZ4uPjW7w9bUmtf25Pq6uroVAoGn0oYceOHQEAn332Gdzc3FrwyYmeTLwkmEiPTJ06FSkpKYiJiUFDQwMmTJigmVZWVqb14KLff/8d586d02k5za11/2m/9+3fvx8dO3ZEnz59Gq3r5+eHbdu24e7du1rjpaWlOuUkIiJqKSMjI0yePBmxsbEPXa2kVCohhNDaBu7bt0+n5bSkVnJyMurr6zWv9+/fjyFDhjQ674svvggbGxts2bLloWlXr17VKSuRIeMZViI94uPjgy5duuD999/HxIkT0aFDB820CRMm4NNPP0VNTQ1u376NdevWwdzcXKflNLdWx44dERAQgAULFuD69etYuXIlIiMjNUd//2n16tUYOnQoXn75ZYSHh8PIyAiSJKG+vh6JiYk6ZSUiImqpsLAwREdHIzc3F19//bVmvFevXnB1dcWUKVMwffp0FBQUICYmRqdltKTWjRs34Ovri0mTJiEjIwOHDx+GJEmNzmtmZoZvvvkGISEhUCqVGDVqFCoqKnDo0CGEh4dj7ty5OuUlMlRsWIn0iLGxMT799FMcP34cb7/9tta0tWvXwtXVFVlZWVAoFNizZw/S09O1fj+1X79+jd4n6ubmBl9f3xbXWrhwIXx9fZGYmIiKigrExMQgODi4ybqOjo44e/Ysdu3ahdzcXCgUCoSGhiIwMLBV1g8REVFzvPjii5gzZw6uX7+udbWSiYkJfvrpJ2zcuBHHjx9H165dkZmZiaVLl2rOwgKAr69vo5fjent7o3fv3i2uNXDgQNTU1ECSJCgUCpw8eRL9+/dvtC4A+Pv7Iz8/H7t374YkSXB0dMRXX32Fl156qRXXEpFhaCP+eZE9ERERERERkR7gPaxERERERESkl9iwEhERERERkV5iw0pERERERER6iQ0rERERERER6SU2rERERERERKSX2LASERERERGRXmLDSkRERERERHqJDSsRERERERHpJTasREREREREpJfYsBIREREREZFeYsNKREREREREeokNKxEREREREeml/wNZNx29bYcW/QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 950x380 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "hr, hc = mixed.hessianstructure()\n",
+    "distinct = np.unique(hr * n + hc).size\n",
+    "print(f\"Jacobian : {mixed.jacobianstructure()[0].size:3d} nnz \"\n",
+    "      f\"of {mixed.m * n} dense\")\n",
+    "print(f\"Hessian  : {hr.size:3d} declared, {distinct:3d} distinct, \"\n",
+    "      f\"of {n * (n + 1) // 2} dense lower triangle\")\n",
+    "dup = [(int(r), int(c)) for r, c in zip(hr, hc)\n",
+    "       if np.sum((hr == r) & (hc == c)) > 1]\n",
+    "print(\"declared by both blocks:\", sorted(set(dup)))\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(9.5, 3.8))\n",
+    "colors = {0: (\"#1f77b4\", \"equation block\"), 1: (\"#d62728\", \"jax block\")}\n",
+    "\n",
+    "for bi, (b, off) in enumerate(zip(mixed.blocks, mixed.offsets)):\n",
+    "    r, c = b.jacobianstructure()\n",
+    "    axes[0].scatter(np.asarray(c), np.asarray(r) + off, s=70, marker=\"s\",\n",
+    "                    color=colors[bi][0], label=colors[bi][1])\n",
+    "    r, c = b.hessianstructure()\n",
+    "    r, c = np.asarray(r), np.asarray(c)\n",
+    "    axes[1].scatter(np.minimum(r, c), np.maximum(r, c), s=70, marker=\"s\",\n",
+    "                    color=colors[bi][0], alpha=0.65, label=colors[bi][1])\n",
+    "\n",
+    "for r, c in sorted(set(dup)):                       # ring the shared entries\n",
+    "    axes[1].scatter([c], [r], s=300, facecolors=\"none\", edgecolors=\"k\",\n",
+    "                    linewidths=1.4, zorder=5)\n",
+    "\n",
+    "axes[0].set(title=\"constraint Jacobian\", xlabel=\"variable\", ylabel=\"row\",\n",
+    "            xlim=(-0.5, n - 0.5), ylim=(mixed.m - 0.5, -0.5))\n",
+    "axes[1].set(title=\"Lagrangian Hessian (lower triangle)\", xlabel=\"variable\",\n",
+    "            ylabel=\"variable\", xlim=(-0.5, n - 0.5), ylim=(n - 0.5, -0.5))\n",
+    "for ax in axes:\n",
+    "    ax.set_xticks(range(n)); ax.grid(alpha=0.25); ax.legend(fontsize=8)\n",
+    "axes[0].set_yticks(range(mixed.m)); axes[1].set_yticks(range(n))\n",
+    "fig.suptitle(\"Who declared what.  Overlap at (T, T) is where the two blocks meet.\",\n",
+    "             fontsize=10)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6aff3d30",
+   "metadata": {},
+   "source": [
+    "## 9. The sensitivity layer comes along free\n",
+    "\n",
+    "`pounce.Solver` takes a `Problem`, not an `NlProblem` — so everything in\n",
+    "`pounce.sensitivity` works on a mixed model with no extra plumbing. Here we ask\n",
+    "a question that spans both blocks: **how does the design move if the feed rate\n",
+    "changes?**\n",
+    "\n",
+    "$q$ appears only in the equation block's balance rows, so perturbing those rows'\n",
+    "right-hand sides is a feed-rate perturbation. The answer necessarily flows\n",
+    "through the JAX block, since the rates must re-satisfy the surrogate. We check\n",
+    "the parametric step against a re-solve at the perturbed model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "697fe597",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T20:03:49.146263Z",
+     "iopub.status.busy": "2026-09-06T20:03:49.146032Z",
+     "iopub.status.idle": "2026-09-06T20:03:49.500660Z",
+     "shell.execute_reply": "2026-09-06T20:03:49.499088Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "converged: True | KKT dim: 30\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "         sens step    re-solve\n",
+      "CA1       -0.00000     0.00001\n",
+      "CA2        0.00002     0.00002\n",
+      "CA3        0.00000     0.00000\n",
+      "r1         0.00280     0.00280\n",
+      "r2         0.00107     0.00107\n",
+      "r3         0.00046     0.00046\n",
+      "V          0.07912     0.07910\n",
+      "T          0.19915     0.19763\n"
+     ]
+    }
+   ],
+   "source": [
+    "solver = pounce.Solver(prob)\n",
+    "xs, _ = solver.solve(x0=x0)\n",
+    "xs = np.asarray(xs)\n",
+    "print(\"converged:\", solver.converged, \"| KKT dim:\", solver.kkt_dim)\n",
+    "\n",
+    "# d(q) = +0.1 L/min scales each balance row's constant term by dq*(CA_in - CA).\n",
+    "dq = 0.1\n",
+    "rhs = [-dq * (CA_in_star[i] - xs[i]) for i in range(N)]\n",
+    "step = np.asarray(solver.parametric_step(list(range(N)), rhs))[:n]\n",
+    "\n",
+    "perturbed = Mixed([NlBlock(pounce.build_nl_problem(\n",
+    "    n=n,\n",
+    "    objective=algebraic_cost,\n",
+    "    constraints=[(q + dq) * (CA_in[i] - v[i]) - v[iV] * v[N + i] for i in range(N)],\n",
+    "    g_l=[0.0] * N, g_u=[0.0] * N)), JaxBlock()], n=n)\n",
+    "p2 = pounce.Problem(n=n, m=perturbed.m, problem_obj=perturbed, lb=lb, ub=ub,\n",
+    "                    cl=[0.0] * perturbed.m, cu=[0.0] * perturbed.m)\n",
+    "p2.add_option(\"print_level\", 0)\n",
+    "p2.add_option(\"tol\", 1e-10)\n",
+    "x2, _ = p2.solve(x0=list(xs))\n",
+    "truth = np.asarray(x2) - xs\n",
+    "\n",
+    "names = [f\"CA{i+1}\" for i in range(N)] + [f\"r{i+1}\" for i in range(N)] + [\"V\", \"T\"]\n",
+    "print(f\"\\n{'':6}{'sens step':>12}{'re-solve':>12}\")\n",
+    "for k, nm in enumerate(names):\n",
+    "    print(f\"{nm:6}{step[k]:12.5f}{truth[k]:12.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "718a80db",
+   "metadata": {},
+   "source": [
+    "The parametric step reproduces the re-solve, and it did so from one back-solve\n",
+    "against the factor already in hand rather than a second optimization.\n",
+    "\n",
+    "Read the column: the concentration profile barely moves — it is pinned by the\n",
+    "outlet spec — and the extra feed is absorbed almost entirely by $V$ and $T$.\n",
+    "$T$ is the interesting one. **The balance rows we perturbed do not mention\n",
+    "$T$ at all**; it appears only in the JAX block's surrogate rows. It moves\n",
+    "because the KKT system carries the coupling across the block boundary. That is\n",
+    "the whole point of mixing rather than solving the two halves separately, and\n",
+    "it is why the sensitivity layer had to see one problem rather than two.\n",
+    "\n",
+    "## 10. When *not* to do this\n",
+    "\n",
+    "Stacking blocks is the right tool when both halves are cheap and\n",
+    "differentiable. Three neighbouring situations want a different one.\n",
+    "\n",
+    "**The non-equation half is expensive or has no usable derivatives.** That is\n",
+    "glass box / black box, and it has a dedicated method: `pounce.trf_minimize`\n",
+    "(notebook 29, `docs/src/trf.md`). It builds a corrected surrogate inside a\n",
+    "trust region and converges to the *true* model's optimum while calling it a\n",
+    "handful of times. Fitting a surrogate once and optimizing it — which is what\n",
+    "this notebook's model does, deliberately — can converge to a local *maximum*\n",
+    "of the real problem; §7's truth-model check is the reason we measured rather\n",
+    "than assumed.\n",
+    "\n",
+    "**You want to differentiate through the solve.** `pounce.jax.solve` and\n",
+    "`JaxProblem` wrap the solve in a `custom_vjp`, but they need `f(x, p)` and\n",
+    "`g(x, p)` fully JAX-traced, so a mixed problem cannot use them directly. The\n",
+    "machinery underneath is available though: the backward is an implicit-function\n",
+    "back-solve on the KKT system, and `Solver.kkt_solve` reaches the same held\n",
+    "factor §9's `parametric_step` used — on the mixed problem, unchanged. A\n",
+    "hand-rolled `custom_vjp` over it is the route.\n",
+    "\n",
+    "**Your algebra lives in Pyomo.** `pyomo-pounce` writes a `.nl` file and runs\n",
+    "the `pounce` binary, so no Python callback can ride that path. The way to put a\n",
+    "callback inside a `.nl` model is an AMPL *imported function*\n",
+    "(`crates/pounce-nl/src/nl_external.rs`), which POUNCE supports through the\n",
+    "`funcadd_ASL` ABI and `AMPLFUNC` — but that means compiling a shared library,\n",
+    "not passing a Python object.\n",
+    "\n",
+    "And one limit with no workaround: **an `NlExpr` tree has no callback node.**\n",
+    "`build_nl_problem` has nowhere to put the F-segment declarations that would\n",
+    "bind one (`docs/src/python.md`). Mixing happens between blocks, never inside a\n",
+    "single expression — which is why the recipe in §1 is to give the black box's\n",
+    "output its own variable and its own row.\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "* `pounce.Problem` accepts any object with the seven cyipopt methods, and both\n",
+    "  model surfaces already produce one.\n",
+    "* Objectives add, constraint rows stack, Jacobian rows offset, Hessian triplets\n",
+    "  concatenate — repeated entries are summed by the converter, by contract.\n",
+    "* `NlProblem` needs a six-line rename (`jacobian_structure` →\n",
+    "  `jacobianstructure`) and nothing else.\n",
+    "* Give each block's structure explicitly when you know it; the mixed model is\n",
+    "  as sparse as its parts.\n",
+    "* `pounce.Solver` and the whole sensitivity layer work on the result unchanged."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/notebooks/README.md
+++ b/python/notebooks/README.md
@@ -28,6 +28,7 @@ jupyter lab python/notebooks/01_getting_started.ipynb
 |---|---|---|
 | 05 | [`05_pyomo.ipynb`](05_pyomo.ipynb) | Drive POUNCE from a Pyomo model. |
 | 35 | [`35_casadi.ipynb`](35_casadi.ipynb) | POUNCE as a CasADi `nlpsol` plugin: MX models with parameters, `Opti`, warm-started MPC, differentiating through the solve (with the bounded-variable trap that silently zeroes NMPC feedback gains), L-BFGS restricted to the nonlinear variables, timings against CasADi's bundled Ipopt, and a cart-pole worked example — swing-up, then balancing against a control deadline. |
+| 42 | [`42_mixing_equations_and_jax.ipynb`](42_mixing_equations_and_jax.ipynb) | One model, two front ends: `NlExpr` balances and a fitted JAX rate law stacked into a single `pounce.Problem` on a three-CSTR train. Why the meeting point is the cyipopt method set that both surfaces already produce, the four stacking rules (objectives add, rows offset, Hessian triplets concatenate because repeated entries are summed by contract), the six-line rename `NlProblem` needs, machine-precision agreement with an all-JAX twin, and a feed-rate sensitivity that moves a variable the perturbed rows never mention. Also where *not* to stack: `trf_minimize`, `pounce.jax.solve`, Pyomo, and the callback an `NlExpr` tree cannot hold. |
 
 ## Differentiating through the solver
 


### PR DESCRIPTION
Docs-only. No library code changes.

## Problem

"How feasible is it to mix equation-based and JAX functions in defining a problem for POUNCE?" was not answerable from the docs, and the two obvious readings of the answer are both wrong.

The two model surfaces are good at opposite things and nothing said how to combine them. `NlExpr` / `build_nl_problem` gives exact reverse-mode AD on the Rust tape and sparsity read *off* the tape rather than probed — and has no callback node, so a trained network, a table lookup, or a fitted closure has nowhere to live (`docs/src/python.md` says this, but only as a limitation, with no route around it). `pounce.jax.from_jax` takes the network but pays a Python round trip per evaluation and, unless you supply the pattern, probes for sparsity.

Real models want both at once — a flowsheet that is algebra except for one unit, a reactor train that is mass balances except for the rate law. The plausible-but-wrong conclusions the notebook forecloses are (a) that this needs a new POUNCE surface, and (b) that it needs no care at all beyond concatenating arrays.

## Fix

A notebook that builds the model rather than describing it: three CSTRs in series, mass balances as `NlExpr`, kinetics as a tanh network fitted in-notebook to sampled data (1.4% rmse), stacked into one `pounce.Problem`.

The load-bearing observation is that `pounce.Problem` does not want an `NlProblem` or a JAX function — it wants *any* object carrying the cyipopt method set (`crates/pounce-py/src/tnlp_bridge.rs`), and both surfaces already produce one. So the work is stacking two objects that already speak the same protocol, not bridging two foreign things.

The modeling recipe it leads with is to give the black box's output its own variable and one residual row, which keeps the balances pure algebra referring to `r_i`. Stacking is then four rules: objectives add, constraint rows stack, Jacobian rows offset, and Hessian triplets **concatenate**.

That last one is the part worth writing down, and my first pass got it backwards. I assumed duplicate `(row, col)` entries were not summed and wrote a union-and-scatter merge. They are summed: POUNCE's triplet→CSR converter is a port of Ipopt's and states the contract outright — matrices "arrive in triplet (COO) form with possibly repeated `(row, col)` entries" and are compressed "with repeated entries summed" (`crates/pounce-linalg/src/triplet_convert.rs`). Confirmed by declaring `(0,0)` twice with values `3.0` and `-1.0` and reading back `2.0` through `Solver.hessian_vec`. Two blocks' second derivatives at a shared entry *should* add, so the duplicate is the wanted behaviour rather than a hazard, and the union merge was solving a problem that does not exist.

The only real friction is naming: `NlProblem` spells its structure methods `jacobian_structure` / `hessian_structure` where the bridge wants cyipopt's run-together `jacobianstructure` / `hessianstructure`. Six lines of adapter, and that is the whole of it.

Two deliberate choices, either of which is fine to overrule in review:

- The JAX block's seven methods are written out by hand with **closed-form** sparsity patterns rather than calling `from_jax`. `from_jax` returns a finished `Problem` when what is needed is the object, and reaching for `pounce.jax._build._JaxProblem` would teach a private class. Writing it out also lands the supplied-vs-probed pattern point and ties to notebook 33. The cost is that the notebook does not exercise the colored-AD path.
- The JAX block carries an objective term (a soft penalty keeping the optimizer inside the surrogate's training box) as well as constraint rows, so the "objectives add" rule is exercised rather than only asserted. It is 2.8% of the objective at the optimum — real modeling practice, but readable as decoration.

## Blast radius

Three files: the notebook, `python/notebooks/README.md`, `CHANGELOG.md`. No Rust, no Python package code, no workflow. Not a trajectory change; the fixture sweep does not apply.

The notebook imports `pounce.jax`, so it needs the `[jax]` extra to run — as notebooks 02, 09, 11, 14, 17 and 33 already do. No workflow executes notebooks, so this adds nothing to CI time.

## Tests

No tests, and no test would bite here — the deliverable is executed prose. What stands in for them is that the notebook verifies itself, in cells whose numbers are saved in the committed outputs:

- **Against an all-JAX twin.** The same model written entirely in JAX and handed to `from_jax`, sharing nothing with the mixed build but the surrogate and the cost constants. `max |dx*| = 1.8e-14`, `|df*| = 1.4e-14`. Then the gradient and the full Lagrangian Hessian at an **off-solution** probe point: `6.2e-15` and `5.7e-14`. The off-solution point is the one that matters — an index-scatter bug can be invisible at the optimum if both solves happen to land in the same place.
- **Against the withheld truth kinetics.** Substituting `true_rate` into the converged balances recovers residuals at the ~1% level the fit itself carries. The notebook labels this explicitly as *not* evidence about the mixing — it is the cost of having used a surrogate, and would be identical for the all-JAX build.
- **The sensitivity layer on the mixed problem.** A feed-rate `parametric_step` reproduces a re-solve, and moves `T` by 0.199 against the re-solve's 0.198 — even though the perturbed balance rows never mention `T`. The coupling arrives through the JAX block's rows, which is the concrete argument for mixing rather than solving the halves separately.
- **The declared/distinct triplet counts.** 11 declared, 10 distinct, with the overlap identified as exactly `(T, T)` — the summed-duplicate claim above, shown rather than asserted, and ringed in the figure.

Executed end-to-end against a local build of this branch (0.11.0, `maturin build --release`), outputs saved, zero error outputs in the committed file.

Section 10 states what the notebook is *not* evidence about, so the gaps are known ones: `trf_minimize` (notebook 29) is the right tool when the non-equation half is genuinely expensive or has no usable derivatives; `pounce.jax.solve` needs a fully traced `f(x, p)` / `g(x, p)` and so cannot take a mixed model directly, though `Solver.kkt_solve` reaches the same held factor; `pyomo-pounce`'s `.nl` round trip admits no Python callback at all; and the AMPL imported-function route (`crates/pounce-nl/src/nl_external.rs`) does reach inside an expression but wants a compiled shared library.

---

- [ ] Tests fail on the parent commit for the stated reason — **n/a**, no tests; see above for what stands in
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — **n/a**, notebooks are indexed from `python/notebooks/README.md`, matching notebooks 40 and 41, whose commits touched exactly these three files
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — **not run**; no Rust changed. The release build the notebook was executed against compiled clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhjwYZFnafsJBrjBeDhNDs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhjwYZFnafsJBrjBeDhNDs)_