### PR TITLE
fix(curve_fit): dpopt_ddata — the active set, the exact Hessian, and the robust-loss weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,6 +380,52 @@ changes.
 
 ### Fixed
 
+- **`curve_fit(sensitivity="exact")`, and two accuracy defects in
+  `dpopt_ddata` ([#923](https://github.com/jkitchin/pounce/issues/923),
+  [#925](https://github.com/jkitchin/pounce/issues/925)).** The influence
+  matrix was built from the **Gauss-Newton** Hessian, so it dropped the
+  residual-curvature term `Σ rₖ ∇²fₖ`. Measured against re-solving at a
+  perturbed datum (FD-stable across `h`), that is worth 0.6–10% on an interior
+  fit and 27–67% where a bound or constraint holds the fit away from its
+  unconstrained optimum — a wide spread, because the dropped term scales with
+  the residuals, so it is a property of the fit and not only of the model.
+  `sensitivity="exact"` rebuilds it from the exact
+  objective Hessian — central differences of the objective gradient at the
+  optimum, `2n` extra gradient evaluations, once — and takes every one of
+  those cases to ≤ 0.2%. It cannot reuse the held factor, which was built
+  from the Gauss-Newton matrix, so it goes through a dense `n × n` inverse;
+  `True` / `"gn"` keeps the old free back-solve. Rank points with `True`,
+  ask `"exact"` when a specific number matters.
+
+  `sensitivity` is now validated. It was a bare `bool`, so a truthy typo like
+  `sensitivity="exakt"` would have silently delivered the Gauss-Newton answer
+  under an exact-sounding request; it now raises.
+
+  The second defect (#925) was found while implementing the first, and is
+  larger. Under a **robust** `loss` the influence right-hand side is
+  `-2 wᵢ² (ρ′ᵢ + 2 zᵢ ρ″ᵢ) gᵢ`, and the bracket — exactly the per-point weight
+  `gn_hessian` already applies — was missing, so the two sides of the same
+  solve disagreed about which loss was in use. It is identically 1 for `sse`,
+  which is the only loss any `sensitivity=True` test used: the corpus was
+  uniform in exactly the dimension the code was wrong in, the same shape as
+  #922 one setting over. On a fit with real outliers this was 86% for `cauchy`
+  and 73% for `soft_l1`, and worse than the magnitude, the factor reaches
+  `-0.12` on a strongly downweighted outlier — so an outlier's reported
+  influence pointed the **wrong way**, on precisely the points a robust loss
+  exists to handle. Now 0.68% and 0.37%.
+
+  Worth recording that the exact Hessian does **not** repair #925 on its own:
+  it is the left-hand side and #925 is the right. The exact Hessian alone
+  moves `cauchy` from 85.50% to 85.71% — no improvement. Shipping #923 without
+  #925 would have put an exact-sounding label on an 86%-wrong answer.
+
+  Six tests added, mutation-checked independently: disabling the exact Hessian
+  fails only the three `exact_beats_gauss_newton` cases, and restoring
+  `lw = np.ones(m)` fails only the two robust-loss cases. The #922 active-set
+  invariants are re-asserted on the new dense branch rather than assumed —
+  a pinned parameter's row is still exactly zero and `A · ∂p*/∂yᵢ = 0` still
+  holds to `1e-12` under `"exact"`.
+
 - **`curve_fit(sensitivity=True)` ignored the active set
   ([#922](https://github.com/jkitchin/pounce/issues/922)).**
   `CurveFitResult.dpopt_ddata` returned `pinv(J)` — the unweighted,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,6 +380,28 @@ changes.
 
 ### Fixed
 
+- **`curve_fit(sensitivity=True)` ignored the active set
+  ([#922](https://github.com/jkitchin/pounce/issues/922)).**
+  `CurveFitResult.dpopt_ddata` returned `pinv(J)` — the unweighted,
+  unconstrained, Gauss-Newton influence — for *every* fit, including ones with
+  active bounds or active general constraints, where that answer is
+  inadmissible. A parameter pinned at a bound was reported as having nonzero
+  influence when it cannot move at all; free parameters came back with the
+  wrong sign; and with `a + c ≤ 2.6` binding, the returned columns gave
+  `da + dc = 0.78` instead of 0, violating the constraint the fit was solved
+  under. Measured against leave-one-out re-solves, the general-constraint case
+  was off by 4× the scale of the true influence. The influence is now projected
+  onto the joint active-constraint nullspace via the same reduced-Hessian
+  recipe `pcov` already used — pinned rows are exactly zero and
+  `A · ∂p*/∂y = 0` holds by construction. `_data_sensitivity` was never passed
+  `active_mask`, so it could not apply the guard its sibling `_covariance` had
+  carried since the feature landed; the one existing test requested
+  `sensitivity=True` on an unconstrained fit only, and asserted equality to
+  `pinv(J)` — pinning the special case as the general contract. Three tests now
+  cover the branches: bound-pinned, active-constraint nullspace, and an
+  inactive constraint that must *not* project.
+
+
 - **`feral_refine` was documented as `no` and ran as `yes`
   ([#909](https://github.com/jkitchin/pounce/issues/909)).** `pounce
   --print-options` reported the default as `no`, the book said `no`, and on

--- a/docs/src/curve-fitting.md
+++ b/docs/src/curve-fitting.md
@@ -128,13 +128,45 @@ matrix whose entry `[j, i]` is how fitted parameter `j` moves when data point
 `∂p*/∂y_i = 2 wᵢ² · H_S⁻¹ gᵢ`, computed as a single batched back-solve against
 the converged factor (`Solver.kkt_solve_many`).
 
-`H_S` is the **Gauss-Newton** Hessian, the same one `curve_fit` hands the
-solver as its search Hessian and the same one behind `pcov` — so this is the
-first-order influence, not the exact derivative of the re-solve. The two differ
-by the neglected residual-curvature term `Σ rₖ ∇²fₖ`, which grows with the
-residuals: a few percent on a well-fit interior problem, but tens of percent
-where a bound or constraint holds the fit away from its unconstrained optimum.
-Take it as a ranking of points, and re-solve if you need the number itself.
+By default `H_S` is the **Gauss-Newton** Hessian, the same one `curve_fit`
+hands the solver as its search Hessian and the same one behind `pcov` — so this
+is the first-order influence, not the exact derivative of the re-solve. The two
+differ by the neglected residual-curvature term `Σ rₖ ∇²fₖ`, which grows with
+the residuals: measured on a 3-parameter exponential, 0.6–10% on an interior
+fit and 27–67% where a bound or constraint holds the fit away from its
+unconstrained optimum.
+
+`sensitivity="exact"` removes that gap. It rebuilds the influence from the
+**exact** objective Hessian, obtained by central-differencing the objective
+gradient at the optimum — `2n` extra gradient evaluations, once. On the same
+three cases the error drops to ≤ 0.2%. It cannot reuse the held factor (that
+was built from the Gauss-Newton matrix), so it goes through a dense `n × n`
+inverse; on a large-`n` fit that is the trade.
+
+| `sensitivity=` | cost | error vs. re-solve |
+|---|---|---|
+| `True` / `"gn"` | one back-solve per point, effectively free | 0.6–67% |
+| `"exact"` | `+2n` gradient evaluations, dense inverse | ≤ 0.2% |
+
+The Gauss-Newton spread is wide because the dropped term scales with the
+residuals, so it depends on the fit and not just the model: the same
+three-parameter exponential gives 0.6% interior / 67% bound-active on one
+dataset and 10% / 27% on another. Do not carry a number across from one fit to
+the next — if it matters, measure it, which is one `sensitivity="exact"` call.
+
+Use `True` to **rank** points by influence — the ranking is stable well before
+the magnitude is — and `"exact"` when a specific number matters
+([#923](https://github.com/jkitchin/pounce/issues/923)).
+
+Under a **robust** `loss` the right-hand side additionally carries the weight
+`ρ′ + 2zρ″`, the same per-point factor the Gauss-Newton Hessian applies. It is
+identically 1 for `sse`. It matters a great deal otherwise: on a fit with real
+outliers it reaches `-0.12` under `cauchy`, so before
+[#925](https://github.com/jkitchin/pounce/issues/925) a downweighted outlier's
+influence was not merely mis-scaled (86% for `cauchy`, 73% for `soft_l1`) but
+pointed the **wrong way**. Note that `sensitivity="exact"` does not repair
+this on its own — the exact Hessian is the left-hand side, and this is the
+right.
 
 When bounds or general constraints are **active**, the influence is projected
 onto the joint active-constraint nullspace — the same reduced-Hessian recipe

--- a/docs/src/curve-fitting.md
+++ b/docs/src/curve-fitting.md
@@ -128,6 +128,24 @@ matrix whose entry `[j, i]` is how fitted parameter `j` moves when data point
 `∂p*/∂y_i = 2 wᵢ² · H_S⁻¹ gᵢ`, computed as a single batched back-solve against
 the converged factor (`Solver.kkt_solve_many`).
 
+`H_S` is the **Gauss-Newton** Hessian, the same one `curve_fit` hands the
+solver as its search Hessian and the same one behind `pcov` — so this is the
+first-order influence, not the exact derivative of the re-solve. The two differ
+by the neglected residual-curvature term `Σ rₖ ∇²fₖ`, which grows with the
+residuals: a few percent on a well-fit interior problem, but tens of percent
+where a bound or constraint holds the fit away from its unconstrained optimum.
+Take it as a ranking of points, and re-solve if you need the number itself.
+
+When bounds or general constraints are **active**, the influence is projected
+onto the joint active-constraint nullspace — the same reduced-Hessian recipe
+`pcov` uses. A parameter pinned at a bound gets a row of exactly zero, since it
+cannot move at all, and the columns satisfy `A · ∂p*/∂y_i = 0` so a perturbation
+leaves the active constraints satisfied. Before
+[#922](https://github.com/jkitchin/pounce/issues/922) the unconstrained formula
+was returned regardless, which reported nonzero influence for pinned
+parameters, sign errors on the free ones, and columns that violated the very
+constraint the fit was solved under.
+
 ```python
 res = pounce.curve_fit(model, x, y, p0=[1, 1, 0], sensitivity=True)
 db = res.dpopt_ddata[1]              # sensitivity of parameter b

--- a/python/notebooks/44_leverage_and_influence.ipynb
+++ b/python/notebooks/44_leverage_and_influence.ipynb
@@ -1,0 +1,994 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9ca753b2",
+   "metadata": {},
+   "source": [
+    "# Which data points made this fit?\n",
+    "\n",
+    "A fitted parameter is a function of the data that produced it. Change one\n",
+    "measurement and every parameter moves. *How much* it moves is the influence of\n",
+    "that point, and classical regression has a name and a closed form for it: the\n",
+    "**hat matrix**, whose diagonal is the **leverage** $h_{ii}$.\n",
+    "\n",
+    "The closed form is exact for **unweighted, unconstrained, linear** least\n",
+    "squares. Very little real fitting is all three. Rate constants are held\n",
+    "positive; activation energies are bounded by physics; two parameters are tied\n",
+    "by a stoichiometric relation; the noise is heteroscedastic so the fit is\n",
+    "weighted. Once any of that is true, the textbook shortcut stops applying — and\n",
+    "the usual move is to apply it anyway and hope.\n",
+    "\n",
+    "POUNCE ends a fit holding the factorized KKT matrix of the problem it actually\n",
+    "solved. That factorization answers the influence question directly, for the\n",
+    "nonlinear, weighted, *constrained* fit, at the cost of one back-solve per data\n",
+    "point rather than one re-fit per data point. This notebook shows what that\n",
+    "buys, checks every claim against the ground truth — dropping a point and\n",
+    "re-fitting — and ends on the two cases where the classical answer is not merely\n",
+    "imprecise but inadmissible.\n",
+    "\n",
+    "It also serves as the worked acceptance test for\n",
+    "[pounce#922](https://github.com/jkitchin/pounce/issues/922), which is exactly\n",
+    "those two cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1105a491",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:43.087037Z",
+     "iopub.status.busy": "2026-09-07T00:40:43.086973Z",
+     "iopub.status.idle": "2026-09-07T00:40:43.893505Z",
+     "shell.execute_reply": "2026-09-07T00:40:43.892982Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pounce 0.11.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "%matplotlib inline\n",
+    "import os\n",
+    "os.environ[\"RUST_LOG\"] = \"error\"      # tol=1e-12 makes the solver chatty; quiet it\n",
+    "\n",
+    "import time\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import jax.numpy as jnp\n",
+    "import pounce\n",
+    "\n",
+    "print(\"pounce\", pounce.__version__)\n",
+    "OPT = dict(print_level=0, tol=1e-12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e654f4d",
+   "metadata": {},
+   "source": [
+    "## 1. The textbook object, and the one line that generalizes\n",
+    "\n",
+    "For a linear model the fit is $\\hat{\\beta} = (X^T X)^{-1} X^T y$, so the\n",
+    "influence of the data on the parameters is the pseudoinverse,\n",
+    "\n",
+    "$$\\frac{\\partial \\hat{\\beta}}{\\partial y} = X^{+}.$$\n",
+    "\n",
+    "The fitted values are $\\hat{y} = Hy$ with $H = X X^{+}$ the **hat matrix**;\n",
+    "$h_{ii}$ is the leverage of point $i$, and $\\operatorname{tr}(H)$ is the number\n",
+    "of parameters — the effective degrees of freedom the fit spends.\n",
+    "\n",
+    "The line worth noticing is\n",
+    "\n",
+    "$$H = X \\cdot \\frac{\\partial \\hat{\\beta}}{\\partial y},$$\n",
+    "\n",
+    "because it is written entirely in terms of the influence matrix. `curve_fit`\n",
+    "returns that matrix as `res.dpopt_ddata`, and the Jacobian $X$ generalizes to\n",
+    "the model Jacobian $J = \\partial f / \\partial p$ at the optimum. So the *whole*\n",
+    "construction — hat matrix, leverage, effective degrees of freedom — carries\n",
+    "over to fits where no closed form exists, provided the influence matrix is\n",
+    "right.\n",
+    "\n",
+    "Start by checking it against the case where the closed form does hold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3d2b9715",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:43.894898Z",
+     "iopub.status.busy": "2026-09-07T00:40:43.894776Z",
+     "iopub.status.idle": "2026-09-07T00:40:44.194839Z",
+     "shell.execute_reply": "2026-09-07T00:40:44.194294Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dpopt_ddata vs pinv(X) : 2.1510571102112408e-16\n",
+      "hat matrix agreement   : 2.1510571102112408e-16\n",
+      "trace(H)               : 2.0000000000   (n_params = 2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def linear(x, m, b):\n",
+    "    return m * x + b\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "xl = np.linspace(0.0, 10.0, 30)\n",
+    "yl = linear(xl, 2.0, -3.0) + rng.normal(0, 0.5, xl.size)\n",
+    "\n",
+    "rl = pounce.curve_fit(linear, xl, yl, p0=[1.0, 0.0], sensitivity=True, options=OPT)\n",
+    "X = np.column_stack([xl, np.ones_like(xl)])          # the design matrix\n",
+    "\n",
+    "print(\"dpopt_ddata vs pinv(X) :\", np.abs(rl.dpopt_ddata - np.linalg.pinv(X)).max())\n",
+    "\n",
+    "H_text = X @ np.linalg.pinv(X)                       # textbook hat matrix\n",
+    "H_sens = X @ rl.dpopt_ddata                          # built from the influence matrix\n",
+    "print(\"hat matrix agreement   :\", np.abs(H_sens - H_text).max())\n",
+    "print(\"trace(H)               :\", f\"{np.trace(H_sens):.10f}   (n_params = 2)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "257d73a7",
+   "metadata": {},
+   "source": [
+    "Exact agreement, to round-off. Nothing has been gained yet — this is the case\n",
+    "the textbook owns. The point is that the *construction* used no property of\n",
+    "linearity: it read `dpopt_ddata` and multiplied by a Jacobian. Everything below\n",
+    "reuses it unchanged."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89bf7a7d",
+   "metadata": {},
+   "source": [
+    "## 2. A nonlinear fit, with one point placed where it counts\n",
+    "\n",
+    "Exponential decay to an offset, $f(x) = a e^{-bx} + c$. The sampling is\n",
+    "deliberately lopsided: a dense cluster over $x \\in [1, 5]$, plus a **single\n",
+    "isolated point at $x = 0.15$**. That lone point is nearly the only evidence\n",
+    "about the early, fast part of the curve, so the fit has no choice but to\n",
+    "listen to it. Its noise draw is small, so it will look unremarkable in a plot\n",
+    "of residuals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9cfb7873",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:44.196217Z",
+     "iopub.status.busy": "2026-09-07T00:40:44.196128Z",
+     "iopub.status.idle": "2026-09-07T00:40:44.289873Z",
+     "shell.execute_reply": "2026-09-07T00:40:44.289480Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "curve_fit summary  (loss=sse, cov=reduced_hessian)\n",
+      "  status: Solve_Succeeded  |  n=25  params=3  dof=22\n",
+      "  SSE=0.0362537  RMSE=0.0380808  R^2=0.994674  adjR^2=0.994190  reduced-chi^2=0.0016479\n",
+      "  95% CIs (t_{22}=2.074):\n",
+      "             a = +3.03036 +/- 0.05345   [+2.91951, +3.14122]\n",
+      "             b = +1.1764 +/- 0.03242   [+1.10916, +1.24365]\n",
+      "             c = +0.470592 +/- 0.01321   [+0.443203, +0.497982]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def model(x, a, b, c):\n",
+    "    return a * jnp.exp(-b * x) + c\n",
+    "\n",
+    "def model_np(x, a, b, c):\n",
+    "    return a * np.exp(-b * x) + c\n",
+    "\n",
+    "A_TRUE, B_TRUE, C_TRUE = 3.0, 1.2, 0.5\n",
+    "rng = np.random.default_rng(7)\n",
+    "x = np.concatenate([[0.15], np.linspace(1.0, 5.0, 24)])\n",
+    "y = model_np(x, A_TRUE, B_TRUE, C_TRUE) + rng.normal(0, 0.05, x.size)\n",
+    "y[0] = model_np(x[0], A_TRUE, B_TRUE, C_TRUE) + 0.01     # small residual on purpose\n",
+    "P0 = [2.0, 1.0, 0.0]\n",
+    "\n",
+    "res = pounce.curve_fit(model, x, y, p0=P0, sensitivity=True, options=OPT)\n",
+    "print(res.summary())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "81c2b9a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:44.294872Z",
+     "iopub.status.busy": "2026-09-07T00:40:44.294738Z",
+     "iopub.status.idle": "2026-09-07T00:40:44.297663Z",
+     "shell.execute_reply": "2026-09-07T00:40:44.297281Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trace(H) = 3.00000000   (n_params = 3)\n",
+      "leverage of the isolated point x=0.15: 0.9730\n",
+      "mean leverage of the other 24 points     : 0.0845\n",
+      "|residual| there 0.0051 vs median |residual| 0.0354\n"
+     ]
+    }
+   ],
+   "source": [
+    "def jac_at(p, xs):\n",
+    "    \"\"\"dmodel/dp, the (m, n) model Jacobian at parameters p.\"\"\"\n",
+    "    a, b, _ = p\n",
+    "    return np.column_stack([np.exp(-b * xs), -a * xs * np.exp(-b * xs), np.ones_like(xs)])\n",
+    "\n",
+    "J = jac_at(res.popt, x)\n",
+    "Hhat = J @ res.dpopt_ddata               # generalized hat matrix\n",
+    "lev = np.diag(Hhat)                      # generalized leverage\n",
+    "resid = np.asarray(res.residuals)\n",
+    "\n",
+    "print(f\"trace(H) = {np.trace(Hhat):.8f}   (n_params = 3)\")\n",
+    "print(f\"leverage of the isolated point x={x[0]}: {lev[0]:.4f}\")\n",
+    "print(f\"mean leverage of the other {x.size-1} points     : {lev[1:].mean():.4f}\")\n",
+    "print(f\"|residual| there {abs(resid[0]):.4f} vs median |residual| {np.median(np.abs(resid)):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "994aaa23",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:44.298750Z",
+     "iopub.status.busy": "2026-09-07T00:40:44.298664Z",
+     "iopub.status.idle": "2026-09-07T00:40:44.477961Z",
+     "shell.execute_reply": "2026-09-07T00:40:44.476965Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEIAAAGGCAYAAAB/gyR8AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAjF5JREFUeJzt3Qd4U2UXwPGTLmjZu+w9ZIPsIVtABRFxICqoOFERxAEOhgP1c4uiggMRFUVRBBEFBQHZU0DZe+9CWzrzPectCWlpoW3S3oz/73nyJLm5N3mTjtx77jnntdntdrsAAAAAAAAEgCCrBwAAAAAAAJBbCIQAAAAAAICAQSAEAAAAAAAEDAIhAAAAAAAgYBAIAQAAAAAAAYNACAAAAAAACBgEQgAAAAAAQMAgEAIAAAAAAAIGgRAAAAAAABAwCIQAyHGdO3eWJk2a5MprTZ8+XerUqSOhoaFis9nk3Llzct1110ndunVz5fUBALlrwIABUq5cOauH4XO84XPr1auX1KpVS3zZ2bNnzf7Giy++mOOvFRISIk8//XS2t09ISJChQ4ean3tQUJB069ZN/Mmvv/5qfhaLFi0KqNdG9hAIAeAR3hBs2L9/v/Tt29dcoqOjxW63S968eb12vAAAwPslJiaag9xnn31WfNlHH30k7733nvzwww+SlJRkDt59zY8//mh+FkuXLrV6KPBxIVYPAAA8ZeHChRIXFye33HKLhIWFOZfPnDnT0nEBAOBtPv/8c6uHgGwEZNyxYMECqVGjhjRr1kz8kWa46EmwQHttZA8ZIQD8xpEjR8x1eHi41UMBAADwKseOHWMfCTiPQAgAt2mJyaxZs2Tjxo0mXVEvWsea1sGDB+X666+X/PnzS8mSJWXIkCHpnt3QzA6NrBcuXNiUtjRu3FimTp16yTFovevgwYPN7fLlyzvH4bi4lsFkdrwAAN+1bNkyUwZZtGhR811Sv359mTRpkvPxJ554wvST0u+mtMaMGWN6KOzevTvTz+fa80Kfs0+fPlKoUCFp3769eUx7Ozi+c/S5ixQpIldffbUsXrz4otefMGGC1KxZ07xOgwYNTAmDlmXotmm/NzMzrsz2CPnnn3/Me4iMjJR8+fJJw4YN5Z133pH4+PgMn+fTTz8149q+fbtz2ffff2+WXXXVVanW7d69u3k/6R2g33TTTVKgQAEpXry4PPTQQybDMy13fwZ6xv79998370sDAvpYz549ZdOmTRm+v23btpnfE/XSSy85f4b63GnNnTtXGjVqZMamP7/09l2yM4aMeoS49ie51GuvXLnSrDd//nxZtWqV8z1omYmKjY2VESNGSJUqVUxGbenSpeXuu+9O9bfh+lq//PKL2TfLkyePTJw4Ub755hvz2Jo1a2T06NFme31fd911l+nVlpycLKNGjZKyZctKRESE3HDDDXLixIlU723t2rWp9tv0s9Gf79tvv+3MtNDbuq1q2bKlc11HdlNGfTr0d/PWW2+VEiVKmDHr5zN27FhTHuTgeA86jtdee838begYOnTokKmfTXqvHRMTY/7PVK1a1TyXfr733nuv7Nu377LPh1xgBwAPuPbaa+116tRJ97FOnTrZ69ata7/xxhvtixcvtkdFRdm/+OILe1BQkP1///tfqnW///57e3BwsP2BBx6w79ixw37y5En7Bx98YA8NDbVPmDDhkmN466239JvSvnfv3suO7VLjBQD4jv79+9vLli2batns2bPN94Y+tm3bNvupU6fsn3zyiT1Pnjzmu0L9999/5jvjlVdeSbVtcnKyvXLlyvYuXbpk6fnU9ddfb69ataq9R48e9j/++MN+/Phx832XVkJCgn3r1q32O++8054/f3779u3bnY+99957dpvNZh8zZoz9yJEj5rvw1ltvNd9bOl7dNqvjysznFh0dbS9VqpT9hhtuMK8ZGxtr/+eff+xDhgyx//bbbxk+z549e8y49LvaQb/Dw8PDzdj0O1/FxcXZ8+XLZ3/88ccv+rxuvvlm+/z588263377rdlu5MiRWf6ZXu5nMGDAAPN5T5w40X7s2DH77t277bfddpu9UKFC5jkzop+5vsdnnnnmosfOnDljHtPPTcemn93Ro0ftd911l9nP0d8zV9kdg9L9o6eeeirbr92uXTv7lVdemWpZUlKSvXPnzvbChQubfbDTp0/blyxZYq9Ro4a9UqVK5vNzfS39XPv27WvGumXLFvvvv/9u//rrr81j+nv64Ycfmn033d8rVqyYfdCgQfYRI0bY33//ffuJEyfMcxcvXtx+++23X/K96mfz8ccfm5+v/k04TJ8+3byWPk9a+juijy1cuNC5TD9ffT1932vWrDFjmzRpkvn91Pfh4HgPOq533nnHvP6mTZvMvuIVV1xhPqdLSe+1Bw4caC9durRZFhMTY/5WPv30U/vw4cMv+VzIHQRCAORKIES/HFatWpVqeffu3e3Vq1d33tedJN0J0/XT0p0q/SJz3QFMi0AIAASetAf0esBSsWJFe4sWLUxQw9WwYcPsBQsWNAf9qk2bNuaAz9XcuXPNd8k333yT5efTg3Ddds6cOZkae2JiogkOvPjii87vwaJFi5qDTVfnzp2zR0ZGpgqEZGVcmfncVq5caZ5/1qxZ9qyqWbOmvVevXs77Goh48sknzYH7jBkzzLI///zTPP+vv/7qXM/xef3111+pnu+mm24yB5AOnvgZLFiwwCx3Pah2fOb63Pp5uBMIqVKlSqp9FA0o5M2b1/7EE094ZAyXCoRk5rUzCoToz0efQ4MOrjRo4PqeHa9VpkwZe3x8fKp1HUGEhx9+ONVy/R3QcaRdroGAkJCQS/5+ugaO9GRadgMh9913nwmg7dq1K9W6L7zwQqrncbyHhx56KNV6GhzS5fqzu5T0XrtatWr2O+6447LvEdagNAZArtA0SU2jdKUlKrt27TIpk2rFihVy+PBhkx6b3hS8mjqr5SwAAGREyzu0pEVLFzRVPe13SVRUlEnhV/fcc49s2bIlVTq7lnpo6YWWWGT1+ZSWJmjJS1paCvDYY4+ZNHlNz3eUZeosZ1p+odatW2fW69GjR6ptdf20z5nVcV2Opu1raYqWXnz33Xdy8uTJTG/bpUsX+fPPP03Zzs6dO00pgo5Lm3L+9ttvZp3ff//dvI+2bdum2lZfM+0y3T/Qsgwt2fDUz+Dnn38212lLWrQURF9fG4m6o2vXrqnKbAsWLGhKdXfs2JHjY8jMa2dk3rx55rp3796plmvpjv6uOh53LW9ylAqlpY+50hIlLY3R3w9XV1xxhfld2bNnT6rlWmbTvHlz8zvhWvbi+PvIDh3/lVdeKRUrVky13PEzSPv+rr322lT3HaXVmfks09IyMC0T01KbrVu3ZmP0yEkEQgDkWiAkLf2i1jnttYZSHTp0yFxrbbB+oQcHB5uL1lI7vrCOHz+eyyMHAPgSx3fJk08+edF3ifafcv0uufnmm8130SeffGLunzp1ykwtevvtt5uD9qw+nypTpky649IDLD0oGj9+vAn660kAzc7Wnhj6Xej6PNpHK620y7I6rsvRniVz5swxr9OvXz8pVqyYOYHx1ltvOceXET3QPX36tOnhoQEPDSTpwacu1/tKr1u3bm16RGRm/0Dpc3rqZ+B4Du394HgO3V4vX375pdv7Fxm9D/2dyukxZOa1M6KvqWPRn3da2itGT0K50j4fmR2HBjQutdx1fNr/47777jMnw/7991/zO6d/Hw8//PBlf/8u9/70faTlWJb2/aUdq+N3MTOfZXrTFd9xxx0mEKKz9ejv5f3330+PEC9BIARArkh7Bic9ujOovvjiC3OmQJtY6cWxs6iXjh075sJoAQC+yvFd8sEHH2T4XaLNKZUelGsTRc2AOHPmjHz11VfmDLZmimTn+VR6Z8s162Tp0qUyfPhwk6mgzcD1e1EbULoeiDkORh2zoLlKuyyr48oMbUCpTTf1oE/PlDdp0kSGDh1qGmBeijaU1INpzf7QgEenTp3Mwb2+182bN5sGlNqkM21mQFb3D9z5Gehz6Jg008XxHLq94zk0q8QdmX0fOTGGzLx2RjRopWNJ27xUacDO8dk7ZJQNcqlxZGZ8uu/Xpk0bGTZsmDNQpDTDyB36/vR9pOVYlvb9ufNZpqV/zx9++KH5292wYYM8/vjjMm3aNPP3wlS71iMQAsAjtLt8eh3es0LTIbWj97fffiu+MF4AgPfRlH49kMrsd8nAgQNNeYrOsqGZIXrwr7NVZPf5LsWRZeJ68Jc2lV4P3HRmM1c6a4sjsyInxpWWBoj0YO3jjz82M2z89ddfl1xfz/Drd7jOnPHHH384Ax66TM+oa7mNHuynFwjJDE+8Vy030jFo0Cur9KBcf3bu7je4M4acokErNX369FTLtUxLS5wcj+eGtH8fWh6lgbm0+28qsz8LHb/OmrN3795UyzU7y/F4TtPgV506dUwg5JFHHjGlPunNVoXcRSAEgEdoDaXWeupZH0fPj6zSml6NnOu0bJoe+d9//5kzc1qXqSmj6dVcWzleAID30XIDPYDXvh+alq69pbTXhPak0iky27Vrl2r9pk2bmsCHTpm7evXqVNkg2Xm+9FSrVk1q164tr7/+uul3oSUfmn3y008/pUrF114Rmn0xY8YMefnll022iL6OTmWats+WJ8blSr97+/fvb4Iemh2gwSE9e61n5DUocjka5Fi+fLnZ1vF9rQEE3VZLbvTsuE7vmh2eeK+aUarTuWqfFp2+dv/+/eY9rl+/Xl544QUzfeyl6IHswoULLyqlyAp3x5ATdDpi/Rlp2ZFOp6tZKVripJlS2mdkyJAhuTIOzejRPjNff/21+Uz0b1HLorUHTNr+Ivr7MHv2bLOPeDnPPPOMCdTpc2lwR//2dJ9Sp0LW0rgWLVrk2HvS30t9P9rfRgM3+revf/PaOyW9ch3kLgIhADxi8ODBpv65ffv25gvKtWlXVmizrsWLF5sdjauuusrMQ69NwDRFV2ssvW28AADvo00btRRFDz704FNLUfTM78yZM00wIi0NfugZ4/DwcOnbt6/bz5feGWENbmjzSW2KWblyZXMgpwdJ+pgr7YmgJwU+++wz049BDxC1Z4fjAND1+8rdcaUNZOhl5MiRUr16ddPPQIMx+jy6LDPbK93WtTGlY7mOL+17zQpPvFfN+NFeFHog7DgY1eCPnhC53AG/Bi60hEQzU7R8Im3D08xyZww5QX8m+hnee++95vW1VER/5zSb5++//063d0hO0CCQlsVoQEazgwcNGiSvvvqq+Yxc6eevn59mcOXPn9/ZUDUj+ruovzeVKlUyvy/63Br01DK1KVOm5Oh70t9LDTDqvqb+vurn2qpVK7NP687fAjzDplPHeOi5AAAAAOQADdBotoZmEQAA3EMoCgAAAPBi2lRVG5FmtdwFAJA+AiEAAACAl9CpQx999FHTT0Cnl9e+BjfccIO5ren8AAD3EQgBAAAAvITO0qIX7Ruh/Qw0C0SnLNWymHr16lk9PADwC/QIAQAAAAAAAYOMEAAAAAAAEDAIhAAAAAAAgIBxYSLyAKFzdB84cEAKFChg5p0GAACep5W3Z86ckTJlykhQUGCfd2HfAwAA79r3CLhAiO6IlC9f3uphAAAQEPbu3SvlypWTQMa+BwAA3rXvEXCBED0b4/hwChYsaPVwAADwS1FRUebg3/G9603OnTsn69evl9KlS2c6QKFnmLZv3y6RkZHmkhXsewAA4F37HgEXCHGkpOqOCDsjAADkLG8qBTl69Ki89tpr8tVXX8mJEydk8ODB8sorr1x2u7fffltGjBhhzi7t2bNH+vTpI5999pmZ0jQz2PcAAMC79j0Cu2gXAAAEjJ07d0qJEiVk3bp1UrVq1Uxts3DhQhk6dKh8//33smXLFvnvv//kt99+k1dffTXHxwsAAHIGgRAAABAQmjVrJk8++aQUL14809t88skn0rRpU+nevbu5X6lSJbnzzjvNcgAA4JsIhAAAAGRg9erVJhDiqnnz5rJr1y45efKkZeMCAADZF3A9QgAAqSUlJUlCQoLVw4APCgsL8/upcbWXSNGiRVMtK1asmPOxIkWKXLRNXFycubg2bwPgn/gOBXKP9uYKDg72yHMRCAGAAJ5r/dChQ3Lq1CmrhwIfpUGQypUrm4CIP+90uQY1VGxsrPOx9IwdO1ZGjx6dK+MDYA2+QwFrFC5c2Mze5m4zdgIhABCgHDtwJUuWlIiICK+a3QPeLzk5WQ4cOCAHDx6UChUq+O3vT8WKFc37dKX3NQii0++mZ/jw4abBatrp/AD4D75DgdwPPsbExMiRI0fM/Yy+g30mEKKd2//55x8T2Wnbtq0UKlQow3UTExNl4sSJFy3v0KGD1KxZM4dHCgD+lcrr2IFzpPkDWaUzsGhQQL+fMzuVrLfTchedHaZx48Ym06VTp04ybtw4iY+Pd2a+/PTTT3LVVVdl+J7z5MljLjkpKdkuy3eekCNnzknJAnmlWeWiEhzEgRiQG/gOBawRHh5urjUYon9/7pTJWBYIOXr0qPTp08dEdWrXri3btm2Tfv36yZdffik9evRId5tz587Jgw8+KDfccIN54w4NGjTIxZEDgO9z1DPrWSwguxyBAT0o8IVAiP7er1q1ylneokGcpUuXSoECBaROnTpm+R9//CE33XST7N27V8qVKyeDBg2Sjz/+2Cx74IEHZP78+Wb6XL22yq8bDsronzfJwdPnnMtKF8orI3vUlm513TtDBuDy+A4FrOP4u9O/Q58MhOjZozfffFOuvPJK5zLdwRg8eHCGgRAHnfquRYsWuTBKAPBvpPIikH5/zpw5I4899pgzm0UzP/R+3bp1nRmnenZXZ4VxZHRoo9S///7b9P145ZVXTCquBkFatWplWRDkwS9Xiz3N8kOnz5nl429vTDAEyCW+9j8Q8Ac2D/3dWRYI0R2JtHU9el/PKl3OX3/9JZs3b5aqVatKy5YtPdY51h17jsfIxgOnpXs9dj4AIKfpd8Xu3bvNWX09k79x40bTyyF//vxWDw1eTIMamgFyKVpum3Yd7e/xwQcfiNW0HEYzQdIGQZQu011DfbxL7UjKZAAgTWWBViBcccUVXnHsCOtZ3iNk5syZsmfPHnNWRm9/9NFHl1xff3F/+eUXEzRZuHChFC9eXKZPn2661qcnN6awG/DZcpm/+ajoPsea566WQhHenx4MAL5Kvy+6dOlizghof6m1a9eaEkn9DunWrZtZ57///jPfE5fqOwX4Gu0J4loOk14wRB/X9VpWpW8BADjofkGjRo1MewY9fkTu2bRpk1SpUkXy5s0r3iTI6gFs377d1OsuWbLE1Pvky5fvkrXIepZGU1K//vprkxWiywYOHJjhNprKqjvCjktOdG2vUjzlDGSyXWTJjuMef34AwAXauLJ+/fqya9cuEwRRWtqgfR4c2rRpI7Nnz7ZwlIDnaWNUT64HAEBOH+tr8/HMVH0EXCBEe4J88sknsmzZMtMbpFevXhIdHZ3uuhr0aNKkifO+Bk0eeeQRWbBggUl3ymgKu9OnTzsv2vzM09pUv3DWZdG2ox5/fgBACg2A65kFDXps2LDBedFG247G2Vu3bjVfuPv27TOP/fvvv1YPG/AInR3Gk+sBCCzao9Hxvanfp2mPn3RadH3s7NmzF22rJah6LOVKS1R1GuG0dDIMfR6d7lSfS7Mx9Pjucq/vStffuXOn+T7XWbt0G90+rYzGkBXpPYc/fxauY0pMTDQnlvR5M8t1e21YumPHjlQVGK5+/vlnad++vTluT287LXF2rdzQZbkVNLE8EOJKZ4PRaeu0fiuzNMVGP6yMSl602VnBggVTXTyteeViEnK+FnfxNjJCACCn6Awey5cvlzlz5sitt97qvNSrV08WLVpk1nn88cdNU8x33nnHPHbPPfdYPWzAI3SKXJ0dJqPuH7pcH9f1ACAtPXh3fG/qCWgtL9XvSMcsOEFBQXLzzTfL22+/nWq7FStWmMzLY8eOmftz5841pQ46eUXDhg2lZs2a5qS2w+rVq8338tNPP22y8W+88UZzEuNyr+/w7rvvmvKVtm3bmmudKEOfz/Ug/3JjyIxLPYc/fxaOMY0YMcKUEet08NpD67vvvsvU5+bY/oknnjCNx7V5eGRkpPzwww8Xratly9ddd12q7XRfrmzZsiZ7V7f78ccfTXKE9v9s3bq1VKhQwZnx65eBEI08aaTNle7E6vR7jvIVjUx9+OGHJkqW0TZfffWV+dBcp9PNbfnyhEjjCkXM7Z3HomXfyRjLxgIA/ky/7Dt27Ch9+/ZNlRHi2vhsxowZZofif//7n3lMZ/wA/IE2QNUpclXaYIjjvj5Oo1TAOnr8ktEl7Vn8S62b9oA4vXWySmfFcnxvar8tPfu+ePHiVM2g+/XrJ1OmTEm1nd7XCSr0mEtPWPfu3VveeOMNOXjwoDkgv++++8yytNkTmqGp62gGRdOmTTP1+vrYkCFD5IsvvjCZnfp6f/75Z6rnzcoYMpKZ5/D3z2LPnj2yf/9+c/3MM8/I/ffff9Hv3aVoYEO319fU7e+8807Tg8VBT0ppT09HIMRBx6Xb6RT2Os4+ffqYbBEdvy7TAIkGjvy2Wap+KO+995507tzZRLc06jNt2jR59dVXTURK6Qfy4IMPymeffWYiW7ozq1G0rl27mp1cbZq6fv36TEevclLrasVl+a4T5vbf247LzU2ZVxyA7+nx3iI5eib99MacVKJAHvn5kTa5/rqAr9GpcXWK3JEzNsrhqAt/q5GF8pogCFPnAtbS/oQZqV69utx2223O+6+//nqGB546E9qAAQOc9zXLUY+NXI0cOTJbY9QyDD0Q1bIEPbmgJxn0jLzS8T333HPmINfR2+Gbb76R559/3jyuE1vobG06+4qWnmqZgx6bPfvssyZjU5/PYcyYMek2yLzU6+txX7NmzeSmm24y9zVgoJkLmjnhkJUxZCQzz+Hvn8ULL7xgWk84fu763BoU0SBPZuj2jv6eQ4cONb+jmqTgGL9m7+rvfKVKlVJtN3r0aJP84KgI+fzzz83nExKSEpq4/vrrzfP5bSDkjjvukObNm8tPP/1kfvjaxXfUqFEmrce1rEUjUxoEcfyANIKms8RotOmWW24xKTiOwImVtE/IW3NTbi/adkxubur5pqwAkNM0CHIoikaLgDfTYIeegKk36jdz//O7mkrb6iXIBAFwSdrH4d5775WpU6dKqVKlTMuA48ePm/IIB52JU0sdtPeWHvzrgbm2LtDjLqUH25qtr2fxXenBc9oMhLSzembm9bW5Zu3aKZlvDnqQ7yorY8hIZp7D3z+LMmXKOG87AhqaxZFZrmPTUiIdm2uLC9eyGFeu71EnS0lvWWZ/jj47fW6NGjVMbVFGwsPDTWmMK40qaW2Ut2lQrrDkzxMiZ+MSZfG2Y5KcbJcgdkgA+BjNzAik1wV8lWvQQ3uCEAQBvINO1JARPVh0NWzYsAzX1SniXTnOsrtDs/E1w14bbzoOgjW7QUtKXWlJiJ7t14wVLQXRqek1G0FpBoGWLqTdJj2uZauZfX09CHZtoKnS3s/KGDKS2ecIhM8iu3QsRYqktIdQmrHkCKhoOwudve/7778Xb2VpIMSfhAQHSYsqxWTuv4fleHS8/HfojNQu4/nGrACQk/ylPEXTT7NS5woAgCc4Sg2sXDcjOmOJNtR0zQSYN2/eRetpk1ANvOgZfc3E1xk+HfSgW7P4jxw5kqpHo5aNaPAmbbAnq6+vzT7HjRtn+qk4SiV0hlBX7owhq88RCJ9Fdmm/Eg0UqZMnT5pWFzqjq9KyHB239lPxVl41a4yva1PtwjS6mhUCALCGpmdq6eWaNWuYPhcAAO1p2Lq1mc5UyzG0MefAgQPNAWtamvGgmQ8PPfSQOZDu2bOn8zFtW6A9H7p06WICA0uXLpUJEyaYNgcZzeKZldfX59e+Gdp4UyfS0MCD9pB0zZJxZwxZfR+B8Flkl1ZpaM+U+fPnmz4mOtuL9vNUGjjq3r37RZkw3oSMEA9qU72487b2Cbn3qgv9TgAAnqEN5LSe1pVOZVegQIFU081pEzmdik6zQ5g5BgAQ6LT5qp651ywDzZrUKVm15EMnsUhL+1domY+e8Xdt8qmlD3pQ/tZbb5mLPo9mLujkFTqZhWMdbeCZNhshM69fqFAhc2CtZSLaMLNWrVpmJhVtEKptEzI7hrR0Wx2TI7MiK8/hb59FemMKCQkxyxzPmxkaBHn//fdNLxPddtKkSc7PVwMhaWd+Se918+fPb5a50n4paXuj5ASbXVvLBhCNjOkvlc7drB+yJ+lH2XLsH6bRYHhosKwd2UXyhHhvFAxA4NIzDFqXqs270utiDrj7e5ST37e+Jic+i5j4RKn9/Bxze9OYrhIRxrktILfwHZqzXEtBlB5sa58OnaY10HjjZ7Fo0SITuNEeIen9/utUv/q3oZObZBSM8YZ9D741PUhTlLSL+/er90lsQpKs2XPK9A0BAAAAAFyeZktoqYdmQKxatUqeeeYZeeqppyQQWfFZ7Nu3T06dOpXuY5kJbKxcudLMrJMTQRBPIhCSA9PoaiBELdp6jEAIAAAAAGSSZjy8/PLLMn78eFMKq+Ugt912mwQiKz6L999/3/QvSU+PHj1MA9n0yn0cevXqZS7ejkCIh7WumrpPyLCuNS0dDwAAAAD4Ci150IafsOazGDt2rLlcyoYNG8TXMWuMh5UsmFdqlkpp2Ld+3yk5Hcv0jQAAAAAAeAsCITlA+4SoZLvI0h3HrR4OAAAAAAA4j0BIDvUJcfhry1FLxwIAAADA8wJs8k3Ar/7uCITkgOaVi0lYcMpHu2DLUf5JAgAAAH4iNDTUXMfExFg9FCDgxJz/u3P8HWYXzVJzQL48IdK0chFZvO247DsZKzuORUvVEvmtHhYAAAAANwUHB5upQY8cOWLuR0REiM1ms3pYgF+z2+0mCKJ/d/r3p3+H7iAQkkPa1yhpAiFq/uajBEIAAAAAPxEZGWmuHcEQALlDgyCOvz93EAjJIe1qlpCXfvnXWR5zT5vKVg8JAPxW27Zt5aGHHpK+fftaPRQAQADQDJDSpUtLyZIlJSGBWSKB3KDlMO5mgjgQCMkh1UvmlzKF8sqB0+fMzDGx8UkSHuaZHxoAILWDBw9KdHR0lrapX7++vPjii9KzZ88cGxcAwL/pQZmnDswA5B6apeZglFizQlR8YjLT6ALwX8e3i8wdJTLt7pRrve8DDhw4QKM7AACAAEQgJAe1q1HSeVvLYwDA76z5UmRcE5HF74psnJ5yrffXTMmxlzx58qQMHDhQqlevLu3bt5fJkydftE7Xrl2lXLlyUr58eWnevLmMHj1a4uLinI/rdvo8gwYNMuvVqVMnU9sBAADA91Eak4NaVysmIUE2SUy2y/zN2kgpZUcbAPyCZn7MeETEnnzxYzMeFqnQQqRYVY+/bL9+/Uxzui+++MLc12DGzp07U62jwZH4+HhJTk6Wbdu2yZAhQ+TEiRPyzjvvmMenTp0qV1xxhbzwwgumNCYoKChT2wEAAMD3kRGSgwrkDZUrKxYxt3cdj5Fdx7JWvw4AXm2NZmJkNF2g7fzjnrV27VqZPXu2CVi0bNnSXDQgooELV9q8TjM7KlSoIB07dpS33npLPvvsM+fjpUqVMsGPokWLmvXKlCmTqe0AAADg+8gIyWHaJ2TZzhPO8phKxfNZPSQA8IxTe3RW9wwetJ9/3LPWrVtngheazeFQt25dKVIkJejssHLlSnnttddk06ZNcvr0adPR/8yZM6YcJu26ntgOAAAAvoOMkBzW3qVPSEp5DAD4icIVLp0RYh73LO3XERYWdtFy12XaBFWzOapUqWKyRRYtWuTM6rhUv4/sbgcAAADfQiAkh11RuoCULJDH3F6y47icS0iyekgA4BmN7rh0Roh53LO0Qar2B9GLw6FDh1LdX7p0qZln/pVXXpHGjRtLxYoV5fDhwxc9l053aLfbs7wdAAAAfBuBkNyYRrdGyjS65xKSZfn5MhkA8HnaCLXnOBFbkIgtOPW1Ls+BRqnt2rWTWrVqyWOPPSbnzp0zl8GDB6cKaGiPj1OnTsmSJUvMfS1zGTVq1EXPVbZsWdm8eXOWtwMAAIBvIxCSC7RPiMP8zUyjC8CPNOon8vBKkdaPitS5IeVa7+vyHKANTr/55hvTK6Rw4cJSunRpKVasmGlu6tCsWTN56qmnzBS52k9Egye9e/e+6LlGjBghb7/9tmmcqtPnZnY7AAAA+Dab3fU0WgCIioqSQoUKmSZ4BQsWzJXXPB2TII1e+E2S7SJViueTP4a1z5XXBYCMaCaFTjlbuXJlyZs3r/ii48ePmwamGhzR8hj9nx4REeF8XBudaoZH8eLFJSkpyayjs8M4pspV+hV49OhRSUxMdM4ck5ntcPnfIyu+b71VTnwWMfGJUvv5Oeb2pjFdJSKM/vcAgMAWlYXvW/bqckGhiAvT6O44Fi07mUYXANymmSCO4ERkZGSqIIjSfh8lSpQwJYohISGm9CVtMEMf0ylzHUGQzG4HAAAA38WeXS7pdEUp5+15/9J8DwAAAAAAKxAIySWdr7gwje5cAiEAAAAAAFiCgtJcUrVEfqlYLEL2HzkjofOXycGoLRIWHy9B+cIlrHoFiejcUmxhoVYPEwAAAAAAv0YgJJckHT4uQzYtlbLzFkjR2GiJ+V0kxuXx4JJFpeDtPaTgXb0kJLK4hSMFAAAAAMB/URqTC2IXrZa9re+QejN/MUGQ9CQdOSEn35xk1tP1AQAAAACA5xEIyWEa1DhwyzBJjjpr7icGBcmCSjXl9atvkBJTX5dSH4+SfD3aiwQHm8d1PV2fYAgAAAAAAJ5HaUwOSjx0TA71f0YkPsHcj+jcQt5pd618syslK+SOilWlVdXikv+GTmbdo0NelZi5S836hwY8I+UXTaZMBoBXs8cnSMzcJRK/dY8kR8fS9wgAAABez/JAyNmzZ+W///6TwoULS9WqVcVms112m7i4OFm/fr3kzZtX6tatm6ltrBD12Y/OTBANgkROHistNxyWpbtny83BC6TgrM9EatcVaXSHhERWNY8fumO4CYYknz4rUZ//KEWfHmj12wCAi2jwVv/HRU3+WZKOnrjocfoeAQAAwFtZVhoTFRUl999/v1SuXFkGDRokbdq0kSuuuEJWr750Sci8efOkXLly0rdvX+ncubMJhOzcuVO88SypHiAYwcFS4q2nxBYSIl3i5sq8sGFyX/BMueLEXLEvfldkXBORNVPM4yXefNJZJqPb6/MAgDf2PdK+RukFQXK679Hjjz8uS5cu9drny6oRI0bIokWLcvx1rH6fAAAAEuiBkOPHj0u7du3k0KFDsmzZMtm3b5/Url1bBgwYkOE2p0+flptvvlnuu+8+2bZtm+zfv19Kly4td9xxh3gbTRV3HCDku6ZtyhnR49sl4tfHJNhmlxBbsgSLXWz2JBF7ssiMh83jIaVLSL7ubZwHEvo8AOCtfY8kJNj0OdJ+R6W/ezNX+h5NmTLFfAdY+XxDhgyRFStWeOT1v/32W5MZmdOsfp8AAAAS6IEQzQS57bbbJPj8znJISIi0bNnSBEYy8tNPP8mZM2fkiSeecG7z1FNPyeLFi2Xr1q3iTbRe3iG/HhSoNZNFJKMyHtv5x0Xy9+xw4Xm27c3ZgQKAG32PKq6ZJpGfvmB6HUW0b2qu9X7FtdPM48b5vke6vSe8+eab5vvCSpMnT5bt27eLL8nO5+aL7xMAAMDre4SsW7fOZIds2bJF3n77bXnppZcyXHfNmjWmj4j2E3G48sornY9Vr1493X4ienEtyckN2jTQIahIwZQbpzQ4Ys9gC/v5x0WCChe48DxnY3J2oADgRt8jLelLj2bB5VTfo1WrVkmVKlXM94HS7EA9YD9w4IDUrFlT+vfvL/nz53euP3fuXJk9e7YkJiZK+/btpVevXpfsLTVmzBjZs2ePWadMmTLSrVu3VAGE5557zvS3+vjjj81zR0REyLvvvmseW7t2rUybNs08rqWbd955p4SFhaV6fn18wYIFUrZsWbnpppsu+34ffvhhueuuu+Tff/815aNFihQxmZGlSpVKtd7l3mfaz02f9+677zbfvytXrpRChQqZ+zquy71PX2e3282+h77n0NDQTG9z4sQJs42eiAEAAL7L8ulzv/jiC7OzpZdatWpJx44dM1z35MmTUrRo0VTLdIcwKCjIPJaesWPHmp0Wx6V8+fKSG3TmBIfkk+eDL4UrXDojxDwuknzqzIXnyR+RswMFADf6Hl1KTvU9ci3x0CBI/fr15Z9//pEaNWqY7MC2bds6133xxRdNQCBPnjxSvHhxE0DQy6XUq1dPWrRoIU2bNpXY2Fjp3r27fPbZZ87HGzRoYA6eNfjuWE9NmDDB9K7SQIRmPeo49XHXYPwzzzwj99xzj/ku0+fWgMXhw4cvOZ7PP/9cevToIVOnTjU9srRXlp4EOHbsWJbeZ9rSGH3e66+/XmbMmGG+GzW7skmTJs4TBhm9T1+nn6OW1VaqVMmcWHn66adNkCMj+vN89NFHpUCBAuZ3LF++fHLttdeawBsAAPBRdi8RFxdnv+OOO+yVKlUyt9Nz77332hs1apRq2blz53Tvxf7pp5+mu40+fvr0aedl7969Zn29nZPOzlpg31a8jbkcvOvZlIXHttntowrb7SMLprok67Uu18ftdvvBAc84t9XnAQBPi42NtW/atMlcZ/t/WiZ5+n9aqVKl7JMnTza3v/zyS/O94Ur/zzuu8+TJY//uu++cjy1ZssR8Byxfvjzd50uPPla+fPlUy4oVK2b/+uuvnfcPHTpkXuvvv/92LktISLBfccUV9nHjxjnHExYWZp85c6ZznZ9++smMZ8KECRm+fr58+ewdOnS46HmffPJJt96nPu/dd9+d6vuycOHC9q+++irD95mV3yP9ns2N79usWLNmjT04ONh83snJyfZly5bZCxQoYH/vvfcy3ObNN98066xbt87cP3LkiNkX6dmzZ6ZfNyc+i+i4BHvFp2aai94GACDQnc7C963lGSEOmjqsabq7du2SzZs3p7tOxYoVLzoDo01WHY+lR8+OFSxYMNUlN0R0binBJVKyV6J/WZhSG1+sqkjPcSK2ILHbgiXJbpNEe5DYNTFHlxerKokHj0r07EXO6Sf1eQDAK/seZVJO9j3S2cY0K0T7X+i10qwJ5ZghpXfv3s71NbNBS0P++uuvDJ9TMzU+/fRTGTZsmNx7773yww8/yN69eyU6OjrDbbR0JCkpSSZNmiQPPPCAmRXtoYcekvj4eFMuo5YsWWJKKq655hrndprpER5+IYMwI3369HHe1ue48cYbTXmNO+9TaQaL6/elZkk4vlf90Ycffmgasw8cONCUDTVr1sw0XH///fcz3EazjHQbzTxSJUqUkC5duni0YS8AAMhdlgVCtOlpWhoA0R0TTet1pKPOnz/f2UBVdzw0hVhnmXH48ccfTS247vR5E1tYqBS8o0fKnaQkOTrkVbEnJoo06ify8EqRVo/K3KBW8nHSdXJ14psSXfsW8/jRoa+Z9ZVur88DAFZLt+9RJuVk36PGjRub74E//vjDBEW0xHL8+PHmsSNHjjjLJ13pd0xG5SgxMTGmBOSjjz4y5StaKuI4AE7ve8tBy1Q0oKHr60WfQw+ytexCG4M7xqPP6dq3Q28XK1bssu8z7Tr6HvT5svs+HdIGYbSBuQZ0/NXy5culdevWqZZpKZXO2pNRDzHtz6J9VD755BMT/JgzZ4589dVXMnjw4FwaNQAA8DTLun3pDoWeHdM6W91Z0zNm//vf/+TBBx80tbtKm7R16NDB1GbrtLq6U6lnxXSnUpvZadOy559/3tzWJm7epuBdveT0xO9Nc0FtFqhNA7WuPiSyqti6jJJF0Rtk8tLdZt1FizdL/Qmfm/VUUKH8UnBAL4vfAQBcou9RJuV03yPNsNCLBs81KKLTrGufD+17cfToUZPh4Tjg114Q2gi1QoWUnkxpaQaFZibq94ujyenMmTMvWi9ts1VtMKqBEu25oRkD6dHxaNBCe4Zo9oXS25cLVijNSHG1e/duZ8+r7LzPzLpUU1lfpJ+T42SLg+O+BrPSyxrVoNbIkSPN/omeeDl9+rTcfvvtpilvRqxq1A4AALw8I+Sxxx4zOxGa2qspqbpT980336RKT9X033bt2klkZGSqZm+abqxnY/7880+Tvvz444+LNzKzJkx6SeR8VocGOXY37COH7npWzk6fJz2jD0n7Hf/KyHnTpUrfh5xBEF0/ctLLZnsA8AZh1S8cUJ/9eX6Wtj07488Lz1PNsw2rtSxED/gd3xk6w4sGGXRGEP3+0EyJd955x7m+fndokOO6665L9/k0gJCcnOwsg9HSFi27SUszO/R5HLp27WoOqHVKd9eMCs10XL9+vbmtjVH1QFrLMxzGjRsnCQkJmTp5oCcHlAZT9LvwhhtuMPez8z4zK+379HWaNaMBM1eOz1+zYdKjP3894aLZJPpZHDx40Pxcb7311gxfx6pG7QAAIHMsnf/NcRYvI7rDqKUxrvQMnQY+vDX4kVZ4m8ZSZurrcmjAM2b6SC17iZ65wFy0g8hzadbXTBANgoS3bmTRiAEg475HSUdPOPseZSZYm9N9jzTocPXVV5uAufYG0UxDLZXUwETevHnN1K969v7333832RI648rrr79uemGkp1OnTiabREtudMrcFStWXDRbmdIZWvTgWEs19UBXp5XVbBSdDrdOnTrSqFEjk8WhmQAalFCabaDBCp01Rqe51aCL9r3KTGmMZpnoLC46W8yiRYvM7CXai8TxvFl9n5mV3vv0Zfo74ii3ddCMHA2CpJ2O2HV2Ow16NGzY0NwvWbKk2QfRzKNTp06ZmWfSGj58uAwdOtR5X38PCIYAAOA9LA2EBAoNhpRfNFmiPv/RTB+ZdOTis2vHw/NJ8M3dpcGwfmSCAPA6jr5HJ9+c5Ox7FDl57CWn0M2pvkd6hr558+bmtvZ7WLdunQmAaFBBpznVMkoHzZrYuXOnyT7UTIAPPvjgonIR1+fTYLtOI6uBBM28GDJkiFSrVk2+//57EwhwePXVV00ZjPaMcJSP6Fh27Nhhymt0W21WqmNxzTTQYEWrVq3MeMuUKWOCLT///LOzD0lG9KBaG3ZqGak2+tSAjevzZvV9Ks3A1ICNK53KXqf+vdT79GVXXXWVyabRIJTj/fz666/m56SBM6UlRppRpGW6+hnrSZm0/WE0sKGPZdToVrOSHOVPAADA+9h06hgJILrzojuzWuObWzPIuLLHJ0jM3CVm5gRtGrgjJkne3hYrSytUlRubVZTX+jTI9TEBCDznzp0zB8560Os4ALwczQLZ2/oO0/dIRXRucb7vUfF019VgiWvfIw0IE+jNOj0Q//LLL012hi/9Hln9fZseDZbVrVvX9Bt75JFHTNapBrtmzJjhzFCdNm2ayezRjB7NINFsG53V7r333jN9y3QWGc3GcQRVMiMnPouY+ESp/fwcc3vTmK4SEca5LQBAYIvKwvct35q5TM+G5rvmKsl3/n6+hCRZ88LvkhSfJL9vOiyJSckSEuw1sxoDwEV9jw7cMkzEBHVT+h7l697GTJGrs8NoY1TtCWLKYRy9Muh7BC+hWTga/Hj22WdNYEmzPr799ttUZbrafF2b32rPGXXfffdJvnz5TE8yLTfSXjC6zFdKdAEAwMUIhFgsb2iwdKhZUmb9c1BOxiTI8l0npFVVDhYA+F7fo/TQ98h96ZWwIPu0DEkzQDKiQZF9+/alWtavXz9zAQAA/oHUAy/Qte6FWXHmbEjdxA0AvLXvUZHH+5sGqOnR5fq4rkcQxD06w1rFihWtHgYAAIDfICPEC3SoWULCgoMkPilZ5mw8LCN71JGgIN9vSgfAf2mZS9GnB0qRof1T9T0Kyh9hpsiN6NJKbKF8xQAAAMD7sJfqBQrkDZU21YvLH/8dkUNR52TdvlPSqEIRq4cFAFnuewQAAAB4O0pjvES3OhfKY2ZTHgMglyQnJ1s9BPiwAJt4DgAA+AkyQrxEl9qlJHi6TZKS7TJr/UEZ3r2W2GyUxwDIGWFhYRIUFGSmEy1RooS5z/8cZDUIcvToUfN7ExoaavVwAAAAMo1AiJcoki9MWlcrLn9tOSr7T8XKmr2npDHlMQByiAZBKleuLAcPHjTBECA7NAhSrlw5CQ4OtnooAAAAmUYgxIv0qF/aBELUz+sOEAgBkKM0C6RChQqSmJgoSUlJVg8HPkgzQQiCAAAAX0MgxItcXSdSnpm+wcwe88s/B+W5a2szewyAHOUoa6C0AQAAAIGCZqlepFB4qFxVo7i5fTgqTlbsOmH1kAAAAAAA8CsEQrzMdfXLOG/PXH/Q0rEAAAAAAOBvCIR4mc61S0mekJQfi5bHJCYxtSUAAAAAAJ5CIMTL5M8TIh1rlTS3j0fHy9IdlMcAAAAAAOApBEK8vjyGaS0BAAAAAPAUAiFeSDNCIsJSpiP8deMhSaA8BgAAAAAAjyAQ4oXCw4Kl0xWlzO1TMQmyaNsxq4cEAAAAAIBfIBDipXrUL+28/fM6ymMAAAAAAPAEAiFeql3NElIgT4i5/dvGw3IuIcnqIQEAAAAA4PMIhHipPCHB0q1upLl9Ni5Rft902OohAQAAAADg8wiEeLEbGpV13p6+Zr+lYwEAAAAAwB8QCPFiLaoUk9KF8prbC7YcleNn46weEgAAAAAAPo1AiBcLCrLJ9Q1TskKSku00TQUAAAAAwE0EQrxc78aUxwAAAAAA4CkEQrxcjVIFpHbpgub2un2nZfvRs1YPCQAAAAAAn0UgxMeyQn4kKwQAAAAAgGwjEOIDejYoI0G2C+Uxycl2q4cEAAAAAIBPIhDiA0oWzCttqpcwt/edjJVVe05aPSQAAAAAAHwSgRAfcUOjMs7bP6ymPAYAAAAAgOwgEOIjutaJlIiwYHN71voDci4hyeohAQAAAADgcwiE+IiIsBDpVifS3I46lyjz/j1i9ZAAAAAAAPA5XhEIOXPmTKbWs9vtcujQoYsusbGxEghuvLKc8/bUlXstHQsAAAAAAL7IskCIBjAee+wxKVGihJQpU0YKFy4sTzzxhCQkJGS4TXR0tJQuXVrq1KkjDRs2dF5mzJghgaBllWJSvmi4ub1w61E5cCowAkAAAAAAAPh8IGTOnDlSuXJl+e+//0xGyPz582XSpEny3HPPXXbbWbNmpcoIueWWWyQQBAXZ5KYry5vbdrvItFX7rB4SAAAAAAA+xbJASP/+/WXw4MFSrFgxc18zO/r162eCHJeTlJQkp0+flkCk5TE2W8rt71btleRku9VDAgAAAADAZ3hFjxCHnTt3SqlSpS67XocOHUw5TfHixeWZZ56RuLg4CRRlC4dL2+olzO29J2Jl6Y7jVg8JAAAAAACf4TWBkJ9//tn0+tAskYwEBQXJ888/L4cPH5azZ8/KtGnT5KOPPpLhw4dnuI0GSaKiolJdfN0tTVLKYxRNUwEAAAAA8LFAyJIlS+S2226TZ599Vnr06JHhehERETJ69GgpUqSI2Gw2ad++vQmCaDAkOTk53W3Gjh0rhQoVcl7Kl78QRPBVnWuXlCIRoeb27A2H5HRMxg1mAQAAAACAFwVCli1bJt26dZNBgwbJmDFjsrx9tWrVJCYmRo4cOZLu4xoo0X4ijsvevb6fQZEnJFh6NSprbscnJsuMdfutHhIAAAAAAD7B0kDIihUrpGvXrvLAAw/IK6+8ctHjdrvdzAoTGxvrvJ9eIKVAgQKmX0h68uTJIwULFkx18Qc3u5THfLuS2WMAAAAAAPDqQMiaNWvk6quvlt69e8uQIUOcU+G6ZnZoBkfp0qVl6tSp5v7bb79tymeWL18uW7ZsMffffPNNefLJJyUkJEQCyRWlC0r9coXM7X/2n5ZNB3y/9wkAAAAAADnNsujBL7/8YrI19FovDtrHY/Pmzc7mqDqLTHh4uLmv5TPvv/++PPbYY3L06FGpUqWKfPXVVyaYEog0K2T9vpRphL9ZsUfGXF/X6iEBAAAAAODVbPb06k38mM4ao8EWzTbx9TKZqHMJ0vyleRKbkCQF8oTI0hGdJF+ewMqMAQB4J3/6vvXGzyImPlFqPz/H3N40pqtEhPH9DwAIbFFZ+L61vFkqsq9g3lDp2aCMuX0mLlFmrDtg9ZAAAAAAAPBqBEJ83O0tKjpvf7l0d7oNZQEAAAAAQAoCIT6uXrlC0uB809SNB6Jk3fmeIQAA+JP4+HjZunWr1cMAAAB+gECIH+iXJisEAAB/ExsbK08//bS5fezYMenSpYs888wzMmPGDDPrHAAAQGYRCPEDPeqXkYJ5U5qk/bzugJyKibd6SAAAeJQ2P/v+++/N7WLFism7774rNWrUkDlz5kiPHj2kefPmVg8RAAD4CAIhfiA8LFhuvLKcuR2XmCzTVu2zekgAAHjUmTNn5IMPPjC3k5OTpWLFitK/f395//33ZcWKFbJo0aJMPc+ff/4pjRs3lrx580rlypVl3Lhxl93m7NmzMnToUClXrpwJyNx6661koQAA4MMIhPiJfs0vlMd8tWwPTVMBAH4lNDRUgoKCnNPjNWrUSBo2bCj33XefTJw4UbZs2XLZ59i2bZtcc8010rNnTzlw4IC88cYb8vjjj8uUKVMy3CYpKclss2DBAvnll1/kyJEjJhDy7bffevT9AQCA3GOzB9gRc1bmFvY1fT9eKkt2HDe3pwxsLq2rFbd6SACAAJUb37fHjx+X5cuXy7Jly2THjh3yxRdfXHL9xx57zAQzXIMmd911l6xdu1bWrFmT7jb6nHfffbcJolSqVMlrPouY+ESp/fwcc3vTmK4SEZZSIgsAQKCKysL3Ld+afjaVriMQok1TCYQAAPyZ9grp3r27uWTG33//Le3bt0+1rFOnTjJp0iSJiYmRiIiIi7b58ccfpVWrVtkOggAAAO9DaYwf6VK7lJQokMfc/m3TYTlwKtbqIQEA4DbtDVKhQgUpU6aMCVxoOYtmaqxfv14SEhIy/Tza16NEiRKplpUsWdKUkx4+fDjdbTTTRHuJaFZI/vz5JTIyUm6//XY5ePBghq8TFxdnzkq5XgAAgPcgEOJHwkKC5LZmFcztpGS7fLGEqXQBAL7t5MmTMnjwYLn33nvl9ddfl5YtW8p///0nw4cPlwYNGkiTJk3cen5HhbDNZkv3cW3MOnnyZKlevbrpK7Jw4UJTJtO7d+8Mn3Ps2LEmNddxKV++vFtjBAAAnkVpjJ/p16KCfDB/myQk2eXr5XtkcKfqZlYZAAB8NRCis7U899xzFz127Ngx2blzZ6afS7M5jh49mmqZ3tcgSNpMEQfNQtFZYzTworTmeMyYMdK1a1fZu3dvukEOXVdnmXHQjBCCIQAAeA8yQvxMyQJ5pUeDMub26dgE+WENU+kCAHyX9uYICwszwYi0ihcvLk2bNs30c2mvj/nz56da9scff5jMknz58qW7TevWrTPMInHMYpNWnjx5TMDE9QIAALwHgRA/dHfrys7bny3exVS6AACfsnXrVunSpYs88cQT8vXXX5vsigceeEDOnTvn1vMOGjTIZHGMGjXKZJpMnz7dTJ07bNgw5zrTpk0zGSL79qWcSLj//vvl1KlTptzlzJkzpixm5MiRctVVV0nZsmXdfq8AACD3EQjxQ3XLFpJmlYqa29uOnJWFW49ZPSQAALI0G0zjxo1NM1RtjKpBEA1YaNNS7RXy4YcfmilzdaaXrNA+Hzp97owZM0yZzJAhQ+SNN96Qfv36ZbiNNlOdN2+ezJ4929zWAEidOnVMwAQAAPgmmz3A0gWyMrewL5v9z0F5cMpqc7tDzRLy2V3NrB4SACCAePL7VmdoWbt2baqLZmaobt26yaxZsyTQ9j1i4hOl9vNzzO1NY7pKRBht3wAAgS0qC9+3fGv68VS6ZQuHy/5TsfLn5qOy/ehZqVoiv9XDAgAgy0qXLm0u3bt3dy6Ljo42GSM6kwsAAEBWUBrjp0KCg6R/q4rO+58v3mXpeAAA8CRtbqpT6d54441WDwUAAPgYAiF+7JYmFSTi/NS501btk9MxCVYPCQAAAAAASxEI8WOFIkLlxsblzO3YhCSZsny31UMCAAAAAMBSBEL83N1tKovNlnL700W75FxCktVDAgAAAADAMgRC/Fzl4vmke91Ic/vY2TiZvma/1UMCAAAAAMAyBEICwP1XVXXe/vivHZKUHFAzJgMAfFxsbKyMGDFCateuLc2bNzfL4uPj5YEHHpC4uDirhwcAAHwMgZAA0KB8YWlZpZi5vfNYtPy+6ZDVQwIAINMGDRokv/32m9x6661m2lwVFhZmZo75+OOPrR4eAADwMQRCAsT97ao4b49fsEPsdrJCAAC+kQ3y7bffypw5cy6aKrdLly4yffp0y8YGAAB8E4GQANGuRgmpFVnA3F6395Qs23nC6iEBAHBZ+/btk1KlSkmxYsXE5uj+fV5ERIRERUVZNjYAAOCbCIQECN15fKDdhV4hHy7Ybul4AADIjDJlysiRI0fMJW0g5Pvvv5datWpZNjYAAOCbCIQEkOvql5ayhcPN7fmbj8q/BzmLBgDwbtoHZMCAAdKzZ0/5448/THNU7RcycOBAGT9+vDz66KNWDxEAAPgYAiEBJCQ4SO5tW9l5f/x8skIAAN7vzTfflHbt2snw4cNl27Zt0rVrV/nzzz9l2rRp0qxZM6uHBwAAfAyBkABzc9PyUjRfmLk9c/0B2X70rNVDAgDgkkJDQ+XVV1+VEydOyM6dO2X//v2yfft2kyUCAACQVQRCAkxEWIgMPJ8VkmwXef/PbVYPCQCATAkJCZFKlSqZviEAAADZFZLtLeGz7mxZST7+a4ecikmQn9YekEc7VpdKxfNZPSwAAC6ydetW6d69e7qPafPU8PBwqV27tjzyyCPSunXrXB8fAADwPWSEBKD8eULkntYpWSFJyXb5YD5ZIQAA71S8eHFp1aqVmTWmS5cupjnqvffeK9WrV5fdu3dLnz59JCkpSTp06CCrV6+2ergAAMAHkBESoPq3riQTFu6QqHOJ8sPq/fJIx+pSvmiE1cMCACCVIkWKmMaoCxculAYNGjiXP/XUU/L000/L6dOn5bvvvjP3tanql19+ael4AQCA97MsIyQhIUEmTpxozuBUrFhR2rRpI5MmTbrsdseOHZO7777bbFOzZk15/vnnzXMhawrmDZW726RkhSSarBBmkAEAeJ99+/ZJUFBQqiCIgzZLXb58ufO2zigDAADgtRkh77//vmzcuFFGjhwplStXNmd6NNU1KirK1Pmmx263y3XXXWeapf30009y8uRJue2228zZoHfeeSfX34Ovu6tVZflk4U45E5co01btlYc7VpOyhcOtHhYAAE558uSRAwcOyObNm80JEFdz586VvHnzmttaOqONVAEAALw2EDJ48GDT5MxBMzwWL14sn3/+eYaBEN3hWbZsmdkZqlGjhln28ssvy/33328CKkWLFs218fuDQhGhMqB1JXnvj22SkGSX8fO3yYu96lk9LAAAnEqUKCF9+/aVtm3bysCBA+WKK66Q2NhYUy4zbdo0mT59uiQnJ8sHH3wgzz33nNXDBQAAPsCy0hjXIIiD7tg4zuyk56+//pIKFSo4gyDq6quvNqUxS5cuzbGx+rO7W1eWfGHB5vbUFXtl38kYq4cEAEAqn3zyiTnhMWfOHHOyZNSoUSYbVIMhmimq+xSaKXrVVVdZPVQAAOCPgZBffvlFvvjiC4mJ8ewB85o1a+Trr7+WO+64I8N1NDW2VKlSqZY57h88eDDdbeLi4ky5jesFFxTJF2ayQpRmhbwzd6vVQwIAIJXQ0FAZNGiQrFq1Sk6dOmX2B3R/RPuLKQ2ERETQ8BsAAORQICQ+Pt5MXVe6dGlTkqKlKu7S6e+0yVmvXr3Mc2ZEe4QEB6dkLzhoAzW9aFpsesaOHSuFChVyXsqXL+/2eP3NfW2rSsG8KVVS36/eJ9uOnLV6SAAApEtPaGgwxHE5c+aM1UMCAAD+HgjRYIVmX2iz061bt0rLli2lTp068sYbb5hGZVm1Z88eM3NM06ZNzZR36ZXMuNYJHz16NNWy48ePmyCIPpae4cOHm/RZx2Xv3r1ZHmMg9Aq5v11VczvZLvLW71usHhIAAKn2FW644QYpUKCAOamhU+o6LrofAgAAkOM9QsLDw+X222+XP/74Q7Zv3y59+vSR9957T8qVKye9e/c2NbyZoUEJDYLUr19fpk6dalJfL6V58+ayY8cOkxLrsGDBAhM80UBKRt3mCxYsmOqCi93VupIUzx9mbs/656Bs2H/a6iEBAGD069fP9BDTfY2qVavKvHnzZMSIEaYc5oUXXrB6eAAAINCapWoQwpHFoTsp0dHRcv3110vr1q3lxIkTGW63f/9+ZxDku+++SzcIoumvxYsXl2+++cbcv/baa81Uu0OHDpWzZ8+agMjo0aNN8KVs2bLuvpWAFhEWIg93qOa8//pvmy0dDwAASstf1q1bJ5999pk0adJEwsLCpGPHjvLSSy+ZBqraJBUAACDHAyE6u8uUKVOkU6dOUqVKFZMBolPWacmM3tZMD+3b8emnn2b4HOPGjTPZJPPnzzf9RjTgoRc90+OgJS9a+nLu3DlndsesWbNMTxGdKrdSpUpSq1Yt000e7uvbvIKULRxubs/ffFSW78w4kAUAQG7QEyeacaonWzSr8+TJk87H2rVrJxs2bLB0fAAAwPekdMjMgh9//FEGDBggISEhpjzm3XffNT1CXGm/Dm1+evjw4QyfRwMnjz/++EXLNYDioHXA2hNEa4IdNPCxZMkSM2uNjkHPDMEz8oQEy2Odq8sT09ab+/+b8598e3/LS/ZtAQAgJ2mjdMe+QZkyZcz3vzZq13LZuXPnmpMoAAAAORoI0ayM8ePHm3IUvZ0RLV/RnZeMaF3v5aa60wPwjHZwmCYvZ9zQqKx8uGC7bD8aLSt2nZQ/Nx+RjrVST1kMAEBu0X0NzT5VegJEm6DrtLmlSpUyTdopjQEAADkeCOnevXum1ks7zS18Q0hwkDx+dU15aMpqc//lX/6Tq6qXMMsBAMht1atXlxkzZjjvP/3006Y0d/PmzdKsWTOpUaOGpeMDAAC+h6NbXKR73UhpXKGwub3tyFn5ZgVTDgMArKGzxemsMa50pjgtzyUIAgAAsoNACNItSXrm2trO+2/P3SJnziVYOiYAQGDSWeUWLVpk9TAAAIAfIRCCdF1ZsYhcW6+0uX3sbLzpGwIAQG4rX768mSlOZ5kDAACwpEcIAsdT3WrJb5sOSUKSXSYu3Cn9mleUMuen1wUAIDccOnTIzBbTpUsX6datm1SqVClVH7LSpUvLU089ZekYAQCAbyEjBBmqUCxC+resZG7HJSbL679ttnpIAIAAEx8fb0o2u3btamaj27lzp2zbts152bNnj9VDBAAAPoaMEFzSIx2ry3er9snp2AT5YfV+ubt1ZalbtpDVwwIABIgKFSrIzJkzrR4GAADwI2SE4JIKRYTKo52qO++P/nmjOSMHAEBuio6Olr/++ktmzZpl7icnJ8uZM2esHhYAAPBBBEJwWXe0qCiVi+czt1fsOikz1h2wekgAgACyYsUKqVWrlukT4ugHooGQVq1amfIYAACArCAQgssKCwmS53tcmE73pVn/ytm4REvHBAAIHHfeeac88sgjJiDiEBISIg8//LC8/vrrlo4NAAD4HgIhyJQONUtK5ytKmdtHzsTJe/O2Wj0kAEAAOHz4sJw8eVKefPLJVLPFqPr168vKlSstGxsAAPBNBEKQac9fV9tkh6hPF++UbUfOWj0kAICfi42NdQZAdPaYtFPrRkREWDQyAADgqwiEIEvT6T5wVRVzOyHJTuNUAECOq1ixoimD0SaproGQY8eOyZgxY6Rjx46Wjg8AAPgeAiHIkgfbV5OyhcPN7YVbj8lvmw5bPSQAgB/T4Mf48ePl1ltvlfvuu08OHjwovXv3lmrVqklCQoIMGTLE6iECAAAfQyAEWRIeFizPXnuF8/6YnzdJTDyNUwEAOeeaa64xjVKbNGkiTZs2lcTERBkxYoQsWbJEChUqZPXwAACAjwmxegDwPd3qRkqbasVl0bZjsv9UrLw9d6uMuOZCcAQAAE/RoEdQUJCZPvett96yejgAAMAPkBGCbKUpv9CrrrNx6ieLdsrGA6etHhYAwA/9999/pk+Izhqzfv16t5/vn3/+kZ49e5rSmrZt28r06dMzve2qVavMWNq3b+/2OAAAgHUIhCBbKhfPJ490qGZuJyXbZfgP/5hrAAA8qUqVKjJ06FD5448/pEGDBmbK3Ndee0327duX5ec6cOCAtGvXTiIjI+WHH36Qm266yVxmz5592W3PnDkjt912m5QtW9bMVgMAAHwXgRBk2/3tqkr1kvnN7fX7TssXS3ZZPSQAgJ/R6XG1IerKlStNdsj1118vH330kcnM0Bljpk6dmunnGjdunOTLl89srwGVRx99VPr06SMvvPDCZbd98MEHpVevXnLVVVe5+Y4AAIDVCIQg27Q0Zmzves77r8/ZLAdOxVo6JgCA/6pZs6YJWmzfvl1mzpwpW7ZsyVQQw2HBggXSuXPnVNPwduvWTZYvXy7nzp3LcLvPPvtMNm3alKXXAgAA3otACNzSpFJRua15BXM7Oj5JRs7YaPWQAAB+Ki4uzpS03HjjjXLDDTeY6XO1tCWztJxGy2JclSpVSpKSkuTw4fSng9+8ebPpTzJlyhQJCwvL9DijoqJSXQAAgPcgEAK3PdWtlpQokMfc/n3TYZm1/qDVQwIA+Am73S7z58+Xe++91wQx7rzzTsmbN69pcrp//34ZOXJkpp8rOTlZQkJST5gXGhpqrjUYklZ8fLzccsstMnr0aLniiszPjjZ27Fgzra/jUr58+UxvCwAAch6BELitUHiojOpRx3n/uZ82yLGzcZaOCQDgHzZu3ChdunQx2RzvvfeeydzQ7Izu3btfFNS4nBIlSsixY8dSLXPcL168+EXr79mzR9atWycvv/yylCtXzlw++OADU5qjt+fNm5fu6wwfPlxOnz7tvOzduzdL4wQAADkra3sQQAauqRcp3epEyq8bD8mJ6Hh5/qcN8kG/K60eFgDAx1WqVMlkfpQsWdLt52rWrJksXrw41bKFCxdKrVq1pGDBghetX7ly5YuCGJrtMWfOHJOlkl7wROXJk8dcAACAdyIjBB6hjede6FVXikSkpBj/8s8hmbn+gNXDAgD4uPz585sgyPr1601mxosvvugsW5k7d26WnuuBBx4wTU8nTpxoSm5WrFghkydPlkGDBjnX+eWXX0y2h06RGxwc7MwEcVwKFChgMlH0tpboAAAA30MgBB6jfUI0GOLw3I8b5OgZSmQAAO7RUpgWLVrIjz/+KN98841Zpo1LX331VTMTTGY1bNhQvvzyS3n22WdNQKNdu3by0EMPpQqExMTEmAyUxMTEHHkvAADAegRC4FHX1S9jymTUyZgEEwzRs24AAGSHfocMHjzYZGroNLau7rnnHhk3blyWnu/WW2+VAwcOyM6dO+XUqVPyyiuvpJpO99prrzXlMKVLl053+xEjRmQp+AIAALwPgRB43Jjr60rRfClTDGrPkBnrKJEBAGSPNizV8pj27dunClg4enho49KsCgoKMo1T05sONzw83JS9aFlMerSXiE65CwAAfBeBEHhc8fx55IXrL5TIPPvjBtl/KtbSMQEAfJM2HdWZV9Kb3lb7hniiiSoAAAgsBEKQI66tX1p6Nihjbp85lyhDpq6VpGRKZAAAWRMZGSk1a9Y0TVJdSy111hbt9dG7d29LxwcAAHwPgRDkGG2cWrZwuLm9fOcJ+XBB1tOXAQD44osvzKV58+amFEazQDp06CCdOnWSgQMHWj08AADgY0KsHgD8V6HwUHnrloZy68dLRJNB3vp9i7SpVlwalC9s9dAAAD6kRo0aZtrbmTNnyr///mt6e7Rp00ZatWpl9dAAAIAPIhCCHNWsclEZ1KGavPfHNklMtstjU9fKzEfaSL48/OoBALLWK+TGG2+0ehgAAMAPWHo0Gh0dLV9//bVMnTpVKlasKBMnTrzk+rGxsdKlS5eLlj/zzDPSvXv3HBwp3PFop+qycOsxWbv3lOw8Fi2jf94or/VpYPWwAABe6vjx4zJ58uRMrVu8eHG5/fbbc3xMAADAf1gWCImPj5fq1atLt27dzFmetWvXXnYb7Ri/ePFi+eijj6R27dqpUmbhvUKDg+SdWxvKNe8slOj4JPl25T5pWbWY3NConNVDAwB4oZMnT1725IiD7ksQCAEAAD4RCAkNDTV1voUKFZLHHntMDh06lOlt69evLy1atMjR8cGzKhbLJ2OuryuPf7fO3B/xwwapW6aQVC9VwOqhAQC8TLVq1WTDhg1WDwMAAPgpy2aNsdlsJgiSHSNGjDAlMg888ICsWrXK42NDzrjxynJyc5OULJDYhCR5aMpqiYlPtHpYAAAAAIAA4nPT5zZq1Ehuu+02k0USEhJiMkOmTZuW4fpxcXESFRWV6gLrjO5ZV2pFpmSBbD1yVp79cYPY7XarhwUAAAAACBA+NXVHRESELF261Eybp6699lrTN2TIkCHSp0+fdLcZO3asjB49OpdHioyEhwXL+/0aS8/3Fpl+IT+s3i8tKheTm5uWt3poAAAAAIAA4FMZIUFBQc4giMPVV18t+/btMx3m0zN8+HA5ffq087J3795cGi0yUrVEfhl7Y33n/ed+2iAbD5y2dEwAAAAAgMDgU4GQ9Bw+fNgESHTmmfTo8oIFC6a6wHo9G5SR21tUMLfjEpPlvi9WyYnoeKuHBQAAAADwc14dCDl79qy0adNGZs+ebe7//PPPsmbNGufjO3bskNdee82UyOTPn9/CkSI7nr22tjQoX9jc3n8qVgZNWS2JR7aKzB0lMu3ulOvj260eJgAAAADAj1jaI+TOO+80wYydO3eaJqYa9FC///67hIeHS2JioixevNhkfahKlSrJgw8+KHv27JHChQvLli1bpHfv3vLee+9Z+TaQTXlDg+Wj26+U695bJMfOxkm53d9L0AcTdUohEdEGqjaRxe+I9Bwn0qif1cMFAAAAAPgBSwMh2uQ0Ojr6ouWOMpcCBQrIwoULpUaNGuZ+vXr1ZNGiRXLgwAE5evSoVK5cmVIXHxdZKK98eHtjeXrCdHklZIIEaQAk7SQyMx4WqdBCpFhVi0YJAAAAAPAXIVZPhXspwcHBziwRV2XKlDEX+IcmlYrKOzU3in27IxMkLZvImskinUdZMDoAAAAAgD/x6h4hCBx1Ik5JkMZB0mUXObUndwcEAAAAAPBLBELgHQpXEJvpDZIem3kcAAAAAAB3EQiBd2h0h9jEflFhjN43SxvdYdHAAAAAAAD+hEAIvIM2Qu05Tmy2ILHbgiVJbJJoD5Jku01+LP80jVIBAAAAAL7fLBVIRafIrdBCbGsmy8l9W2Xa9iD5OrG97N4SKacW75S7Wle2eoQAAAAAAB9HIATeRTM/Oo+S4iJSfNU+2f3dOrN4zMxNUrJAXrm2fmmrRwgAAAAA8GGUxsBr9bmynDzSsZq5bbeLDJm6Vv7edszqYQEAAAAAfBiBEHi1oV1qyM1Nypnb8UnJcu8XK2XD/tNWDwsAAAAA4KMIhMCr6ZS6L99QTzpfUcrcj45PkgGfLZddx6KtHhoAAAAAwAcRCIHXCwkOknG3NZKmlYqY+8fOxssdny6Tw1HnrB4aAAAAAMDHEAiBT8gbGiwT72wqNUsVMPf3noiV2yYslWNn46weGgAAAADAhxAIgc8oFBEqk+5uJuWLhpv7249Gy+0Tl8nJ6HirhwYAAAAA8BEEQuBTIgvlla8GtpAyhfKa+/8dOmPKZE7HJlg9NAAAAACADyAQAp9TvmiETLm3hZQskMfc37A/yjRQPRuXaPXQAAAAAABejkAIfFLl4vlkysDmUixfmLm/Zs8pefrj6RL36/Mi0+4WmTtK5Ph2q4cJAAAAAPAyIVYPAMiu6qUKyJcDm0vfCUulS9zv8sqxCSLHbWK3idjEJrL4HZGe40Qa9bN6qAAAAAAAL0FGCHzaFaULync3lZRXQidIsM0uwZIsNnuyiD1JRK9nPExmCAAAAADAiUAIfF71/T9KkC2jX2WbyJrJuTwiAAAAAIC3IhAC33dqj9jEnu5Ddl1+ak+uDwkAAAAA4J0IhMD3Fa6QkvmRjiS7yInQyFwfEgAAAADAOxEIge9rdIfJ/UjLbhex2e3Sf21NWb3npCVDAwAAAAB4FwIh8H3FqqbMDqN9QmzB5tpuCxa7zSZPJd4n/8QWl34Tlsn8zUesHikAAAAAwGJMnwv/oFPkVmiR0hhVe4YUriDRdfrKgZknRbYfl9iEJBk4aaW83Lue3NykvNWjBQAAAABYhEAI/CszpPMo5938IvLZXUkyZOpa+eWfQ5KYbJcnp62XPcdjZGiXGhIUlH5fEQAAAACA/6I0Bn4tT0iwvNe3sfRvWdG5bNyf22Tw1LVyLiHJ0rEBAAAAAHIfgRD4veAgm4y+vq6M7FFbbOeTQH5ed0Bun7hMjp+Ns3p4AAAAAIBcRCAEAeOu1pXl4zuaSHhosLm/cvdJ6TlusWw8cNrqoQEAgBySlGyXJduPy09r95trvQ8ACGz0CEFA6VK7lHx7f0u5Z9IKOXImTvafipUbx/8tr95YX65vWNbq4QEAAA/6dcNBGf3zJjl4+pxzWelCeU2WaLe6pS0dGwDAOmSEIODUK1dIZjzcRhqUL2zun0tIlsHfrJWXZm2SxKRkq4cHAMhB+/btk4ceekjat28vffv2lb///vuS6ycmJsqkSZPk1ltvlauvvlqGDBkie/bsybXxwr0gyINfrk4VBFGHTp8zy/VxAEBgIhCCgBRZKK9Mva+F3NyknHPZhIU7ZcBnK+RkdLylYwMA5IyTJ09Ky5YtTTDkySeflPLly5uAyKWCIbfddpssWLBAevXqJcOGDZO9e/dKw4YNZceOHbk6dmSNlr9oJkh6RTCOZfo4ZTIAEJgojUHAyhsabEpiWhU+JYcWTJQyclT27SohD77bVZ65o4fJHAEA+I9x48ZJXFycTJs2TcLCwuSaa66RTZs2yciRI+X3339Pd5tPP/1U8ufXCdlTdOrUSSpVqiSff/65jBkzJhdHj6xYvvPERZkgrjT8oY/rei2rFsvVsQEArEcgBAHNtnaK9Fr8iNhDbJJsTxa73Sb3n/tZRnz4j9To9oDc3bqS2BxTzQAAfNq8efOka9euJgjicP3118ugQYMkISFBQkNDL9rGNQiigoODJTw8XOLjyR70ZkfOnPPoegAA/0JpDALX8e0iMx4RsSeLzZ4kwWKXEFuyBIldXg7+SL6Y9Yfc+8VKSmUAwE/s3r1bypQpk2qZ3tcgyMGDmesX8d1338m2bdukZ8+eGa6jWSdRUVGpLshdJQvk9eh6AAD/YnkgZNGiRfLII4/Iiy++mOltZsyYIYMHD5annnpKVqxYkaPjgx9bM1lzQi5arAkgdrHJLcHzZe6/R6T7OwtN6iwAwLdpwCNPnjyplml2h+Oxy1m1apXcc889Mnz4cGnVqlWG640dO1YKFSrkvGgvEuSuZpWLmtlhMsrp1OX6uK53OUy/CwD+x7JAiHZhr1evnmlWtnr1avnxxx8ztd3QoUPlrrvukiJFisi5c+fMjsg333yT4+OFHzqlXf/T35kJChKpEnrc3D4UdU5u/XiJvDtvK7PKAIAPK1q0qJw4kTqwffz4cedjl7J27Voza8yAAQPkpZdeuuS6Gig5ffq086INVpG7goNsZopclTYY4rivj+t6l6Izy7R59Q/pO2GpmWFOr/U+M84AgG+zLBCifRe++uor06m9adOmmdrmv//+k7ffflsmT54so0aNknfeeccEUjQ7RAMrQJYUrpBuRogKEpu0adJYWlRJ2THWkz9v/r5F+ny4RLYfPZvLAwUAeELjxo0vyiRdtmyZaX6qJ1gysn79euncubOZbvfdd9+97Oto1knBggVTXZD7utUtLeNvbywlC+a5aOY4Xa6PXwrT7wKA/7IsEKLNxjQjJCtmzpwphQsXNo3OXKe1O3LkiNmRAbKk0R0ZZoTo8vwt7pIpA1vIY52ri+OE0dq9p+TadxfKp4t2SjKpsQDgU7SsRQMhs2fPNvd37dolX3zxhVnu8Oeff0qLFi3k6NGj5v6GDRvMTDG33nqrmXUGvkWDHXOHtnPe//yuprLoqY6XDYIw/S4A+DfLe4RkhTYn0zpbDaI4VKlSxflYemhYhgwVqyrSc5yILUjEFpz6WpcXq2pSZh/rXEO+e6ClVCoWYTY7l5AsY2ZuktsmLpW9J2KsfhcAgExq27atvPHGG3LjjTdKzZo1pVatWqbcRXuOuZbK6MkV3X9Q9913nymnWblypQmQOC4jRoyw8J0gK1zLX7QnyOXKYbI6/S4AwPf41PS5sbGxUqBAgYuanGlgRB/LqGHZ6NGjc2mE8DmN+olUaJHSOFV7hmi5jGaKaJDExZUVi8ovg9vKa79uls//3mWWHdq5UX59Z7x0KRMnFatcIbbGF28HAPAuQ4YMMRkg27dvl8jISCldOnVmQMeOHWXJkiVSsmRJc//jjz+Ws2cvLoksVqxYro0ZuY/pdwHAv/lUIERrbE+ePJlqmTYhS0pKyrD+VhuWaYNVB80IoXs7UtHgRedRl10tIixERvWsI1fXLiV/fvOWPJ3wvpldxnbALskHf5Ogv98Rm2aSaHAFAOC1dJ+hUaNG6T6mTVM148Ohbt26uTgyeAum3wUA/+ZTpTG6M7Jz585U2R8bN250PpYeGpbB01oVOS0jkj6QYJtdQmzJ5jpYkkWSkyX5p4cl7vBWq4cIAAC8ZPpdAID38epAiAY8Bg4caGaWUddff725/uSTT5zrvPfee1K7dm2pX7++ZeNEgFkzWfNALlpss6XMLjNt4lhZvO2YJUMDAADeM/2uNlNdsv24/LR2v7mmuSoAeAdLS2NGjhwp+/fvl6VLl8rhw4dN0EO9//77JpNDG5Vp0KNNmzbSqlUrU8s7fvx4efDBB2XWrFmmTEZrfH/55Rcr3wYCjfYSyWC2GZvYpcC5A9Jv4jLp2aCMDL+mlpQuFJ7rQwQAAJ6ZfnfkjI1yOCqlea5j+l0NgmRm+l2dWca16WrpTG4LAPDjQEiDBg1Mvw7XWlzlmBUmIiJCJkyYIK1bt3Y+1r9/f9PIbNGiRSZYolPaFSpUKNfHjgCmDVUzSpa12WSfvYS5OWPdAfl902F5sH1Vue+qKpI39MJsRwAAwPtpwKJ1teJSb9Rvzul321YvcdlMEA2CPPjl6otOmxw6fc4s1wALwRAACNBASO/evS/5eFhYmDNLxJUGT/r27ZuDIwMuQWeVWfxOug/pflG5jvdL4UUxciomQWITkuTN37fI1BV7TXbItfVKi01raAAAgF9Ov6vlL5oJkl7uqC7TrfXxLrUjMzWVLwAgwHqEAF47y4zODmMLErEFp7rWWWN6dmwj84e1lwGtKjl3cPafipWHv1ojt3y0VNbtPWX1OwAAADlk+c4Tqcph0guG6OO6HgDAGj41fS7gNXSK3AotTONU0zNEy2U0U0SDJFo9ExFmptrt17yCvDDrX/lry1GzfPmuE3L9+4ule91IefzqmlKtZH6L3wgAAPCkI2fOeXQ9AIDnEQgBskuDHp1HXXKV6qUKyKS7msqfm4/ICzP/lZ3Hos3y2RsOyZyNh+SmK8vL4M7VpUxhGqoCAOAPShbI69H1AACeRyAEyGHaE6RjrVLSploJmbpyr7w7b6vkO7tLbg5eIOXWHZWf15eUpAb95Oau7aV4/jxWDxcAALhB+4jo7DDaGDW9PiG28zPP6HoAAGsQCAFySVhIkNzRoqLcHDxfQmc9Icm6M2S3i11sYls/Q55dd79ENOsv919VRUoW5CwRAAC+SPuD6RS5OjuMBj1cgyGO1qj6eGYapWrjVe0lomU0mkGSmWatAIDLIxAC5Kbj2yXPL4+JSHJKp2KzL2MXu13kRdtH0nFxDZm8dLf0bVpe7m9X9eKSmePbM+xLkpnXzva2AAAg03RqXJ0id+SMjXI4Ks65XDNBNAiSmalzdQpenV3GtfFq6SxsDwDIGIEQIDdpIMJ5PugCnVHXbrfJLcHz5bXEW2XSkt3y1fI90ufKcjKwbRWpWiK/yJovRWY8cn778xPw6TS+OoONNm+95Ou6sS0AAMgyDVa0rlZc6o36zdz//K6m0rZ6iUxldGgQRDNK0pbWaLmNLtcgC8EQAMg+ps8FcpNmY6RbMayptCLtS8ZKeGiwuZ+QZJevl++VTm8skBETfxT7T4+I2JNF7Empr2c8nJLtkRF9bEY2twUAANnmGvTIbFmLlsNoJkh6ewuOZfq4rgcAyB4CIUBu0pKUdDJClE1sUrt2XVn8dEcZ1KGq5M9zIWGr3K7vJSnD/R3b+UyTrGWhZGpbAACQq7QniGs5TFq6O6CP63oAgOyhNAbITdqXQ0tS0mU3jxfNFyZPdK0l911VVb5Zvkc+W7xLysUeFVsGmSRmO5NpkvUslMtuCwDwmPj4eHNJKygoSEJCLuySpbeO60xkoaGhzvshkmTWDzEtuC+9bkJCgti1KVUmntdT66qwsLBsrZuYmCjJyclurxsfn3ihLDQTz6vvTd+jY92Uzzfp/HOl/qxd101KSjKXtK/t2Nb1fae3rsPBk2fMd742U1dBpq+YPd314uMLmN8d/R263POq7K6rn5d+FhkJDg42F29ZVz9r/V3zxLquf585te7l/u7d+R+RlXUD9X9Een/3ObHu5f7msrJubvzdJ/ng/4hL/b5fNP5MrwnAfdqcVPtyaEmKa78OvdblLs1LC4WHmoapd7WuLDun/iKydVm6AQ3NFDliKymRdrvzn2dms1DMcvM4ACCnvfHGG5I378WzglWvXl1uu+025/3XX389wwOoihUryoABA5z3b8r7j7zzxpp01y1Tpozce++9zvvvv/++nD59Ot11S5QoIQ899JDz/oQJE+To0aPprluoUCF57DFt/J3i888/lwMHDqS7bkREhDzxxBPO+1OmTJHdu3dneBAwYsQI5/1vv/1Wtm7dKhkZOXKk8/b06dNl06ZNGa4bIo0kUVJ2lmfOnCnr1q3LcN1hw4ZJvnz5zO05c+bIypUr5Y7zvcvTftaDBw+WwoULm9vz5s2TJUuWXPR8jm2PH2sq+cqm9PVYuHChLFiwIMMxFLNdIcfsKWOoHXJEmobuu2idf2atkX9mifTv318qVapklq1atUpmz56d4fP27dtXatSokbL9P//ITz/9lOG6ffr0kTp16pjb//77r0ybNi3Dda+//npp2LChub1t2zb5+uuvM1y3e/fu0qxZM3N7z549MmnSpAzX7dy5s7Ru3drcPnjwoEycODHDddu1ayft27c3t/V3d/z48Rmu27JlS7n66qvNbf2beOedjE5SiTRp0kSuvfZaczsmJsb8fWakQYMG0qtXL3Nb/4bHjh2b4bq1a9eWm266yXn/Uuu68z9C35uOOz38j7hg+PDhzsBJdv5HZCQz/yMcHnzwQSlZsmSm/kcMHDhQypYta24vXbpU5s6dm+G6gfQ/Yty4cZJZBEKA3KbNSSu0yPQMLjrtbs1uD4l926dmdhnXkEZKwNwut66sLhH7FknfZuXl+gZlpVBEaJayUAAAgPcolj9Mjp/JOJ8TAOAem/1SuUd+KCoqykQpNdpZsGBBq4cDZN6aKc5MEk2Y1b9cvX4q4T6ZltQuVeDk6tql5KYm5aVNteIpjdlctr0oC4VZYwDkAL5vL/4s9Oxpep9FdtLeY+ITpfbzc0zZxcpnO0tE2MXntkh7T6GfVcMX/zDffZvGdJWwoJQU6symvZ89Fy9NXkw525r2s75cKru+tmPbdaO7S748oZlKOZ+3+ag8NGWtuW1zKY1xnAx5+9aG0qV2ZIap7L9vOiRjf/lPDkVd6DUSWTCvPHNdHelev6zPpr1TGnP5dSmNyd66lMb4R2nMiRMnTPZSZvY9yAgBfDCTxHZqj9gKV5C4ev2k5b5w2bp0t6zbe8qsFp+YLDPXHzSX0oXySu/GZaXPlb2k8sOZz0IBAHie7pS77phfar3M0nKPlOe9/C6d64GJL6zreuDnzrqJZm4AW7afV38cjrKaS33Wrjvkrq/t2Na1fDW9dV11r1dWxt8eJCNnbJTDUXHOriT6vT6yR+0Mp87V5/z93yPy8Df/nA+dXHiN/VEJ8tBXa2V8UJDZ/nJjcKUHO5n9vfSGdfWz9qV1lTesG6j/I3Jr3az8zfnaukFe8HeflXUVgRDAl2jgovMo5908InJjKZEbrywn/x6Mku9W7pMf1+6XE9Ep0X/tKv/+n9vN5cqKRaRH/f5yTfPSUrLAxTXqAADAe2iwonW14lJv1G/m/ud3NZW21Utccgrey029q1vq45pNkpmpfAHA0/T/lM56deTMOXNMktmpxT2NQAjgJ64oXVCe71Fbnu5eS/7474h8t3KvzN9y1PyzUat2nzSX0TM3SYvKxaRHgzLSrW6kmaUGAAB4H9eDg8wcLGRl6t2WVYt5dKwAAicYkZTN7X/dcNAEY13/T10u0y2nEAgB/Iz2CNEAh170n9P01fvl+9X7ZMvhs+ZxLbtcsuO4uTz30wbTR+Ta+qWlU62SUiy/5pgAAABfpN/7nlwPgPeyKhjxaza31+0e/HL1RRlrh06fM8vH3944V4MhBEIAP6b/FHUKXr1sPnRGZq4/ID+vOyC7jsc4/4Eu2HLUXPT/ZpOKRaVL7VLmUql4yrRgAADAN2S29DUz63lL+jrgr9z5G7MqGPFrNrf3xrI9AiFAgKgZWUBqRtaUoV1qyMYDUSYgog1V95+KNY9rBc3yXSfM5aVf/pXqJfObgMh1ZWPkikMzxHaaJqsAAHgzPZDSgyE9KEnvgEMPLyILpRxw+Ur6OuDNrMjKsCoYkeTG9t5YtkcgBAgw2sW8btlC5qL9RNbsPSW/bTwsv206JDuORjvX23rkrDQ8PlNqhkyQJJvN9NwXm01si98RG9PuAgDgdfTgQw+k9GBID0NcD1gchyX6+KUO1LwtfR3wVlZkZVgZjFjuxvbeWLaXMvEvgIANijSuUCSlwerj7WXe4+3M7cYVCkvloIPySsgECbbZJUSSJUgv9iSdpFuSfxokH07/Xf7efkzOJWQ8v3i2Hd8uMneUyLS7U671PgAAuCw9gNIDqZIFU/f90kyQywUxLneQpfRxRyN2wNfp7/KS7cflp7X7zXVmf7cdwYy0gQFHMEMfz4m/sawEI9JyNxhxxI3tPVm25ylkhABwqloiv1Rtl18eaFdVYn75VWwrgkQ0+OHCZhNJstskedUXctuyeNOcVQMnLaoUM5eG5QtL3tDMzTmerjVfisx45HxM+3xse/E7ImShAACQY1Pvejp9nR4j8NfyFCuzMqwMRpR0Y3tPle15EoEQAOmKiNmfJqn2ApvYpZztqLkdn5gsS3ecMBeRrakCI+2LR0ndIz9LSNTezPUX0cwPDYLYky9+bMbDIhVa0J8EAIAcmHrXk+nr9BiBPzcNtbJExMpgRDM3tvdE2Z6nURoDIH0auHD+a0otKChIatWqIzc2LiflioSneswRGNn/5wSpN72zyOJ3JWnDD5K86F2xv9dETi7+TOw6h2961kzO8DXNcvP4ZVBWAwBAtngifT27JQMITPr70ObVP6TvhKUy+Ju15lrvZ+b3xKryFCuzMhzBiEvsLZvHLxWMcKwnWQxGuLu9O2V7OYFACID0afbGJTJCanR7SN64uYEseqqjLHyyg7x+UwPpc2U5KV80XCrZXPqL2JIlWOwSJEkm06Pgb0Okz8tfygOTV8lHC7bLil0nJDb+fPnNqT0ZvqZZbh6/TFnNuCYm+CIbp6dc6/01U9z8MAAA8H/uHGR5ssdIdvs2wDrZ+Zm5EzRz53fNnT4bnsrKyO7fmNXBiG4e2H7u0HbO+1q2p8cSVmSKURoDIH1agqJ9ObQkxbVfh17rcpcSlfJFI8xFAyEqauY8sa1Kv7+I3W6TTrG/yWsbi8qvGw+Z5fq/ulrJ/PJUSF7pIOdnqLmI7XyWSgYoqwEAwC3upq97oscIZTWBUZ7i7lSuVpanWF0i4ghGjJyxUQ5HxTmXR2by7yS7PYQ8tX12yvZyAhkhADKmzUkfXinS+lGROjekXOv9yzQtLXjuoARllE1iE6kUfCzVMg3Wbzl8Vl440FjsycmStnJG72o5zeFqN+dcWQ0lNQAAuHXG190DTE+V1QRqRok7M6DkdnmKu1kZVpanWJ2V4YnMimA3gxHeEsxwBxkhAC5Nsyg6j/JYf5Fgm026tW4uc+pdJav3nJQ1e07Khv1RsuXwGdmVXFqeSrxPXg352GSOaAmOXVKun0q8V6Z9uFMK5NkrNSILSI1S+aVGqQJSs1QBc7+4O2U1vjhTjQZqNLij7yszjWgBAMik7J7xdecA090MAU9llLg724072/ta01B3fma+3DTUG7Iy/CUYYSUCIQA8Tw/KNZCQLrsENb5DahYrIDUjC0jfZinlLnGJSbLl0FnZcKCevL2jg1Tc/b3kjd4ve5KLy9Sk9rLbHmnWOxOXKKt2nzQXV8+HJ0t/u0hwVstqfLGkxhcDNwAAn5Kdgyx3DjA9VVaT3YN6TwRR3Nne3W2z876tLE/xVNNQK2cw8ZcSkUBFaQyAnOsvYgsSsQWnvk7TX8QhT0iw1CtXyARGHr+1u/R5aqJ0HTlLOj78vjzap6vc366KdKhZQsoWTj1LjcMX59po/czFZTV2kSR7sgzf2VBemLlJvly6W/7edkz2nYxJSRn1xEw12ZWdchzXwI32YHG91sANJT0AAIu4UzLgboaAu41a3S3LcWd7X20a6s7PzNebhrqOw/U9EczwHWSEAMgZmpmg2RRulG+EBgdJrciC5uLqzLkE2XrkrGw5dEY2Hz4jWw+flc2H88hTMRmU1STcJ9O2h4ps35nqeUKCbPJh+ArpYNeZbS5mnuFyM9XkdlZHZgI3WS1lAgDAQ7JbMuBuhoA72QnuZka4s70vNw1152fmD01D4dsIhADwrv4imVAgb6g0rlDEXFydirlK/tvRV4LXfin2k3ucZTV/nyyoexoXPU9isl22xBWV9sE2EdvFuyC6ydTNIr9+ssyclYgsmFciC4Wb26UK5jXXhSNCxaYdYLPCnXIcd6cYBgAgh2XnANPdvg3uHNS7W5bjzvbuvraVTUPd/Zm5G8hwPAflKcgOAiEA/EbhiDApXLeRiF5E5AoR6aqz0iTb5fCZc7LzaLTsOBYtO49Fy94TMbL3ZKzMOtFJ7pefTQmNazzD3Be7fHy2tezemnqWG1d5QoLkygIn5Oag+VI+6JjE5S8n+yvfKHlK1ZDi+cOkRP48UqJAHikU7hIwcSer4xKNaC87xTC8F81vAfiZrB5gupsh4M5BvbuZEe5s78tNQz2V1UHTUARkIGTLli2yYMECyZs3r3Tr1k1KlCiR4boJCQny/vvvX7T86quvltq1U2rEACCtoCCblDaZHOHSqlrxNI+2lZhlQRL+62BJ1q9tR5MRm8ib4Y/IkeSyIglJGT53T/sf8krMBGcZjj3KJrYDk83sN9OSLkxrFhpsk2L58kjxAmHybOwaaWa3p9ukSctxkk/szqDp6+Ub0ZrHcwoH697X/JafCQA/4k6GgDsH9e5mRrizva83DfVEVgeBDARcIOTDDz+UoUOHyjXXXCMnT56URx55RGbOnClt2rRJd/24uDgZMmSI3HLLLRIZmTKDhDp79mwujhqAv4lofqdItdZiS3NA+USxqjLMbpeTMQlmB+NQVKwcOh0nh07HyqGoc5J8bLu8cmiCBJtdB8fuQ0rDVu1VsiK5pnO2m4Qku9lGL6tDCkqTYJH0vue1HOfj9Yny7j+zpYhmuESESZGI0PO3U66b1hopV/07Wuy2lOCL4wA68dp3JaRolQzzRdwSSDPV5GZwwZ0yqUD6mQAIGNnNEHDnoN7dzAh3trc6K8MbylOAgAqE7N+/Xx577DEZN26cDBw40Cy766675J577pH//vvvkjX3ul2LFi1ycbQAArWfif4vKpovzFxql0ndtFXmThc5HJQya0uqbXTnI0jGVlor04rcI8fOxsvRM3Fy7GycnIiOl2+T2sn9wRmX42hfk3P2ZFMTnH7dcHWpaHtdbgmeL+VsR2WfvUTKFMPTikrY9F+lQN4QKRgemnKdN831+eXaZ6Xg+et8eYIlX54QyRcWIhF5giUiNFhCgoN8e4rh7Mrt4EJ2y6QC6WcCIOBkN0Mguwf17gYT3NneG7IyKE9BILIsEPLTTz9JSEiI3H777c5lDz74oHz++eeydu1aadQopcY/PXPnzpV169ZJ1apVpV27dhIaGppLowaAzDUuDbLZpVWxaGnVp2Gq5dqv5GRMvBxZaZPI+cMk2eYox0lp2PpliWESGVJb8sYkyImYeDkVE2+ySdLSTJPXEm+9aHl8UrIcj443F3do7xMTHMkTLA8nTZE+dkm3XCfZbpP1M96TjbWHSN6QYAkPC5a8oUHmdl69nWaZ3tbnznKD2dxgRXAhu81vmT0IADx6UO+JYEJ2t/eGrAwCGQg0lgVCNm3aJJUqVTK9QRxq1arlfCyjQIgGTxYtWiSlS5eWV155RcLDw01QpXr16hmW0+jFISoqyuPvBUCAykbjUu1XUix/HpH294jUa39ROU7/YlWlv8v6drtdouOT5GS0BkUSTBDFXKL1OsEESs6cS5Qoc0kwt3V64ajYBDkTl+hseeJQyXZQbg5e4Mwk0eyUXfaLd7DiEpMlLjFeTkSLhIfuFwky6SoXsduTZc+O/+SZzRuy9NGZwEhocKrgiN4P12WhQZInJFjCQoIuXIJ12YXbeq3TKzseN4+53A9L85hz3fPXIUFBEhJsM1Moe6SJbXZlt/ktswcBQI5klLgTTHBne7IygAAJhJw5c0YKFy6calnBggUlODjYPJaesLAwWbVqldSvX9/cP3funHTs2NGU1mjD1fSMHTtWRo8enQPvAEDAc7dxaSamF9aD9Px5QsylfPrlwRnS7JPoeA2MpARJ8vzztVRa/LTpLeLIQnkgZKb8WP5pWVSgq8TEJZn1Y+KTJDouMeV2XJIcSihpmsGmd+CtyzWgklXnEpLNRSThkutlNnDjDg2GaFDkzaBl0tWWnG7mS5LdLouXr5K3tyy+EEQJDpLQ89teCKxo0MVlWZBNgoNtEmyzmR3SoPPXjttFE9vJTfZ3zKfrurtqPmm7XeblvVpi1x1Is61IteTiUt406JV0fybHQyLlxOEzF7ax2SQoKGUnWZelXOTC7aCU2xFhwd6ZrQMAucTdYII72xPIAAIgEBIREXFRwCM6OlqSkpLMYxkFQhxBEKXZJA899JD0799fYmNjTXZIWsOHDzcNWV0zQsqXL+/R9wIgQGkgQ3tHaNmEa08JvdblFvdo0OwT7QGilzLHD4j8/bSGR7QCJ5Xe+16R3g/3yXi8x6uIfdz5niYui/Vpgm0iNbs/JK+FlZNziUlyLiFJYuOTnbdTLskSG5904fGEZIk7/1is4/GEJIlPTF2SclPwfHklxGVGHrGZ3ippZ+RxV2Ky3Vx2hRQXu76htB/Q+f4tG2IKy+qoUx4P2qwIvtc013V9n3r9VOK9Mm3mSRE5mc5r1ZB5Yclm5qG0fWaS7cly47KqsnvpX5JVm1/sZrJxAAAA/JllgZAaNWrIN998I4mJiabcRW3fvt1cZ1TmklFwJDk52cwck14gJE+ePOYCADlCG2hq7whvn8LUnbKPYlXFlk7Ax8xY03OcdGrU0iND1AwWLcnRoEji0a1SYtJEsdnTzMgjIv8LnSA9rustp8LLm/XjHZekZEk4f63341xup1rn/CUp2W76ryQmJ0tikl2WJnSX+6N/doaz0jax/S6pfYZjdydoo4/rDEMXNb89P+NQejTAos9tAij2tAGU+y657aVoVoi/0xMi2qhdy3C1zPa+++677H5HdrYBAADey7JAyHXXXSfDhg0z0+X26tXLLPviiy+kTJky0qxZM3Nfe3uMHz9err76aqldu7Zs27bN9BVxBE60dn7y5MlSs2ZNKVEi66nZAOARmShxsZy7PSXcCfhkcjpazWDRfiF6kSXfpRu4MUtsNmkX/atIy1GZe80iWRjrGvvFAR+bXYJ7jpM/G/UzwZqUDBINptglMSlZ7Me3S7HPb08/aBM2Qfpdf4vE5q9oyms0+JJsrnWq5JT7ulyfNym5q5yz26Vosl3uO7+u4+LYJuU6ZQzJydVkYmwXqXd4hhSKOygnwyJlVdHrJG9YWenr3PbCNvo6+r2Z8nyS6rauo8P390BITEyMtGrVypTiDhgwwJTVXnnllfL3339L3bp1PbYNAADwbpYFQvRMipataFmLnlk5ceKECWp8++23pk+I0nKXIUOGyGeffWYCIatXr5Ybb7xROnXqZPqLzJ4922SRfP/991a9DQDwDdltyuluwCe709G6E7hxZwrcywR8NFgTphdTlHLe0m8zDtqITRod+1mkYU4FymqKSBfnvTY59Cr+4qOPPpJ9+/bJ3r17pUCBAmb/o3379vLss8/Kjz/+6LFtAACAd3PZk8t9L774ovzwww+mvKVixYqyZs0aZ3aI0pKWwYMHmyCIuvnmm80MMZoVkpCQYHZGNEukbdu2Fr4LAPABpnGrPfuNXd2djtaelPpasy70cU8Hbtx5zbQBnz6fplxfLpOEGVx8xi+//CJdu3Y1AQ2Hm266SebMmWN6lHlqGwAA4N0sywhx0OwOvaRHe368/fbbqZZpEOTRRx/NpdEBgJ+worGrO31Jsjsjjy9NgYtct2PHDmnYsGGqZRUqVDCz0B08eFDKlSvnkW20tFcvrj1GAACA97DZtUg4gOjOSKFCheT06dOm3hcAAkom+3V4xLS7RTZOT8nGSMsWJFLnhpSsi4ysmZJx4CajEhd3XzO7n+m4Jhm/5sMrva95boB+32rQ4p577pHRo0c7l/3555/SsWNH2bp1q1SrVs0j24waNSrV+g7e9FkAABDI+x6WZ4QAAPy0sau7mRLZadBqRXaGl0+jjAt05+jkydTTER8/ftxca+8xT22jPdCGDh2aasesfPnybo8fAAB4BoEQAEDOyG55izuBG0+8pj9Poxzg6tevL+vXr0+1TO9HRkZK8eLFPbaN9jjTCwAA8E6WNksFAPgxR6aElofYglNf51SmhBWvmd0mq8h1t99+uyxatEiWL19u7h87dkw+//xzueOOCwGypUuXSp8+fcxsdpndBgAA+BZ6hAAA/KcviZWvCZ/4vh02bJh8+OGH0rx5c9mwYYOZme7nn3+W/Pnzm8enTZtmZoXR6XIdjVAvt42vfhYAAPiTrHzfEggBAAAB9X27fft22bRpk5QuXVquvPJKsdku9JXZv3+/LFmyRK699loze11mtvHlzwIAAH9BIOQS2BkBACDn8X17AZ8FAADe9X1LjxAAAAAAABAwCIQAAAAAAICAQSAEAAAAAAAEDAIhAAAAAAAgYBAIAQAAAAAAAYNACAAAAAAACBghEmAcswXr1DoAACBnOL5nHd+7gYx9DwAAvGvfI+ACIWfOnDHX5cuXt3ooAAAExPduoUKFJJCx7wEAgHfte9jsAXaqJjk5WQ4cOCAFChQQm83msefV6JPu4Ozdu1cKFizosecNRHyWnsNn6Vl8np7DZ+n/n6XuXuiOSJkyZSQoKLArcS+37+GtP0N/wmecO/iccx6fcc7jM/bdzzgr+x4BlxGiH0i5cuVy7Pn1B8kfjGfwWXoOn6Vn8Xl6Dp+lf3+WgZ4JktV9D2/8GfobPuPcweec8/iMcx6fsW9+xpnd9wjsUzQAAAAAACCgEAgBAAAAAAABg0CIh+TJk0dGjhxpruEePkvP4bP0LD5Pz+Gz9Bw+S9/HzzDn8RnnDj7nnMdnnPP4jAPjMw64ZqkAAAAAACBwkRECAAAAAAACBoEQAAAAAAAQMAiEAAAAAACAgBFi9QB83alTp+SVV16RZcuWSeHCheXuu++WHj16WD0snxQXFyffffedTJ48WUJCQmTWrFlWD8ln7du3Tz788ENZuXKl5MuXT7p06SL33HOPhIaGWj00n5OcnGx+L3/88Uc5evSoVK9eXR588EGpX7++1UPzaQcPHpRbb71VwsPD5ddff7V6OD6pRYsWFy0bNmyY9OnTx5LxIHs+//xz8z9GvwM7d+4sQ4YMoUGfhy1dutR8J/7333/ywQcfSOPGja0ekl+Jj4+XL774Qn777Tc5ffq0+X7U3+MyZcpYPTS/smHDBvnoo49k06ZNUqxYMenVq5f07dtXbDab1UPzS4888oisWLFC3n777XS/b5E9L7zwwkXHeFdccYV89tlnktsIhLghMTHR7LToweXw4cNl8+bN0rt3b3Mgrzv4yBrdMWnYsKGUKlXKfJki+weY7du3N0E53RE5cuSIPPvsszJ37lyZNm2a1cPzOU899ZScOHFCbrzxRhPs/Pbbb6V58+ayePFidqbdCC7169fPfK76+4rs0QD8u+++K02bNnUuq1y5sqVjQtZ3CF9//XV58803pVChQvL000+bADb/qz3nmWeeMd9/un82adIkiYqKsnpIfkc/Ww163HTTTVKwYEEZN26cNGrUSFavXi1ly5a1enh+Yfny5fLYY49J//79zef977//ykMPPWSCIy+//LLVw/M7EyZMkPnz55vPV096w3O2b99u9qdHjRrlXJY/f36xhM4ag+z56quv7MHBwfaDBw86lw0ePNheqVIlS8flq06dOmWu//e//9lLlSpl9XB8VlxcnLm4mjVrls4OZd+9e7dl4/JV0dHRFy2rUKGCfeTIkZaMxx+MGTPG3rNnT/O3XqxYMauH47P0b/r333+3ehjIpqioKHt4eLh9/PjxzmULFy40P9eVK1daOjZ/3LfYu3ev+Wz//PNPq4fkd86cOZPqvu6D6P/2V1991bIx+ZuYmBh7cnJyqmUjRoywV61a1bIx+auNGzfay5QpY1+2bJn5nzF79myrh+RX+vfvb+/Xr5/dG9AjxA3z5s0zZ+IiIyOdy66//nrZtWuXiXYha/RsGNwXFhZmLq4ckVZNX0XWREREpLqvqdWaZdOgQQPLxuTLNJNGU3snTpxo9VD8gp5R6dChg8kAW7hwodXDQRb/FmJjY1OV07Zu3dqkvGsGAzyDfYucl/ZsrmZKa3kX+xyeo2WkriUwWkqnWYHsi3jWuXPn5JZbbpE33nhDKlSoYPVw/Pr7r0OHDibbWjNbExISLBkHgRA37N69+6L6R8d9fQzwBnrieOzYsVK3bl2pWrWq1cPxSfr3rPWh9erVM8HPd955R2644Qarh+VzTp48aUpiNAhSokQJq4fj87QOXwMgI0aMkOLFi0unTp0sqbFF9v+v6IGN68kUvV+6dGn2IeDzfW8OHTpEz7wccNddd5n9EP0/oUE+LfeC52j5kZbp0+IgZwOnd9xxh9l3ueaaa0xp6NVXX23KpnMbPULcoNGrtA3NNGLreAzwlh4XGnldtGgRDbWySfvWaLMsbQKntftax9+kSRN6hGSRNuzVrLlu3bpZPRS/qRl3fAdpQ+SgoCAZOnSoDBgwgL91H6D7CdoYPDg4+KL9CPYh4Kt0f2PQoEHy4osvkq2QAx5//HHTX2vNmjUyZswYs2+ifeDgvu+//17mzJkj69ats3oofu2NN95IdfzcqlUrqV27tsyYMcM0AM5NBELcULRoUfPPyNXx48fNtaa2AlYbOXKkjB8/3szKwSwn2Zc3b15nx/CuXbua0reXXnrJfGkiczSINH36dHOmxfFZaqNUXa73n3vuObn22mutHqZPSRuI1+bdr776quzZs0cqVqxo2biQ+X0IDXicPXs2VWmB7kewDwFfpKUaeoZ38ODBZhIBeJ5m96qrrrrK/N944IEH5NFHHzVNauF+JpNOhKHZCcoRkNaJB3755RdTwgHP77vojDHaVFkDUARCfIieDdY/Ck3l0TNxji8B/QHrDxWw0ujRo026mf7z1rpzeI6msu/fv9/qYfgU3WFbsmRJqmVfffWVmXJRz2hRtuU+TUVPr68NvJMjo0ynZ9RaaaX9h7TPmM64AfhahpqeKNADcy3HRc7T8hg9cNcTCgRC3KczeGkJr4Oe7NYTNPfff7/53UbO0F5C+lnny5dPchs9Qtxw++23m2nYdE56pdMrae8ArSuz4ocJOGhKqv5D1yBI27ZtrR6OT3vttdckOjraeV+DnTNnzpTu3btbOi5fo+n/mvnhetFGZFoaoLfpGZI1muWlKegOevCsU7FqnxA+S99Qq1YtkxKsU186zjzqz1B/ftddd53VwwMyTad81rPoGgTRrDR43jfffCObNm1y3tcDdj3ZVadOHSlfvrylY/MXNWvWTLWP4ghW6/9qTnB7hmZA6u+t4ztPr7XcS5MKrOi9R0aIGypVqiRffvmlDBw4UN566y05fPiwNG/e3ARDkHWaeqZnjDVdXiODjvT5qVOnkuadBfpFqWUG2tfiiSeeSPWYnnl3fK7IfFlMtWrVTBq7dhM/evSoPPzwwzJs2DCrh4YAVqVKFVOH/88//5gyim3btpmU0vfee8/qoSELpkyZYvrmaJaZ9gbR5tZacsfJFM+ZNWuWCTA5ZjB56KGHzNlz3XfTC9ynTZv1hMH8+fNT7WPo2XTdH4H7NGtSG6UeOHBAChcubEp027VrJz/99JPVQwMyTb/ndD9av/N0ghHNrtbgv55gtCIz2KZz6Ob6q/oZnf5u8+bN5h+TBkeQPTotqWbVpKU9BfRgFJkTExMj69evT/cxjWgzlWDWJSUlydatW032gmYxpJ2eGNmjQU/dqbvyyiutHorP0n4S+jnqd0/aKSzhO7Zs2WKmw9T/0fp/Bp6jO9160JhWuXLlzAXu09p+3RdOSw9wKHv0fAnksWPHTBYI+3M5S7MVVq1axb5zDtDAtH7v6YkcLfGyCoEQAAAAAAAQMOgRAgAAAAAAAgaBEAAAAAAAEDAIhAAAAAAAgIBBIAQAAAAAAAQMAiEAAAAAACBgEAgBAAAAAAABg0AIAAAAAAAIGARCAAAAAABAwCAQAgAAAAAAAgaBEABeKTk5Wb777jvZtGlTquULFy6UuXPnWjYuAADgnw4ePCjffPONnDx50rnMbrfLtGnTZMOGDZaODYBnEQgB4JWCgoJkzZo10rVrVzlx4oRZtmrVKuncubPExMRYPTwAAOBnSpQoIW+99ZYMHDjQuex///ufPPDAA1K0aFFLxwbAs2x2DXMCgBdKSEiQ1q1bS4UKFWTSpEnSuHFj6dChg3z44YdWDw0AAPihbdu2SaNGjUxARK9btWolU6dOlV69elk9NAAeRCAEgFfbunWr2RGpUqWKxMfHy+rVqyUiIsLqYQEAAD/12WefySOPPCKlSpWSTp06yccff2z1kAB4GIEQAF5v0KBB8sEHH8gPP/wgN9xwg9XDAQAAfq5atWqyb98+OXTokBQuXNjq4QDwMHqEAPBqGzdulE8//VRq164tL7/8simXAQAAyCnvv/++HDt2TIoVKyavvPKK1cMBkAPICAHgteLi4qRZs2bSsGFDefPNN6V+/foyYMAAeemll6weGgAA8EM6W12TJk1k4sSJEhkZaZq262x17dq1s3poADyIQAgArzV06FD58ccfZe3atVKwYEGzI9K9e3f5448/pG3btlYPDwAA+BHtRda8eXOpU6eOfPnll2bZE088YZqlrl+/nhIZwI9QGgPAKx08eNDU5U6ZMsUEQZROnavT2M2aNcvq4QEAAD/z559/Sr169UxpjINmoepJmNmzZ1s6NgCeRUYIAAAAAAAIGGSEAAAAAACAgEEgBAAAAAAABAwCIQAAAAAAIGAQCAEAAAAAAAGDQAgAAAAAAAgYBEIAAAAAAEDAIBACAAAAAAACBoEQAAAAAAAQMAiEAAAAAACAgEEgBAAAAAAABAwCIQAAAAAAIGAQCAEAAAAAABIo/g8ImGBQcEbGAAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1100x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(1, 2, figsize=(11, 4))\n",
+    "xf = np.linspace(0.0, 5.2, 300)\n",
+    "ax[0].plot(xf, model_np(xf, *res.popt), '-', lw=2, label='fit')\n",
+    "ax[0].plot(x, y, 'o', ms=5, label='data')\n",
+    "ax[0].plot(x[0], y[0], 'o', ms=11, mfc='none', mec='crimson', mew=2, label='isolated point')\n",
+    "ax[0].set_xlabel('x'); ax[0].set_ylabel('y'); ax[0].legend(); ax[0].set_title('the fit')\n",
+    "\n",
+    "ax[1].stem(x, lev, basefmt=' ')\n",
+    "ax[1].axhline(J.shape[1] / x.size, ls='--', c='gray', label='average leverage n_p/m')\n",
+    "ax[1].set_xlabel('x'); ax[1].set_ylabel('leverage $h_{ii}$')\n",
+    "ax[1].legend(); ax[1].set_title('leverage is where the information is')\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa7ad854",
+   "metadata": {},
+   "source": [
+    "One point carries leverage far above the $n_p/m$ average while its residual is\n",
+    "utterly ordinary. Residual plots — the reflex for finding problem points —\n",
+    "cannot see it, because leverage and residual are different questions. A\n",
+    "high-leverage point is not an error; it is a point the fit *depends on*, which\n",
+    "is worth knowing whether or not it is also wrong."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f59a6a16",
+   "metadata": {},
+   "source": [
+    "## 3. Does the linearization tell the truth?\n",
+    "\n",
+    "`dpopt_ddata` is a derivative: it predicts the effect of an *infinitesimal*\n",
+    "nudge. The question practitioners actually ask — \"what if I drop this point?\" —\n",
+    "is a finite change. Classical regression bridges the two with\n",
+    "\n",
+    "$$\\hat{p}_{(i)} - \\hat{p} = -\\frac{\\partial \\hat{p}}{\\partial y_i}\n",
+    "\\cdot \\frac{r_i}{1 - h_{ii}},$$\n",
+    "\n",
+    "the **DFBETA**, where the $1/(1-h_{ii})$ factor accounts for the fit having\n",
+    "been pulled toward the point being removed. Nothing guarantees this holds for a\n",
+    "nonlinear model. So check it the only way that settles it: actually drop each\n",
+    "point and re-fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c3793e24",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:44.480381Z",
+     "iopub.status.busy": "2026-09-07T00:40:44.480166Z",
+     "iopub.status.idle": "2026-09-07T00:40:45.425164Z",
+     "shell.execute_reply": "2026-09-07T00:40:45.424710Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  a: max |predicted - actual| = 1.78e-03   (0.7% of the largest actual shift)\n",
+      "  b: max |predicted - actual| = 3.06e-03   (4.4% of the largest actual shift)\n",
+      "  c: max |predicted - actual| = 1.02e-03   (11.8% of the largest actual shift)\n"
+     ]
+    }
+   ],
+   "source": [
+    "pred = -res.dpopt_ddata * (resid / (1.0 - lev))[None, :]     # (n_params, m) DFBETA\n",
+    "\n",
+    "actual = np.zeros_like(pred)\n",
+    "for i in range(x.size):\n",
+    "    keep = np.ones(x.size, bool); keep[i] = False\n",
+    "    ri = pounce.curve_fit(model, x[keep], y[keep], p0=P0, options=OPT)\n",
+    "    actual[:, i] = ri.popt - res.popt\n",
+    "\n",
+    "for j, nm in enumerate(res.param_names):\n",
+    "    num = np.abs(pred[j] - actual[j]).max()\n",
+    "    den = np.abs(actual[j]).max()\n",
+    "    print(f\"  {nm}: max |predicted - actual| = {num:.2e}   \"\n",
+    "          f\"({100*num/den:.1f}% of the largest actual shift)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "19a87b64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:45.426556Z",
+     "iopub.status.busy": "2026-09-07T00:40:45.426477Z",
+     "iopub.status.idle": "2026-09-07T00:40:45.484607Z",
+     "shell.execute_reply": "2026-09-07T00:40:45.484147Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeoAAAHqCAYAAADLbQ06AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAW01JREFUeJzt3Qd4E+UfB/BfW2bLElB2QQFR9hBkCCp7QxkioIAIIgqyZCpbBQEFZImAyJa9ZSMKypSpCAKyd9nQAoXe//m+ePmnO0mT3uXy/TxP2uQuyb25XO537/bTNE0TIiIiMiV/oxNAREREcWOgJiIiMjEGaiIiIhNjoCYiIjIxBmoiIiITY6AmIiIyMQZqIiIiE2OgJiIiMjEGaiIiIhNjoPYhU6dOFT8/Pzl16pTRSSEDvPLKK/Laa68luMysjEyrN+0nKyhcuLDUrVvX6GSYBgM1kcm99NJLUrVqVaOTYXncz0m7L7i/HZfMiecSkcVs27ZNvIWRafWm/UTWwxw1ERGRiTFQk5w7d07effddyZ49u6RIkUKeffZZ6d+/vzx8+ND2nFWrVqn6bf0WFBQkpUuXlhkzZties3z5crVu2bJlMbaxefNmtW7evHlObTc+N2/elC5dukhwcLB6fa5cuaRz585que748eNqu6ifX7x4sbz44ouSMmVKKVq0qKxbty7Ge0ZERMiwYcOkYMGCkipVKsmYMaM0a9bMqXr9yZMnS7FixdTrM2TIoOra9u3bF+U5WP7+++/HeG2TJk0kX758tseZM2eWP/74QzZt2mTb9zlz5rSt/+GHH9Qy/HdX3ateP3js2DGpVq2aBAYGqu9o8ODBEttkez/99JN6j3Tp0knq1KmlXLlysnbt2hifS09/QECAPP3009KoUSM5cuRIrNs+fPiw2naaNGmkXbt2saZ1zJgxUY5J+1vx4sWd2nZC+zmuOmpHvmtn96e9kJAQeeaZZ9RxGV2rVq3UNsPDw9XjX375RapUqaI+S/r06aVs2bIyZ86cBLcRXUL7Ir7vyF3Htc6VfWZJmOaSfMOUKVNwhGsnT560LTt16pSWJUsWrVy5ctru3bu1u3fvaps2bdJy5sypNW7cONb3iYyM1C5evKgNHz5c8/f315YsWaKWR0REaNmyZdPq1q0b4zUtW7bUnnrqKS08PNzl7dq7f/++VqJECbW9devWabdu3dI2btyo5ciRQytatKgWFhamnnfs2DH1mZs2bap99NFH2tmzZ7ULFy5o9evX11KnTq1dunTJ9p6PHz/W6tSpo2XOnFn78ccftRs3bqjX16pVS23n8uXLCaarb9++WkBAgDZq1CgtNDRUO3r0qFazZk21rT179tielz59eq1Dhw4xXo/Pnjdv3ijLSpUqpVWpUiXW7U2fPl19PvxPSIUKFbRXX301wWWFChVSy0NCQrS9e/eqfTtmzBi1nVmzZkV57qRJkzQ/Pz+tX79+2pkzZ9Rn/uKLL9RxsXz58ljT8eDBA+3AgQNa9erVteDgYO3mzZtRtl2+fHm1z/744w+1z+fPnx9nWqObN2+eSg+ON2e3Hd9+jm3bjn7XzuzP6FatWqWet2jRoijL8R6BgYFax44d1WP8prHdDz/8UB3f9+7dU2l4++23VbqcFd++iO87ctdxnZh9ZkUM1D4eqJs3b65lyJBBu3r1apTnLlu2TD13+/bt8b5n1apV1Q9W16dPH3XywslCh5MhTiKdOnVy23a/++479bwVK1ZEWb5mzRq1fNy4cVECdZkyZaI87/Tp02r5V199ZVuGkw2WLVy4MMpzkX6ktXfv3vGm6fz581qyZMm0tm3bRll+584dLVOmTFFOSu46oTnDmUCdPHlydTFlDxdGFStWtD2+du2aFhQUFGtQbNiwoVagQIF403Pu3Dm1v3FRZL9tBPl//vnHofTb27p1q5YyZUrtpZdeUoHK2W07E6id+a4d3Z+xefTokbr4xMWivW+//ValX78gwOfAY1eCcmwSCqJxfUfuDNSu7jMrYtG3j1u5cqUq0kNRlD0UoenFafD48WMZNWqUlChRQhV768VVGzduVMXLOhRl47n2ReJz585VxXNY58x2//zzzxhFmiiCBxSZobi7Tp06UV5fs2ZNVRSH9faiPw/F5WnTppV///03SprwnvXr14/yXBQjooWqvi9QhGefJr3Y79dff5VHjx6pYlV7SA/Spa/3BijezJ07d4xl9vvr559/lnv37knTpk1jvB6teY8ePSqXL19Wj8+cOSPvvPOOqp5Injx5lKJO++MHUD2RP39+p9KLItKGDRtK1qxZ1feIolKdM9t2lLPftSP7MzYoqm/Tpo2sX79ezp8/b1v+/fffqyL3UqVK2d7L399f3nvvPVmzZo36XjzJle/IWa7uMytioPZh+DHfvXtX1S0nS5ZMnRRwww8eQQyuXbum/vfu3Vv69eun6oDxQ8FJCCUyODna158hiL366qvqRKKbNm2alCxZ0lZv6Mx244L1qLvDa6LLkiWLhIaGRlmWLVu2GM9Dnap9ffalS5dU/ThO8nq68P76BYkjaQIEi+iwDPvp1q1b8b6HWerfHN1f0Lhx4yj7C7dOnTrZ9klYWJhUrFhR9u/fLwsWLJDr169LZGSk7b2i17/myJHDqbTiu65du7Y6JlevXh1l/zu7bUc5+107sj/jggtcpFlvh/DXX3/Jrl27olz4FipUSJYuXSr3799X9ceoK65QoYLMnDlTPMHZ78iV4zox+8xq2D3LhyEgofEPTrSzZs2K97n4waNBSNu2baMsP3nyZIzn4gSChi5bt25VuVE0GpkwYYJL243rB45GXleuXFHrEUjtIRdXpEiRKMuiPyc2yN3jRHDjxo1YLwB0ceXCkCZ9+9FhGXJz2B+A/3fu3InxPPtck5Ec3V+ARnl6SUhs0NgMudopU6aohmbxHTuA/eQoBKYGDRrI6dOnVU4SAcveli1bnNq2o5z5rh3dn3FBI8vXX39dpk+fri6WceGLBpEtW7aM8jyUBOGGQPb777/Ld999J61bt1ZBHrlyd4rrO3LncZ2YfWY1zFH7MPwQcPW9YcMGFZwSgpODvYMHD6pbdAjo+MHihIIbWsS2aNHC5e3GBoEBuV8EAXsoIkRuPb7AEZd69erJ7du3Y7RYdhRKEpCzRM7GHkoQ8J6VKlVS6yFv3ryqaD/6yQw5v+hQ1fDgwQMxG+xjXHDNnz/foedHP34Sm9vDRRoCEYISWl/H9507sm1n9rMz37U7oHrlxIkT6jeDi1u0BtcvFqJDbholDEuWLFGfG8XwznL1mLPCcW1GDNQ+bsSIESr3iDpc5IBxNYwcAYp6kePVu5rgSh1Fh8g94WSE56I+DCes6HDyRmBeuHChzJ49W70PTh6ubDcuyLGjjq5Dhw7qNXg96kxxQkM9VvScvyPefPNNdQGB3AdO5Cjaxfvu3btX+vTpo+ro44PuI927d1c5n9GjR6tiVtSdonsXLh7Q7UvXvn17dZGDLka4ODhw4IB8+OGHqktNdPg8OPkhJx+9hCGx3bMSAzlqfE5cjPXq1UsFErRFwGdGDhYXbICcLJ47cOBA1c0Nxcb43BcvXkzU9r/88kt1TKJLH+qgY+PMtuPbz4n5rt0BdeEIzDi+UdRvX+wNuFBBV8Xdu3erYxa5apRiIRAiN67r2rWrOl5iC5yu7gt77jquKRqjW7ORsa2+AV2t0K0jT548qqVl9uzZVUvupUuXqi5LcPv2bdWaE12q0NK3cuXK2sGDB7VmzZppuXPnjrEtdNvAtnDbvHlzrOlxZLvxuX79uno9WsWiBS5ej+4qaI2s01t947NHh9dFb7GMVrboBlKyZEnV/QWtWNGKeOTIkVG68sRn4sSJWpEiRbQUKVJo6dKlUy127bvr6F3chg4dqrp9pUqVSrUoPnz4cKytY9GCvkaNGlqaNGnUZ0G6Pd09C93UosO+xncfHbrV4TNmzJhRfRa09sb3cOTIEdtzdu3apVrr4vU4hrp06aL2J9I+cODABLcdW1rx3enHWPRbsWLFnN52fPs5rhbnjnzXzu7PuHTu3FmlC78XHD/20L0RPR1efvllLW3atKorJLpQzZkzJ8rz8NnxHvv27Yt3W/Hti/i+I3cd1+7aZ1bhhz/RgzcRERGZA4u+iYiITIyBmoiIyMQYqImIiEyMgZqIiMjEGKiJiIhMjIGaiIjIxDiEqAMwBN+FCxfUONQc1o6IiBILPaMxOA0Gz4lvyGJgoHYAgjRm3iEiInKns2fP2mZziwsDtQP0GZ2wQzFpAxERUWJgiFVkAPX4Eh8Gagfoxd0I0gzURETkLo5Up7IxGRERkYkxUBMREZkYAzUREZGJsY7ajV24Hj58KFaVPHlyCQgIMDoZREQ+h4HaDRCgT548qYK1lWXIkEGyZs3KvuREREmIgdoNndYvXryocptoap9Qx3Vv/YxhYWFy5coV9ThbtmxGJ4mIyGcwUCfSo0ePVBDD6DKBgYFiValTp1b/EayfeeYZFoMTESUR62X/ktjjx4/V/xQpUojV6RciERERRieFiMhnMFC7iS/U2/rCZyQiMhsGaiIiIhNjoCYiIjIxBmoiIiITY6tvkzgZek8W7Dkr526ES86nUssbL+WSZzMHeXTqzuvXr6v7mTJlYpcrIiKTYqA2AQToPosPqsZa6LOM/5N/OSFfNi4qTV/yzDzY06ZNk/nz59u6XKH71YwZM+S1117zyPaIiMg1LPo2QU4aQTpSE3kcqUX533vxQTkVes8j2+3fv7/8+eef6oZA3bVrV2nRooWEh4d7ZHtEROQaBmoT5Kbj6vaE5fP3nPXYtpF7R5A+fPiwVK5c2XafiIjMg4HaYKiTRsCMDZZjvSesW7dO8uXLJ88//7yEhIRIy5Yt1fbOnz/vke0REXmzn3/+WYYPH27IthmoDYaGY/HlqLHeE6OpNWvWTDp27KgalB09elT27duntmf1iUWIiJy1efNmqVOnjgrWGDY6qTFQGwytu+PLUTfzQGMyTCJy69YtadiwoW0SkS1bttiGQyUioic2bdokdevWlUqVKsmyZcskWbKkb4PNQG0wdMFC625/P5EAf78o/7E8jwe6aGECkTx58ki/fv1k586dMm/ePGnbti2HCCUisrNr1y6pV6+eLUjrkxMlNXbPMgF0wSqdJ6NqOKb3o0ZO2hNBGpCLXrNmjQwcOFA++OAD1Yd66tSpqiV4unTpPLJNIiJvU6hQIenevbt8+umnkipVKsPS4afFVe5KNrdv35b06dOr4uLogez+/fty8uRJefbZZw39IpOCL31WIvLtOuksWbKoQG1EXImORd9ERET/2bBhg2o4NmLECDELBmoiIiIRWb9+vdSvX1+NKzF58mQxC9ZRExGRz9uwYYM0aNBABeklS5ZIypQpxSyYoyYiIp+XMmVKlZs2W5AGBmoiIvJZe/fuVYOYoAsWJioyW5AGBmoiIvJJa9eulfLly8s333wjZsZATUREPhmkGzZsKNWrV5cPP/xQzIyBmoiIfDZIL1y40JTF3fbY6puIiHzK6tWrVZBetGiRpEiRQsyOgdpHNW/eXIoWLSp9+/Y1OilEREnixo0b8tRTT8nYsWNVAzJvCNLAom8fdfXqVTV0HRGRr+Si8+TJoybawHwH3hKkgTlqs7h2QmTfLJGbZ0QyBIuUeFskU16jU0VEZIkg3ahRI6ldu7YUL15cvA0DtRnsmy2yojPmSMEs1E/+/zZWpP54kRItPbbZ8PBw6dGjh5oMHXNRt2vXTjp3RjqIiKxh1apV0rhxYzV+948//uhVOWkdi77NkJNGkNYiRbTHUf+v6PRkvYeMHz9eIiIiZObMmdKrVy81P/X333/vse0RESWliIgI6datm1cHaWCO2mgo7lY56dj4PVlfdZBHNv3iiy/aOvoXLlxYjh8/Ll988YW0bdvWI9sjIkoqmqZJ8uTJVYnhM88847VBGpijNhrqpFVxd2y0/9Z7RoUKFaI8rlixopw4cULu3bvnsW0SEXnaypUr1ZCgmPM5Z86cXh2kgYHaaGg4Fl+OWq33jOgHr/744cOHHtsmEZEnrVixQtVJIxedOnVqsQIGaqOhdXd8OWq13jMOHToU5fGBAwckU6ZMqp8hEZG3Wb58uTRp0kTNgoU6aRR9WwEDtdHQBQutu/38RfwCov7Hcg920frll19k7ty56j7qp0eMGCEdO3b02PaIiDzl1KlT0rRpUzWn9Lx58ywTpIGNycwAXbCCyyZ5P2oc1Gj5/cEHH8jdu3fVY7T8JiLyNnny5JGlS5eqoUGtFKSBgdosEJQ91Lo7NnpXhXTp0qn+1BhOL23atEm2fSIid1i2bJmcPn1aunTporphWRGLvn1U5syZVZAGNLhgkCYib7N06VJVErh9+3bVHcuqGKiJiMjrLFmyRN544w3Vwnv27Nni5xdX7xnvx0BNREReZePGjdKsWTNbkE6WzNq1uAzURETkVUqXLi2ffvqpTwRprwzUuJJC8/uyZctK+/bt5ezZs/E+/9KlS9K/f3+pUqWK1KhRQ4YOHSp37txJsvQSEZH7BjM5fvy4pE+fXgYOHOgTQdrrAvWGDRukVq1a6mrq888/l8uXL6thMOOaVxkzQpUvX15SpUoln3zyiZoZavHixVKtWjU1WDsREXmHRYsWqakq0aXU13jV5ciAAQNUvQSKPABBOlu2bDJ58mQ1+1N0AQEBcvjwYRWodc8++6yagAKTh0cf65qIiMxn4cKF0rx5c3X+HzVqlPgar8lRY0COnTt3qom/dQjAKNLetGlTnK+zD9KQMmVK9R/9homIyHuC9IwZM3ymuNsrA/X58+dVPznkoO1lz549wXpqe4MHD1azqbz88stxPufBgwdq1hX7GxERJb20adNK69atZebMmT4ZpL0qUOt1ynqOWIfHjtY3jxw5Ul2dzZkzJ0ZO296wYcNUYwX9litXrkSmnoiInIHqycjISKlZs6ZMmzZNVWX6Kq8J1JjVCa5duxZlOR7r6+Izbtw41fobneQxT2l8+vbtqxqo6TdncuxERJQ48+fPVw2BUdRNXhSoUeSNYm5cZdnbsWOHlCpVKt7XTpgwQXr27KlafNvXcccFuXQMr2l/IyKipJmHoEWLFurWqlUro5NjCl5V4I9+02jh/e6776qZUjBF45EjR1Snd92QIUPk4MGDqik/TJo0SXr06KGCtJkHbD99+7QsPbZULty9INnTZJeQ/CGSO11uj27zwoULat+hxKBIkSLSpk0bNVEHEZFRQbply5by1ltvyffff+/Txd32/DQvGskcddEI0igWyZIli9y8eVNGjx6tlunatWunctl//vmn3LhxQxWLI0eMwG4PneVDQkIc2i4ak6GuGsXg0XPX9+/fl5MnT6puX/HVe8cHAXrQ9kHiJ36iiWb7P7j8YGmYr6F4wrZt21TpwmuvvaZuR48eVYPDYOL1uLjjsxIRxQWZBYQkXwjSt+OJK14dqHWhoaFy9epVFXwx85M95A7DwsKkQIECasCTQ4cOxfoewcHBkjFjRsMDNXLS9ZfVl0gtMsY6fz9/WdlwpQSnCxZ3wlf+/PPPy6uvvipTp061LT937pxqER8XBmoi8gS9rRHO2WD1IO1soPaqom/7KRpxi419C2182cWLFxczQ24aOejYYPmSY0uka6mubt3msWPH1DB89lUGEF+QJiLyBPTC6dixo5qqslChQkYnx5S8pjGZVaFOGsXcscFyrHc3VAkAqg+IiIwM0mgw1qRJE3nhhReMTo5pMVAbDA3H4stRY7276TnnEydOuP29iYgcgRI9BGkMZoIqOF8o7nYVA7XB0Lo7vhx1o/yN3L7NHDlyqL7kX3zxhap31sU3FCsRkbvcu3dPevfubQvS/v4MRfHh3jEYumChdTcajgX4BUT5j+Xubkimw0ACaOWN4iaMoYu6/FWrVnlkW0REOow2FhQUpHrnMEg7xisbk1kNumCVfKakajim96NGTtpTQRrQYv7AgQOydetW1Z+6WLFialYxIiJPmTVrlkyfPl1Wr17NoZmdwEBtEgjK7m7dnRAMcP/6668n6TaJyDdhUg30k8a4F9HnbKD4scyBiIg8ClVtCNIYkAqjS7K42zncW0RE5DEYJfKdd95RQfrbb79lkHYBi76JiMhj0PYFddI1atRgkHYR9xoREbkdGo1NmTJF3a9VqxaDdCJwzxERkVthUg00Gtu7d6/RSbEEBmo38cK5TVzq/0hElFCQRn10hw4dZMKECUYnxxJYR51IyZMnFz8/PzWb19NPP63uW/Ei5OHDh+ozoviKc1YTUWwWL16sgvT7778v48ePZ3G3mzBQJxLGp8XY2Zgi8tSpU2JlgYGBanpQ/viIKDaYOhdDE/fq1YvnCTfyyvmozThvKOZRjYiIECtfkGCAFCuWGBBR4sybN09eeeUVjjbmBMvPR23WQMbZX4jI16Bl93vvvSdDhgyR/v37G50cS2LZBBERueS7775TQfrDDz+UTz/91OjkWBYDNRERuZSTRsvuTp06ybhx41gt5kEM1ERE5LTMmTNLt27d5JtvvmGQ9jA2JnNzpT8RkZX99ttvUr58eQbnJIwrzFETEZFDJk2apFp3L1u2zOik+BQGaiIiStDEiRPlgw8+kC5dukjDhg2NTo5PYaAmIqIEgzRadnft2lVGjx7NYu8kxkBNRERxQjOmjRs3qiD99ddfM0gbgAOeEBFRrPQ5DObPn8+RCQ3EHDUREcWASTXy58+v5jDQJx8iYzBQExFRjCDduXNnNRNW7ty5jU6Oz2OgJiIiG4wyhiD98ccfy8iRI5mTNgEGaiIiUq5duyaDBw9WQXrEiBEM0ibBxmRERCSRkZGSKVMm2b9/v+TIkYNB2kSYoyYi8nFjx46VunXrSkREhOTMmZNB2mQYqImIfNiYMWNUH+kiRYqoLlhkPgzUREQ+CqOMYQas3r17y/Dhw5mTNikGaiIiH7Rt2zbp3r279OnTR4YNG8YgbWIs5yAi8kEVKlSQtWvXSvXq1RmkTY45aiIiH4LxuufNm6eCc40aNRikvQADNRGRjxg1apT06NFDDh8+bHRSyAkM1EREPgCjjPXs2VM+/fRTGTJkiNHJIScwUBMRWdy0adOkV69etiDN4m7vwsZkREQWV7t2bTWoCcbwZpD2PsxRExFZ1NSpU+Xy5cuSLVs2+eijjxikvRQDNRGRBWEAk/bt28vChQuNTgolEgM1EZHFYACTvn37ysCBA6VTp05GJ4eMqqM+fvy4rFixQs6cOSOPHj2KMek4EREZk5Pu16+fCtKDBg0yOjlkVKBes2aNNG7cWMqUKSO//PKL6jR/4MABuXTpklStWtUd6SIiIhdg9ivMKT1gwACjk0Ju4qdpmubsi0qVKqVaD7Zp00Y1TsBbPHjwQN577z1JlSqVTJ48Wazk9u3bkj59erl165akS5fO6OQQEcWATFOlSpXYYMyCccWlOuq///5bmjRpou4HBARIeHi4pEyZUhW5LF261LVUExGRSz777DN57bXXVLAm63EpUCMwp0mTRt1Hs/8TJ048eTN/f7l37557U0hERHEaOnSo9O/fXw1kgmBN1pPMHR3pUeTdqlUr1Q2gfPny7kkZERElGKRRF43/GHWMrMmlHLV9v7wvv/xSChQoIGPGjJG0adOqDvZERORZ6G2DOaUZpK3PpRw1WnfrMmTIINOnT4/SNYv99oiIPAejjWXJkkVWr14tyZJxJGircylHjRbfrqwjIqLEQd/oQoUKyZUrVxikfYRbRyY7ffq0ZMyY0Z1vSUREdkEafaQxp/QzzzxjdHIoiTh1OVa4cOFY70NkZKQapSwkJMR9qSMioihB+osvvlDDg5LvcCpQt2vXTv3v1q2b7b4uefLkkidPHqlZs6Z7U0hE5OPOnj0rX3/9tRrDu0+fPkYnh8wcqLt27ar+Z86cWd566y1PpYmIiETUqI8orcyVK5ccOXJEsmfPbnSSyFvqqBmkiYg8H6QxscYbb7yhgjWDtO/i7FlERCYM0hjIBEODjhgxQo36SL6Ls2cREZksSGNI0M8//1xGjhwpH3/8sdFJIm8M1BgFZ+LEibbZs9auXRtl9iwiInINBjFhkKZET3MZGBioOttjYg50uL9z546kTp1aLl68KMWKFVPrrITTXBJRUsEpefPmzVKlShWjk0LePM0lZ88iInJ/nfTy5ctVKSWDNNnzd9fsWd9++620aNHC47Nnbdy4URo0aCBly5aV9u3bq/6FCdmyZYu8+eabUrx4cdmzZ49H00dE5GyQ7tevn5pc499//zU6OWRCXjV71oYNG6RWrVpSunRpVYeDgekrVKigig7igsEB0MUBgR0N3u7eveux9BERORukMcrY8OHD1YAmGEyKyC111EYpV66c5M2bV2bPnq0e379/XxW940Dv1atXrK9BUXxQUJCcO3dODRrw888/Oz25OuuoicgT0GAM5y4Gad9z29N11EZATnjnzp2qqF2HFuaoy9m0aVOcr0OQJiIyIwxmglJIBmlyS/csjOPtqFOnTom7nT9/XhUTIQdtD6P1oN7andDVDDf7Kx8iInfAeWzcuHFqhMfcuXPLu+++a3SSyCqBGjO36I4dO6aKbHA1iPpi2L17tyxYsEB69uzpkYRGRESo/ylTpoyyHI/1de6Cge8xSw0RkbuDNIq6R40apeZMQANcIrcFagxuoqtWrZpMnz5dWrZsGeU5aOg1Y8YM8YRMmTKp/9euXYuyHI/1de6COu/u3btHyVGjfpuIKDFBGhmZr776Sr755hsGaXKYS3XUyD3Xq1cvxnIs27Vrl3gCirxRzB39/Xfs2CGlSpVy67aQS0flvv2NiCgxkJPWg3Tnzp2NTg5ZPVBjZLJ169bFWI5lnmy8hX7TaHih14HPnTtXTf1mX8czZMgQadKkicfSQETkinz58qm6aQZpSpKxvnFl2KpVK9WvGXXUKNLBQCKzZs1SM714yieffKIGBEC/7SxZssjNmzdlypQpUrJkSdtzMJsXgrcOM3xhxB+9Hrtdu3ZqVLX3339f3YiIPAXnRnQJrVy5snTo0MHo5JCv9aNetWqVjB49Wg4fPqweFyxYUNXr1qlTRzwtNDRUrl69qlqiY4xxexipLCwsTAVzuH79ugre0WXNmlXdHMF+1ETkLJxacU7EYFB79+6VEiVKGJ0kMhFn4opXDXhiFAZqInIGTqvoGz127FiZMGGCfPDBB0YniUzGmbjiUtE3ERElHKQxHXDHjh2NThJ5Oa8Z8ISIyBtgaGMUdTNIk88NeEJEZPacNCYKQtsXNCALCAgwOklkEV4z4AkRkZmDdJcuXWTx4sWq1wlmEiTyuQFPiIjMGqQ/+ugj1UcaU+oySJNPD3hCRGTGID1+/HiZPHmyvPfee0YniSzIqwY8ISIyk6NHj6pqwO+++06NnEjkCV454ElSYz9qIrKH02ZkZKRqMHbp0iWHB08iMt2AJ99++60lhulkoCYiHU6ZH374oRoBEblpPz8/o5NEFo8rLtVRO4p9CInISpCLRpCeNGmSVKxYkUGakgRHJiMiciJIo9EYZvGzn7WPyJMYqImIHDBnzhxbkG7btq3RySEfwkBNROSAFi1aSO7cuaVSpUpGJ4V8jEfrqImIvL24GyOOoSsqWngzSJMRGKiJiOII0ui1ghHHLl68aHRyyIe5FKgxCo8j61BMRETkjUG6Q4cOqj4aXbAwwBORUVzqR40uCXG9LL513or9qIl8S9++feXLL7+UH374gUGaDI8rbm1Mdvr0acmYMaM735KIKMmhVXexYsXkzTffNDopRM4F6sKFC8d6Xy8qOnPmjISEhLgvdURESQTnsFGjRql66fz586sbkdcF6nbt2qn/3bp1s93XJU+eXPLkySM1a9Z0bwqJiJIgSGNSDdRHFypUyJJzFpCPBOquXbuq/5kzZ5a33nrLU2kiIkrSII2Mx4wZM2TmzJkM0mQ6LtVR60H677//Vjd48cUX1Y2IyFug4at9kG7ZsqXRSSJyT6C+fPmytG7dWtatWycpUqRQyx4+fCi1atVSB/zTTz/tytsSESUp9FJBUTeDNFmuHzXqctCkfN++fXL//n11w/0bN25w8nQiMr3Hjx/Lxo0b1f0ePXowSJP1+lGnTp1a/vrrL3nuueeiLP/3339Va3DM02ol7EdNZK0gje5XmGTjyJEjki9fPqOTRD7otqf7UWfNmlUF6+iwDOuIiMwapN955x0VpHFjkCbLFn2jmAjzsoaGhtqW4T6WsQiJiLwhSHMwE/IWLuWoV61aJQcOHJDVq1ervtMoPceoZGhQdvLkSVmzZo3tuXv27HFneomIXHLv3j05duyYzJ07V5o1a2Z0cog8G6hxJcqrUSLylpz0lStXJFu2bLJt2zY1XSWR5RuT+Ro2JiPy3iCNrqQ7duxQDWBTpkxpdJKIkn5SDvwQgFepRGQmODdh5qv58+fLvHnzGKTJtxqTwaxZs1RXLLT0xg33sYyIyGiPHj2KEqSbNm1qdJKIkjZQjx07Vjp27Kgm4EDDDPwQcB+zzmAdEZGR9u/fL8uWLWOQJt+to3722WdlzJgx0qBBgyjL8cPo3r27GvjESlhHTeQ9OWl/f391QwOyZ555xugkESU6rriUoz5//rxUrlw5xnIsO3funCtvSUSU6CD99ttv22b5Y5Amq3ApUCNHvWLFihjLly9frtYRESV1kMasfosWLZLXXnvN6OQQuZVLrb779eunxsrdsGGDlClTRi3buXOnqg+aMmWKe1NIRJRAkMaIiEuWLJEFCxZISEiI0UkiMj5Qo18iBg8YMWKEmuoSU8UVLFhQjVhWvXp196aQiCgekyZNYpAmS+OAJw5gYzIic+eod+/eLeXKlTM6KUTmaUym+/vvv9WVLG64T0SUFCIiIlT1G4YETZYsGYM0WZpLRd+XL19Wxd8o9k6RIoVahgk5atWqJTNmzJCnn37a3ekkIrIF6RYtWqjuoNG7iBJZkUs56vbt26vs+r59++T+/fvqhvs3btxQ64iIPBWkmzdvrnqYoIU3AzX5ApfqqDFkKAa4f+6556Isx0AnGEo0LCxMrIR11ETm0KFDB5k+fboK0vXr1zc6OUTmnZQja9asKlhHh2VYR0TkCZ06dZJ69epJ3bp1jU4KkbmLvtFn8cMPP5TQ0FDbMtzHMqwjInIXtH/57LPPVEldkSJFGKTJ57hU9F28eHE5cOCAakiWJ08ewVucPn1a/aCwzn7Kyz179oi3Y9E3kTFwTmnWrJn89NNPsmnTJnnllVeMThKRdxR9v/nmm+pGROTJIP3GG2/ImjVrVBdQBmnyVRzwxAHMURMlrcePH0vjxo1VkF66dKnUrl3b6CQReeeAJ0REnoDqs1KlSjFIEzmTo0ZdtKNOnTolVsIcNVHSFXf/+uuvUrVqVaOTQuR9ddSDBg2y3T927JiMHDlS1R+VLl1aLcNYuxgUv2fPnolJOxH5cJBu2rSpmpXvxIkTauIfInIiULdp08Z2v1q1amrQgehdsfQhRImInPHgwQMVpNevX6+KuxmkiRLZmCxDhgxy5syZGNl1ZOWDg4Pl5s2bYiUs+iZKmiCN8btr1qxpdJKIvL8xWWBgoJqQIzosCwoKcuUtichH3b17Vy5evMggTeTOftS9evWSVq1aqbok1FEjU46BTWbNmiUjRoxw5S2JyAdz0ih9y5Ili+zcuVP8/dkJhchtgbpr166SL18+GT16tKxcuVItK1iwoBoov06dOq68JRFZ3bUTIvtmidw8I/cDs0vj0b/JuSvXZe/evVFGMyQiNwRqwHi7HHOXiBxxfe1weWrHMEGDmAePNGmyIFw2n3wkK77pzSBNlACWNRGRRx2Z8ZE8tX2Y+KEL1iNNGs9/EqSXvxko1a5MfpLTJiL356iJiOJz+vZpmbymi/z58G/xy5lVSt5/IAX2X5etZx7JyuaBUvW5ZII+J34oDq/6/3EaiCgqBmoicrulx5bKwN8HqIamkjy5aI80OZEmmfhXTCMTgkOlqhb+3zMjVZ01EcWNRd9E5FYjts2UAb8NUPXR4ucnkRGanP7mjFxZelUtG5U7s5xJ9iSPoJ6TIdjgFBOZGwM1EblNlRkfyKzjI/UQLJEPI+XMuDNy78g9CXoxSAVuWJI26EmxNx6UeNvYRBNZsegb/R+nTp0q27Ztkxs3bsRYv3btWvGUjRs3yrhx4+Ty5ctSpEgRGTBggOTKlcvtryEi57wzb7Zc0bb+F339ngTpb87IvX/uSe5uuSVNwTTqeQjh5//LUd8o108yZsprbMKJrJij7tixowwZMkSNQla4cOEYN0/BACsYTxyDrHz++ecq8FaoUEENwebO1xCRc75YOFv23h9uy0lD6JrQJ0G66/+DNCCO54h4JEfzviMZa/Q2KMVEFh/rG+OTbt++XQ1ykpTKlSsnefPmldmzZ6vH9+/fV4P39+3bV42W5q7XRMexvoni1uOHt2W97Hvy4L+ibYiMiJQH5x9I6jyp//9kTVOBevbTDaVonc8MSC2Rj4z1nTJlyiSf3QbjAWOYQftJ5FOlSiVVqlSRTZs2ue01ROS4Dxf2fRKkEaD9/ivunnBGwk+Fi39y/xhBGobkqssgTeQElwL1W2+9JcOGDZPIyEhJKufPn1ddPaJfIGTPnl3Onj3rttfodfC42rG/EVFUozeMll/vrbTloiMfRMrpsaflzoE78jj8cdQn/xekx0Vml4ZVUERORB5tTPbxxx+rumgUJz/77LPiZ1fcBWhk5m4RERG23Lw9PNbXueM1gIuQwYMHuyHVRNbUcU5j2RZx1PZYD9Jhx8MkT/c8EvRCUIwg3TM8nbzWcb0RySXyvUD97rvvSpo0aaRRo0ZqbuqkkClTJvX/2rVrUZbjsb7OHa8B1F93797d9hg5arYSJ3pi+e45T4K03QX6uSnn4g3S3R5ml1YM0kRJF6i3bNkiBw8elPz580tSQfE1iqx37dol9erVsy3fsWOHvP766257jZ7jjp4LJyKR06e3ypiDX4gERC1Fy1w7s2SqlkmCCsQM0jkf+knb9xikiZK0jhrzx2bMmFGSWvv27VX/7VOnTqnHc+fOlSNHjqgcvg7dxpo0aeLUa4goYUs39ZL6P3eU0P+CNIq7Ly+9rFp3Bz4XGGuQ9n+syZr3DhmVZCLfzVGHhITIoEGD1HzUyf4buCApfPLJJ/Lvv/9KgQIF1MUCJp2fMmWKlCxZ0vacM2fOqEDszGuIKOGc9KCzP0mkfcOxMacl/N9wSVcynaTOHbN1d4Cmyf53/zIqyUS+3Y+6WLFiqugb9by5c+eO0Zhsz5494kmhoaFy9epVyZMnj6RObXeCEFGtucPCwlRgdvQ1CWE/avJ1Y+bXlR/CT8ljdMGyC9K5u+eONScdHB4gqzseMC7BRCbnTFxxKTvcvHlzdTNK5syZ1S02cTX6iu81RBSPfbPlQuhh0YICVTF3jCAd7Vq/fWQW+agjxykgcheXAnWfPn3clgAiMrFrJ0RWdJbsGdKqEcX8kvlJYN5AeSbkGQl6/v856ZSaJq+HhUvnF9tIcOUBhiaZyGoSXcH8+PGTgQ0CAgLckR4iMpN9s9To3DWu3ZVvzvtLUME0kqVJlv+v1zTVInXJ+UsSXKS5CIM0kXmmuZw1a5Ya9AT1vbjhPpYRkYXcPCN3H0TK+zNvy9XxZ0QLe6waiflr2pP/IjI43F+Cmy8SaTDe6NQSWZJLOeqxY8eq1tTvv/++av2NxmSYpAOPr1+/Ll26dHF/Sokoyd1NmVVqz7kn+y89lnVvBUrO61dkSUSQXEiWTLI/eiyNcteQ4DbfGZ1MIktzqdU3hg0dM2aMNGjQIMryZcuWqRG90B3KStjqm3wRJrWpXa2y7N+7WwXpcrmiXdf7+Yt02iPC+aSJzDd7Fia7qFy5cozlWHbu3DlX3pKITHgiuffwsaybPFDKBacQ8Qt4Epz1//XHM0gTmbXoGznqFStWSMuWLaMsX758uVpHRN6dk8a87Rh+F2MiqHESrr39pGHZzTMiGYJFSrzNIE1k5kDdr18/adu2rWzYsEHKlCmjlmHe53nz5qlRv4jIO925c8c2f/uvv/76/8GMEJSrDjI2cUQ+yqVA3bp1azXhxYgRI2TdunXqx1ywYEFZtWqVVK9e3f2pJKIkC9IYdVD/XRORlwbqRYsWqYkvGJSJrAFBulatWnLo0CEVpMuWLWt0kogoMY3JMHxoZGSkKy8lIhPC1LV//fWXrF+/nkGayAqBGvNQ//nnn+5PDRElqQcPHqj/mK/9xIkT8vLLLxudJCJyR6Du2rWravGNOmn0mUaXLPsbEXlH96vXX39dtTUBI+aYJyIPDXiSUCMTF97S1DjgCVkNjumaNWvK4cOHVe+N0qVLG50kIp9y29PTXP7999+upo2IDIYTA4I0fscM0kTm53CgRgOTHTt2qPtr165Vxd9E5H0wPv+RI0dk48aN8tJLLxmdHCJyV9F3ihQp5N69e5I8eXJV9G214u34sOibrAS/45MnT6oZ74jIQkXfGNCkc+fOtlahP/zwQ5zPbdOmjTPpJSIPw8ng7bffli+++EIFaAZpIu/hcKCeNm2a9O7dWxV7w6effhrncxmoicwVpGvUqCFHjx61dcciIh9o9c2ibyLzu3nzpgrSx44dUw3HSpUqZXSSiEiSoNX3xYsXXU0bESURXEw3btxYBWk0HCtZsqTRSSIiF7gUqLNmzerKy4goCaHkCy28g4KCGKSJfG1kMiIyrxs3bsiAAQPk0aNHUrFiRQZpIi/HQE1ksSBdrVo1mTBhgpw6dcro5BCRGzBQE1ksSKOP9KZNmyRfvnxGJ4mIkrKOev/+/Q6/afHixV1NDxG5OJ901apV5fTp07J582YpVqyY0UkioqQO1CVKlHD4TX2p6xaRGaDBWJUqVdSsdgzSRD5a9I1iNf02ZcoUyZs3ryxcuFDVg+GG+1g2depUz6aYiGyuX78uW7ZsEX9/fzVdJYM0kfW4NOBJkSJFZNasWTGKuFE83qpVKzl48KBYCQc8IbMGaRR3X7lyRfWVTp06tdFJIiKzDHhy/PhxyZUrV4zlWIZ1RJQ0Qfrs2bOq4RiDNJF1udTq+4UXXpAhQ4aofpo63McyrCOipAnSaDhWtGhRo5NERB7kUo564sSJUrduXVm0aJEq/kbpOYq9Hz58KKtXr3Z/KokoSpEZ6qQRpFENRUTW5lIdNaBcfebMmXL48GHbNJitW7e2ZB0u66jJDK5duyYBAQGSIUMGdXGMIUKJyPpxxeVA7UsYqMlooaGhqvsV2oGsWrXK6OQQURLGFZdHJrt3754sX75cRo8ebVv2zz//sA81kYeC9KVLl+TLL780OjlElMRcCtQIyIUKFZIOHTpI9+7dbcuHDh0q8+fPd2f6iHyafZBGnTR+d0TkW1wK1F27dpU33ngjxrzUXbp0kVGjRrkrbUQ+b926dXL58mX5+eefGaSJfJRLddRPPfWUGvgfjVrQoEV/i7t370qmTJnkwYMHYiWso6akdv/+fUmVKpW6f/PmTfVbIyLr8HgddWRkpOqKBfYtTzGUKDZMRA66dkJk4yCRRW2f/L92Qq5evSplypSRb7/9Vj2FQZrIt7nUjxpT6aGIG2ML64EadWkfffSR1KxZ091pJLKmfbNFVnTG5S6mslH/r6wbLVWWpZOrdyKkUqVKRqeQiLy16BtT6b322muqaO7o0aPy6quvyp49e+Tpp5+Wbdu2Sfbs2cVKWPRNHslJj39JRIu0LbpyL1KqzAyTq/c0+XnDGnmxXA0jU0hE3jzWd+7cudXEG7Nnz1YBGkXhjRo1suyAJ0Rut2/Wfznp/+uz8cGTIN0mrbx4b7uIMFATkYuBGuMMb9y4UTp27BjnOiKKx80z/xV3/9/oGqmk7yuRkj+z/3/riYhcbEyG2Xpig5w1upEQUQIyBKsc9eW7kVJj9j05fj1S0qfyk/yZAp7ktNV6IiInc9T2U1hGn84SQfr333+XHDlyuC91RFZV4m25vG60VJ4ZJjfCNXkcaZ+71tR6IiKnA3X+/Pljva9D47Jx48ZxzxIl4FJEkFRenEZuht9RddIFUNytt/6uP14kU16jk0hE3hioMcgJPPvss7b7uuTJk0uWLFkkWTKXqr2JfAZKn2rXri23Hohs2bhenr+z7UmdNIq7kZNmkCYiO05F1Tx58qj/d+7ckTRp0jjzUiL6D+aSxhgEwcHB8vzzz6MJptFJIiITc3lksnnz5sVYjmXoG0ZEMWFs/EGDBqnfD3pHPAnSREQeCNQ9evRQ01xGh7G+e/Xq5cpbElk+SFeuXFmmTp2qZsIiIvLoyGSYeAOtvjE5h73r16/LCy+8IFeuXBEr4chklNgg/frrr6sLWXRfjK0hJhH5lttJMSnHtWvXYizHMn2yDiJ6Mga+HqS3bNnCIE1ETvN3dVKOjz/+WJ18dGhg1r17d1X3RkRPoNQJLbwRpPPly2d0cojIlyblqFixoqqnLlGihJqPet++fZI2bVr55ZdfbK3DrYJF3+SsCxcuyL///iuvvPKK0UkhIl+dlOPQoUMyc+ZM2bt3r5rqsmHDhtKqVSvOR00+7/z586q4OyAgQP1OOLYAESWGy2cQBOTOnTGXLhFFD9L3799Xxd0M0kSUWA6fRY4cOaL+o1W3fj8ueA6RLwZpzNOOBpUI0s8995zRSSIiXwrUL774ovqP+mj9flxcqPYm8npoUJkxY0Y18A+DNBEleaA+e/ZsrPeJfB0ajqExCEqSduzYodpsEBEleaDOmTNnrPeJfNm5c+dUcXe5cuVk1qxZDNJEZFyg3r9/v8NvWrx4cVfTQ+Q1ULKEhmOPHj2SoUOHGp0cIvL1QI3+0o5iHTX5UpBGwzGrjR1ARF44MtmNGzdstylTpkjevHll4cKFcurUKXXDfSzDpAOetHHjRmnQoIGULVtW2rdv71B9OU6kb775psrp79mzx6PpI9+watUqBmkiMu/IZEWKFFH1cdGLuFE8jkFPDh48KJ6wYcMGNRzjwIEDVZ3g2LFj1TYxqERcA6306dNHtm/fLiEhIdKtWzc1KQLqFJ3BkclIFx4eLqlTp1b3cTxwgB8iMuWkHJg5K1euXDGWYxnWecqAAQOkWbNm8umnn0qVKlVkwYIFqkvM5MmT43xN//791bCmTZo08Vi6yDecOXNGXaTOmTNHPWaQJqKk4FKgRjeUIUOGqKI/He5jmacGO8EEIDt37lQ5al2qVKlUwN60aVOcrwsKCvJIesi3YHx7lMRg5jiO301EScml8Q0nTpwodevWlUWLFqnib5SeowgaIzKtXr3aY6M+YTvZsmWLsjx79uyq3tqdHjx4oG72RRTku/Qgja5XqJMODg42OklE5ENcCtSoH8bMQJiU4/Dhw2pZrVq1pHXr1k7V4aIoe8WKFfE+Z+XKlapIPSIiQj1OmTJllPV4rK9zl2HDhsngwYPd+p7kvbp27Sr+/v6qfQODNBH51KQc7dq1k0aNGsX7nCxZsqj/mTJlUv+vXbsWZT0e6+vcpW/fvmpubfscdWx18uQb0JMhLCyMxwAReVegxlzUKHJGzhqtqeGff/6R/PnzOzw6E3InjuZQUOSNYu5du3ZJvXr1bMsxZCP6s7oTcunRc+7kW9Dl8N1335UffvhBBWh3XwwSEXm0MRkCcqFChaRDhw5Rcp4YnWn+/PniKeg3jdwNTqIwd+5cNZMXTqg6NGhjC29KDBxfqJNG3TQRkVcGatTZvfHGG3Lx4sUoy7t06SKjRo0ST/nkk0+kWrVqUqBAAZUTf//999XgKyVLlozShcZ+Gk7UgaPBW40aNWzF7Xj87bffeiyd5P1BGvNIo+EYi7uJyCsHPHnqqafk5MmTkiFDBlXMrb8FulChiNC+xbQnhIaGytWrV9WIUPrgEzqMVIb6RARzuH79ugre0WXNmlXdHMEBT3wDei2gpAjHM4I0J58hIk9xJq64VEeNvqQ4qYF9fTRyI0kxCETmzJnVLTbRc0CYHxg3ooSkSJFCjXZXtGhRBmki8u6ibxQ/60XceqBGLvejjz6SmjVrujeFRB6GBpFo24CcNAbUYZAmIq8v+tYHgMDIYEePHpVXX31VTXbx9NNPy7Zt21TrbCth0bd1nThxQvUawLGMke9QrUNE5PVF37lz51YTb8yePVsFaBSFoz+0swOeEBkJQRoXnGjngMFMGKSJyIxcCtRvvfWWCtIdO3Z0f4qIkgAaHSJIBwYGqiBttVIgIvLxOuqlS5fK/fv33Z8aoiSCEe8aN27MIE1E1gzUlSpV8tjkG0SehGlYMbodWniPGTOGQZqIrFn0XbhwYVX8vWbNGilYsKA66dnr1KmTu9JH5NYgjeLuHDlyqKFnHR3qlojI61p9JzTntP3IYFbAVt/e79ixY6p1d5o0aVRxd/TpUomILNXq22qBmHwjSKdNm1Y2b97MIE1E1q+jJvImmOkNw80ySBORTwXqH3/8UV5++WWVZcetbNmysmDBAvemjigRMB49eidgEpatW7cySBOR7wTq4cOHq6kly5UrJ5MmTVI3BOp33nlHRowY4f5UEjkJI+ZVqFBBPv74Y/WYDceIyKcak6EP6nfffScNGjSIsnz58uVqjupLly6JlbAxmfcFadRJY6QxFHfjeCUi8ta44lKOGjNn4UQYHZbps2oRGYFBmoisxqVAjSLvxYsXx1i+aNEitY7IKBg1j0GaiMTXi75R74dRnerXry+lS5dW0wNico4VK1ZIt27d1KQdVhr8hEXf5hcWFqbG7caxePfuXdUVi4jICnHFIwOeWK3PNQO1ueEYq1q1qkycOFFdPBIRmR0HPCGf8ffff6s6acyFjp4HRERW41KgJjJbkEadNP4TEVkNRyYjr/XBBx8wSBOR5TFHTV5r7ty5kixZMgZpIrI05qjJq/z111+quBuD6mBIUAZpIrI6BmryuiB9/fp1lZMmIvIFDNTkFf78808VpLNnzy6bNm2SzJkzG50kIqIkwWwJmR4GMKlWrZotSGfKlMnoJBERJRkGajK9NGnSyOTJk9VsWAzSRORrWPRNpnXo0CEZNmyYGhYUI44xSBORL2KgJtMG6cqVK8vChQslPDzc6OQQERmGgZpM5+DBgypI58qVSzZu3Kgm2yAi8lUM1GQq//zzj1SpUsUWpDNmzGh0koiIDMVATaaCAN2yZUsGaSKi/7DVN5nCgQMHVKOx4sWLq7nOiYjoCeaoyXD79+9XddJ9+vQxOilERKbDQE2G2rdvn6qTfu6552TevHlGJ4eIyHRY9E2GBumqVauqIL1hwwbJkCGD0UkiIjId5qjJMA8ePJASJUowSBMRxYOBmgzpghURESFly5ZlkCYiSgADNSWpvXv3qgA9ePBg9djPz8/oJBERmRoDNSVpkEaddP78+aVnz55GJ4eIyCswUFOSBunnn39e1q9fL+nTpzc6SUREXoGBmpLEokWLVJBet24dgzQRkRP8NAwHRfG6ffu2Ci63bt2SdOnSGZ0cr3L37l01nzQOM8yCxQk2iIjEqbjCHDV5zO7du1Uf6c2bN6tGYwzSRETOY6AmjwXpatWqSb58+eSll14yOjlERF6LgZrcbteuXSpIFyxYUNauXcvqAiKiRGCgJrdCXfT7778vhQoVYpAmInIDjvVNbg3SqItevny5aiTBIE1ElHjMUZNb7Ny5U82Cdf36dcmVKxeDNBGRmzBQU6Lt2LFDqlevLg8fPpTkyZMbnRwiIkthoKZEB+kaNWpI0aJFZc2aNZI2bVqjk0REZCkM1OSy0NBQqVmzpgrSP/30E4M0EZEHsDEZuSxz5szyww8/qDG8MfoYERG5H3PU5LTff/9dvv76a3W/YcOGDNJERB7EQE1OB2nUSaMLVkREhNHJISKyPAZqcthvv/2mgnTJkiVl9erVbOFNRJQEGKjJ4fmk0XCsVKlSquEYi7uJiJIGAzU5BHNJd+jQQeWkg4KCjE4OEZHPYKtvSrC4O1OmTPLCCy/IqFGjjE4OEZHPYY6a4rRt2zZVJz148GCjk0JE5LMYqClWW7duVXXSZcqUkWnTphmdHCIin8VATbEG6Vq1asnLL78sq1atksDAQKOTRETksxioKYZHjx5J5cqVZeXKlQzSREQG87pAvXHjRmnQoIGULVtW2rdvL2fPno33+ZcuXZL+/furKRhR3zp06FC5c+dOkqXXm/z111/y+PFjef3112XFihUM0kREJuBVgXrDhg2qSLZ06dLy+eefy+XLl6VChQpy69atWJ+PoFO+fHlJlSqVfPLJJ9K5c2dZvHixVKtWjaNqRbNlyxZVHz169Gijk0JERHb8NE3TxEuUK1dO8ubNK7Nnz1aP79+/L9myZZO+fftKr169Yn0NnoNAbZ9rLFy4sGrRjCDviNu3b0v69OnVBUG6dOnEikG6Tp066qIGOenUqVMbnSQiIku77URc8Zoc9d27d2Xnzp1Su3Zt2zIEYBRpb9q0Kc7X2QdpSJkypa0elp4EaexTXLQwSBMRmY/XBOrz588LMv/IQdvLnj17gvXU9tAnOGfOnKpFc1wePHigrnbsb1a1cOFCeeWVV9QkGwzSRETmY+jIZAMGDFC5uPig5XGuXLlsdcp6jliHx47WN48cOVIFpvXr18fIadsbNmyY5Qf5QIO6tGnTyrhx4+Thw4fx7g8iIvLRQN2uXTtp1KhRvM/JkiWL+o9hLOHatWtR1uOxvi4+CEho/b1kyRKpVKlSvM9FnXf37t1tj5GjxsWCVWzevFmaNm0qa9asUQ3IGKSJiMzL0EAdHBysbo5AkTeKuXft2iX16tWzLd+xY4fqThSfCRMmSM+ePVWLb/s67rgglx49524VqM/H/sPFStGiRY1ODhERWaWOGtBveurUqXLq1Cn1eO7cuXLkyBF59913bc8ZMmSINGnSxPZ40qRJ0qNHDxWk0bLZl9kH6WXLljEnTUTkBbyqexbqohGU58+fr4rEb968qfr92gdqFKcjl/3nn3/KjRs3VLE4mr7nyZMnynsNHDhQQkJCfKZ7Flq5FyxYUHVvW7p0KYM0EZGBnIkrXhWodaGhoXL16lUVfKO3VEYL8LCwMClQoIAa8OTQoUOxvgeK3DNmzOgTgRpfsZ+fn5w+fVpd4DBIExEZy/KBOql5c6DGaG7Dhw9XRd1o5U1ERMaz5IAn5Dx0Q6tfv77KQSdPntzo5BARkQsYqC0epDELFrqksbibiMg7MVBb0JkzZ9QMY1WrVlVB2qpdzYiIfIGh/ajJM9BQbs6cOao7GoM0EZF3Y47aQtauXav6jQNGfGOQJiLyfgzUFgrSDRs2VP8jIyONTg4REbkJA7WFgnT16tVlwYIF4u/Pr5WIyCp4Rvdyv/76qwrSNWrUkEWLFrG4m4jIYhiovRwm1ujWrZuavjNFihRGJ4eIiNyMgdqL+0mfPHlSMmTIoObPZpAmIrImBmovtGrVKjUL1siRI41OChEReRgDtRcGaXS9Qh/pMWPGGJ0cIiLyMA544oVBum7dumqqT47fTURkfcxRe5nGjRszSBMR+RBOc+kF01zu379fte5m/2giImvgNJcWsmLFCilTpox8//33RieFiIgMwEBtYsuXL5cmTZqombBat25tdHKIiMgADNQmDtJNmzZVo47NnTuXddJERD6Krb5N5GToPVmw56ycuxEuv02dJtVq1VXTVTJIExH5LgZqk0CA7rP4oGgPwsQvZaBI6fZyIzJSlh24JE1fymV08oiIyCAs+jZJThpB+u6R3+XMpLZy/8opiRR/0fyTSe/FB+VU6D2jk0hERAZhoDZJbjrsn9/l6oovJVWeEpI80/9z0H5+fjJ/z1lD00dERMZhoDaBLetWyeVlX0rg8+Ulc72Pxc8/wLYO3dxRZ01ERL6JddQGCwsLk99njZSgAhUkU90eUYK0nqPO+VRqw9JHRETGYo7aQMgtBwYGysp1m+XpejGDtP6cZmxMRkTksxioDbJo0SKpVauWhIeHS6VShWRE0xLi7ycS4O8X5f+XjYtKnsxBRieXiIgMwqJvAyxcuFCaN28uzZo1s/WRRhes0nkyqoZjqJNGcTdy0gzSRES+jYHawCA9Y8YMSZbs/18BgnLvmi8Ymj4iIjIXFn0nocOHD6sg/eabb8rMmTOjBGkiIqLYMFIkoYIFC6ocdf369SUgIGbDMSIiougYqJNYSEiI0UkgIiIvwqJvIiIiE2OgJiIiMjEGaiIiIhNjoCYiIjIxBmoiIiITY6AmIiIyMQZqIiIiE2OgJiIiMjEGaiIiIhNjoCYiIjIxBmoiIiITY6AmIiIyMQZqIiIiE2OgJiIiMjEGaiIiIhPjfNQO0DRN/b99+7bRSSEiIgvQ44keX+LDQO2AO3fuqP+5cuUyOilERGSx+JI+ffp4n+OnORLOfVxkZKRcuHBB0qZNK35+fmKlKzpcfJw9e1bSpUtndHJMjfvKMdxPjuF+coyV95OmaSpIZ8+eXfz946+FZo7aAdiJOXPmFKvCD8BqPwJP4b5yDPeTY7iffHs/pU8gJ61jYzIiIiITY6AmIiIyMQZqH5YyZUoZOHCg+k/x475yDPeTY7ifHMP99AQbkxEREZkYc9REREQmxkBNRERkYgzUREREJsZA7aPu378ve/fulWPHjjn8mmvXrsm+ffvkxo0b4kuD3fz5559y4MABefz4scOvw2t27NghVnTy5En5448/5N69ex59jbe7cuWK7N69W65everwa27evCnbtm2Ty5cvi6/AoB979uyRU6dOOfyaS5cuyf79+31nWGc0JiPfsnz5cu2pp57S8uXLp2XIkEErW7asdvny5Tifv2fPHq1y5cpa5syZteLFi2uBgYHaW2+9pd2/f1+zsr/++kvto6xZs2o5cuTQgoODtd27d8f7mhkzZmglS5ZU+zd9+vSaldy6dUurWrWqliZNGu35559X/2fOnOn213i7yMhIrXPnzlrKlCm1ggULqv89evSI9zXHjh3T2rZtq2XLlk3z8/PTpkyZovkCfE6cTwoUKKAFBQVptWrV0u7evRvn8zdv3qyVLl1a/SaLFSumpU6dWuvSpYva51bGQO1jLly4oH4YI0aMUI/v3bunAktISEicr5k3b576gehOnjypZcmSRevbt69mVY8fP9YKFSqkNWnSxHYSaN26tZY7d27twYMHcb6uX79+6sJm3LhxlgvU7dq1UyfU69ev206yyZIl044ePerW13i7qVOnqguSgwcPqse4uEOwnjNnTpyvWbVqlXodfo94ri8Eauwff39/be7cuerxlStXtDx58qiLnLh899136vel27dvnwrwEyZM0KyMgdrHfP3111q6dOmiBJvZs2drAQEBWmhoqMPv06ZNG61ixYqaVf3+++/otqjt37/ftuz48eNq2Zo1axJ8vdUCNUpPcIE3fvx42zJcwGTPnl375JNP3PYaKyhfvrwqcbLXsGFDrUqVKg693lcCdffu3VWJlb3hw4er382jR48cfp+qVatqzZs316yMddQ+BnXMRYoUkRQpUtiWlSlTRtW/Hjx40OF6W9Rv58uXT6y8n5IlSyZFixa1LcubN69kzJhRrfM1R48elbCwMClVqpRtGSaoeemll+LcH668xgrw2ew/s/4bs/Jndud+unXrlvz7778OvUd4eLhqD2LlcxFwUg4vhwMVjXTikzVrVtuBfP36dcmUKVOU9fpjrHPEF198oRqhzZs3T7wJGnc9evQozvVBQUFSokQJ275AUI4+Wxr2laP7yUr0zxzbsfP333+77TVWaKSJ32RsnxmNMFGKaaUZ+BIDx8eLL76YqHNRt27dJCIiQjp27ChWxkDt5dCitE+fPvE+p169etK7d291P3ny5CqXYw8nFrDPZcdl6tSpMmTIEJk/f74ULFhQvMngwYNtc4vH5rnnnpOZM2fa9hNOutFhXzmyn6wG+wOi75P49ocrr/F28X1mlNAwSP9fbL8xZ85FgwcPltmzZ8vatWslW7ZsYmUM1F4uODhYdedwVO7cuWXjxo1Rlp0/f972XvH5/vvv5cMPP5Q5c+ZISEiIeJs1a9Y4tZ/Q9QOBHfOQw8OHD9WFUUL7yYqwP/RjBVUnOjzW17njNd4uICBAcuTIYftN+cJndhX2R2z7CRL6jX322WcycuRIWb16tbzyyitidayj9jHVqlWTv/76S06cOGFbtnz5clU8rp9McZWL4G/fX/qHH35QxUu4gm3atKlY3euvv65yQCtXrrQtW7dunQrWVatWtS3buXOnnDlzRqwO87G/8MILsmLFiij9hLdv366OKR2KtA8dOuTUa6wGnw3HjT6NAtp04LH9Zz537pz8/vvv4suwP3799VdVJ21/LkL1k14EjnXbtm2L0v8eVW/Dhg2TVatWyauvvio+wejWbJS00Or21VdfVX0QFy1apH311Vda8uTJtWnTpkXp04lDY+XKlerxggULVDcK9FfcunWr7WbfTcKKevbsqWXKlEn7/vvvtVmzZqk+ru+9916U52C9fQvmw4cPq33TrVs31UVH31fx9Q31FkuXLlW9A4YOHarulytXTh1HDx8+tD2nQYMG6vhy5jVW888//6ieFegZsWLFCq1FixaqX/2pU6dszxk2bJhq3W3f31w/VlKkSKH17t1b3bdyN7bw8HDVz7xSpUrasmXLtAEDBqhjxb5Xxc8//6zOReiGBWPHjlWPP/vssyjnIr0rnFVx9iwfhKtTFBv99ttvqli3VatW0rBhwyjFT82aNZMRI0ZI+fLl5csvv4ySs9Qhx/Tjjz+KVSEnhDp5XOXjfu3atVWpAnLaurp160qDBg2kffv26nG/fv1ULiE6lEhYoWXqhg0bZMqUKaqxD1pvo+3DU089ZVuPz4/qgnHjxjn8Gis6fPiwfPXVV2pENvQW6Nmzpzz//PO29ag+QlXSpk2b1GOUQsTWIKpGjRrSv39/sarQ0FB1fkELcOSi33//fVWapcPyzp07234/H3/8cawj/iEXbn/MWQ0DNRERkYmxjpqIiMjEGKiJiIhMjIGaiIjIxBioiYiITIyBmoiIyMQYqImIiEyMgZqIiMjEGKjJlP755x812L6rg01EH8/ckffHoCYYrnDBggVqikZHYUzw9evXq8Ff7IddtZpdu3apfYMpTjENYWyD4CQEg+ksXrxYzMSRNJ0+fVoNfGNmZk+jGb97b8FATS5DMMP4157w008/qVGIXLFkyRL59NNPnXp/jPuDUaAwwhhOJpjGc+vWrQnOIYxJOjCe9dChQ2XZsmWWDdQdOnRQY7wvWrRIDhw4IJs3b1YjRtmPXY39bi+2Zbt375bWrVuLmURPU2zpxrGAfZAUYtu+I89JyjS6wpXv3pF94QsYqMllyFHp02d6mwIFCkitWrVsj5FDRC4cOWNM4YmhQTG04YwZM+J9H0w4kTp1anWSRI4aU2VaDeb7nTZtmpqQBTnqd955Rw2LielTdRjWsW3btlFeF9syDDvbpEkTMZPoaYot3UnJke0bnUZXuPLde+Pn9AROc+mjMOOTPntPUFCQmsA9rrGoMV7xwYMH1Q+tZMmSak5dLNu/f7/cvHnTNt536dKlVTHw3bt3pWLFirbXY6auI0eOSJ06dZzednwuX76scrwIlBhDGu8VPcAgjcj1It2YIUyHQKPPDYzcM4IzIKeYMmVKNb/thQsXVHG4/vmQfn3KS8BY6fpYzXgO1uE5W7ZskYwZM6r9hRMN0qePX4yxjbHM399fjaOeIUMG2/s9evRI5VgxqxDGy8YsZ88884zar4B9iFKM/PnzxzsXuP37XLt2Tb1PoUKFbGNNowjyjz/+kPTp06v9Yv+ZosM+wAXZ48eP1Uxh9tMSVq9e3TYjFvYF9re+r7JkyRJjGdKM/Wof4FFci+8IyzDe9dmzZ9UsbrFNCYn9hs+D9fiOfvnlF3njjTdiTTcuKDCzEtIBqNLAWOP169dXj5EulJzUrFkzSppi+yz2+xrHQ0LpxAxi+K6efvppKVu2bJSx4VHlgotCbFd36dIlNT48Pktc2y9atKjt+e5IozPHgP4d4eIVpSl431KlSqnj25nP7ux378i+8BUM1D4KP1QU1QKCAk5kLVq0kEmTJkU54b/33nvqpIcfHaacQ2DB9HIItggAWKa/T+bMmdW648ePRwnUmJRh1KhRtkDtyLYTMmvWLPnggw/k5ZdfVgEX6cHA/eXKlbMFcaxDwMRk9DjBIODoARNF35hwAydMXHTgpA94Dk4uCPx4D0xgoqe1UqVKUU5oKMrDPkBxN56DCwF8RsyVi20iyCFAlilTRm0XOVIUTeLEiH2L1+JzYFIPfXrR5s2bq+1g27iYQNDHCTwwMFB+/vlnefbZZ9XFBKb569q1a6z7Rn8fTCKCwF68eHF59913VaBGlcCECRPU94l9j+8KFylxTReIdOjzeOOiBCd2QLDBiRQnWVx8YF/ghKrvK5zIoy9D9QIuWlD82bhxY7UMJRGY4xz7BM9NlSqVWoYJK1q2bGk7DjFpDC7ukG7sN1zcoQQkrkCNqggEwI8++kg9RikA0oxAj2MY9e2YjAbfnV4kizTF9ln06RDwnVapUiXOdOJ5bdq0Ua/DRRgCFr43VA/pQc3+uNMhWOH4x2eJa/v2wSkxaQRnjwH9OypcuLD6LnCRhP2HUhZnPrv9fnbku3dkX/gMo6fvInM4e/asmopv48aNtmWff/65ljFjRjVtnw7r79y5o+6PHDlSTVloD1Nh1qlTJ8qySZMmaXnz5nVq26NHj9YKFSoU52vy5cunTZw40fb40qVL2m+//abuY0pFPz8/bcOGDbb17dq1U9PpxfX+27dvV9Pn6Z8N8DnweeKD6QpLlSoVZVmVKlXUNIenT5+Okj5Mezl+/HjbskGDBmmZM2fWbt68qR5j20hDo0aNtEePHqllCxcuVMuaN2+uPX78WC2bPn26ei/9OdHp71OtWrUo00liutLs2bNr58+fty1DenLmzBnvtJMXL15U73fo0CHbsilTpmi5c+e2PUY606dPH+V1sS3DVJdBQUG2x5g+FO89depU2zJMYRgcHGx7jGlG8T76NJG3b9/WChcurKZEjEunTp20kJAQdR+fF1NKFilSRFu+fLltG+XLl481TbGl25F0zp49WwsMDLRNTRkWFqam9WzatGm8xzWmdbT/LLFtPzpX0+jKMaC/r/10rvgc2P7169cd/uyufPeO7AtfwDpqH/bgwQNVtIRiUuRqc+TIoa6UdaifRY4aRa06XK2nSZPG49tOCHJmKGZ7+PCheowiTlzJ61CUXrVqVdvj1157zamW3ImFXHJwcLDtMUoakidPrqbx0/Xq1UtVFejF57p27dpJQECAuq+XEKCRG4rL9WWoXrh48WK8acC2sE3d9OnTVa4IOdOFCxeqkhLkjtBgB7kqoyAnhRyv/XeFEhLkDgHHCBqy6UWiKNWw34+xwXuglAQ5MJREIPeIxoK4DyipwHPcmU4Uz6IOVq9iwDHao0cP1RgKucKkkFAaE3MM2De+RE4Y1SFo05GYz55QeukJFn37KNT3oTgRRcMIaiimQh0eijN1+MHYz6GblNtOyHfffadO1qgLe+WVVyQkJEQVvel1YnhvezgZoUg4qaA+zh7q4xBo9ACsn8zwPKyzZz9XM9Id17KEPk/0NJw6dUrtHwQ+e5h7XIcTq37xg/rxypUri6ehOF2/CLH/fLiYwz5C3aX9RRjkyZMn3vdEMS6KtVHloQdl1PV/8sknKnBs375dXSi5M534HlFlYg/VFwhoCISotvC0hNLoyDEQG1QX2LenwAUgLq71Y9fVz55QeukJBmofhZMUfpxjx461LUOuw356cvwwUafnDPzo0JjFXvSA4si2E4Lno24PJwFc1Q8aNEj17504caKYgd5QTYf6e1yMRIdggnVJkYZ06dKp+j1c5MRl9erVql5eb7iTFIE6IbjoQqNFewl1g8M+RfsABGncUC9cokQJ1cce/edxMRI9+CdWbN+x/lj/jh35fXiSI8dAbFCXjfpp+8Zh9seuI5+dXMeibx+FhjbooqRDQ5vofYbRqnfOnDnqqliHxmN6jgtF4NFPMrjKRitve3pxozPbToje+hgNVdB9A0XDyKm7U2yfz1XI9SNnuGfPHtsyNLRBUMRFR1JAAybkpNBIx559S240EEIxJm4DBgxwal8hF5TQMldUqFBBVR3YBzhHBvZALhrHLy7msI8RpIoVKyZDhgxRuevovQQSm258x2iMaF/Ui+JlBEa9ESJ+H0iP/XEV/ffhyPZdTaMjx0BscA7Ad6BDtRV6U+hVM458dle46xjydsxR+ygUPaNlLK6S8SMcM2ZMjKKmzz//XJ0k0QoZrVJRn4oTOOqUU6RIoYq60LVp5MiRkitXLnXyQ11i//79Vb0TfrxooYxiRpwkndl2QlD/jHQhDUgXWrF26dJF3AnvjbQhN4YTRvTuWc5Ay1YUzaN7EOr68NmHDx+u0mzfBsCTsF204Mb31LFjR1XsiAsHtKxF6URi4ISMQNqvXz91X+9GE32ZK7p166YuINDvHfWgqF9FLjl6iUFsgXr8+PGqxb1epIpl6IGANDnzWRzdv2jFj2MTvxfsU7RgRktv+4tfVPWghTd+B9j/S5cuTXD70Vs6JyaNrhwD2H+dOnVSrbnx2x8xYoS6QEbre0c/uysc2Re+gDlqH4XuPchZ4AeFHC0ameDHgICiQ24V61H/ix8yGnjgqloPVghk6IuK1yOHg25OaECFRmGoU0U/TQQ35GrQB9OZbUcfkCQ65MCxfaQLdek4KfTt21etQ5En+hDbw4WE3i0ktvdH8RyK4+0bX6FrT58+fdSFBrqHoPgvOpw40EjJHgIDcm7RIeDjogbFr2i4g+JHBA0dto002BcV4gSJZfZ11MgJYllcFw2xvQ/gYgPdX1BNgO1j/yNHlFAjPlxE4f3s6yijD3iSPXt2VQWBfYRjAV2oYlsWfdAL1DUjYEUv6sb2EBAAnwPfM4qukVYcJ1999VWCF00IyngflLbocAxgGY5pXfQ0xZZuR9KJi1Ec88i1IseJgIz0ogGmDmnGMhyjKAHCcYKcqH0dcWzbj87VNLp6DOC7x0U3SoAwpsLgwYNl8uTJtvWOfHZXvntH9oUv8EPTb6MTQUQUH9R32jcQROkEimvRR588C/3/kWNGlRUZg0XfRGR6yHkhh4wSGxR7o7gYDd+IfAGLvonI9FDFguJUVEOgSx+6XTnbD5pcE1sRNSUtFn0TERGZGHPUREREJsZATUREZGIM1ERERCbGQE1ERGRiDNREREQmxkBNRERkYgzUREREJsZATUREZGIM1ERERGJe/wMpCf2P+tzWSgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 500x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(5, 5))\n",
+    "for j, nm in enumerate(res.param_names):\n",
+    "    ax.plot(actual[j], pred[j], 'o', ms=5, label=nm)\n",
+    "lim = 1.05 * np.abs(actual).max()\n",
+    "ax.plot([-lim, lim], [-lim, lim], 'k--', lw=1)\n",
+    "ax.set_xlabel('actual shift from re-fitting without the point')\n",
+    "ax.set_ylabel('predicted from dpopt_ddata')\n",
+    "ax.set_title('leave-one-out: linearization vs. truth')\n",
+    "ax.legend(); plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1612f4ea",
+   "metadata": {},
+   "source": [
+    "The linearization tracks the re-fits closely, and it did so with **one\n",
+    "factorization** instead of $m$ fits. Where it is off, the gap is the neglected\n",
+    "residual curvature: `curve_fit` builds `dpopt_ddata` from the **Gauss-Newton**\n",
+    "Hessian, the same one behind `pcov`, so the influence is a first-order\n",
+    "quantity. Treat it as a ranking of points that is cheap and reliable, and\n",
+    "re-solve when a specific number has to be exact."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b202beb1",
+   "metadata": {},
+   "source": [
+    "## 4. Cook's distance: one number per point\n",
+    "\n",
+    "Leverage says how much the fit *listens* to a point; the residual says how much\n",
+    "the point *disagrees*. Cook's distance multiplies the two into the thing you\n",
+    "usually want — how far the whole parameter vector moves if the point leaves,\n",
+    "measured in the fit's own covariance metric."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "95850195",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:45.485833Z",
+     "iopub.status.busy": "2026-09-07T00:40:45.485748Z",
+     "iopub.status.idle": "2026-09-07T00:40:45.489238Z",
+     "shell.execute_reply": "2026-09-07T00:40:45.488814Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cook's D from influence vs from re-fits: rank correlation 0.9992, same top-3: True\n",
+      "\n",
+      "rank       x  leverage   |resid|     Cook D\n",
+      "   1    0.15    0.9730    0.0051     6.9388\n",
+      "   2    2.04    0.0665    0.0809     0.1011\n",
+      "   3    4.30    0.0797    0.0647     0.0797\n",
+      "   4    3.96    0.0716    0.0685     0.0789\n",
+      "   5    1.35    0.1533    0.0406     0.0712\n",
+      "\n",
+      "largest-residual point is x=2.04, Cook rank 2 of 25\n",
+      "most influential point is  x=0.15, residual rank 24 of 25\n"
+     ]
+    }
+   ],
+   "source": [
+    "Pinv = np.linalg.pinv(res.pcov)\n",
+    "cook = np.einsum('ji,jk,ki->i', pred, Pinv, pred) / len(res.popt)        # from influence\n",
+    "cook_true = np.einsum('ji,jk,ki->i', actual, Pinv, actual) / len(res.popt)   # from re-fits\n",
+    "order = np.argsort(cook)[::-1]\n",
+    "print(f\"Cook's D from influence vs from re-fits: rank correlation \"\n",
+    "      f\"{np.corrcoef(np.argsort(np.argsort(cook)), np.argsort(np.argsort(cook_true)))[0,1]:.4f}, \"\n",
+    "      f\"same top-3: {set(order[:3]) == set(np.argsort(cook_true)[::-1][:3])}\\n\")\n",
+    "\n",
+    "print(f\"{'rank':>4} {'x':>7} {'leverage':>9} {'|resid|':>9} {'Cook D':>10}\")\n",
+    "for r_, i in enumerate(order[:5], 1):\n",
+    "    print(f\"{r_:>4} {x[i]:>7.2f} {lev[i]:>9.4f} {abs(resid[i]):>9.4f} {cook[i]:>10.4f}\")\n",
+    "\n",
+    "big_r = int(np.abs(resid).argmax())\n",
+    "print(f\"\\nlargest-residual point is x={x[big_r]:.2f}, Cook rank \"\n",
+    "      f\"{list(order).index(big_r)+1} of {x.size}\")\n",
+    "print(f\"most influential point is  x={x[order[0]]:.2f}, residual rank \"\n",
+    "      f\"{list(np.argsort(np.abs(resid))[::-1]).index(order[0])+1} of {x.size}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f6e80a8",
+   "metadata": {},
+   "source": [
+    "The two rankings disagree, which is the entire reason the influence matrix is\n",
+    "worth computing. Sorting by residual finds points that fit badly. Sorting by\n",
+    "influence finds points the answer *rests on* — and those are the ones whose\n",
+    "measurement you would want to repeat."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50403b20",
+   "metadata": {},
+   "source": [
+    "## 5. A parameter at a bound has no influence at all\n",
+    "\n",
+    "Now the case the textbook formula gets wrong in kind, not degree.\n",
+    "\n",
+    "Bound the offset $c \\in [1, 2]$ when the data prefer $c \\approx 0.5$. The fit\n",
+    "lands with $c$ pinned at 1.0. A pinned parameter **cannot move**: perturb any\n",
+    "$y_i$ by any small amount and $c$ stays exactly where the bound holds it. Its\n",
+    "influence is identically zero, and the effective degrees of freedom drop from 3\n",
+    "to 2, because the data are no longer determining $c$.\n",
+    "\n",
+    "`pinv(J)` knows none of this — it has never heard of the bound."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "29fab646",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:45.490538Z",
+     "iopub.status.busy": "2026-09-07T00:40:45.490458Z",
+     "iopub.status.idle": "2026-09-07T00:40:45.545315Z",
+     "shell.execute_reply": "2026-09-07T00:40:45.544954Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "popt        : [3.03234 2.67695 1.     ]\n",
+      "active_mask : [False, False, True]  cov_source: reduced_hessian(projected)\n",
+      "\n",
+      "influence row for the pinned parameter c : max |.| = 0.000e+00   (exactly zero)\n",
+      "what pinv(J) would have reported for c   : max |.| = 5.516e-02\n",
+      "\n",
+      "trace(H) = 2.00000000   (3 parameters - 1 active bound = 2 effective)\n"
+     ]
+    }
+   ],
+   "source": [
+    "KW_B = dict(bounds=[(0, np.inf), (None, None), (1.0, 2.0)])\n",
+    "rb = pounce.curve_fit(model, x, y, p0=P0, sensitivity=True, options=OPT, **KW_B)\n",
+    "Jb = jac_at(rb.popt, x)\n",
+    "\n",
+    "print(\"popt        :\", np.round(rb.popt, 5))\n",
+    "print(\"active_mask :\", [bool(v) for v in rb.active_mask], \" cov_source:\", rb.cov_source)\n",
+    "print()\n",
+    "print(\"influence row for the pinned parameter c :\",\n",
+    "      f\"max |.| = {np.abs(rb.dpopt_ddata[2]).max():.3e}   (exactly zero)\")\n",
+    "print(\"what pinv(J) would have reported for c   :\",\n",
+    "      f\"max |.| = {np.abs(np.linalg.pinv(Jb)[2]).max():.3e}\")\n",
+    "print()\n",
+    "print(f\"trace(H) = {np.trace(Jb @ rb.dpopt_ddata):.8f}   \"\n",
+    "      f\"(3 parameters - 1 active bound = 2 effective)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e82018a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:45.562539Z",
+     "iopub.status.busy": "2026-09-07T00:40:45.562419Z",
+     "iopub.status.idle": "2026-09-07T00:40:48.416455Z",
+     "shell.execute_reply": "2026-09-07T00:40:48.416052Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     x                                    a          b          c\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.15  dpopt_ddata                 1.71794    0.49400    0.00000\n",
+      "        re-solve (truth)            1.61227    0.28470    0.00000\n",
+      "        pinv(J), the old answer     1.72379    0.51401    0.00227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2.91  dpopt_ddata                -0.02457   -0.05045    0.00000\n",
+      "        re-solve (truth)           -0.01378   -0.02907    0.00000\n",
+      "        pinv(J), the old answer     0.11333    0.42112    0.05346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "sign agreement with the re-solve, over the 2x25 free-parameter entries\n",
+      "   dpopt_ddata :  96.0%\n",
+      "   pinv(J)     :  34.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ground truth: perturb one datum, re-solve, difference\n",
+    "def refit_influence(fit_kw, i, h=1e-4):\n",
+    "    yp = y.copy(); yp[i] += h\n",
+    "    ym = y.copy(); ym[i] -= h\n",
+    "    fp = pounce.curve_fit(model, x, yp, p0=P0, options=OPT, **fit_kw)\n",
+    "    fm = pounce.curve_fit(model, x, ym, p0=P0, options=OPT, **fit_kw)\n",
+    "    return (fp.popt - fm.popt) / (2 * h)\n",
+    "\n",
+    "def show(tag, fit_kw, M_new, M_old, idx):\n",
+    "    row = lambda v: \"\".join(f\"{t:>11.5f}\" for t in v)\n",
+    "    print(f\"{'x':>6}  {'':<24}{'a':>11}{'b':>11}{'c':>11}\")\n",
+    "    for i in idx:\n",
+    "        truth = refit_influence(fit_kw, i)\n",
+    "        print(f\"{x[i]:>6.2f}  {'dpopt_ddata':<24}\" + row(M_new[:, i]))\n",
+    "        print(f\"{'':>6}  {'re-solve (truth)':<24}\" + row(truth))\n",
+    "        print(f\"{'':>6}  {'pinv(J), the old answer':<24}\" + row(M_old[:, i]))\n",
+    "\n",
+    "show('bound', KW_B, rb.dpopt_ddata, np.linalg.pinv(Jb), (0, 12))\n",
+    "\n",
+    "# the robust version of the claim: sign agreement with the truth over every point\n",
+    "truth_b = np.column_stack([refit_influence(KW_B, i) for i in range(x.size)])\n",
+    "free = [0, 1]\n",
+    "agree = lambda M: np.mean(np.sign(M[free]) == np.sign(truth_b[free]))\n",
+    "print(f\"\\nsign agreement with the re-solve, over the {len(free)}x{x.size} free-parameter entries\")\n",
+    "print(f\"   dpopt_ddata : {100*agree(rb.dpopt_ddata):5.1f}%\")\n",
+    "print(f\"   pinv(J)     : {100*agree(np.linalg.pinv(Jb)):5.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a3f2a06",
+   "metadata": {},
+   "source": [
+    "The pinned row is zero, matching the re-solve exactly. `pinv(J)` reports a\n",
+    "confident nonzero influence for a parameter that is welded in place, and on the\n",
+    "free parameters it disagrees with the truth in **sign** on most points, because\n",
+    "it is answering a question about a different, unconstrained fit. That is\n",
+    "[#922](https://github.com/jkitchin/pounce/issues/922): before the fix,\n",
+    "`dpopt_ddata` returned exactly the `pinv(J)` row above.\n",
+    "\n",
+    "Note that the projected answer is right in structure and direction but not to\n",
+    "the last digit — at $x = 0.15$, the extreme-leverage point, the $b$ component\n",
+    "sits well off the re-solve. That gap is the Gauss-Newton linearization from\n",
+    "section 3, now being asked to work at a point where the fit is most curved. The\n",
+    "projection is what fixed the *kind* of error; the magnitude is still\n",
+    "first-order."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0444d4a7",
+   "metadata": {},
+   "source": [
+    "## 6. Influence lives in the constraint's null space\n",
+    "\n",
+    "The sharper version. Tie two parameters with $a + c \\le K$ and choose $K$ so it\n",
+    "binds. Then $a + c = K$ holds *no matter what the data say*, so any admissible\n",
+    "data perturbation must satisfy\n",
+    "\n",
+    "$$\\frac{\\partial a}{\\partial y_i} + \\frac{\\partial c}{\\partial y_i} = 0$$\n",
+    "\n",
+    "for every point $i$ — the influence vector lies in the null space of the active\n",
+    "constraint. This is not an approximation to check; it is a structural identity\n",
+    "that any correct answer satisfies exactly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "97551b62",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:48.417807Z",
+     "iopub.status.busy": "2026-09-07T00:40:48.417725Z",
+     "iopub.status.idle": "2026-09-07T00:40:48.465172Z",
+     "shell.execute_reply": "2026-09-07T00:40:48.464694Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a + c = 2.6000000100   (K = 2.6, constraint is active)\n",
+      "\n",
+      "da/dy + dc/dy, over all points\n",
+      "   dpopt_ddata : max |.| = 3.297e-12\n",
+      "   pinv(J)     : max |.| = 1.187e+00\n",
+      "\n",
+      "trace(H) = 2.00000000   (3 parameters - 1 active constraint = 2 effective)\n"
+     ]
+    }
+   ],
+   "source": [
+    "K = 2.6\n",
+    "KW_C = dict(constraints=[{'type': 'ineq', 'fun': lambda p: K - (p[0] + p[2])}])\n",
+    "rc = pounce.curve_fit(model, x, y, p0=P0, sensitivity=True, options=OPT, **KW_C)\n",
+    "Jc = jac_at(rc.popt, x)\n",
+    "\n",
+    "print(f\"a + c = {rc.popt[0] + rc.popt[2]:.10f}   (K = {K}, constraint is active)\")\n",
+    "print()\n",
+    "print(\"da/dy + dc/dy, over all points\")\n",
+    "print(f\"   dpopt_ddata : max |.| = {np.abs(rc.dpopt_ddata[0] + rc.dpopt_ddata[2]).max():.3e}\")\n",
+    "pj = np.linalg.pinv(Jc)\n",
+    "print(f\"   pinv(J)     : max |.| = {np.abs(pj[0] + pj[2]).max():.3e}\")\n",
+    "print()\n",
+    "print(f\"trace(H) = {np.trace(Jc @ rc.dpopt_ddata):.8f}   \"\n",
+    "      f\"(3 parameters - 1 active constraint = 2 effective)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "dd4cfba3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:48.466355Z",
+     "iopub.status.busy": "2026-09-07T00:40:48.466281Z",
+     "iopub.status.idle": "2026-09-07T00:40:48.633662Z",
+     "shell.execute_reply": "2026-09-07T00:40:48.633245Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     x                                    a          b          c\n",
+      "  0.15  dpopt_ddata                 0.03903   -0.07695   -0.03903\n",
+      "        re-solve (truth)            0.03479   -0.06975   -0.03479\n",
+      "        pinv(J), the old answer     1.07884    0.43831    0.10858\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2.91  dpopt_ddata                -0.04618   -0.00502    0.04618\n",
+      "        re-solve (truth)           -0.04645   -0.00455    0.04645\n",
+      "        pinv(J), the old answer    -0.10035   -0.03187    0.03848\n"
+     ]
+    }
+   ],
+   "source": [
+    "show('constraint', KW_C, rc.dpopt_ddata, pj, (0, 12))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d63e723e",
+   "metadata": {},
+   "source": [
+    "The influence now moves $a$ and $c$ in exact opposition, as the binding\n",
+    "constraint requires, and matches the re-solve. `pinv(J)` moves them the *same*\n",
+    "direction — a perturbation that walks straight off the feasible set, describing\n",
+    "a fit that was never solved.\n",
+    "\n",
+    "This is the failure mode worth internalizing. The old number was not noisy or\n",
+    "slightly stale; it was self-consistent, plausible, dimensionally correct, and\n",
+    "describing a different problem. Nothing about it looked wrong."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92e2f55f",
+   "metadata": {},
+   "source": [
+    "## 7. What it costs\n",
+    "\n",
+    "The influence matrix is $m$ columns, each a back-solve against a factorization\n",
+    "that already exists. The alternative — re-fitting without each point — is $m$\n",
+    "optimizations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "4c116e68",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:48.634994Z",
+     "iopub.status.busy": "2026-09-07T00:40:48.634922Z",
+     "iopub.status.idle": "2026-09-07T00:40:49.839779Z",
+     "shell.execute_reply": "2026-09-07T00:40:49.839452Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plain fit                       :    34.61 ms\n",
+      "fit + full influence matrix     :    34.91 ms  (1.01x the plain fit)\n",
+      "25 leave-one-out re-fits         :   854.56 ms  (24.5x the influence matrix)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t0 = time.perf_counter()\n",
+    "for _ in range(5):\n",
+    "    pounce.curve_fit(model, x, y, p0=P0, sensitivity=True, options=OPT)\n",
+    "t_sens = (time.perf_counter() - t0) / 5\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "for _ in range(5):\n",
+    "    pounce.curve_fit(model, x, y, p0=P0, options=OPT)\n",
+    "t_fit = (time.perf_counter() - t0) / 5\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "for i in range(x.size):\n",
+    "    keep = np.ones(x.size, bool); keep[i] = False\n",
+    "    pounce.curve_fit(model, x[keep], y[keep], p0=P0, options=OPT)\n",
+    "t_loo = time.perf_counter() - t0\n",
+    "\n",
+    "print(f\"plain fit                       : {1e3*t_fit:8.2f} ms\")\n",
+    "print(f\"fit + full influence matrix     : {1e3*t_sens:8.2f} ms  \"\n",
+    "      f\"({t_sens/t_fit:.2f}x the plain fit)\")\n",
+    "print(f\"{x.size} leave-one-out re-fits         : {1e3*t_loo:8.2f} ms  \"\n",
+    "      f\"({t_loo/t_sens:.1f}x the influence matrix)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfba9bbe",
+   "metadata": {},
+   "source": [
+    "The gap grows with the size of the dataset, since the re-fit route costs one\n",
+    "full solve per point while the factorization is paid for once. That is the same\n",
+    "accounting as the parametric sensitivity elsewhere in POUNCE: the expensive\n",
+    "object was already built, and the derivative is a back-solve against it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "805ba4a1",
+   "metadata": {},
+   "source": [
+    "## 8. Influence on a decision, not on a parameter\n",
+    "\n",
+    "Parameters are rarely the deliverable. Suppose the fit is used to pick an\n",
+    "operating point — the $x$ at which the response first drops below a threshold\n",
+    "$y^{\\star}$:\n",
+    "\n",
+    "$$x^{\\star}(p) = -\\frac{1}{b} \\ln\\left(\\frac{y^{\\star} - c}{a}\\right).$$\n",
+    "\n",
+    "The chain rule carries influence straight through:\n",
+    "$\\partial x^{\\star}/\\partial y_i = (\\partial x^{\\star}/\\partial p)\n",
+    "\\cdot (\\partial p / \\partial y_i)$. That composite is the number a decision\n",
+    "actually rests on, and it need not rank the points the way leverage does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6a1af45b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:49.841262Z",
+     "iopub.status.busy": "2026-09-07T00:40:49.841174Z",
+     "iopub.status.idle": "2026-09-07T00:40:49.878468Z",
+     "shell.execute_reply": "2026-09-07T00:40:49.878059Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x* = 1.2106  (response crosses y* = 1.2)\n",
+      "top 3 points by influence on the decision : [1.   1.17 1.35]\n",
+      "top 3 points by leverage                  : [0.15 1.   1.17]\n",
+      "\n",
+      "d x*/d y[1] : predicted +0.21876   re-solve +0.22132\n"
+     ]
+    }
+   ],
+   "source": [
+    "YSTAR = 1.2\n",
+    "a_, b_, c_ = res.popt\n",
+    "xstar = -np.log((YSTAR - c_) / a_) / b_\n",
+    "dxs_dp = np.array([\n",
+    "    1.0 / (a_ * b_),                                  # d/da\n",
+    "    np.log((YSTAR - c_) / a_) / b_**2,                # d/db\n",
+    "    1.0 / (b_ * (YSTAR - c_)),                        # d/dc\n",
+    "])\n",
+    "infl_dec = dxs_dp @ res.dpopt_ddata                   # (m,) influence on x*\n",
+    "\n",
+    "print(f\"x* = {xstar:.4f}  (response crosses y* = {YSTAR})\")\n",
+    "top_dec = np.argsort(np.abs(infl_dec))[::-1][:3]\n",
+    "top_lev = np.argsort(lev)[::-1][:3]\n",
+    "print(\"top 3 points by influence on the decision :\", np.round(x[top_dec], 2))\n",
+    "print(\"top 3 points by leverage                  :\", np.round(x[top_lev], 2))\n",
+    "\n",
+    "# spot-check the composite against a re-solve\n",
+    "i = int(top_dec[0]); h = 1e-4\n",
+    "yp = y.copy(); yp[i] += h\n",
+    "rp = pounce.curve_fit(model, x, yp, p0=P0, options=OPT)\n",
+    "ap, bp, cp = rp.popt\n",
+    "xs_p = -np.log((YSTAR - cp) / ap) / bp\n",
+    "print(f\"\\nd x*/d y[{i}] : predicted {infl_dec[i]:+.5f}   re-solve {(xs_p - xstar)/h:+.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e7b37039",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T00:40:49.879574Z",
+     "iopub.status.busy": "2026-09-07T00:40:49.879513Z",
+     "iopub.status.idle": "2026-09-07T00:40:49.933727Z",
+     "shell.execute_reply": "2026-09-07T00:40:49.933277Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAGGCAYAAACHemKmAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAS7JJREFUeJzt3QmczfX+x/HPWIcwsu+RpCzVJbJkiZR2pUWXipKo3PY/upUlrpZbt0UXrVokRSnlSrZQhFBJC1LIlm0IY53/4/11z7lnjjPjzMyZOed3zuv5eJyHOb/tfM8y5nM+v8/380tKT09PNwAAAMBjCkR7AAAAAEBOEMgCAADAkwhkAQAA4EkEsgAAAPAkAlkAAAB4EoEsAAAAPIlAFgAAAJ5EIAsAAABPIpAFAACAJxHIAnGgW7duVq1atag9/mOPPWZJSUm2c+fOPDn+nXfeaaVLl863/eLhPYmV1yGRhfsZ4P0Bco5AFvCInj17Wrly5aI9DMQJPk8A4gGBLICYN2LEiBxle3O6X7zhdYhtvD9AzhHIAgAAwJMIZAEPOP/88+2VV16xbdu2uVpU323r1q0ZtlNWp2vXrpaSkmJlypRxp4/37t17zPGWLl1qnTp1srJly1rRokWtfv36Nnr06LDG8vbbb1u9evUsOTnZ7Tdp0qRMtw33cbRd586drUKFCla8eHFr0qSJvfPOO1nWEP700092zTXXWOXKle2EE06wM844w5588klLS0vLcj/5z3/+Y61atbISJUq4fc8991z75JNPQtY3hvuaZiac/YcOHZrhfdW27du3t5kzZ2b7OYcS/Doc7/OU08cJ57V999133WN9++23/mWffvqpW9aoUaMMx9IYateuHbH3xLe/nudf//pXO/HEE91nLTvvQW7HMH/+fKtYsaKdd955tmPHjkw/p9l9nDfffPOY38u8rl0HYgGBLOAB06dPt1tuucUFhOnp6f5bYI3jkSNH7I477rDu3bvb+vXrbcyYMS7ofOSRRzIc6/PPP7fmzZu7wFJ/VP/44w978MEH7b777nN/zLOiP5b6o3r55Zfbr7/+6gKUCRMm2JdffnnMtuE+jgKFZs2a2cGDB23GjBluOwW7H330kf3+++8hx3Ho0CHr0KGD/fnnnzZ37lwXkCnw3b59uwuKsjJ+/Hi75JJLrGHDhvbjjz/azz//7AKoyy67zMaOHZth23Bf08yEu/9DDz3kf0/13JYtW2annHKKG+cPP/yQ6+ecnc9TXr+2Cg4LFCiQ4VgaT7Fixdzz1vvve+302dBYcvKaZkb79+rVy+3/yy+/uCAy3Pcgt2PQ69iuXTu7+OKLbdq0aS6QPt5Yw3kcLb/xxhvtyiuvtN9++82mTJliH374YcjfSyDupAPwhFtuuSW9bNmyIdd17do1Xb/OU6ZMybC8R48e6aVKlcqw7PTTT08/44wz0g8dOpRh+aBBg9KTk5PTt2/fHvIxDh8+nF61atX0Nm3aZFh+4MCB9Bo1arjH37FjR7Yfp06dOm7b4O0C3XHHHekpKSn++z/++KN7vPHjx2e6T6j9jhw5kl6tWrX0Ro0aHbNts2bN0itWrOgfR3Ze01Byu7+UL18+vX///tl6zuG8Dll9nnL6ONl5bRs3bpx+/vnn+9efeeaZ6ffcc4/7XLz99ttu2aJFi9w4JkyY4N8uUu/JxIkTw35ege9BdsegbfU7I0OGDEkvUKBA+rBhw8J6f8J9HP1eVqlSJf28887LsJ1e61q1ah3zewnEGzKyQJwoVKiQXXDBBRmWNWjQwHbt2uU/Zbx69WqXXbrqqqusYMGCGbbV6WadOl64cGHI4+t0szKkysYGKly4sMswBQr3cVauXOlu11133THbZaV69eruNKsyU+PGjXNZw3DoOSizpXEFU2nD5s2bbfny5dl6TbMS7v66/8ADD9ipp57qTg37Tm8rO7lq1apcPefsyo/XVlnWefPm2b59+2zLli2uzEBZW5UkKFMpn332mcvcKoMZKLfviV7XSy+99Jjl4bwHORmDsrs33HCDDR8+3GWsdVYiXOE8jl73DRs2uNcvkH6fLrroorAfC/AqAlkgTqi+NDgYLFWqlPvXVyO3adMm9++QIUPcH0ltr5sCBtUySmaBi2+56vuCBS8L93EUxEjVqlWz9VxVR6uAp2bNmu60q06Jq47z8ccft/3792e6n+85VKpU6Zh1vmWBgUg4r2lWwt1fwd8bb7xhzzzzjG3cuNGdUtYpbj0/lVzk5jlnV368tgpk9WVmzpw5/rKCli1buuUKYEX/nn322cecfs/te1K+fHkrUqTIMcvDeQ9yMgYFnR988IF7DTt27Hjc8WX3cXyvu7YNtT8Q7whkgTih7NHx+Gpqn3jiCZcpOnz4sLv5/mjrpkkwoaieUpRZCxa8LNzHUVAhmdXCZqVx48Y2depU9wdd9bht2rSx/v37W79+/TLdR5nG4z2HwLrjcF7TrISzv7Jpqg1W7bAy2wrctJ9eN2U4c/uccyKvX1sFrQpeFTArYNXxFVwq+6jPwuLFi119Z3B9bCTeE51ByM17kN0x6HXRc1S9sM5GqNY4XOE8ju/30velMFCoZUC8IZAFPEIzwHObeatbt647daoJWgoqs7tvlSpVbPLkyRmW64+9Jpfk5HG0TZ06ddwpVwW6OaGAqHXr1vb888+7AExZvqyeg7K/oTotvP/++y6zrBnf0aBJcYE0qUevbW6fc24+T3n12uq56ri+QNYXsCprqe008UpjCxXIxsp7kB2a9KgvBJqIpaBdGd9I8f1eBnfd0O+TvowA8Y5AFvAI1cZpJvmsWbNyHPTJiy++6GZkd+nSxb755hvXymft2rUu6FSNYmbHVlnAsGHDbPbs2a7OT1k2/WG++eab7cwzz8zx44waNcrV1OrU7nfffWd79uyxJUuWuO4ImWVqFRRcf/317rXQ6WodW10OVJertkaZ0XNQllgZP81W1/GVjbv77rtdBlDrVAqRnxSEKEh89tlnXRsynYrWa/Taa69laD2V0+ec3c9Tfr22ClJVM6vtfHWgykAqa6mOBgq0FQDG0nuQG+rkoLpgfb5VXqOOCZHg+71URvnhhx92WVj9nqkzQ7S+lAH5iUAW8IibbrrJTRq5+uqr3enRUH1kw6GMkIINBRWq2dNpVC3TH271ncxq0pVqJlVHqJq/GjVquP2vuOIKa9GiRY4fR5N5FOjo+bRt29bV9fXu3dtNXsmsdlanptVqSH/ATzvtNJfF0x9x1eSqljMrKmlQYKaARRlhtVjSxDO1K1ILo2hQxlJfBvRanHTSSfbee++5LHVg4Jeb55ydz1N+vba+bKt61QYGXL7lytiGqmWN5nuQWwqKFcyqDlnBbODEwtzQ7+Xrr7/ufrc0WU+TvPT7o+A8VKYZiCdJal0Q7UEAAIDIuvXWW90FKFJTU6M9FCDPkJEFACDOqMZYdbM6CwLEMwJZAAA8TDWxt912m78WXSULKhlRqYgmzgHxjEAWAAAPU11skyZNrGfPnq6mWXXO6tOrCXtNmzaN9vCAPEWNLAAAADyJjCwAAAA8iUAWAAAAnpS/nb9jhK40pEbdJUuWzPXlDgEAABA5qnrdvXu3u1iJLvqRlYQMZBXEqjgeAAAAsWndunVWrVq1LLdJyEBWmVjfC1SqVKloDwcAAAD/pctEK+Hoi9eykpCBrK+cQEEsgSwAAEDsCaf8k8leAAAA8CQCWQAAAHgSgSwAAAA8KSFrZAEAOHz4sB08eDDawwASTuHCha1gwYIRORaBLAAg4XpUbtq0yXbu3BntoQAJq3Tp0lapUqVc9/MnkAUAJBRfEFuhQgUrXrw4F8YB8vmL5N69e23Lli3ufuXKlb0dyB44cMDef/99+/HHH6179+5Ws2bN4+6Tmprq9tm8ebM1bNjQLr744tj/j2jnOrO92zJfX7ysWWku0pAXDh9Jt4VrttuW3WlWoWSyNa1VxgoWiPHPC4A8KyfwBbFly5aN9nCAhFSsWDH3r4JZ/S7mpswgqoHs2LFjrV+/fi4YnTp1qrVt2/a4gezatWvt3HPPtapVq9rZZ59tzz//vDVt2tQFtjEbzCqIHdHY7ND+zLcpVNTszq8JZiNs6vKNNnjyCtuYmuZfVjkl2QZeVs86Nsjdt0AA3uOriVUmFkD0+H4H9TuZm0A2ql0LateubUuWLLGXXnop7H0U+CoNPXfuXBfEzpo1yyZPnmwTJkywmKVMbFZBrGh9Vhlb5CiI7fPWkgxBrGxKTXPLtR5AYorZxAeQIJIi9DsY1UC2WbNmLqWcnVNCH374od1www1WqNDRZPKpp55qrVu3ju1AFlEpJ1AmNj3EOt8yrdd2AADAmzzVR1ZlBfv27bM6depkWK77P/30U6b77d+/3123N/CG+Kaa2OBMbCCFr1qv7QAAyK377rvPNmzY4M4cv/POOy7xhrznqUD2zz//dP+mpKQc08LBty6U4cOHu318t+rVqUONd5rYFcntACCYzujMX73NPlz2u/s3r8/waFK0Oi74rF+/3lasWJHt4yi58/3339uCBQvsyJEjtmjRItuxY0eER5t47rnnHnd777337JdffrHLL7/8mInqS5cuDetYen/y6z1ZtmyZv4NATmn/b775xn9fn8tt2/KnXNJTgWyJEiX8H4ZAmoHqWxfKgAED3D6+27p16/J8rIgudSeI5HYAEEg19uc+PtOuf2mB3fXOMvev7udl7f3dd9/tMn0+L7/8svXq1Stbx1CAdcopp9jVV1/tjqeg9rzzzrPPP/88D0acWBSHaDa+ujGF6o86f/58u/LKK497nB9++MHat29vBQrkT4h29dVXuwnzuaH9r7vuOv/9adOmuU5U+cFTgawyqfqQrFy5MsNy3a9bt26m+xUtWtRKlSqV4Yb4phZb6k6QWSm5lmu9tgMAL04krVatmtWvXz9b+7zyyisukFWwpIysrw0Scq9///7upsBQJYyTJk3K8XFuv/32Y84+e0mfPn1c4J4fX5BiPpD96KOP7N///rf7WRO8rrjiCnvzzTft0KFDbtnPP/9sc+bMsc6dO0d5pIgl6hOrFlsSHMz67ms9/WQBeHUiaceOHe2uu+7y39ffw19//dU/p0RJHpUO+Hz77bfu9K+SOwpiQ80tUZmer+QgcKK1lu3ZsyfDtso86pi//faba3IfaPny5a5eVMtXr17txhW8jY/GqlPpepxgWT1GZnSWVqfwf//992PWafkff/zhHkuvl8ozjkfPQ+UXgdLS0txrsnXrVv+yUaNG2WmnnWZPPPGEy3Z36tTJsmvNmjX2ySefWI8ePTIs1/uhbLres8D3JnhffUEJXK+AWuPUTe99VmWYwVatWuVKBPQehKL3ROMJ9b7pM3b99de77lJxHciqLmPQoEH29NNPu/tjxoxx92fPnh0ykJXHH3/cfajUqeBvf/ubtWvXzi677DK75pprLGbpYgfqE5sVrdd2iBj1iR3ZrZFVKJXxta+UkuyW00cWgJcnkgaXFvzf//2f3XrrrXbmmWe6IFedgdRv3Rds6e/nV199ZV9//bULtEK1vlQA2rx5c3flJZ/du3e7ZQqSfF599VXXClOnk1u1auUyw4E1kjqtfOedd7rOQkpAaUw6Xa4AMLDmt3HjxtagQQP3N/zkk092rTXDfYzMspna569//at77EsvvTTDBG/FCwr+9VhKgOlsrjKomQWHvsBYz/+zzz5z97Vtly5d3GsYqh9xkSJFLKc0QUwT2APn8iig1HNXD32N+aSTTnK99wNjqQYNGlijRo3sqquucs9p8eLFbp0CTY1Tt27duln58uXda5QVvcb16tVzvf31vlSsWNFef/11/3oFtlqux1GphMY6c+bMY47ToUMH+89//pNpIBxXGVmd6h84cGDIiyGoWFopdp8aNWq4X7SePXu6D6u+AcX0xRBEFznQxQ56fW528/8+fO5nLdONiyHkCQWr0+9t478/pkcTm9evHUEsgLicSDpv3jwX4CqTpoyZOv0888wz/osQXXLJJXbhhRe6DN0///nPHD2Gkk2aoa86SAW3yqgqGFTAGZidU1CqQEZ/sxWM6V8lrES1uRdddJErc9BEIY33yy+/tI0bN2brMQIpFnj22Wfd6Wztowymsq4PP/xwhu0UzOu093fffefGNGXKFJc0y4yCOrX9VJwiffv2dcf/+OOPI35hjYULF7qgP9DQoUPdGJRh1nj1RcQ3OWvXrl3u/TznnHPcMo1Lr5kvG92kSRN/RlbPV9ltfT70voSijK3el9tuu81lq5UpV69+lQroseWFF16wL774wn0R0fumoDrU8f7yl7+4L0R6zLwU1St7nXXWWe6WleBZf6K6kZtvvtk8RUGqbgcCTs1UOsOsyAnRHFVCCCwf4PK0AOJ5IqkykApefJOPlBVTABNJOkuqDKlO9euUu/7V/UcffdSVM+j0uigDqEBVlAlURtE3FgWPCk61f3Ly0ddKV+y89tprs/UYwfW/yhTqap+iTOIDDzzgOgkowPVRFrtKlSru51q1ark4ROPKqhRAZ4uV4VUGUkGhAuFy5cpZpG3evPmY56aMpiZ+KROsK2Cp//6NN97o1k2cONEFn3p+hQsX9j8n3QKp24XOZutYCpT1RUEBa6gvA/ry07JlS385hTLMuoCVAlZlfl977TX3GvqSj2eccYYrI1CZZyDfJaADO23EXSALAIAXJ5JqYleois2k/5YvRWsiqYK3QMoYBte25pZOV2/fvt2VDgRSVjCwBjOrsSgYVeCaWTAY7mMEUi2uguVAOiWvx1SA6BtPTl4jnc6/4IIL3AQunbYPdQY5EhTUB5ZfyIMPPuhKCnQK//zzz3cBqAJ2zRtauXKlCzIz69ykrKq+HChQ15hPOOEE9zrptc/sddccpODXXfv5AmXtHzzBXsF3cCDrex55PaGQQBYAgGxOJFV3AgWt6XE2kdRXphc4sergwYPHBFsXX3yxjR49OsePo+Axq4sT5eQxSpYseUyQ67uvdbmhGlGVLKgUUqfYVdubF1S7GzwJT1lQLVPtqmpRH3roITfpXVnt4sd5HXVxBvXaV520JmCJssqZ1QTrdddzVNY5M3otgwP/UF8EfBPp9JzivkYWAACviOeJpL5sZeBsftVtBtIkINVNBgeN2cn8asK2+roHTu4OzOLl5DFUUqH60EA6HX766afnqpb1008/dTWiEyZMcJOmVCubVxOY9Lz1egcGmr7nrJIAlUk899xz7nnpC0br1q1diUbwhRZ8r6OypyrJ8AWxmrin+tasHl8lCMFts/TFRiUHogmE06dPz7A++HUXlV8oCxxc5hBpZGSBbFJbHc1I1mQO1cFRdwskHgWrLU8pZw0HTfNPJG1Vp7zn/y/QKXRN0tGEJmXzNGlo2LBhGbZRdwTVZupCCvfff7/L+GkCkiaTaXJQOFRXqQ4LOu09ePBgV0s7a9YsVwuqyU05eQydglcpgTomqGuBajxHjBjhAtCc0mPqNP7IkSNdaYFKGxRIaqK5OiflRY2zalIVGKrzhKj+VPW5CjJVTqBOTwpOdaq/devWbhKcujGojlflBwq89YVE759eP41dnRAUzD755JPHXFQqkI6r2maVMihg1yQzTZrTBLF//etf1qJFCzd5Ttup+4E6R6muVuUW+uwE0use3EYsLxDIAtmgRufqERnYfkf1cjqV6OUsDADvTSQNviCC6hY1ESiQOv0EttJSPWXwrH9NjipTpoy/tECz8YcMGWKPPfaYC4B0ydXevXv76zA1iUdBonqEaoKVJiApSxeYXW3YsOExdZgKVrWtj8oG1Nbqgw8+cF0MFBTde++9YT9GqNdD2Ux1Y1AwrGBOz0UBqI9aVGniWSAFa3qdgikbrNfhkUcesZtuusk/2VwTztSKS3Wkkb76loJNvQbqDOALZMePH++CUb1eql9VEBnYP3jcuHGulZpeR2VytZ+vxlXBrepbFXgrQNYXB7VBCywd0ReXwLrhN954w5UuqB5YQao+V5p85yunUDCvjLACepU76L7eo8DODyqF0JeAt99+2/JaUnq4HYbjiOpJ9GHUt5J8v8qXuhb84+hsSXtwA10L8sHeA4es3iOfup9XDLnQihcplKur+QT/wvj+dHn9lCKQCHTKVY3jdbrTN1veKxSg6KbT2/AeBX/6QuC7aEVmFNSrjlXBbF6fls8rw4cPdxP5lHXPye9iduI0MrJABK7mo2BW6zvUq+T5U4sAgOhRVlYTubxswIAB+fZYTPYCPHY1HwCJSZOWdCEgeJPqfHUaH5FFRhaIg6v5AIh/mmwD79Ilg1XHisgiIwvEwdV8AABIRASyQDau5pNZ9auWV47i1XwAAEhEBLJANq7mI8HBbDxczQcAAC8ikAXCFM9X8wEAwIuY7AVkQ7xezQcAAC8iIwt47Go+AADgKAJZAACyY+c6sw3LMr9pfYTpMrMLFixwlyjFUTt27LDvv/8+Xx4rUq+/rtql4xw4cCDfn0O8orQAAIBwKUgd0djs0P7MtylU1OzOr81KV4/Yw/7888/WvHlz++OPP9ylP2Hu8qfnnHOO1a9fP88fK1Kv/7p169xx9G+1atUsKSnJ2rVrZ59//rmddtppER1zoiAjCwBAuPZuyzqIFa3Xdsgz8+fPt1mzZtmdd95pXr/aV69evfL1kq7xhkAWAACPOnz4sDs1vWrVKjty5Ih/uX7WKeydO3ces89XX31l27dvP+4xZPfu3e446enpLhu5ePFi27Vrlx08eNAt1+3rr7/OcLxg27Zts++++8727dt3zKn1cMYQynPPPWfXX3+9FStWzL9MY/z111/thx9+cMcLpuP++OOPtmbNmgzLs/NcgoUzbh3P9/xDuemmm2zy5Mm2du3asB8X/0MgCwCAB3300Ufu9HSnTp2sY8eOVrNmTXeKWgoUKOAyfcGXtf3yyy/dqW0FqMc7hnzzzTdue2U+dQr/jjvucEGb9r/77rvdTaf4q1evbtddd50LVAMNHz7cqlSpYtdcc41VrVrV+vbt6463ZcuWsJ5HKKpT/fjjj61Dhw7+ZTpVf+aZZ7rLwF577bVuPJMmTfKv//DDD91jtG3b1s4//3xr0aKF/f77725duM8lO6+/z9NPP+2e/9VXX+2e/xNPPHHMcU455RSrUaOGOx6yj0AWAACPUdaxa9eu9vrrr9vKlStdcPn3v//dBXHKmIrWv/322xn2Gzt2rLVq1cpOOumksI7ho0lJGzZscNncRo0aWZkyZfxZzCVLlrhs4ooVK1ym1Gfp0qXueB988IHLhCpbqmXZfR7B9Dh//vmnC1x9Hn/8cRcwaozKfi5fvtyfWdV9BdL333+/bdq0yVavXu0CTAW/Es5zycnr/+2339oDDzxgEydOtJ9++sllgpXRDuUvf/mLe3xkH4EsAAAe89JLL1m9evVcELZo0SJbuHChnXXWWS6I0s/y17/+1QVtCj59mcx3333XunXrFvYxfB5++GErVOjY+eEKFpW1VTCnbOjs2bP969544w1r2bKlXXzxxe5+qVKlrF+/ftl+HsE2b97s/i1btqx/mUoVlIX2lRToeDfffLP7+eWXX7bTTz/d7r33Xv/2Gqtu4T6XnLz+Y8aMcdnnSy65xN1PSUmx/v37hzyenouCbGQfXQsAAPAYZfiU4Qye7KQspa/+VKfIW7du7bKwmt3/6aefutPoyk6GewwfZXADqd5TGckpU6bYySef7ILUjRs3Zgguf/nlFzv11FMz7Fe3bt1sP49gycnJ7t+0tDQrWbKk+1mZzyuvvNKd6lfpgE71d+nSxQoXLuwC08DsbbBwnkuwcMatLxHBzzezzgR6LoH1vggfgSwAAB6jYO7ss8+2Tz75JMvtlH3VKW+dSldAq+ygZspn5xiibGegZ555xp1+16l8ZSV9WVtNWvJRkLlnz54M+6kkICfPI5CCTVFpQPny5d3PderUceUEuqmbwbBhw1zWdM6cOVa8ePFMyxTCfS7Bwhl3qOcffN9n/fr11rBhw+M8c4RCaQEAAOEqXvZon9isaL22y0OatKSJRQq+AmmCUuCMfU0ySk1NdROfNOHJV1aQnWOEomxj48aN/YGfOgYo4xtI6+fOneu6AvjMnDkzR88jkCZNaYKUWnAFB4gNGjRwE8pGjx7tHlvPXVlpPYbqfIOzoOE+l2DhjFuBrgLpwMzytGlHL28eSCUfKk9o3759lo+J0AhkgSg7fCTd5q/eZh8u+939q/sAYpQucqCLHfT63Ozmqf9brp+1TLcIXwwhlJ49e7oazfPOO8/efPNNmz59uutQoDpNX0cCN9zSpV0WVt0GihYt6q/XzM4xQtE+CoxfeeUVF/SpHlf1pYHUAUBBoUoZpk6das8++6w99dRTbp0uBJCbMfTo0cPee+89//1bbrnF7rrrLjfzX8GiugNoUprqUvUYKo1QoKgaYXU8UNnBjBkzwn4uOXn99fwLFixonTt3ds9f65X9DabHPOGEE1w5BLKP0gIgiqYu32iDJ6+wjalHMwNSOSXZBl5Wzzo2qBzVsQHIhIJU3Q4EnCaudIZZkRPy7CEV6KjOVTWfonpKTUYaOXKkjRs3zmU9FUQpYPKVDvioDZdaTV100UVWpEgR//JwjqF6UT1ucGmBakqVBZ0wYYLbT50QRowY4bKgPiVKlLB58+bZkCFDXGCp+lAFi1dddZU73Z/d5xGod+/erlxCpQTKwqp7wIsvvuiOr6yosqFqpyV6LI1LQaS20Sl/9aD1BfXhPJecvP7aR8cIfP4Kou+77z73pcJHx9BEtMD3BuFLStfXpQSjWhl9S9MpB/2S5iv9x/ePKkd/fnBDnv7Hh6P2Hjhk9R45eppoxZALrXiRQjFxPAWxfd5aYsG/gEfzFGYjuzUimAUiTKeT1QapVq1a/klDyDsKKgODNmUl//nPf/p7uOaGugKoVdYjjzxiXqUJcZowptKPRAtk07L4XcxOnEZGFogClQ8oExvqW2T6f4NZre9Qr5IVLOALbQHAW3TVKmU4lY3UVbMeffRRd4uE7t27m9dp4pq6JSDnqJEFomDhmu0ZyglCBbNar+0AwKt0+l8XC9AVvlR3qgs0+E75A5FARhaIgi270yK6HQDEIl1tK/gyuUAkkZEFoqBCyeSIbgcAQCIikAWioGmtMq47QWbVr1qu9doOAACERiALRIEmcKnFlgQHs777Ws9ELyBvJGDDHiAufwcJZIEoUWsttdiqUCrjVYIqpSTTegvII74+oHv37o32UICEtve/v4O+38mcYrIXEEUKVlueUs4aDjp62cIxPZpYqzrlycQCeURXWlLD+i1btvib5fuuMgUgfzKxCmL1O6jfRf1O5gaBLBBlgUGramIJYoG8ValSJfevL5gFkP8UxPp+F3ODQBYAkFCUga1cubJVqFDBXVoUQP5SOUFuM7E+BLIAgISkP6SR+mMKIDqY7AUAAABPIpAFAACAJxHIAgAAwJMIZAEAAOBJBLIAAADwpKgHsq+++qqdeeaZrpdYhw4dbOnSpVluv3v3brv//vutXr16rn3KOeecY6+99lq+jRcAAACxIaqB7Lhx46xPnz72wAMP2BdffGG1a9e2du3a2caNGzPdp3fv3vbhhx/aK6+8YkuWLHH3b731VpswYUK+jh0AAAAJHMgOHz7cevToYd26dXNB7AsvvGBFixa1kSNHZrqPAt6uXbta8+bNXUZW+9evX98tBwAAQOKIWiC7c+dO++6776x9+/b+ZWpMrYzsvHnzMt3v8ssvt08++cQ2bdrk7s+ZM8dWr15tl156ab6MGwAAALEhalf22rBhg/u3YsWKGZbrkoEqGcjMv/71L5fBVTZW2dv09HR78cUXMwTEwfbv3+9uPrt27YrIcwAAAEACT/YqUCDjEAoVKuSC08zccccdLtBVJvaXX36x0aNHuzrbKVOmZFnCkJKS4r9Vr149os8BAAAACRTIKvMqW7duzbB8y5Yt/nXBtm/f7rKvQ4YMsVatWlmVKlWse/fudsUVV9gTTzyR6WMNGDDAUlNT/bd169ZF+NkAsePwkXSbv3qbfbjsd/ev7gMAEI+iVlpQrlw5O/nkk23u3LnWqVMn/3JlWq+++uqQ+yhTq1tycnKG5bp/5MiRTB9LJQi6AfFu6vKNNnjyCtuYmuZfVjkl2QZeVs86Nqgc1bEBABBXpQV33XWXvfzyy67jwIEDB1wJgCZx3Xbbbf5t/va3v1mLFi3cz2XLlrVmzZq57davX++C2tmzZ9t7771nl1xySRSfCRAbQWyft5ZkCGJlU2qaW671AADEk6hlZKVv376utODiiy+2PXv2WM2aNW3SpElWp04d/zZ79+7NMDnr3XfftbvvvttOP/10F/yeeOKJds8997iLJACJSuUDysSGKiLQsiQzt75DvUpWsIDuAQDgfVENZJOSkly96+DBgy0tLc2KFSt2zDbPP/+8HTp0yH9fE7UmTpzoflYnAkoGALOFa7Yfk4kNDma1Xts1r102X8cGAEBcBrKBAW2oIFYyWy4EscBRW3anRXQ7AAC8IOrttwDkXoWSyRHdDgAALyCQBeJA01plXHeCzKpftVzrtR0AAPGCQBaIA5rApRZbEhzM+u5rPRO9AADxhEAWiBPqEzuyWyOrUCpj7XillGS3nD6yAIB4ExOTvQBEhoLVlqeUs4aDprn7Y3o0sVZ1ypOJBQDEJTKyQJwJDFpVE0sQCwCIVwSyAAAA8CQCWQAAAHgSgSwAAAA8iUAWAAAAnkQgCwAAAE8ikAUAAIAnEcgCAADAkwhkAQAA4EkEsgAAAPAkAlkAAAB4EoEsAAAAPIlAFgAAAJ5EIAsAAABPIpAFAACAJxHIAgAAwJMKRXsAAGLb4SPptnDNdtuyO80qlEy2prXKWMECSdEeFgAABLIAMjd1+UYbPHmFbUxN8y+rnJJsAy+rZx0bVI7q2AAAoLQAQKZBbJ+3lmQIYmVTappbrvUAAEQTgSyAkOUEysSmh1jnW6b12g4AgGghkAVwDNXEBmdiAyl81XptBwBA3ASyBw4ciPQhAeQzTeyK5HYAAMRMINupUyfbunXrMct/+OEHa9asWSTGBSCK1J0gktsBABAzgezmzZvtjDPOsGnTpvmX/fvf/7bGjRtb3bp1Izk+AFGgFlvqTpBZky0t13ptBwCApwLZuXPnWs+ePe2SSy6xu+66y/07YMAAGzVqlI0bNy7yowSQr9QnVi22JDiY9d3XevrJAgA810e2UKFCNmTIEPfzo48+agULFrQ5c+ZYixYtIj0+AFGiPrEjuzWygR99b5t37fcvr0QfWQCAlzOyaWlpLhP72GOP2UMPPWStWrWyK664wj788MPIjxBA1ChYnX5vG//9MT2a2Lx+7QhiAQDezcg2adLE9u3b50oMzjnnHDty5Ig9+eSTdu2111r37t1t9OjRkR8pgKgILB/g8rQAAM9nZBs1amRLly51Qaw7SIEC1q9fP5s/f74rMQAAAABiMiP7+uuvZxrgfv3117kdEwAAAJD/F0QoXrx4pA8JAAAARCYjK1999ZVNnDjR1q5da4cOHcqwbsKECTk9LAAAAJB3GVn1ij3vvPNcEDt+/HgrUaKEu6qXAtukJCaCAAAAIEYD2X/84x/29ttv2zvvvOPujxkzxpYvX2733HOPFSlSJNJjBAAAACJTWrBy5Uq78MIL3c+FCxe2vXv3utpYXd2LS9QCAAAgZjOy+/fvt2LFirmfq1Sp4soKRAHtwYMHIztCAAAAIJKTvXyuuuoqu/HGG+2aa66xyZMnW/v27XN7SAAAACBvAlld0SuwXrZo0aI2e/Zsd8WvoUOH5uSQAAAAQN4Hsueee67/5+TkZBs+fLjllFp3KTDevHmzNWzY0OrXrx/Wfn/88Yd98cUXrja3devWbhwAAABIHBG/IEJ2bN++3V3m9uabb7axY8da8+bN7e677z7ufk899ZTVrFnTRo4c6W4tWrSwdevW5cuYAQAA4OGM7K5du+zJJ5+0efPm2Y4dO45Zv2zZsrCO8+CDD9q+ffvsu+++c71odZEFBbMXXXSRvytCsPfff9/69etn06ZNs3bt2vm7KDDJDAAAILHkKJBVBvWbb76x6667zkqXLp2jB05PT3d9aB966CEXxIqys7qpR21mgexjjz3mJpj5glipU6dOjsYAAACABAtkP/30U5dF1en9nFIpQGpq6jE1sQ0aNLAlS5aE3EfZ26+//tpuvfVW++mnn1zmV+2/mjVr5vrZZtUuTLfAjDIAAAASsEa2VKlSdsIJJ+TqgRXESnBGt0yZMv51wbZt22ZHjhxxbb4uvfRSd0ncHj16uEliv/76a6aPpcloKSkp/lv16tVzNXYAOXf4SLrNX73NPlz2u/tX9wEAyLeMbK9evax///72wgsv5LhbgO+CCnv27MmwfPfu3f51wXyP9dtvv7lL4qrtl2pjNdnr3nvvdfWzoeiKY1ofmJElmAXy39TlG23w5BW2MTXNv6xySrINvKyedWxQOapjAwAkSCCrCyA0btzY1bLq1H5SUlKG9atWrTruMWrUqOHKAYIzqbpfu3btkPuUK1fOTjzxRFc/qyBWdIyOHTvaW2+9leljaVvf9gCiF8T2eWuJBedfN6WmueUjuzUimAUA5H0ge9NNN1nVqlWta9euOZ7sVaRIEevQoYONHz/eevbs6Zapl+zMmTNtxIgR/u2+/PJL1zP2iiuucPcvv/xyl40NpPu5qdcFkLdUPqBMbKgiAi3TV2Gt71CvkhUskPGLMQAAEQ1kFy5c6LKu1apVs9x4/PHHrWXLlnbttde6CVuvvfaanXXWWS5Q9nn11VdtwYIF/kB2yJAhblsF0dpXLbs0+Wz69Om5GguAvLNwzfYM5QShglmt13bNa5fN17EBABJsspeysVl1CQiXOhSojddpp53muhDcdttt7lK3gcdWsNqpU6cMJQnqVqB9v/32W6tbt679+OOPrk4WQGzasjstotsBAJCrGtl77rnHRo8ebSVLlszVK6mSAGVZM6OuBMEqVKjgJnAB8IYKJZMjuh0AADkOZF988UXbsGGDvfvuu1axYsVjJnutX7+eVxeAX9NaZVx3Ak3sClUnq/9BKqUku+0AAMjTQHbYsGE52Q1AgtIELrXYUncCBa2Bwazva7DWM9ELAJDngWz37t1zshuABKbWWmqxNfCj723zrv9daU+ZWPrIAgDyLZAFgJxQsNrylHLWcNA0d39MjybWqk55MrEAgPzrWgAAORUYtKomliAWAJBTBLIAAADwJAJZAAAAJGYgq8vHbtmyJTKjAQAAAPIykD1y5Ig9+eSTVq5cOXdxAvWS1c9apnUAAABATHYtePTRR+3555+3/v37W7NmzdwFEebPn2+PPfaY7d271wYOHBj5kQIAAAC5DWRfeukld1Wvdu3a+Ze1bNnSGjVqZDfddBOBLAAAAGKztEA1sWefffYxyxs3bky9LAAAAGI3kD3ttNPszTffPGb5G2+8YXXr1o3EuAAAAIC8qZHt3LmzTZ482Zo2beqWffXVVzZjxgybOHFiTg4JAAAA5H1G9oorrrDFixe7TgUKZj/++GMrX768W6Z1AAAAQExmZB966CEbOnSovfXWW5muAwAAAGIuIzts2LAcrQMAAABi8hK1y5cvdyUGAAAAQEyVFqgmNtTPoit67dy50/r27Ru50QEAAACRCGRHjBjh/r3++uv9P/sULlzYatas6XrJAkB+OXwk3Rau2W5bdqdZhZLJ1rRWGStYICnawwIAxFog26VLF3829vzzz8+rMQFAWKYu32iDJ6+wjalp/mWVU5Jt4GX1rGODylEdGwAgRmtkCWIBxEIQ2+etJRmCWNmUmuaWaz0AIL5FdLIXAORXOYEysekh1vmWab22AwDELwJZAJ6jmtjgTGwgha9ar+0AAPGLQBaA52hiVyS3AwB4E4EsAM9Rd4JIbgcAiPOuBcnJ4f9BSEsjCwIg76jFlroTaGJXqCpYNd+qlHK0FRcAIH6FHchOmjTJ//PSpUvdpWh79+5tTZo0ccsWLVpko0aNsr///e95M1IA+C/1iVWLLXUnUNAaGMz6OshqPf1kASC+hR3IduzY0f/z0KFD7Z133rFLL73Uv+y6666zNm3a2BNPPGEDBgyI/EgBIID6xI7s1sgGfvS9bd61379cmVj6yAJAYsjWBRF8vvnmG2vduvUxyxXIdu3aNRLjAoDjUrDa8pRy1nDQNHd/TI8m1qpOeTKxAJAgcjTZq0yZMvbuu+8es1zLypYtG4lxAUBYAoNWLk8LAIklRxnZRx991G6++Wb76KOPXI1senq6LV682KZMmWKvv/565EcJAAAARCKQvfHGG+20006zZ5991t5//323rF69erZgwQI7++yzc3JIAAAAIO8DWWnatKmNHTs2p7sDAAAA0bsgwubNm23+/Pm5GwEAAACQX4Hsjh07XOutSpUqWYsWLfzLL7/8cvviiy9yckgAAAAg7wPZBx54wP27evXqDMv79u3rJoIBAAAAMVkj+8knn9jChQutevXqGZarg8HcuXMjNTYAAAAgshnZnTt3WkpKivs5Kel/PRt37dplBQsWzMkhAQAAgLwPZJV59bXd8gWy6iU7fPjwDDWzAAAAQEyVFihg7dixo82ePdsFsAMGDLBp06bZDz/8YHPmzIn8KAEAAIBIZGRbtmxpX375pQtiTz/9dJs0aZK7QMJXX33FBREAAAAQ2xdEaNiwIZejBQAAgDcviAAAAADEfCBbunTpsG/ZMWvWLOvcubOde+651qdPH/v999/D3veNN95wpQxPP/10th4TADJz+Ei6zV+9zT5c9rv7V/cBAB4vLXj55Zcj/uAzZsxwk8b+/ve/W69evey5555z9bfffvutlSpVKst9NbHsoYcecnW6a9eujfjYACSeqcs32uDJK2xjapp/WeWUZBt4WT3r2KByVMcGAMhFIHv11VdbpD388MN2zTXX2KBBg9z91q1bW+XKlW306NH+q4eFkpaWZtddd53961//4kpiACIWxPZ5a4kF5183paa55SO7NSKYBYAYE7Ua2T179tiCBQvskksu8S8rVqyYtW/f3mVqs3LPPfe4XrYqSQCA3FL5gDKxoYoIfMu0njIDAIiTrgVqtTVx4kR3Wv/QoUMZ1k2YMOG4+69fv96VBVSpUiXDct3PKpDVhRg+++wzW7ZsWdhj3b9/v7sFXoEMAHwWrtmeoZwgmMJXrdd2zWuXzdexAQAinJEdN26cnXfeeS6IHT9+vJUoUcLVrCqwDbxkbVYOHjzo/i1atGiG5crK+tYF++2336x37942duxY95jZuYCDLqnru1WvXj3sfQHEvy270yK6HQAghgPZf/zjH/b222/bO++84+6PGTPGli9f7k75FylSJKxjlC17NKuxbdu2DMu3bt3qXxds8uTJtnfvXrvjjjtctwLdfv75ZxdY6+fDhw+H3E9XHktNTfXf1q1bl81nDCCeVSiZHNHtAAAxXFqwcuVKu/DCC93PhQsXdsFl8eLFXcBYt27dsI6hSV26LVq0yC677LIMJQtt2rQJuY8meDVr1izDsq5du1rjxo3t3nvvtYIFC4bcT1nf4MwvAPg0rVXGdSfQxK5QVbA6z1QpJdltBwDweEZW9aYqAfDVtKqsQBTQZlYWEMott9zi2nr5MqQqU9CxtNxn6NCh1qVLF/dz+fLl/ZlY303jqFChApfGBZBjBQskuRZbElwc5buv9doOABAHk718rrrqKrvxxhtdGy2d+lfXgey031q9erXVqVPHBcRbtmyxUaNGuQyrz6+//urKFgAgL6m1llpsDfzoe9u863+TQ5WJpY8sAMRRIDt37twM9bI6bT979mzXEksZ1HCpnla1tps3b3ZBbO3atV2JQnCw++eff2Z6DO1fsmTJnDwNAMhAwWrLU8pZw0HT3P0xPZpYqzrlycQCQDwFsrqcrE9ycrLrCpAbFStWdLdQTjrppCz3rVfv6OlAAIiEwKBVNbEEsQAQZzWy6g4Q6nS/lmXWOQAAAACIeiD7+OOPu5ZXoU7z//Of/4zEuAAAAIDIB7IjR46022+//ZjlWqbJWgAAAEBMBrLbt28P2bNVyzRxCwAAAIjJQFbdCZ5//vljlj/77LNuHQAAABCTXQuGDRvm+sWqDVfr1q0tPT3d5syZ467SNWPGjMiPEgAAAIhERrZly5a2YMECq169uk2cONE++OADq1GjhlumdQAAAEDMXtnrrLPOsrFjx0Z2NAAAAEBeZmQ3bNiQoc3WM888Y5UqVXLZ2LVr1+bkkAAAAEDeB7L33nuv1axZ0/28fv16GzBggLtVrVrVrQMAAABisrRg+vTpNnr0aPfz1KlT7cILL7S77rrLunTpYg0aNIj0GAEAAIDIBLJHjhyxPXv2WEpKin322Weug4EULVqUS9QCQIDDR9Jt4ZrttmV3mlUomWxNa5WxggWSoj0sAEjcQLZt27Z2yy23WKtWrWzy5Mn2xBNPuOVffPEFXQsA4L+mLt9ogyevsI2paf5llVOSbeBl9axjg8pRHRsAJGyN7AsvvGClS5e2jz/+2JUYnHTSSW7566+/bgMHDoz0GAHAk0Fsn7eWZAhiZVNqmluu9QCAKGRkK1eubOPGjTtm+bvvvpvL4QBAfJQTKBObHmKdlqmwQOs71KtEmQEA5HdGFgCQOdXEBmdig4NZrdd2AICcI5AFgAjTxK5IbgcACI1AFgAiTN0JIrkdACA0AlkAiDC12FJ3gsyqX7Vc67UdACDnCGQBIMI0gUsttiQ4mPXd13omegFA7hDIAkAeUJ/Ykd0aWYVSRTMsr5SS7JbTRxYAotR+CwBwfApWW55SzhoOmubuj+nRxFrVKU8mFgAihIwsAOShwKCVy9MCQGQRyAIAAMCTCGQBAADgSQSyAAAA8CQCWQAAAHgSgSwAAAA8iUAWAAAAnkQgCwAAAE8ikAUAAIAnEcgCAADAk7hELQB4yOEj6bZwzXbbsjvNKpRM5mphABIagSwAeMTU5Rtt8OQVtjE1zb+sckqyDbysnnVsUDmqYwOAaKC0AAA8EsT2eWtJhiBWNqWmueVaDwCJhkAWADxQTqBMbHqIdb5lWq/tACCn9H/I/NXb7MNlv7t/vfB/CqUFABDjVBMbnIkNpD81Wq/tmtcum69jAxAfpnq0dImMLADEOE3siuR2ABAvpUsEsgAQ49SdIJLbAYgPhyNQCuD10iVKCwAgxqnFlk7xKTsS6k+Jmm9VSjnaigtAYohUKcBCj5cuEcgioSSlrjc7uDPzDYqXNStdPT+HBByX+sTqj5NO8SloDQxmfR1ktZ5+skBilQKkBy33lQKM7NYo7GDW66VLBLJIGFVsqyWPamp2eH/mGxUqanbn1wSziDn6o6Q/TgM/+t427/rfZ7iSByZjAIic45UCJP23FKBDvUphfbn1eukSgSwSxolJuy0pqyBWDu0327uNQBYxScFqy1PKWcNB09z9MT2aWKs65cnEAgl0Zb5IlwI09XjpUkwEsuvWrbPNmzfbqaeeaqVKlTru9ocPH7aff/7ZChUqZLVq1XL/AkAiCPyjx+VpgcSraY10KUBBj5cuRbVrQVpamnXu3Nnq1q1rN9xwg1WqVMmef/75LPcZNmyYVa1a1e13wQUXWM2aNe3jjz/OtzEDAABEq71VXpQCdPxv6VKFUkUzLFcmNjv1ttEQ1VTm4MGDbeHChbZ69WqrXLmyTZo0ya688kpr2rSpnXPOOSEzsfv27bMVK1ZYmTJHU9yDBg2y6667zh1DgXDMn0aoWtQKRntQAADAkzWteVUK0NGjpUtRzci+9tpr1rNnTxfESqdOnaxBgwZueSgFCxa0oUOH+oNY6dOnj+3du9eWLFlisUbfsM59fKZd/9ICu+udZe7f85/+PNrDAgAA+dSnNTs1rdkpBZCkoHW5LQXwYulS1DKyGzZscHWxjRs3zrBc2dilS5eGfZxFixa5f2vXrp3pNvv373c3n127dlm0WmNs3pVmFpsT/5ADtPMCgPgUqzWtQheTGAhkt28/+s2jbNmMM+p037fueLZu3Wp9+/a1a6+91tXZZmb48OGujCG/hHOVDN92lBl4F+28ACA+RbJPa161t/JqKUDclBYULlzYP+ErkGpgixQpctz9U1NTrWPHjq4u9uWXX85y2wEDBrjtfTd1SchLxzuN4LP41x15Og5ktCO9pKUXzFjIHjLwVBY10u28AACeEOlLtvpqWjMLL7W8cg7bWxX0YClA3GRkq1evbgUKFLDff/89w3Ldr1GjRpb7qjRAHQtUMzt16lQrWbJkltsXLVrU3fJLuKcH/vgzNq+SEa82WDlL673QiqkU4NA+s1c7Hl1x81SzQsWO/kwpAAAktEj3afV6e6tYF7WMbPHixa1Fixb20Ucf+Zft2bPHpk+fbh06dPAvW7VqVYaaWV8QK9OmTbOUlBSLNeGeHihfgmLZ/JaeUs2syllmlc7430L9rGW6EcQiwURiMgsQT5/nvKxp9WJ7q1gX1fZb6kCgoFWn/ps3b+56yFaoUMF69erl3+axxx6zBQsW2PLly+3gwYN20UUX2Zo1a+zVV1+17777zr9dnTp1rGLFihYLjtcaw+fsmifm46gAIG8mswDx9HmmptVbotp+q02bNjZr1iz77bff7Nlnn7X69evbvHnzrESJEhkC1EaNGrmf1WYrKSnJLdMErv79+/tvvu4FsSCc1hi+7QDA6w3agXj6PFPT6i1Rv7Zry5Yt3S0z/fr18/+sMgIFul6QWWuMiqWSzQ5EdWgAElykG7QD8fR5pqbVW6KakY13Cman39vGf1+nEQLvAyH70m5YlvltZ9523EBiiHSDdiDePs/UtHpH1DOy8e6Y0wh2nHZN8Fw7ryxbcGWjnRd9aZFf8mIyCxCRy7jn4HR7Xn2eqWn1BgJZIEbaeWWrLy2BLHIhryazAPE0OUuoaY19lBYAuUA7L3hRXk5mAeJpchZiH4EsACSYcDqrMJkFXrlyFp/nxEYgCwAJiMksiBYmZyGSqJEFgATFZBZEA5OzEElkZAEggTGZBfmNyVmIJDKyQLz3pVVXhcxko6sCAESiXdbxLuOe9N+SACZnIRwEskCMoC8tgERol8WVsxBJBLJAjKAvLYBY5WuXFZxB9bXLyu6Eqswu414pB4ExEhuBLBBrfWmL1DQ7sCdjX9oiJ0RzWAAS2PHaZSlvqvUd6lXKVhaVyVmIBCZ7AQCAfG2X5cPkLOQWGVkAQExNBkJitMsCIoFAFgAQU5OBkDjtsoDcIpAFEDbaeSG/JgMhdtAuC7GMQBZAWGjnhfyeDITYKPWgXRZiGYEsEKci3ZeWdl6IxGSg5rXD+7whtko9aJeFWEUgC8SpSPelBTLDZKDEKPWgXVZiSfJIKRmBLBDH6EuL/MBkoMQp9aBdVuwGikkRPJ6XSskIZAEAucJkoNhCqUfeiOVAsUqEj+elUjICWQBR45VTV8gak4FiC6UesR94RjpQPNFDgWekEcgCiAovnbrC8TEZKHZ4tdQjkQJPRA6BLICo4A9D/GEyUGzwYqkHgSdyikAWQFTaeSE+MRkocfq+RjKDSuCJnCKQBRA37byouYWX5XXfV2U965Tcb7e1PtlalNlstmFzQsxqR3wjkAUQF+28+MOKeOv7qs90mV27bcTYH6zUxadZi9rlshV4BpZ66Fhziz9gBQ/uN5thR2/BOHUPDyKQBRAX+MOKeOr7qsBzZtH7LDnp4NEFoYLPMAJPX/mAfj8KHuH3A/FXSkYgCwCZoFQB2bJz3dFAMJufl1B9XxV4+oPYzBB4elakA8UdET6eF0rJfAhkASAEShXiZ/JTpAPPTI81ovHR4DKbn5d47+caD2I9UNyQB4FnLJeSBSKQBRAVsX7qKi9KFcjw5m7yU4bJSsH1ovkYeIakz0FWx8ri8xJr/VzjQawHnnkRKKZ7JPCMNAJZAFHhpVNXsZrhjeVrtef2eMGTn/w1owcPRmSyUm4Cz/zu+5oIEjHwRGQQyAKImkT6wxDpDG+sX6s9N8cLNfkpnmtGs+r7migIPJFTBXK8JwDAG4Gxx44XavJTvPP1fa1Qqqh5KYOapWyWBrnAs8pZR4NNH/2sZbp57AsK8gcZWQBxIdZrbhG+RJ38FHyJ30Q7dQ/kBIEsgLjAH9b44aXJT76uCvvX/WFtI3A8X0cGLwSenLpHLCCQBRA3+MMaH7wy+Smwq0L9pDXWNoJVAQSeQHgIZAEgBEoVoscLk5+Cuyro85KWXjjrCWk5qRkl8ASyRCALACFQqhAbk58GfvS9bd51nEljOaH3ToHl8frIhgg8Q3VV0Oel3f6njnZXsAM2sejgoyv4vAB5ikAWAPIhI0aGN3eTn/T6HS5Q1AoeidDrp4BSrb9cP9nsfVHJrKuCgtkN6eWsmAWsI4MK5CkCWQDwYIY31q/VHqnj+SY/6fU70CfCGXJtq1s2v6gkalcFIBYRyAKABzO8sX6t9nierOSlrgpAvCOQBQCPivVrtcdK4BmqXZayqgpI1SGhYIS7KhzNIQPIDwSyAICEENguy0cB6ZCLalqHCHVVIIgFEuwStT/++KPdd9991q1bN3v88cftzz//zJN9AACJy9cuK3iSlrKqd72zLGKXlK2UkmzPdjkr1+MF4IFAdsmSJda4cWPbvn27tWrVyiZMmOD+3b9/f0T3AQAkrlDtsnxy06NWwez0e9v474/p0cTm9WtnHepVysVRAXgmkB0wYIC1bdvWXnvtNbvtttts6tSp9tNPP7n7kdwHAJC4MmuXFYlg1tdVQVy9bcB9AHEcyCqDOnPmTLv66qv9y8qWLWvt27e3KVOmRGwfAEBio10WEL+iFsiuXbvWDh06ZDVq1MiwXPd/+eWXiO3jC4B37dqV4QYASAy0ywLiV1J6enpULmO9fPlya9iwoX355ZfWvHlz//J+/frZxIkTbdWqVRHZRwYNGmSDB//3coEBUlNTrVSpUhF7TgCA2KyRPffxmVm2y9IkLdW3UhoARJ8SjikpKWHFaVHLyGqAsmPHjgzLt23bZqVLl47YPr66Wr0Yvtu6desi8AwAAF7ga5clwWGq777WE8QC3hO1QLZatWp24okn2rfffpthue6fccYZEdtHihYt6iL6wBsAIHH42mUp8xpI97Vc6wF4T9RKC6Rv376u68CiRYtcRvXzzz93HQlmzJhh7dq1c9uMGjXKfv75Z3v66afD3ieSKWsAQPwIeWUvMrFATMlOnBbVK3sNGzbM9YU9/fTT3e2rr76yBx98MENAunjxYluwYEG29gEAIBQFrc1rl432MADEQ0ZW9PDKrm7evNkaNGhgtWrVyrD+66+/dhc/6NChQ9j7HA8ZWQAAgNiUnTgt6oFsNBDIAgAAxCZPdC0AAAAAcoNAFgAAAJ5EIAsAAABPIpAFAACAJxHIAgAAwJMIZAEAAOBJUb0gQrT4Oo6pvQMAAABihy8+C6dDbEIGsrt373b/Vq9ePdpDAQAAQCbxmvrJZiUhL4hw5MgR27Bhg5UsWdKSkpKy/EagYHfdunVcOMHjeC/jB+9l/OC9jB+8l/FjVwy8lwpNFcRWqVLFChTIugo2ITOyelGqVasW9vZ6I/nFjA+8l/GD9zJ+8F7GD97L+FEqyu/l8TKxPkz2AgAAgCcRyAIAAMCTCGSzULRoURs4cKD7F97Gexk/eC/jB+9l/OC9jB9FPfZeJuRkLwAAAHgfGVkAAAB4EoEsAAAAPIlAFgAAAJ5EIJuJJUuW2A033GBt2rSxW2+91VavXh3tISGHFi9ebD179rRmzZrZF198Ee3hIIe2b99u//jHP+zSSy+1yy+/3J544gnbs2dPtIeFHNi/f7+NHDnSrrrqKrvwwgvtgQcesLVr10Z7WMilUaNGuf9nX3755WgPBTnQr18/9/4F3v72t79ZrCOQDeHbb7+1c88910qXLm39+/d3V7lo3ry5uxoYvOWxxx6z2267zerVq2dfffWV7dixI9pDQg41atTI9u7da3369LGbbrrJ3nzzTevQoYMdPHgw2kNDNnXr1s1WrVplN998s9111132448/WpMmTWzTpk3RHhpy6Ouvv3b/3+p9Xb9+fbSHgxz46aef3BW9nnnmGf9N/9/GOroWhNC5c2fbtm2bzZ49290/fPiw1a5d26655hp78sknoz08ZENqaqq7OsjOnTvtxBNPtMmTJ7uMHrznzz//tBIlSvjvr1ixwurXr2+ff/65tW7dOqpjQ/boC0nx4sUz3Nd7+/bbb1uXLl2iOjZkny4l2rhxYxsxYoT16tXLunfvboMGDYr2sJBNnTp1clc91fvoJWRkQ5gxY4Zddtll/vsFCxa0Sy65xKZPnx7VcSHvLnGH2BcYxAbeP3DgQJRGhJwKDGJl7ty57tLhDRo0iNqYkHPK2l188cV2wQUXRHsoyKVp06ZZ27ZtXeJu9OjRLpEX6wpFewCxmMHTrUqVKhmW6/5vv/0WtXEByGjYsGFWoUIFV/YD75kzZ4793//9n/v/9o8//nBnSwhkvWfMmDH2zTff2KJFi6I9FOSSzlreeOONrjZ25cqVNnjwYPvPf/5jkyZNslhGIBvEV28XfEWLYsWKUYsHxIh///vf9tprr9nHH39sJ5xwQrSHgxxo2LChq8FTEKvMzx133GHz5s07JomA2K6pvP/++23WrFmWnJwc7eEgApP1fLHP+eefb3/5y19cokBllsrSxipKC0KcilYpgWZIB1LNbNmyZaM2LgBHvfLKK3bPPffYuHHjOJXp8eyPMj8q41LG59ChQ/bCCy9Ee1jIhgkTJrj3TZ19fLPcN27c6LoWtGvXLtrDQzYFJ/D0fipRoIx7LCMjG6Rw4cLu9JZOk6hlk49mvOvbCYDoURb29ttvt7feestNykR8KFSokJUrV862bt0a7aEgGzSpq3379hmWXXnlldaxY0fXLQbetmvXLjcRM9bPepGRDeGWW26x8ePHu5YwolnRSq1rOYDoeOONN6x3794uiNVEBHiTamKfe+45l8kLzOwp63PRRRdFdWzInqpVqx7Td1RZPc18Vzs1eMfmzZtdb2ff5K60tDTr27evC2JjvdMPGdkQVKv1/fff21lnnWUnnXSSm+T1yCOPxPybiWOpdmvAgAH+X07Vcw0dOtS6du3qfknhnfY+PXr0sFKlStlTTz3lboFNvJUFgjfoD6N6cleqVMnVw6qMS0Gt6mXV/gdAdMoqf/rpJytfvrz7IqILlNSoUcOmTp3qfldjGX1ks7BlyxbX2LlWrVqungveoz+SP//88zHL9QdUv6TwBn0RyWxW9Mknn+y6F8Bb1DZNv5slS5Z0fzg1NwHet3TpUn8wBO9JS0tzHQv0f2rFihXNCwhkAQAA4EnUyAIAAMCTCGQBAADgSQSyAAAA8CQCWQAAAHgSgSwAAAA8iUAWAAAAnkQgCwAAAE8ikAUAAIAnEcgCAADAkwhkAcCDVq1aZePHj3eXevXZt2+fW7ZmzZqojg0A8guXqAUAD9q1a5edeeaZdtVVV9lTTz3llt1+++02ffp0d737E044IdpDBIA8RyALAB71xRdfWNu2be2TTz6x/fv3W+fOnd2yJk2aRHtoAJAvCuXPwwAAIq1ly5b24IMP2k033WSHDh2yQYMGEcQCSChkZAHAw/bu3WsVK1a0kiVL2rp166xgwYLRHhIA5BsmewGAhw0cONBOPPFE2717t7300kvRHg4A5CsysgDgUTNnzrQLL7zQZs2aZStXrrQ777zTlixZYnXr1o320AAgXxDIAoAHbd++3c444wzr3r27DR061C279tpr7ZdffrH58+db4cKFoz1EAMhzlBYAgAdNmTLFLr30Ulda4DN69Gg7/fTT7fPPP4/q2AAgv5CRBQAAgCeRkQUAAIAnEcgCAADAkwhkAQAA4EkEsgAAAPAkAlkAAAB4EoEsAAAAPIlAFgAAAJ5EIAsAAABPIpAFAACAJxHIAgAAwJMIZAEAAOBJBLIAAAAwL/p/zNbKNyJpNmAAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 700x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(7, 4))\n",
+    "ax.stem(x, np.abs(infl_dec) / np.abs(infl_dec).max(), basefmt=' ',\n",
+    "        linefmt='C0-', markerfmt='C0o', label='|influence on $x^*$| (scaled)')\n",
+    "ax.stem(x + 0.04, lev / lev.max(), basefmt=' ',\n",
+    "        linefmt='C1-', markerfmt='C1s', label='leverage (scaled)')\n",
+    "ax.set_xlabel('x'); ax.set_ylabel('scaled to max')\n",
+    "ax.set_title('the decision has its own ranking')\n",
+    "ax.legend(); plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f1a1553",
+   "metadata": {},
+   "source": [
+    "## What to take away\n",
+    "\n",
+    "- **The influence matrix generalizes the hat matrix.** `J @ res.dpopt_ddata` is\n",
+    "  the hat matrix whenever the textbook has one, and remains meaningful when it\n",
+    "  does not. Its diagonal is leverage; its trace is the effective degrees of\n",
+    "  freedom.\n",
+    "- **Leverage and residual are different questions.** The most influential point\n",
+    "  in this notebook has an unremarkable residual, and the largest residual\n",
+    "  belongs to a point that barely matters. A residual plot cannot find the first\n",
+    "  one.\n",
+    "- **The classical formula is inadmissible once anything binds.** A parameter at\n",
+    "  a bound has exactly zero influence, and under an active constraint the\n",
+    "  influence lies in that constraint's null space. `pinv(J)` violates both,\n",
+    "  silently, while looking entirely reasonable — which is why\n",
+    "  [#922](https://github.com/jkitchin/pounce/issues/922) survived from the\n",
+    "  feature's first commit: the only test that asked for `dpopt_ddata` asked on\n",
+    "  an unconstrained fit, and asserted equality with `pinv(J)`.\n",
+    "- **It is a linearization, and says so.** Built from the Gauss-Newton Hessian,\n",
+    "  it ranks points cheaply and reliably; when an exact number matters, re-solve.\n",
+    "- **Cheap because the factorization already exists** — one back-solve per\n",
+    "  point, against a matrix the solve had to build anyway.\n",
+    "\n",
+    "Related: [`22_curve_fit.ipynb`](22_curve_fit.ipynb) for the fitting API,\n",
+    "[`40_shadow_prices_expire.ipynb`](40_shadow_prices_expire.ipynb) for how far a\n",
+    "first-order sensitivity can be trusted, and\n",
+    "[`43_sobolev_training.ipynb`](43_sobolev_training.ipynb) for the same\n",
+    "factorization answering a different question."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/notebooks/44_leverage_and_influence.ipynb
+++ b/python/notebooks/44_leverage_and_influence.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9ca753b2",
+   "id": "87d8ccce",
    "metadata": {},
    "source": [
     "# Which data points made this fit?\n",
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "1105a491",
+   "id": "656ada15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:43.087037Z",
-     "iopub.status.busy": "2026-09-07T00:40:43.086973Z",
-     "iopub.status.idle": "2026-09-07T00:40:43.893505Z",
-     "shell.execute_reply": "2026-09-07T00:40:43.892982Z"
+     "iopub.execute_input": "2026-09-07T01:44:08.285108Z",
+     "iopub.status.busy": "2026-09-07T01:44:08.285031Z",
+     "iopub.status.idle": "2026-09-07T01:44:08.983796Z",
+     "shell.execute_reply": "2026-09-07T01:44:08.983400Z"
     }
    },
    "outputs": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e654f4d",
+   "id": "b90f0219",
    "metadata": {},
    "source": [
     "## 1. The textbook object, and the one line that generalizes\n",
@@ -101,13 +101,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3d2b9715",
+   "id": "05ea8cf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:43.894898Z",
-     "iopub.status.busy": "2026-09-07T00:40:43.894776Z",
-     "iopub.status.idle": "2026-09-07T00:40:44.194839Z",
-     "shell.execute_reply": "2026-09-07T00:40:44.194294Z"
+     "iopub.execute_input": "2026-09-07T01:44:08.985165Z",
+     "iopub.status.busy": "2026-09-07T01:44:08.985061Z",
+     "iopub.status.idle": "2026-09-07T01:44:09.271910Z",
+     "shell.execute_reply": "2026-09-07T01:44:09.271541Z"
     }
    },
    "outputs": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "257d73a7",
+   "id": "0070c7e4",
    "metadata": {},
    "source": [
     "Exact agreement, to round-off. Nothing has been gained yet — this is the case\n",
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89bf7a7d",
+   "id": "0941fbbb",
    "metadata": {},
    "source": [
     "## 2. A nonlinear fit, with one point placed where it counts\n",
@@ -169,13 +169,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9cfb7873",
+   "id": "fbbea1cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:44.196217Z",
-     "iopub.status.busy": "2026-09-07T00:40:44.196128Z",
-     "iopub.status.idle": "2026-09-07T00:40:44.289873Z",
-     "shell.execute_reply": "2026-09-07T00:40:44.289480Z"
+     "iopub.execute_input": "2026-09-07T01:44:09.273509Z",
+     "iopub.status.busy": "2026-09-07T01:44:09.273425Z",
+     "iopub.status.idle": "2026-09-07T01:44:09.361220Z",
+     "shell.execute_reply": "2026-09-07T01:44:09.360781Z"
     }
    },
    "outputs": [
@@ -214,13 +214,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "81c2b9a8",
+   "id": "aad0429d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:44.294872Z",
-     "iopub.status.busy": "2026-09-07T00:40:44.294738Z",
-     "iopub.status.idle": "2026-09-07T00:40:44.297663Z",
-     "shell.execute_reply": "2026-09-07T00:40:44.297281Z"
+     "iopub.execute_input": "2026-09-07T01:44:09.362408Z",
+     "iopub.status.busy": "2026-09-07T01:44:09.362341Z",
+     "iopub.status.idle": "2026-09-07T01:44:09.365071Z",
+     "shell.execute_reply": "2026-09-07T01:44:09.364661Z"
     }
    },
    "outputs": [
@@ -255,13 +255,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "994aaa23",
+   "id": "d831fce6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:44.298750Z",
-     "iopub.status.busy": "2026-09-07T00:40:44.298664Z",
-     "iopub.status.idle": "2026-09-07T00:40:44.477961Z",
-     "shell.execute_reply": "2026-09-07T00:40:44.476965Z"
+     "iopub.execute_input": "2026-09-07T01:44:09.366208Z",
+     "iopub.status.busy": "2026-09-07T01:44:09.366141Z",
+     "iopub.status.idle": "2026-09-07T01:44:09.530399Z",
+     "shell.execute_reply": "2026-09-07T01:44:09.529850Z"
     }
    },
    "outputs": [
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa7ad854",
+   "id": "7740bcaa",
    "metadata": {},
    "source": [
     "One point carries leverage far above the $n_p/m$ average while its residual is\n",
@@ -305,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f59a6a16",
+   "id": "922525ee",
    "metadata": {},
    "source": [
     "## 3. Does the linearization tell the truth?\n",
@@ -326,13 +326,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "c3793e24",
+   "id": "0d09b23a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:44.480381Z",
-     "iopub.status.busy": "2026-09-07T00:40:44.480166Z",
-     "iopub.status.idle": "2026-09-07T00:40:45.425164Z",
-     "shell.execute_reply": "2026-09-07T00:40:45.424710Z"
+     "iopub.execute_input": "2026-09-07T01:44:09.531687Z",
+     "iopub.status.busy": "2026-09-07T01:44:09.531602Z",
+     "iopub.status.idle": "2026-09-07T01:44:10.423049Z",
+     "shell.execute_reply": "2026-09-07T01:44:10.422616Z"
     }
    },
    "outputs": [
@@ -365,13 +365,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "19a87b64",
+   "id": "7e2b8896",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:45.426556Z",
-     "iopub.status.busy": "2026-09-07T00:40:45.426477Z",
-     "iopub.status.idle": "2026-09-07T00:40:45.484607Z",
-     "shell.execute_reply": "2026-09-07T00:40:45.484147Z"
+     "iopub.execute_input": "2026-09-07T01:44:10.424249Z",
+     "iopub.status.busy": "2026-09-07T01:44:10.424169Z",
+     "iopub.status.idle": "2026-09-07T01:44:10.477333Z",
+     "shell.execute_reply": "2026-09-07T01:44:10.476866Z"
     }
    },
    "outputs": [
@@ -400,20 +400,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1612f4ea",
+   "id": "b74d146b",
    "metadata": {},
    "source": [
     "The linearization tracks the re-fits closely, and it did so with **one\n",
-    "factorization** instead of $m$ fits. Where it is off, the gap is the neglected\n",
-    "residual curvature: `curve_fit` builds `dpopt_ddata` from the **Gauss-Newton**\n",
-    "Hessian, the same one behind `pcov`, so the influence is a first-order\n",
-    "quantity. Treat it as a ranking of points that is cheap and reliable, and\n",
-    "re-solve when a specific number has to be exact."
+    "factorization** instead of $m$ fits. Where it is off, the gap has a specific\n",
+    "cause: by default `curve_fit` builds `dpopt_ddata` from the **Gauss-Newton**\n",
+    "Hessian, the same one behind `pcov`, which drops the residual-curvature term\n",
+    "$\\sum_k r_k \\nabla^2 f_k$.\n",
+    "\n",
+    "That default is a deliberate trade — it is a back-solve against a factor the\n",
+    "solve already built, so it is effectively free. `sensitivity=\"exact\"` buys the\n",
+    "missing term for $2n$ extra gradient evaluations. Section 7 measures both."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b202beb1",
+   "id": "19466e97",
    "metadata": {},
    "source": [
     "## 4. Cook's distance: one number per point\n",
@@ -427,13 +430,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "95850195",
+   "id": "eb92c04c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:45.485833Z",
-     "iopub.status.busy": "2026-09-07T00:40:45.485748Z",
-     "iopub.status.idle": "2026-09-07T00:40:45.489238Z",
-     "shell.execute_reply": "2026-09-07T00:40:45.488814Z"
+     "iopub.execute_input": "2026-09-07T01:44:10.478614Z",
+     "iopub.status.busy": "2026-09-07T01:44:10.478520Z",
+     "iopub.status.idle": "2026-09-07T01:44:10.481838Z",
+     "shell.execute_reply": "2026-09-07T01:44:10.481444Z"
     }
    },
    "outputs": [
@@ -477,7 +480,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f6e80a8",
+   "id": "811df626",
    "metadata": {},
    "source": [
     "The two rankings disagree, which is the entire reason the influence matrix is\n",
@@ -488,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50403b20",
+   "id": "37d572d0",
    "metadata": {},
    "source": [
     "## 5. A parameter at a bound has no influence at all\n",
@@ -507,13 +510,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "29fab646",
+   "id": "6dd4f0e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:45.490538Z",
-     "iopub.status.busy": "2026-09-07T00:40:45.490458Z",
-     "iopub.status.idle": "2026-09-07T00:40:45.545315Z",
-     "shell.execute_reply": "2026-09-07T00:40:45.544954Z"
+     "iopub.execute_input": "2026-09-07T01:44:10.483059Z",
+     "iopub.status.busy": "2026-09-07T01:44:10.483000Z",
+     "iopub.status.idle": "2026-09-07T01:44:10.536739Z",
+     "shell.execute_reply": "2026-09-07T01:44:10.536305Z"
     }
    },
    "outputs": [
@@ -551,13 +554,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "e82018a8",
+   "id": "21c6c40b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:45.562539Z",
-     "iopub.status.busy": "2026-09-07T00:40:45.562419Z",
-     "iopub.status.idle": "2026-09-07T00:40:48.416455Z",
-     "shell.execute_reply": "2026-09-07T00:40:48.416052Z"
+     "iopub.execute_input": "2026-09-07T01:44:10.537988Z",
+     "iopub.status.busy": "2026-09-07T01:44:10.537895Z",
+     "iopub.status.idle": "2026-09-07T01:44:13.244708Z",
+     "shell.execute_reply": "2026-09-07T01:44:13.244348Z"
     }
    },
    "outputs": [
@@ -581,7 +584,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  2.91  dpopt_ddata                -0.02457   -0.05045    0.00000\n",
+      "  2.91  dpopt_ddata                -0.02457   -0.05045    0.00000"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "        re-solve (truth)           -0.01378   -0.02907    0.00000\n",
       "        pinv(J), the old answer     0.11333    0.42112    0.05346\n"
      ]
@@ -628,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a3f2a06",
+   "id": "fa0566cd",
    "metadata": {},
    "source": [
     "The pinned row is zero, matching the re-solve exactly. `pinv(J)` reports a\n",
@@ -642,13 +652,16 @@
     "the last digit — at $x = 0.15$, the extreme-leverage point, the $b$ component\n",
     "sits well off the re-solve. That gap is the Gauss-Newton linearization from\n",
     "section 3, now being asked to work at a point where the fit is most curved. The\n",
-    "projection is what fixed the *kind* of error; the magnitude is still\n",
-    "first-order."
+    "projection fixed the *kind* of error; the magnitude is dealt with in section 7.\n",
+    "\n",
+    "The two are independent, and the order matters: no Hessian, however exact,\n",
+    "would have put a zero in the pinned row. That is a statement about which\n",
+    "directions are available, not about curvature."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0444d4a7",
+   "id": "6eef6781",
    "metadata": {},
    "source": [
     "## 6. Influence lives in the constraint's null space\n",
@@ -667,13 +680,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "97551b62",
+   "id": "4193bdbe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:48.417807Z",
-     "iopub.status.busy": "2026-09-07T00:40:48.417725Z",
-     "iopub.status.idle": "2026-09-07T00:40:48.465172Z",
-     "shell.execute_reply": "2026-09-07T00:40:48.464694Z"
+     "iopub.execute_input": "2026-09-07T01:44:13.246091Z",
+     "iopub.status.busy": "2026-09-07T01:44:13.245999Z",
+     "iopub.status.idle": "2026-09-07T01:44:13.291378Z",
+     "shell.execute_reply": "2026-09-07T01:44:13.290952Z"
     }
    },
    "outputs": [
@@ -711,13 +724,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "dd4cfba3",
+   "id": "270ad219",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:48.466355Z",
-     "iopub.status.busy": "2026-09-07T00:40:48.466281Z",
-     "iopub.status.idle": "2026-09-07T00:40:48.633662Z",
-     "shell.execute_reply": "2026-09-07T00:40:48.633245Z"
+     "iopub.execute_input": "2026-09-07T01:44:13.292594Z",
+     "iopub.status.busy": "2026-09-07T01:44:13.292509Z",
+     "iopub.status.idle": "2026-09-07T01:44:13.451730Z",
+     "shell.execute_reply": "2026-09-07T01:44:13.451388Z"
     }
    },
    "outputs": [
@@ -747,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d63e723e",
+   "id": "a8cd71e2",
    "metadata": {},
    "source": [
     "The influence now moves $a$ and $c$ in exact opposition, as the binding\n",
@@ -762,10 +775,184 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92e2f55f",
+   "id": "77e5d813",
    "metadata": {},
    "source": [
-    "## 7. What it costs\n",
+    "## 7. Paying for the exact answer\n",
+    "\n",
+    "Everything so far used the default influence, built from the Gauss-Newton\n",
+    "Hessian. `sensitivity=\"exact\"` rebuilds it from the exact objective Hessian —\n",
+    "central differences of the objective gradient at the optimum, $2n$ extra\n",
+    "gradient evaluations, once. It cannot reuse the factor the solve is holding\n",
+    "(that one *is* the Gauss-Newton matrix), so it pays a dense $n \\times n$\n",
+    "inverse as well.\n",
+    "\n",
+    "Measured against the re-solve on all three fits from this notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "69c54274",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T01:44:13.453128Z",
+     "iopub.status.busy": "2026-09-07T01:44:13.453056Z",
+     "iopub.status.idle": "2026-09-07T01:44:25.923978Z",
+     "shell.execute_reply": "2026-09-07T01:44:25.923477Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "             fit         gn      exact\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   unconstrained     0.56%     0.00%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    bound active    67.40%     0.16%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      constraint    10.31%     0.00%\n",
+      "\n",
+      "the section 5/6 invariants still hold under 'exact':\n",
+      "   pinned row max abs : 0.0e+00\n",
+      "   max abs(da + dc)   : 3.1e-12\n"
+     ]
+    }
+   ],
+   "source": [
+    "def influence_error(r, fit_kw):\n",
+    "    truth = np.column_stack([refit_influence(fit_kw, i, h=1e-5) for i in range(x.size)])\n",
+    "    return np.abs(r.dpopt_ddata - truth).max() / np.abs(truth).max()\n",
+    "\n",
+    "print(f\"{'fit':>16}  {'gn':>9}  {'exact':>9}\")\n",
+    "for nm, kw in [('unconstrained', {}), ('bound active', KW_B), ('constraint', KW_C)]:\n",
+    "    g = pounce.curve_fit(model, x, y, p0=P0, sensitivity=True, options=OPT, **kw)\n",
+    "    e = pounce.curve_fit(model, x, y, p0=P0, sensitivity='exact', options=OPT, **kw)\n",
+    "    print(f\"{nm:>16}  {influence_error(g, kw):8.2%}  {influence_error(e, kw):8.2%}\")\n",
+    "\n",
+    "eb = pounce.curve_fit(model, x, y, p0=P0, sensitivity='exact', options=OPT, **KW_B)\n",
+    "ec = pounce.curve_fit(model, x, y, p0=P0, sensitivity='exact', options=OPT, **KW_C)\n",
+    "print(f\"\\nthe section 5/6 invariants still hold under 'exact':\")\n",
+    "print(f\"   pinned row max abs : {np.abs(eb.dpopt_ddata[2]).max():.1e}\")\n",
+    "print(f\"   max abs(da + dc)   : {np.abs(ec.dpopt_ddata[0] + ec.dpopt_ddata[2]).max():.1e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98071de7",
+   "metadata": {},
+   "source": [
+    "Worth being precise about what changed. The exact Hessian is the **left**-hand\n",
+    "side of the solve; the active-set projection in sections 5 and 6 decides which\n",
+    "directions the answer is allowed to use. They are independent, and only the\n",
+    "projection can put a zero in a pinned row — no Hessian would have.\n",
+    "\n",
+    "The **right**-hand side has its own story, and it only shows up under a robust\n",
+    "loss. There the objective is $\\sum \\rho(z_i)$ rather than $\\sum r_i^2$, and the\n",
+    "influence right-hand side picks up a per-point factor $\\rho' + 2z\\rho''$ — the\n",
+    "same weight the Gauss-Newton Hessian already carries. It is identically 1 for\n",
+    "`sse`, which is why it is easy to miss. It is emphatically not 1 on an outlier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "4dccdf63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T01:44:25.925292Z",
+     "iopub.status.busy": "2026-09-07T01:44:25.925228Z",
+     "iopub.status.idle": "2026-09-07T01:44:28.516826Z",
+     "shell.execute_reply": "2026-09-07T01:44:28.516380Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "weight rho' + 2 z rho'' : range [-0.1222, +0.9993]\n",
+      "   on the three outliers: [-0.0049 -0.0079 -0.0101]\n",
+      "   -> negative, so an outlier's influence points the OTHER way\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "influence error vs re-solve: 0.68%\n",
+      "sign agreement on the outlier columns: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "rng2 = np.random.default_rng(3)\n",
+    "xo = np.linspace(0.1, 5.0, 30)\n",
+    "yo = model_np(xo, A_TRUE, B_TRUE, C_TRUE) + rng2.normal(0, 0.05, xo.size)\n",
+    "OUT = [5, 17, 26]\n",
+    "yo[OUT] += [1.4, -1.1, 0.9]                      # three genuine outliers\n",
+    "\n",
+    "KW_R = dict(loss='cauchy', f_scale=0.1)\n",
+    "ro = pounce.curve_fit(model, xo, yo, p0=P0, sensitivity=True, options=OPT, **KW_R)\n",
+    "\n",
+    "# the per-point weight the robust loss applies\n",
+    "rr = np.asarray(ro.residuals) ; z = (rr * rr) / KW_R['f_scale'] ** 2\n",
+    "fac = 1.0 / (1.0 + z) - 2.0 * z / (1.0 + z) ** 2     # rho' + 2 z rho'' for cauchy\n",
+    "print(f\"weight rho' + 2 z rho'' : range [{fac.min():+.4f}, {fac.max():+.4f}]\")\n",
+    "print(f\"   on the three outliers: {np.round(fac[OUT], 4)}\")\n",
+    "print(\"   -> negative, so an outlier's influence points the OTHER way\\n\")\n",
+    "\n",
+    "truth_o = np.column_stack([\n",
+    "    (pounce.curve_fit(model, xo, yo + 1e-5*(np.arange(xo.size)==i), p0=P0, options=OPT, **KW_R).popt\n",
+    "   - pounce.curve_fit(model, xo, yo - 1e-5*(np.arange(xo.size)==i), p0=P0, options=OPT, **KW_R).popt)/2e-5\n",
+    "    for i in range(xo.size)])\n",
+    "print(f\"influence error vs re-solve: {np.abs(ro.dpopt_ddata - truth_o).max()/np.abs(truth_o).max():.2%}\")\n",
+    "print(f\"sign agreement on the outlier columns: \"\n",
+    "      f\"{np.array_equal(np.sign(ro.dpopt_ddata[:, OUT]), np.sign(truth_o[:, OUT]))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41ac2adb",
+   "metadata": {},
+   "source": [
+    "A robust loss downweights an outlier so hard that pulling the point *up* moves\n",
+    "the fit *down* — the weight it loses outruns the pull it gains. The influence\n",
+    "matrix reports that, negative sign and all, and it agrees with the re-solve.\n",
+    "Before [#925](https://github.com/jkitchin/pounce/issues/925) it did not: the\n",
+    "factor was missing, so the reported influence of every downweighted outlier\n",
+    "pointed the wrong way, on exactly the points a robust loss is there to handle.\n",
+    "\n",
+    "Both of these are worth stating as one rule. An influence number has a\n",
+    "left-hand side (which curvature), a right-hand side (which loss), and a\n",
+    "feasible subspace (which active set). Getting two of the three right produces\n",
+    "an answer that is confident, self-consistent, and wrong."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab11f824",
+   "metadata": {},
+   "source": [
+    "## 8. What it costs\n",
     "\n",
     "The influence matrix is $m$ columns, each a back-solve against a factorization\n",
     "that already exists. The alternative — re-fitting without each point — is $m$\n",
@@ -774,14 +961,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "4c116e68",
+   "execution_count": 15,
+   "id": "86ef2199",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:48.634994Z",
-     "iopub.status.busy": "2026-09-07T00:40:48.634922Z",
-     "iopub.status.idle": "2026-09-07T00:40:49.839779Z",
-     "shell.execute_reply": "2026-09-07T00:40:49.839452Z"
+     "iopub.execute_input": "2026-09-07T01:44:28.518265Z",
+     "iopub.status.busy": "2026-09-07T01:44:28.518166Z",
+     "iopub.status.idle": "2026-09-07T01:44:29.903317Z",
+     "shell.execute_reply": "2026-09-07T01:44:29.902841Z"
     }
    },
    "outputs": [
@@ -789,9 +976,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "plain fit                       :    34.61 ms\n",
-      "fit + full influence matrix     :    34.91 ms  (1.01x the plain fit)\n",
-      "25 leave-one-out re-fits         :   854.56 ms  (24.5x the influence matrix)\n"
+      "plain fit                       :    34.68 ms\n",
+      "fit + full influence matrix     :    35.13 ms  (1.01x the plain fit)\n",
+      "fit + exact influence matrix    :    35.23 ms  (1.02x the plain fit)\n",
+      "25 leave-one-out re-fits         :   856.61 ms  (24.4x the influence matrix)\n"
      ]
     }
    ],
@@ -807,6 +995,11 @@
     "t_fit = (time.perf_counter() - t0) / 5\n",
     "\n",
     "t0 = time.perf_counter()\n",
+    "for _ in range(5):\n",
+    "    pounce.curve_fit(model, x, y, p0=P0, sensitivity='exact', options=OPT)\n",
+    "t_exact = (time.perf_counter() - t0) / 5\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
     "for i in range(x.size):\n",
     "    keep = np.ones(x.size, bool); keep[i] = False\n",
     "    pounce.curve_fit(model, x[keep], y[keep], p0=P0, options=OPT)\n",
@@ -815,13 +1008,15 @@
     "print(f\"plain fit                       : {1e3*t_fit:8.2f} ms\")\n",
     "print(f\"fit + full influence matrix     : {1e3*t_sens:8.2f} ms  \"\n",
     "      f\"({t_sens/t_fit:.2f}x the plain fit)\")\n",
+    "print(f\"fit + exact influence matrix    : {1e3*t_exact:8.2f} ms  \"\n",
+    "      f\"({t_exact/t_fit:.2f}x the plain fit)\")\n",
     "print(f\"{x.size} leave-one-out re-fits         : {1e3*t_loo:8.2f} ms  \"\n",
     "      f\"({t_loo/t_sens:.1f}x the influence matrix)\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cfba9bbe",
+   "id": "d2a4c57e",
    "metadata": {},
    "source": [
     "The gap grows with the size of the dataset, since the re-fit route costs one\n",
@@ -832,10 +1027,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "805ba4a1",
+   "id": "621f79b5",
    "metadata": {},
    "source": [
-    "## 8. Influence on a decision, not on a parameter\n",
+    "## 9. Influence on a decision, not on a parameter\n",
     "\n",
     "Parameters are rarely the deliverable. Suppose the fit is used to pick an\n",
     "operating point — the $x$ at which the response first drops below a threshold\n",
@@ -851,14 +1046,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "6a1af45b",
+   "execution_count": 16,
+   "id": "c8e9e4d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:49.841262Z",
-     "iopub.status.busy": "2026-09-07T00:40:49.841174Z",
-     "iopub.status.idle": "2026-09-07T00:40:49.878468Z",
-     "shell.execute_reply": "2026-09-07T00:40:49.878059Z"
+     "iopub.execute_input": "2026-09-07T01:44:29.904877Z",
+     "iopub.status.busy": "2026-09-07T01:44:29.904780Z",
+     "iopub.status.idle": "2026-09-07T01:44:29.942777Z",
+     "shell.execute_reply": "2026-09-07T01:44:29.942235Z"
     }
    },
    "outputs": [
@@ -902,14 +1097,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "e7b37039",
+   "execution_count": 17,
+   "id": "1ac2d2a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T00:40:49.879574Z",
-     "iopub.status.busy": "2026-09-07T00:40:49.879513Z",
-     "iopub.status.idle": "2026-09-07T00:40:49.933727Z",
-     "shell.execute_reply": "2026-09-07T00:40:49.933277Z"
+     "iopub.execute_input": "2026-09-07T01:44:29.944657Z",
+     "iopub.status.busy": "2026-09-07T01:44:29.944552Z",
+     "iopub.status.idle": "2026-09-07T01:44:30.002913Z",
+     "shell.execute_reply": "2026-09-07T01:44:30.002348Z"
     }
    },
    "outputs": [
@@ -937,7 +1132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f1a1553",
+   "id": "f0a84b38",
    "metadata": {},
    "source": [
     "## What to take away\n",
@@ -957,8 +1152,15 @@
     "  [#922](https://github.com/jkitchin/pounce/issues/922) survived from the\n",
     "  feature's first commit: the only test that asked for `dpopt_ddata` asked on\n",
     "  an unconstrained fit, and asserted equality with `pinv(J)`.\n",
-    "- **It is a linearization, and says so.** Built from the Gauss-Newton Hessian,\n",
-    "  it ranks points cheaply and reliably; when an exact number matters, re-solve.\n",
+    "- **The default is a linearization, and there is a knob.** `sensitivity=True`\n",
+    "  is built from the Gauss-Newton Hessian and is effectively free; it ranks\n",
+    "  points cheaply and reliably. `sensitivity=\"exact\"` costs $2n$ gradient\n",
+    "  evaluations and a dense inverse, and takes every fit here to within 0.01% of\n",
+    "  a re-solve.\n",
+    "- **An influence number has three parts**: which curvature (the Hessian), which\n",
+    "  loss (the right-hand-side weight), and which directions are available (the\n",
+    "  active set). Sections 5–7 are one example of each getting it wrong. Two out\n",
+    "  of three still produces a confident, self-consistent, wrong answer.\n",
     "- **Cheap because the factorization already exists** — one back-solve per\n",
     "  point, against a matrix the solve had to build anyway.\n",
     "\n",

--- a/python/notebooks/README.md
+++ b/python/notebooks/README.md
@@ -106,6 +106,7 @@ jupyter lab python/notebooks/01_getting_started.ipynb
 |---|---|---|
 | 22 | [`22_curve_fit.ipynb`](22_curve_fit.ipynb) | `pounce.curve_fit` — SciPy-style nonlinear least squares with exact Jacobians, covariance, and confidence intervals. |
 | 23 | [`23_curve_fit_minima.ipynb`](23_curve_fit_minima.ipynb) | `pounce.curve_fit_minima` — find *every* parameter set that explains the data, each a full `CurveFitResult`. |
+| 44 | [`44_leverage_and_influence.ipynb`](44_leverage_and_influence.ipynb) | `res.dpopt_ddata` — which data points made the fit. Leverage and the hat matrix generalized past the linear/unweighted/unconstrained case, Cook's distance and DFBETA validated against leave-one-out re-fits, and the two cases where the textbook `pinv(J)` is not merely imprecise but inadmissible: a parameter at a bound has *zero* influence, and under an active constraint the influence lies in its null space. |
 
 ## Boundary value problems
 

--- a/python/notebooks/README.md
+++ b/python/notebooks/README.md
@@ -106,7 +106,7 @@ jupyter lab python/notebooks/01_getting_started.ipynb
 |---|---|---|
 | 22 | [`22_curve_fit.ipynb`](22_curve_fit.ipynb) | `pounce.curve_fit` — SciPy-style nonlinear least squares with exact Jacobians, covariance, and confidence intervals. |
 | 23 | [`23_curve_fit_minima.ipynb`](23_curve_fit_minima.ipynb) | `pounce.curve_fit_minima` — find *every* parameter set that explains the data, each a full `CurveFitResult`. |
-| 44 | [`44_leverage_and_influence.ipynb`](44_leverage_and_influence.ipynb) | `res.dpopt_ddata` — which data points made the fit. Leverage and the hat matrix generalized past the linear/unweighted/unconstrained case, Cook's distance and DFBETA validated against leave-one-out re-fits, and the two cases where the textbook `pinv(J)` is not merely imprecise but inadmissible: a parameter at a bound has *zero* influence, and under an active constraint the influence lies in its null space. |
+| 44 | [`44_leverage_and_influence.ipynb`](44_leverage_and_influence.ipynb) | `res.dpopt_ddata` — which data points made the fit. Leverage and the hat matrix generalized past the linear/unweighted/unconstrained case, Cook's distance and DFBETA validated against leave-one-out re-fits, and the two cases where the textbook `pinv(J)` is not merely imprecise but inadmissible: a parameter at a bound has *zero* influence, and under an active constraint the influence lies in its null space. Then what the default costs in accuracy: `sensitivity="exact"` against a perturb-and-re-solve oracle, and the robust-loss weight that runs to -0.12 so a downweighted outlier's influence used to point the wrong way. |
 
 ## Boundary value problems
 

--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -873,7 +873,9 @@ def _solve_fit(
     dpopt = None
     if sensitivity and not pr.streaming:
         dpopt = _data_sensitivity(
-            solver, pr.model_jac, pr.xdata, pr.w, pr.m_con, popt, factor_ok
+            solver, pr.model_jac, pr.xdata, pr.w, pr.m_con, popt, factor_ok,
+            active_mask=active_mask, jac_combined=pr.jac_combined,
+            g_combined=pr.g_combined, cl=pr.cl, cu=pr.cu,
         )
 
     return CurveFitResult(
@@ -1849,7 +1851,10 @@ def _covariance(
     return s2 * np.linalg.pinv(M), "jacobian"
 
 
-def _data_sensitivity(solver, model_jac, xdata, w, m_con, popt, factor_ok):
+def _data_sensitivity(
+    solver, model_jac, xdata, w, m_con, popt, factor_ok,
+    active_mask=None, jac_combined=None, g_combined=None, cl=None, cu=None,
+):
     """``dpopt/ddata`` (n_params x n_data).
 
     For a (weighted) least-squares fit the implicit-function theorem gives
@@ -1858,10 +1863,44 @@ def _data_sensitivity(solver, model_jac, xdata, w, m_con, popt, factor_ok):
     trustworthy each ``inv(H_S) g_i`` is a back-solve against pounce's
     converged factor, fanned out in one ``kkt_solve_many`` call; otherwise the
     same value is formed from the dense Gauss-Newton Hessian.
+
+    That formula is only admissible with **nothing active**. A parameter
+    pinned at a bound cannot move at all, and a data perturbation must leave
+    the active constraints satisfied -- so where bounds or general constraint
+    rows bind, the influence is projected onto the joint active-constraint
+    nullspace, exactly as the covariance is (:func:`_projected_covariance`).
+    Differentiating the KKT system of the constrained fit w.r.t. ``y_i``::
+
+        [ H_S  A^T ] [ dp   ]   [ 2 w_i^2 g_i ]
+        [ A    0   ] [ dlam ] = [      0      ]
+
+    gives ``dp = Z (Z^T M Z)^-1 Z^T w_i^2 g_i`` with ``M = H_S / 2`` the
+    Gauss-Newton Hessian and ``Z`` an orthonormal basis of ``null(A)``. Rows
+    for bound-pinned parameters come out exactly zero and ``A dp = 0`` holds
+    by construction; the unconstrained branch is recovered when ``Z = I``.
+    As with the covariance, ``A`` is the linearization at ``popt``, so for
+    nonlinear constraints this is the first-order influence (pounce#922).
     """
     J = model_jac(xdata, popt)            # (m, n) dmodel/dp at the optimum
     n = popt.size
     m = J.shape[0]
+
+    # --- anything binding? project onto its nullspace ------------------
+    A_gen = _active_constraint_jac(popt, jac_combined, g_combined, cl, cu)
+    if _n_active(active_mask, A_gen) > 0:
+        rows = []
+        if active_mask is not None and active_mask.any():
+            rows.append(np.eye(n)[active_mask])       # unit row per pinned bound
+        if A_gen is not None and A_gen.shape[0] > 0:
+            rows.append(np.atleast_2d(A_gen))
+        Z = _nullspace(np.vstack(rows))               # (n, n - rank)
+        if Z.shape[1] == 0:                           # active set pins popt fully
+            return np.zeros((n, m))
+        Jw = J * w[:, None]
+        M = Jw.T @ Jw                                 # = H_S / 2
+        reduced = Z @ np.linalg.pinv(Z.T @ M @ Z) @ Z.T
+        return (w ** 2)[None, :] * (reduced @ J.T)
+
     dim = solver.kkt_dim
     if not factor_ok or dim is None or m_con != 0:
         Jw = J * w[:, None]

--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -695,6 +695,11 @@ def _solve_fit(
 ) -> CurveFitResult:
     """Run one pounce solve from ``p0`` against a built ``_FitProblem`` and
     assemble the full :class:`CurveFitResult` (covariance, CIs, sensitivity)."""
+    # Validate here rather than at each public entry point: every surface that
+    # produces a CurveFitResult funnels through this function. A typo like
+    # ``sensitivity="exakt"`` is *truthy*, so without this it would silently
+    # deliver the Gauss-Newton answer under an exact-sounding request.
+    sens_mode = _resolve_sensitivity(sensitivity)
     pr = prob
     problem_obj = _make_problem_obj(
         pr.objective, pr.gradient, pr.gn_hessian, pr.n, pr.m_con,
@@ -871,11 +876,27 @@ def _solve_fit(
     # dpopt/ddata is (n_params x n_data) -- the size of the data -- so it is not
     # offered in streaming mode (see ``curve_fit_streaming``).
     dpopt = None
-    if sensitivity and not pr.streaming:
+    if sens_mode and not pr.streaming:
+        hess = None
+        if sens_mode == "exact":
+            if not pr.jac_exact:
+                import warnings
+
+                warnings.warn(
+                    "pounce.curve_fit: sensitivity='exact' differentiates the "
+                    "objective gradient, which here is built from a "
+                    "finite-difference model Jacobian -- the resulting Hessian "
+                    "carries that error squared and may be worse than the "
+                    "Gauss-Newton default. Supply `jac=` or use a "
+                    "JAX-traceable model.",
+                    stacklevel=2,
+                )
+            hess = _exact_objective_hessian(pr.gradient, popt)
         dpopt = _data_sensitivity(
             solver, pr.model_jac, pr.xdata, pr.w, pr.m_con, popt, factor_ok,
             active_mask=active_mask, jac_combined=pr.jac_combined,
             g_combined=pr.g_combined, cl=pr.cl, cu=pr.cu,
+            residual=pr.residual, loss_fn=pr.loss_fn, fs2=pr.fs2, hess=hess,
         )
 
     return CurveFitResult(
@@ -956,14 +977,16 @@ def curve_fit(
     f_scale: float = 1.0,
     jac: Callable | str | None = None,
     alpha: float = 0.05,
-    sensitivity: bool = False,
+    sensitivity: bool | str = False,
     options: Mapping[str, Any] | None = None,
 ) -> CurveFitResult:
     """Fit ``f(x, *params)`` to ``(xdata, ydata)`` using pounce.
 
     Parameters mirror :func:`scipy.optimize.curve_fit` where they overlap.
     Extras: ``loss`` (smooth/robust loss family), ``constraints`` (general
-    relations between parameters), ``sensitivity`` (compute ``dpopt/ddata``),
+    relations between parameters), ``sensitivity`` (compute ``dpopt/ddata``;
+    ``True``/``"gn"`` for the Gauss-Newton influence, ``"exact"`` to build it
+    from the exact objective Hessian instead -- see below),
     and ``alpha`` (confidence level for the returned intervals).
 
     ``p0`` is optional: when omitted, the number of parameters is read from the
@@ -1003,6 +1026,28 @@ def curve_fit(
     (the exact Hessian) whereas ``curve_fit`` reports the Gauss-Newton
     ``2 s^2 (J^T J)^-1`` (the scipy convention; identical for linear models
     and in the small-residual limit, a few percent apart otherwise).
+
+    ``sensitivity`` selects how ``dpopt/ddata`` is built, and the same
+    Gauss-Newton caveat applies to it:
+
+    ``True`` (or ``"gn"``)
+        The Gauss-Newton influence, read off the factor the solve already
+        holds. One back-solve per data point and effectively free.
+    ``"exact"``
+        Rebuilds the influence from the **exact** objective Hessian,
+        recovering the residual-curvature term Gauss-Newton drops, at ``2n``
+        extra gradient evaluations. It cannot reuse the held factor (that was
+        built from the Gauss-Newton matrix), so it goes through a dense
+        ``n x n`` inverse.
+
+    Measured against re-solving at a perturbed datum, on a 3-parameter
+    exponential, ``True`` is off by 0.6-10% on an interior fit and 27-67%
+    where a bound or constraint is active -- a wide spread, because the term
+    Gauss-Newton drops scales with the residuals, so it is a property of the
+    fit and not only of the model. ``"exact"`` reduces all of those to
+    <=0.2%. Prefer
+    ``True`` to *rank* points by influence and ``"exact"`` when a specific
+    number matters (pounce#923).
 
     Returns
     -------
@@ -1405,7 +1450,7 @@ def curve_fit_minima(
     f_scale: float = 1.0,
     jac: Callable | str | None = None,
     alpha: float = 0.05,
-    sensitivity: bool = False,
+    sensitivity: bool | str = False,
     options: Mapping[str, Any] | None = None,
     method: str = "multistart",
     n_minima: int = 10,
@@ -1851,9 +1896,57 @@ def _covariance(
     return s2 * np.linalg.pinv(M), "jacobian"
 
 
+_SENS_MODES = {"gn", "exact"}
+
+
+def _resolve_sensitivity(sensitivity):
+    """Normalize the ``sensitivity`` argument to ``None`` | ``"gn"`` | ``"exact"``."""
+    if sensitivity is None or sensitivity is False:
+        return None
+    if sensitivity is True:
+        return "gn"
+    mode = str(sensitivity).lower()
+    if mode not in _SENS_MODES:
+        raise ValueError(
+            f"sensitivity must be True, False, 'gn' or 'exact'; got {sensitivity!r}"
+        )
+    return mode
+
+
+def _exact_objective_hessian(gradient, popt):
+    """Central-difference the objective gradient into the **exact** Hessian.
+
+    ``curve_fit`` hands the solver the *Gauss-Newton* matrix as its search
+    Hessian, so the factor it converges holding omits the residual-curvature
+    term ``sum_k r_k d2f_k``. This recovers it in ``2n`` gradient evaluations,
+    once, after the solve -- the object is only wanted at ``popt``.
+
+    The step ``eps**(1/3)`` is the optimum for a central difference of a
+    quantity that is itself computed to machine precision (truncation
+    ``O(h^2)`` against round-off ``O(eps/h)``); it is scaled per coordinate so
+    a large parameter is not differenced with a step below its own ulp. The
+    result is symmetrized because finite differences do not preserve symmetry
+    exactly, and the caller inverts it (pounce#923).
+    """
+    p = np.asarray(popt, dtype=float)
+    n = p.size
+    H = np.empty((n, n))
+    step = np.finfo(float).eps ** (1.0 / 3.0)
+    for j in range(n):
+        h = step * max(1.0, abs(p[j]))
+        e = np.zeros(n)
+        e[j] = h
+        H[:, j] = (
+            np.asarray(gradient(p + e), dtype=float)
+            - np.asarray(gradient(p - e), dtype=float)
+        ) / (2.0 * h)
+    return 0.5 * (H + H.T)
+
+
 def _data_sensitivity(
     solver, model_jac, xdata, w, m_con, popt, factor_ok,
     active_mask=None, jac_combined=None, g_combined=None, cl=None, cu=None,
+    residual=None, loss_fn=None, fs2=1.0, hess=None,
 ):
     """``dpopt/ddata`` (n_params x n_data).
 
@@ -1880,10 +1973,38 @@ def _data_sensitivity(
     by construction; the unconstrained branch is recovered when ``Z = I``.
     As with the covariance, ``A`` is the linearization at ``popt``, so for
     nonlinear constraints this is the first-order influence (pounce#922).
+
+    Two refinements on top of that (pounce#923):
+
+    ``hess`` overrides ``H_S``. Passed the exact objective Hessian from
+    :func:`_exact_objective_hessian`, this drops the Gauss-Newton truncation
+    -- worth 10% on an interior fit and 67% on a bound-active one here. It
+    also forces the dense path: the factor ``solver`` holds was built from the
+    Gauss-Newton matrix, so it cannot answer for a different ``H_S``.
+
+    The right-hand side carries the robust-loss weight. Differentiating
+    ``dobj/dp = 2 J^T (rho' r w)`` w.r.t. ``y_i`` gives
+    ``-2 w_i^2 (rho'_i + 2 z_i rho''_i) g_i``, and that bracket is exactly the
+    per-point weight :func:`gn_hessian` already applies. It is identically 1
+    for ``sse``, which is why omitting it went unseen; under ``cauchy`` it
+    reaches ``-0.12`` on a downweighted outlier, so the influence of an
+    outlier was not merely mis-scaled but pointed the wrong way.
     """
     J = model_jac(xdata, popt)            # (m, n) dmodel/dp at the optimum
     n = popt.size
     m = J.shape[0]
+
+    # --- right-hand side: -d2obj/dp dy_i, per data point ---------------
+    lw = np.ones(m)
+    if residual is not None and loss_fn is not None:
+        r = np.asarray(residual(popt), dtype=float)
+        z = (r * r) / fs2
+        _, rho1, rho2 = loss_fn(z)
+        lw = np.asarray(rho1 + 2.0 * z * rho2, dtype=float)   # 1 for `sse`
+    rhs_w = 2.0 * (w ** 2) * lw
+
+    def _dense(H):
+        return rhs_w[None, :] * (np.linalg.pinv(H) @ J.T)
 
     # --- anything binding? project onto its nullspace ------------------
     A_gen = _active_constraint_jac(popt, jac_combined, g_combined, cl, cu)
@@ -1896,22 +2017,24 @@ def _data_sensitivity(
         Z = _nullspace(np.vstack(rows))               # (n, n - rank)
         if Z.shape[1] == 0:                           # active set pins popt fully
             return np.zeros((n, m))
-        Jw = J * w[:, None]
-        M = Jw.T @ Jw                                 # = H_S / 2
-        reduced = Z @ np.linalg.pinv(Z.T @ M @ Z) @ Z.T
-        return (w ** 2)[None, :] * (reduced @ J.T)
+        H = hess if hess is not None else 2.0 * ((J * w[:, None]).T @ (J * w[:, None]))
+        reduced = Z @ np.linalg.pinv(Z.T @ H @ Z) @ Z.T
+        return rhs_w[None, :] * (reduced @ J.T)
 
+    # An explicit ``hess`` is not the matrix the held factor was built from,
+    # so the ``kkt_solve_many`` fast path cannot answer for it.
     dim = solver.kkt_dim
+    if hess is not None:
+        return _dense(hess)
     if not factor_ok or dim is None or m_con != 0:
         Jw = J * w[:, None]
-        inv_hs = np.linalg.pinv(2.0 * (Jw.T @ Jw))
-        return (2.0 * (w ** 2))[None, :] * (inv_hs @ J.T)
+        return _dense(2.0 * (Jw.T @ Jw))
 
     rhs = np.zeros((m, dim))
     rhs[:, :n] = J                         # pack each g_i into the x-block
     lhs = solver.kkt_solve_many(rhs.reshape(-1), m).reshape(m, dim)
     inv_hs_g = lhs[:, :n].T                 # (n, m): column i = inv(H_S) g_i
-    return (2.0 * (w ** 2))[None, :] * inv_hs_g
+    return rhs_w[None, :] * inv_hs_g
 
 
 # --------------------------------------------------------------------------

--- a/python/tests/test_curve_fit.py
+++ b/python/tests/test_curve_fit.py
@@ -158,6 +158,87 @@ def test_sensitivity_matches_pinv_and_finite_difference():
         np.testing.assert_allclose(r.dpopt_ddata[:, i], fd, rtol=8e-2, atol=2e-2)
 
 
+def _refit_influence(fit_kw, x, y, p0, i, h=1e-4):
+    """Ground-truth ``dpopt/dy_i``: perturb one datum, re-solve, difference."""
+    yp = y.copy(); yp[i] += h
+    ym = y.copy(); ym[i] -= h
+    fp = pounce.curve_fit(expdecay, x, yp, p0=p0, **fit_kw)
+    fm = pounce.curve_fit(expdecay, x, ym, p0=p0, **fit_kw)
+    return (fp.popt - fm.popt) / (2.0 * h)
+
+
+def test_sensitivity_zero_for_bound_pinned_parameter():
+    """A parameter pinned at a bound cannot move, so its influence is 0.
+
+    pounce#922: this returned ``pinv(J)`` -- a nonzero row for the pinned
+    parameter, and *sign errors* on the free ones.
+    """
+    rng = np.random.default_rng(3)
+    x = np.linspace(0.2, 5.0, 25)
+    y = expdecay_np(x, 3.0, 1.2, 0.5) + rng.normal(0, 0.05, x.size)
+    p0 = [3.0, 1.0, 0.5]
+    kw = dict(bounds=[(0, np.inf), (None, None), (1.0, 2.0)])
+
+    r = pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=True, **kw)
+    assert r.active_mask[2] and not r.active_mask[0] and not r.active_mask[1]
+
+    # the pinned row is exactly zero, not merely small
+    np.testing.assert_array_equal(r.dpopt_ddata[2], np.zeros(x.size))
+
+    # and the free rows now agree with a re-solve in sign and rough size
+    # (the residual gap is the documented Gauss-Newton linearization)
+    for i in (0, 12):
+        fd = _refit_influence(kw, x, y, p0, i)
+        got = r.dpopt_ddata[:, i]
+        assert np.all(np.sign(got[:2]) == np.sign(fd[:2]))
+        np.testing.assert_allclose(got[:2], fd[:2], rtol=0.75, atol=1e-3)
+
+    # the old answer is emphatically not this one
+    J = np.column_stack(
+        [np.exp(-r.popt[1] * x), -r.popt[0] * x * np.exp(-r.popt[1] * x), np.ones_like(x)]
+    )
+    assert np.abs(r.dpopt_ddata - np.linalg.pinv(J)).max() > 0.1
+
+
+def test_sensitivity_lies_in_active_constraint_nullspace():
+    """With ``a + c <= K`` binding, every column satisfies ``da + dc = 0``.
+
+    pounce#922: the returned matrix violated the constraint it was fitted
+    under, by ``da + dc = 0.77`` on the most influential point.
+    """
+    rng = np.random.default_rng(3)
+    x = np.linspace(0.2, 5.0, 25)
+    y = expdecay_np(x, 3.0, 1.2, 0.5) + rng.normal(0, 0.05, x.size)
+    p0 = [3.0, 1.0, 0.5]
+    con = [{"type": "ineq", "fun": lambda p: 2.6 - (p[0] + p[2])}]
+    kw = dict(constraints=con)
+
+    r = pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=True, **kw)
+    assert abs((r.popt[0] + r.popt[2]) - 2.6) < 1e-6      # constraint is active
+
+    # the perturbation stays on the constraint surface
+    np.testing.assert_allclose(
+        r.dpopt_ddata[0] + r.dpopt_ddata[2], 0.0, atol=1e-9
+    )
+
+    for i in (0, 12):
+        fd = _refit_influence(kw, x, y, p0, i)
+        np.testing.assert_allclose(r.dpopt_ddata[:, i], fd, rtol=0.75, atol=1e-2)
+
+
+def test_sensitivity_unaffected_by_an_inactive_constraint():
+    """An inactive constraint constrains nothing, so do not project on it."""
+    rng = np.random.default_rng(3)
+    x = np.linspace(0.2, 5.0, 25)
+    y = expdecay_np(x, 3.0, 1.2, 0.5) + rng.normal(0, 0.05, x.size)
+    p0 = [3.0, 1.0, 0.5]
+    slack = [{"type": "ineq", "fun": lambda p: 50.0 - (p[0] + p[2])}]
+
+    free = pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=True)
+    lax = pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=True, constraints=slack)
+    np.testing.assert_allclose(lax.dpopt_ddata, free.dpopt_ddata, rtol=1e-6, atol=1e-8)
+
+
 # --------------------------------------------------------------------------
 # 6. Parameter constraints: positivity, range, general relation.
 # --------------------------------------------------------------------------

--- a/python/tests/test_curve_fit.py
+++ b/python/tests/test_curve_fit.py
@@ -239,6 +239,134 @@ def test_sensitivity_unaffected_by_an_inactive_constraint():
     np.testing.assert_allclose(lax.dpopt_ddata, free.dpopt_ddata, rtol=1e-6, atol=1e-8)
 
 
+# --- pounce#923: Gauss-Newton vs. the exact Hessian, and the robust RHS ----
+
+def _outlier_fixture():
+    """Exponential decay with three genuine outliers -- the robust-loss case."""
+    rng = np.random.default_rng(3)
+    x = np.linspace(0.1, 5.0, 30)
+    y = expdecay_np(x, 3.0, 1.2, 0.5) + rng.normal(0, 0.05, x.size)
+    y[[5, 17, 26]] += [1.4, -1.1, 0.9]
+    return x, y, [2.0, 1.0, 0.0]
+
+
+def _influence_error(r, fit_kw, x, y, p0):
+    """Max abs error of ``r.dpopt_ddata`` vs. re-solve, relative to its scale."""
+    truth = np.column_stack(
+        [_refit_influence(fit_kw, x, y, p0, i, h=1e-5) for i in range(x.size)]
+    )
+    return np.abs(r.dpopt_ddata - truth).max() / np.abs(truth).max()
+
+
+@pytest.mark.parametrize(
+    "kw",
+    [
+        {},
+        {"bounds": [(0, np.inf), (None, None), (1.0, 2.0)]},
+        {"constraints": [{"type": "ineq", "fun": lambda p: 2.6 - (p[0] + p[2])}]},
+    ],
+    ids=["interior", "bound-active", "constraint-active"],
+)
+def test_sensitivity_exact_beats_gauss_newton_against_a_resolve(kw):
+    """``sensitivity='exact'`` drops the Gauss-Newton truncation (pounce#923).
+
+    The default influence is built from the Gauss-Newton Hessian, so it omits
+    the residual-curvature term ``sum_k r_k d2f_k``. Measured against
+    re-solving at a perturbed datum that is worth 10% on an interior fit and
+    25-27% where a bound or a constraint holds the fit away from its
+    unconstrained optimum (the residuals are larger there, and the dropped
+    term scales with them).
+    """
+    x, y, p0 = _outlier_fixture()
+    gn = pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=True, **kw)
+    ex = pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity="exact", **kw)
+
+    # the mode must change only the reported influence, never the fit itself
+    np.testing.assert_allclose(gn.popt, ex.popt, rtol=1e-9)
+
+    err_gn = _influence_error(gn, kw, x, y, p0)
+    err_ex = _influence_error(ex, kw, x, y, p0)
+    assert err_ex < 0.01, f"exact influence off by {err_ex:.1%}"
+    # ... and it is a real improvement, not a wash. This is the assertion that
+    # fails if 'exact' silently returns the Gauss-Newton answer.
+    assert err_ex < err_gn / 5.0, f"gn {err_gn:.1%} vs exact {err_ex:.1%}"
+
+
+def test_sensitivity_exact_preserves_the_active_set_invariants():
+    """pounce#922's guarantees must survive the pounce#923 path.
+
+    The exact Hessian cannot reuse the held factor, so it takes a different
+    branch. The projection is re-checked on that branch rather than assumed.
+    """
+    x, y, p0 = _outlier_fixture()
+
+    bnd = pounce.curve_fit(
+        expdecay, x, y, p0=p0, sensitivity="exact",
+        bounds=[(0, np.inf), (None, None), (1.0, 2.0)],
+    )
+    assert bnd.active_mask[2]
+    np.testing.assert_array_equal(bnd.dpopt_ddata[2], np.zeros(x.size))
+
+    con = pounce.curve_fit(
+        expdecay, x, y, p0=p0, sensitivity="exact",
+        constraints=[{"type": "ineq", "fun": lambda p: 2.6 - (p[0] + p[2])}],
+    )
+    np.testing.assert_allclose(
+        con.dpopt_ddata[0] + con.dpopt_ddata[2], np.zeros(x.size), atol=1e-9
+    )
+
+
+@pytest.mark.parametrize("loss", ["cauchy", "soft_l1"])
+def test_sensitivity_carries_the_robust_loss_curvature_weight(loss):
+    """The influence RHS needs the robust-loss weight ``rho' + 2 z rho''``.
+
+    ``d2obj/dp dy_i = -2 w_i^2 (rho'_i + 2 z_i rho''_i) g_i``. That bracket is
+    exactly the per-point weight ``gn_hessian`` already applies, and it is
+    identically 1 for ``sse`` -- which is why omitting it went unseen for as
+    long as it did. On a fit with real outliers it reaches -0.12 under
+    ``cauchy``, so a downweighted outlier's influence was not merely
+    mis-scaled but pointed the wrong way (measured: 86% for cauchy, 73% for
+    soft_l1). Found while fixing pounce#923; it is a separate defect, and note
+    that the exact Hessian alone does *not* repair it.
+    """
+    x, y, p0 = _outlier_fixture()
+    kw = {"loss": loss, "f_scale": 0.1}
+    r = pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=True, **kw)
+
+    truth = np.column_stack(
+        [_refit_influence(kw, x, y, p0, i, h=1e-5) for i in range(x.size)]
+    )
+    err = np.abs(r.dpopt_ddata - truth).max() / np.abs(truth).max()
+    assert err < 0.05, f"robust influence off by {err:.1%}"
+
+    # the outliers are the entries the weight acts on, so pin their sign too
+    out = [5, 17, 26]
+    assert np.array_equal(
+        np.sign(r.dpopt_ddata[:, out]), np.sign(truth[:, out])
+    ), "sign disagreement on the downweighted outliers"
+
+
+def test_sensitivity_mode_is_validated():
+    """A truthy typo must not silently deliver the Gauss-Newton answer."""
+    x, y, p0 = _outlier_fixture()
+    for bad in ("exakt", "GN2", 0.5, [1]):
+        with pytest.raises(ValueError, match="sensitivity must be"):
+            pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=bad)
+
+    assert pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=False).dpopt_ddata is None
+    np.testing.assert_array_equal(
+        pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity="gn").dpopt_ddata,
+        pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity=True).dpopt_ddata,
+    )
+
+
+def test_sensitivity_exact_warns_when_the_jacobian_is_finite_difference():
+    """Differentiating an FD gradient squares the error -- say so."""
+    x, y, p0 = _outlier_fixture()
+    with pytest.warns(UserWarning, match="finite-difference model Jacobian"):
+        pounce.curve_fit(expdecay, x, y, p0=p0, sensitivity="exact", jac="fd")
+
+
 # --------------------------------------------------------------------------
 # 6. Parameter constraints: positivity, range, general relation.
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Three defects in `res.dpopt_ddata`, found in that order, each uncovered by
fixing the one before it. Together they take the influence matrix from *wrong
by 86% with the sign flipped* to *within 0.2% of a perturb-and-re-solve*.

Fixes #922
Fixes #923
Fixes #925

| | error vs. re-solve, before | after |
|---|---|---|
| bound-active fit | 67% | **0.16%** |
| constraint-active fit | 4x too large, off the feasible set | **0.00%** |
| `loss="cauchy"` | 85.50%, sign flipped on outliers | **0.68%** |
| `loss="soft_l1"` | 72.97% | **0.37%** |

# 1. The active set was ignored (#922)

`res.dpopt_ddata` ignored bounds and constraints entirely. It returned the
unconstrained Gauss-Newton influence — numerically `pinv(J)` — for every fit,
so on a constrained fit it described a problem that was never solved.

### The defect

Two consequences, both measured against perturb-and-re-solve ground truth on
`a*exp(-b*x)+c`:

* **A parameter pinned at a bound cannot move**, so its influence is
  identically zero. The shipped answer reported 0.026–0.057 for it, and got
  the *sign* wrong on the free parameters (column 12: reported
  `a=+0.0127, b=+0.1468`; truth `a=-0.0408, b=-0.0431`).
* **Under an active `a + c <= K` the identity `da/dyᵢ + dc/dyᵢ = 0` holds for
  every point.** The shipped answer gave `da + dc = 0.78` — a perturbation
  walking straight off the feasible set — and was off by 4× in scale.

Root cause: `_data_sensitivity` was never passed `active_mask` or the
constraint Jacobian, even though `_covariance` next door has taken both since
gh#829 and `_projected_covariance` / `_active_constraint_jac` / `_nullspace`
were already in the file.

### The fix

Differentiating the constrained KKT system

```
[H_S  Aᵀ] [dp]   [2wᵢ² gᵢ]
[A     0] [dλ] = [   0   ]
```

gives `dp = Z (Zᵀ M Z)⁺ Zᵀ wᵢ² gᵢ` with `M = H_S/2` and `Z` an orthonormal
basis of the active set's null space. That is applied whenever anything binds,
and the pinned row falls out **exactly** zero rather than approximately so.
When the active set pins the parameters completely, the whole matrix is zero.

### After

| check | before | after |
|---|---|---|
| pinned-bound influence row | 5.5e-02 | **0.000e+00** |
| `max abs(da + dc)`, active constraint | 1.19 | **3.3e-12** |
| sign agreement with re-solve, 2x25 free entries | 34.0% | **96.0%** |
| `trace(J @ dpopt_ddata)` | always `n_params` | `n_params - n_active` |

That last row is the effective degrees of freedom the data actually determine,
and it only comes out right after the fix: 3.0000000122 / 2.0000000398 /
1.9999999974 on the unconstrained, bound-active and constraint-active cases.

The residual error on the constrained fit is the pre-existing Gauss-Newton
linearization, **not** the projection — substituting the full Hessian into the
same projection reproduces the re-solve to 2.9e-4. That was filed as #923, and
is section 2 below.

### Why it survived from the feature's first commit (177f0f13)

Exactly one test used `sensitivity=True`, on an unconstrained unweighted fit,
and it asserted `assert_allclose(dpopt_ddata, pinv(J))` — pinning the special
case as the general contract. Its FD check ran at `rtol=8e-2`, wide enough to
absorb the 2.2% Gauss-Newton gap. Bounds and constraints are well covered from
`test_positivity_bound_active` onward, but never with `sensitivity=True`.

The corpus was uniform in exactly the dimension the code was wrong in — the
failure mode the repo already has a name for.

### Tests

Three added, each reaching a branch the others do not:

* `test_sensitivity_zero_for_bound_pinned_parameter` — exact zero row, sign
  agreement with re-fits, and `max abs(dpopt_ddata - pinv(J)) > 0.1` so the
  test fails if the old formula comes back.
* `test_sensitivity_lies_in_active_constraint_nullspace` — the null-space
  identity at `atol=1e-9`.
* `test_sensitivity_unaffected_by_an_inactive_constraint` — a *slack*
  constraint must **not** trigger the projection. The branch the other two
  never take.

Mutation-checked: disabling the projection fails exactly the two
defect-naming tests (61 pass) and prints `da+dc = 0.7776`.

#
# 2. The Hessian was Gauss-Newton (#923)

`curve_fit` hands the solver the Gauss-Newton matrix as its search Hessian
(`_curve_fit.py:1430`, documented at `:1001`). That is the right call for the
search and the wrong one for `dpopt/ddata`: the influence identity is
`dp = 2 wᵢ² H_S⁻¹ gᵢ` with `H_S` the **objective** Hessian, and GN drops
`Σₖ rₖ ∇²fₖ`.

Measured against perturb-and-re-solve, that term is worth 0.6–10% on an
interior fit and 27–67% where a bound or constraint holds the fit away from
its unconstrained optimum. The spread is wide on purpose: the dropped term
scales with the residuals, so it is a property of the *fit*, not only of the
model, and a number carried across from one dataset to the next will be wrong.

**`sensitivity="exact"`** rebuilds `H_S` by central-differencing the objective
gradient at `popt` — `2n` gradient evaluations, step `eps**(1/3)·max(1,|pⱼ|)`,
symmetrized — and solves the same projected KKT system through a dense
pseudo-inverse. Error against the re-solve drops to **≤ 0.2%** in every case.

`True` and `"gn"` keep the old free path, so nothing that works today changes.
`popt` is untouched either way: the exact Hessian is built *after* the solve
and used only for the influence matrix. The exact branch cannot reuse the held
factor — that factor is the GN matrix and cannot answer for a different `H_S`.

| `sensitivity=` | cost | error |
|---|---|---|
| `True` / `"gn"` | one back-solve per point, effectively free | 0.6–67% |
| `"exact"` | `+2n` gradients, dense inverse | ≤ 0.2% |

At notebook 44's size (n=3, m=25) that is 1.02× a plain fit, against 24.4× for
25 leave-one-out refits.

# 3. The robust-loss curvature weight was missing from the RHS (#925)

This one came out of building #923, and it is the more serious of the two.

Under a robust loss the objective is `fs2 · Σ ρ(zᵢ)` with `zᵢ = rᵢ²/fs2`, so

```
∂²obj/∂p ∂yᵢ = -2 wᵢ² (ρ′ᵢ + 2 zᵢ ρ″ᵢ) gᵢ
```

The bracket is exactly the per-point weight `gn_hessian` already computes, and
the RHS never applied it. It is identically 1 for `sse` — which is why no test
saw it, the same uniform-corpus failure as #922.

Measured: **cauchy 85.50%, soft_l1 72.97%**. Worse than the magnitude, the
factor reaches **−0.12** under cauchy, so a downweighted outlier's influence
pointed the *wrong way* — the reported answer said adding to that residual
would push a parameter up when it pushes it down. With the weight applied:
0.68% and 0.37%.

**The two are independent, and the ordering matters.** The exact Hessian alone
moves cauchy 85.50% → 85.71%. Shipping #923 without #925 would have put an
exact-sounding label on an 86%-wrong answer.

## Tests for #923 and #925

All mutation-checked, and the checks separate cleanly — forcing `hess=None`
fails exactly the three `exact_beats_gauss_newton` cases; forcing `lw=ones`
fails exactly the two robust-loss cases; neither touches the other's.

* `test_sensitivity_exact_beats_gauss_newton_against_a_resolve`, parametrized
  interior / bound-active / constraint-active, asserting both an absolute
  bound and a 5× improvement over `"gn"` — the ratio is what fails if the
  exact path quietly falls back.
* `test_sensitivity_exact_preserves_the_active_set_invariants` — #922's
  pinned-row and null-space invariants must hold on the new dense branch,
  which shares no code with the `kkt_solve_many` path.
* `test_sensitivity_carries_the_robust_loss_curvature_weight`, cauchy and
  soft_l1, asserting magnitude **and sign** on the outlier columns.
* `test_sensitivity_mode_is_validated` and
  `test_sensitivity_exact_warns_when_the_jacobian_is_finite_difference` — the
  exact Hessian differences the gradient, so an FD Jacobian differences a
  difference, and the user is told.

Its fixture is a 30-point exponential with three injected outliers, chosen so
the robust weighting actually engages (`f_scale=0.1`); the FD reference is
checked stable across `h` (0.000% drift) and every fit is asserted converged,
after an earlier probe at `f_scale=0.05` diverged and produced a garbage
"truth".

## Docs and notebook

`docs/src/curve-fitting.md` gains the mode, the cost/error table, and an
explicit statement that `"exact"` does **not** repair the robust-loss RHS —
that is #925's fix, not this mode's. Notebook 44 gains section 7, which
measures the accuracy table, re-checks the #922 invariants under `"exact"`,
shows the `ρ′ + 2zρ″` weight running to −0.12, and times all three paths.

# Also here

`python/notebooks/44_leverage_and_influence.ipynb`, the companion notebook and
worked acceptance test. It builds the hat matrix and leverage out of
`dpopt_ddata` (agreeing with `X @ pinv(X)` to 2.2e-16 on a linear fit),
validates DFBETA and Cook's distance against 25 leave-one-out re-fits (rank
correlation 0.9992, identical top 3, at 1/24 the cost), and ends on the two
cases above. Its fixture is built so leverage and residual disagree: the most
influential point ranks 24th of 25 by residual.

Executed against 0.11.0 with all three fixes applied, so the saved outputs
are the fixed numbers.

---

Full Python suite **1477 passed** with all three fixes in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5CB3GErgSn6qJtXERRWbm
