### PR TITLE
fix(sensitivity): the path walk checks its own answer against the box, and a row limit is in it on both arms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -768,18 +768,72 @@ changes.
   for a row limit has `.var` naming the `Constraint`, not a `Var`, with the
   same `bound` and `action` values a variable bound produces.
 
-  The convex arm is **not** covered — `G` rows carry no bound metadata there
-  either, and that is [#929](https://github.com/jkitchin/pounce/issues/929).
+  The convex arm needed a different repair, because its KKT has no `s` block
+  to make contiguous with `x` — see the next entry.
+
+- **The same limit, on the convex arm, needed a block that was not there
+  ([#929](https://github.com/jkitchin/pounce/issues/929)).** The fix above
+  works because the NLP KKT already carries `dⱼ(x) = sⱼ`, so every constraint
+  has a primal coordinate for the walk to index. The convex active-set KKT
+
+  ```text
+  [ H   Aᵀ  B_aᵀ ] [ dx ]
+  [ A   0   0    ] [ dy ]
+  [ B_a 0   0    ] [ dz ]
+  ```
+
+  has none. An **inactive** `Gⱼx ≤ hⱼ` appears in it nowhere at all, so a step
+  driving it past its limit was silent and the answer came back infeasible; an
+  **active** one has a multiplier row but no primal coordinate, so a
+  perturbation driving that multiplier negative went on holding a row the
+  solution had left.
+
+  `pounce_sens_core::rowlimit::RowLimitView` adjoins an observer `t = G_w x`
+  through a multiplier, immediately after the `x` block so it lands inside the
+  primal prefix the walk indexes. The adjoined block is triangular — `dmu =
+  r_t`, one base back-solve on `r_x + G_wᵀ r_t`, then `dt = G_w dx + r_mu` —
+  so **the base factorization is untouched and the fix costs no
+  factorization**. Releasing an active row generalizes the arm's existing row
+  neutralization from a single `±1` coupling to a whole `G` row, which reuses
+  the symbolic factor.
+
+  Measured on `min ½‖x‖²` subject to `Σx = b`, `x₀ + x₂ ≤ 1` and `x₁ ≤ 0.8`,
+  a fixture whose closed form is known on all three of its branches. Walking
+  `b: 0 → 4`, the row reached `x₀ + x₂ = 2.133` — **1.133 past a stated cap**,
+  with an empty segment list; it is now `1.000`, with breakpoints naming the
+  row at fraction `0.5` and the variable bound at `0.65`. Coming back,
+  `b: 4 → 0` left `(0.5, −0.5, 0.5, −0.5)` with the row still pinned at `1.0`;
+  it is now the origin to `2.1e-14`. A third base reaches the *other* branch —
+  the row already active with a multiplier of `4.1e-5`, released at fraction
+  `8.2e-5` rather than mid-walk — which is a distinct branch of the same rule
+  and had to be measured separately.
+
+  Two things the augmentation deliberately does not do. It is skipped whenever
+  any cone block is present, because there `active_rows` is a cone normal (or,
+  at an apex, the whole block) and `active_ineq` is provenance rather than a
+  `G` row — pinned by a leg that walks a boundary SOC far enough to drive a
+  coordinate the cone does not sign-constrain through zero. And a released
+  *variable bound* is still the base's own business: `RowLimitView` lifts the
+  base's `BoundRow`s and multipliers itself rather than leaving the caller to
+  concatenate two lists, since the walk releases a row only when it finds it
+  in both.
+
+  `QpSensitivity::path_segment_target` resolves a segment to
+  `PathTarget::Variable` or `PathTarget::InequalityRow`, the convex arm's
+  counterpart of `slack_rows()` above, so a consumer cannot read a row index
+  as a column index — the gh#450 hazard in this arm's own index space.
+
+  **`QpSensitivity::parametric_step_bounded` is not covered** and still
+  carries the whole defect: on the same fixture it returns `x₀ + x₂ = 2.1333`
+  against a cap of `1.0`, and in reverse leaves the row pinned at `1.0` where
+  the truth is the origin. It is a different edit rather than the same one —
+  that entry point returns `refine_step_onto_bounds`'s mixed list of released
+  multiplier rows and pinned primal rows, so adjoining observers shifts the
+  meaning of half that list and needs an API decision and a fixture of its
+  own. The NLP arm has no matching gap, because gh#928 widened its box
+  globally rather than through a view.
 
 ### Changed
-
-- **The path walk's box-repair budget is the base-activity table's length**
-  ([#928](https://github.com/jkitchin/pounce/issues/928)), rather than a
-  fixed constant. Each pass adds at least one bound to the watch list and
-  never removes one, so a budget of that size cannot be exhausted before the
-  list is, which makes the exhausted arm unreachable by construction instead
-  of by argument. Measured, no fixture in the corpus reaches even a second
-  pass.
 
 - **A walk that releases two bounds at once with no curvature in the released
   coordinates is refused rather than answered**, and the gap now has an open
@@ -789,6 +843,15 @@ changes.
   releases sharing a constraint make it singular. Refusing is an improvement
   on the pre-#928 behaviour, which was to return a point outside the box in
   silence, but it is not the right final answer.
+
+
+- **The path walk's box-repair budget is the base-activity table's length**
+  ([#928](https://github.com/jkitchin/pounce/issues/928)), rather than a
+  fixed constant. Each pass adds at least one bound to the watch list and
+  never removes one, so a budget of that size cannot be exhausted before the
+  list is, which makes the exhausted arm unreachable by construction instead
+  of by argument. Measured, no fixture in the corpus reaches even a second
+  pass.
 
 
 ## [0.11.0] - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -833,17 +833,38 @@ changes.
   own. The NLP arm has no matching gap, because gh#928 widened its box
   globally rather than through a view.
 
-### Changed
-
 - **A walk that releases two bounds at once with no curvature in the released
-  coordinates is refused rather than answered**, and the gap now has an open
-  issue ([#930](https://github.com/jkitchin/pounce/issues/930)). Holding a
-  bound the path reached is a Schur pin on the already-factored released
-  system, which must be invertible before the pins go on; two curvature-free
-  releases sharing a constraint make it singular. Refusing is an improvement
-  on the pre-#928 behaviour, which was to return a point outside the box in
-  silence, but it is not the right final answer.
+  coordinates is answered, not refused
+  ([#930](https://github.com/jkitchin/pounce/issues/930)).** Holding a bound
+  the path reached is a Schur pin on the already-factored released system, so
+  `K⁻¹` has to exist before a single pin goes on. Releasing a bound takes its
+  `Sigma` off the diagonal; with no curvature there the diagonal is exactly
+  zero, and two released variables sharing a constraint row are left with
+  linearly dependent stationarity rows. The walk reported `augmented solve
+  failed`.
 
+  The pin did not change — the *operator* it rides on did. On failure the walk
+  retries against `K_released + Σ_pin E Eᵀ`, whose pinned diagonals are raised
+  until it inverts, and the same Schur row goes on top. `Eᵀw = 0` annihilates
+  exactly the term that was added, so the system actually solved is the
+  released one, in the identical frame and units; a walk that takes the plain
+  operator on one segment and the regularized one on the next still
+  accumulates a single `h.mult` per hold. `Σ_pin` is the gh#737 ceiling — the
+  stiffest diagonal the row's own couplings survive — so the held coordinate
+  creeps by roundoff rather than being infinitely stiff, which is bounded by a
+  test rather than asserted.
+
+  The fallback is triggered on the **pinned rows' residual**, not on the
+  factorization returning an error, and referenced to the pin's own
+  right-hand side rather than to `max|d|`. Both choices are load-bearing and
+  both were measured: at rank deficiency one the plain factorization absorbs
+  the singularity, returns `Ok`, and hands back a held row carrying a fifth of
+  the step — while the multiplier rows run at `3e11`, so a 200% miss reads
+  `3e-12` against `max|d|`. The answer is checked against a re-solve at the
+  perturbed parameter, which is the only guard in the layer that reads a
+  number the sensitivity code did not produce.
+
+### Changed
 
 - **The path walk's box-repair budget is the base-activity table's length**
   ([#928](https://github.com/jkitchin/pounce/issues/928)), rather than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -719,6 +719,77 @@ changes.
   there, which is what makes an endpoint check sufficient for it rather than
   a patch over the symptom.
 
+- **A limit written as a constraint row was watched by nothing
+  ([#928](https://github.com/jkitchin/pounce/issues/928)).** The second half
+  of the same issue, and the broader one: it needs no degeneracy at all.
+
+  `x <= 1` as a variable bound and `cap: g(x) <= 1` as a row describe the
+  same feasible set. They were not the same thing to the sensitivity layer.
+  A variable bound's multiplier is in `z_l` / `z_u` and the quantity it
+  constrains is a row of the `x` block; a row's limit bounds the **slack**,
+  so its multiplier is in `v_l` / `v_u` and the quantity it constrains is a
+  row of the `s` block. `bound_variable_rows` emitted only the `z` half and
+  `bound_context`'s box covered only the `x` block, so a row limit had no
+  entry in the reach scan, no entry in the base-activity table, no breakpoint
+  it could appear as, and nothing for the box repair above to add to its
+  watch list.
+
+  Measured on `min ½(x − p)²` subject to `x ≤ 1` stated as a row, with `x`
+  carrying no bound of its own: from `p = 0.8` a step to `p = 1.3` walked `x`
+  to **1.300000000 against a true 1.000000000**, three tenths past a stated
+  cap, with an empty segment list. The reverse is worse than a lost record —
+  from `p = 1.3` a step to `p = 0.8` left `x` **pinned at 1.0 against a true
+  0.8**, because nothing took the cap's stiffness out of the operator. At the
+  kink itself both directions were wrong by half the perturbation, which is
+  the two-sided average a degenerate base point returns when nothing watches
+  the bound. Every one of those is now exact to about `1e-10` and carries a
+  segment naming the cap.
+
+  What made the repair small is that blocks `x` and `s` are **contiguous** in
+  the compound KKT vector, so the `(x, s)` prefix is one box and the walk
+  needs no second index space; `path_direction` already pins a generic Schur
+  unit row on any KKT row, so the reach half needed no backsolver arithmetic
+  at all. The release half did: the barrier's `s`-block diagonal is now
+  rebuilt with the released entry's `v / s` taken out, and stays `None` when
+  no slack bound is released, because the factorization cache keys on the
+  diagonal object's identity.
+
+  `BoundRow.var_row` — and so a `PathSegment.var_row`, and a `pinned` row
+  from `parametric_step_bounded` — is therefore a **primal KKT row** rather
+  than a var-x index: below `block_dims()[0]` it is a variable, at or above
+  it the limit is a constraint's own. The new `slack_rows()` accessor
+  (`Solver::d_slack_rows` in Rust) resolves such a row back to its
+  inequality, the primal counterpart of `inequality_multiplier_rows`.
+  Indexing a variable-length vector by the number instead returns a
+  neighbouring variable's answer, the gh#450 hazard, so every consumer inside
+  the crate now decides the block before it uses the value.
+
+  In `pyomo-pounce` the record follows: a `sens_active_set_changes()` entry
+  for a row limit has `.var` naming the `Constraint`, not a `Var`, with the
+  same `bound` and `action` values a variable bound produces.
+
+  The convex arm is **not** covered — `G` rows carry no bound metadata there
+  either, and that is [#929](https://github.com/jkitchin/pounce/issues/929).
+
+### Changed
+
+- **The path walk's box-repair budget is the base-activity table's length**
+  ([#928](https://github.com/jkitchin/pounce/issues/928)), rather than a
+  fixed constant. Each pass adds at least one bound to the watch list and
+  never removes one, so a budget of that size cannot be exhausted before the
+  list is, which makes the exhausted arm unreachable by construction instead
+  of by argument. Measured, no fixture in the corpus reaches even a second
+  pass.
+
+- **A walk that releases two bounds at once with no curvature in the released
+  coordinates is refused rather than answered**, and the gap now has an open
+  issue ([#930](https://github.com/jkitchin/pounce/issues/930)). Holding a
+  bound the path reached is a Schur pin on the already-factored released
+  system, which must be invertible before the pins go on; two curvature-free
+  releases sharing a constraint make it singular. Refusing is an improvement
+  on the pre-#928 behaviour, which was to return a point outside the box in
+  silence, but it is not the right final answer.
+
 
 ## [0.11.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -662,6 +662,63 @@ changes.
   covered, so a check that stops warning fails as loudly as one that warns
   spuriously.
 
+### Fixed
+
+- **`parametric_step_path` could return a point outside a variable's box
+  ([#928](https://github.com/jkitchin/pounce/issues/928)).** With no
+  breakpoint recorded and no warning, on any model whose Hessian diagonal is
+  below the activity classifier's identification floor — which is every LP,
+  and every model whose cost is linear in the coordinate that reaches the
+  bound.
+
+  This is gh#852 reached through the other door. That fix taught the walk to
+  keep watching a bound the factorization carries as a finite penalty rather
+  than enforces, and it learns which those are from `weakly_active_bounds`.
+  Where there is no curvature to divide by, every bound classifies
+  `UNIDENTIFIED`, that list comes back empty, and the walk's own
+  base-activity test — which is exactly `Σ > 1` — bars the bound from the
+  reach scan anyway. The bound is then neither held by the factorization nor
+  watched by the path, and the direction carries the variable straight
+  through it.
+
+  Measured on a five-bus AC-OPF at the load where a generator reaches its
+  rating: at linear generation cost — the normal case in dispatch — the walk
+  predicted **202.98 MW against a 170 MW nameplate**, with zero segments.
+  Adding a quadratic cost term worth 0.1% of the linear one at that output
+  changes nothing physical and fixes it, by lifting the diagonal over the
+  floor. On a three-variable LP reproducer, 11 of 37 base points returned a
+  point outside the box, relative violation up to 0.9999, and the violating
+  band begins at the first point above `Σ = 1`.
+
+  Widening the classifier is not the fix and was rejected: admitting
+  `UNIDENTIFIED` wholesale also admits genuinely enforced bounds
+  (`Σ = 1.1e11` on the same LP) and makes the augmented system singular. The
+  quantity that would discriminate inside the class is the curvature that is
+  by hypothesis unmeasurable there. So `step_along_path` no longer relies on
+  being told: it checks its own answer against the box and treats a
+  base-active bound the answer *crossed* as measured proof the factorization
+  did not enforce it, adds it to the watch list, and re-walks. Threshold-free
+  — no `μ`, no curvature, no units — and a no-op whenever the first walk
+  already lands inside the box, which is the whole existing corpus: the
+  fixture sweep diffs empty across all 194 fixture-legs on both the `exact`
+  and `lbfgs` legs.
+
+  A repair that cannot reach the box is now reported rather than returning
+  the out-of-box point silently — returning it is gh#928's own signature, a
+  violation with nothing in the record naming it. The exception is a walk the
+  caller capped: `max_iter` bounds segments, so `max_iter = 0` asks for the
+  plain linear step, which is outside the box whenever the bound binds and
+  was legal to ask for before the repair existed.
+
+  Measured on a second reproducer with **two** soft bounds coupled through
+  the equality, over 48 base points either side of both kinks and four
+  perturbations each: 48 of 192 cases returned a point outside the box
+  before, **192 of 192 now reproduce the re-solve exactly**, and the new
+  report never fires. On that corpus no case is wrong while staying inside
+  the box, on either version — the defect and the box violation coincide
+  there, which is what makes an endpoint check sufficient for it rather than
+  a patch over the symptom.
+
 
 ## [0.11.0] - 2026-09-03
 

--- a/crates/pounce-convex/Cargo.toml
+++ b/crates/pounce-convex/Cargo.toml
@@ -47,6 +47,11 @@ tracing.workspace = true
 # FERAL backs the in-tree unit tests so the IPM runs end-to-end against
 # a real sparse symmetric factorization without external solvers.
 pounce-feral.workspace = true
+# Already a normal dependency; repeated here so the *integration* tests can
+# drive `step_along_path` against a bare `QpKktBacksolver` — which is what
+# `parametric_step_path` did before gh#929 adjoined the row observers, and
+# therefore the only way to measure the defect from outside the crate.
+pounce-sens-core.workspace = true
 
 [lints]
 workspace = true

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -91,7 +91,9 @@ pub use qp::{
     BoxScreen, NEG_INF, POS_INF, QpIterate, QpProblem, QpResiduals, QpSolution, QpStatus, Triplet,
     screen_variable_box,
 };
-pub use sensitivity::{ConeBlockKind, QpKktBacksolver, QpSensitivity, ReducedHessian, SensError};
+pub use sensitivity::{
+    ConeBlockKind, PathTarget, QpKktBacksolver, QpSensitivity, ReducedHessian, SensError,
+};
 pub use sos::{
     PolyProblem, Polynomial, SosBound, SosSolution, sos_constrained_lower_bound,
     sos_constrained_lower_bound_opts, sos_lower_bound, sos_lower_bound_opts, sos_minimize,

--- a/crates/pounce-convex/src/sensitivity.rs
+++ b/crates/pounce-convex/src/sensitivity.rs
@@ -2642,6 +2642,11 @@ impl QpSensitivity {
             &[],
             &[],
             &[],
+            // How far outside its box the answer has to land before the
+            // walk treats a base-active bound as one the factorization
+            // never enforced. The same floor the release decision uses;
+            // this arm has no bound relaxation to widen it.
+            RELEASE_FLOOR,
         )
         .map_err(SensError::Refinement)?;
         self.last_residual = Some(bs.last_residual());

--- a/crates/pounce-convex/src/sensitivity.rs
+++ b/crates/pounce-convex/src/sensitivity.rs
@@ -74,6 +74,7 @@ use pounce_sens_core::backsolver::{BoundRow, SensBacksolver};
 use pounce_sens_core::boundcheck::{
     BoundMultiplier, PathSegment, RefineStop, refine_step_onto_bounds, step_along_path,
 };
+use pounce_sens_core::rowlimit::{RowLimitView, WatchedRow};
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
 use std::rc::Rc;
@@ -1372,6 +1373,19 @@ fn soc_boundary_curvature(
 /// from a [`QpProblem`] and its [`QpSolution`], then call
 /// [`parametric_step`](Self::parametric_step) for each parameter
 /// perturbation — the factorization is reused across queries.
+/// What a [`PathSegment`] of a convex parametric walk is about.
+///
+/// The walk reports a primal KKT row, and this arm's primal prefix is the `x`
+/// block followed by one observer coordinate per inequality row (gh#929).
+/// [`QpSensitivity::path_segment_target`] is the only conversion.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PathTarget {
+    /// Variable `x[j]` reached or left one of its own bounds.
+    Variable(usize),
+    /// Inequality row `Gᵢx ≤ hᵢ` became binding, or stopped being.
+    InequalityRow(usize),
+}
+
 pub struct QpSensitivity {
     n: usize,
     m_eq: usize,
@@ -1450,8 +1464,9 @@ pub struct QpSensitivity {
     ir_scratch: IrScratch,
     /// Factored (regularized) KKT values; a release starts from these.
     kkt_vals_reg: Rc<Vec<f64>>,
-    /// Per active bound, the value slots a release neutralizes.
-    release_slots: Rc<Vec<(usize, usize)>>,
+    /// Per active row (inequality rows then bound rows), the value slots a
+    /// release neutralizes.
+    release_slots: Rc<Vec<(Vec<usize>, usize)>>,
     /// One spare linear-solver instance, drawn from the caller's factory at
     /// build, reserved for the released system.
     ///
@@ -1802,36 +1817,56 @@ fn assemble_kkt(
     }
 }
 
-/// For each active bound, the two value-array slots a release has to touch:
-/// the `±1` coupling the multiplier row to its variable, and that row's own
-/// diagonal.
+/// For each **active row** — the inequality rows first, then the bound rows,
+/// the order [`assemble_kkt`] emits them in — the value-array slots a release
+/// has to touch: every coupling from the multiplier row into the `x` block,
+/// and that row's own diagonal.
 ///
 /// Precomputed once at build so a release is an array rewrite plus a
 /// [`Factorization::refactor`] — the sparsity pattern is unchanged by
 /// neutralizing a row, so the symbolic factorization is reused.
+///
+/// # Why the couplings are a `Vec`
+///
+/// A bound row has exactly one, its `±1` against the variable. A general
+/// inequality row has one per nonzero of `Gⱼ`, and releasing it means zeroing
+/// all of them: leaving any behind leaves the row still coupled to `x` while
+/// its diagonal says it is free, which is not a system anybody wrote down.
+/// The bound case was the only one that existed until gh#929 gave the walk a
+/// way to *reach* an inequality row's limit, at which point releasing one
+/// became reachable too.
 fn release_slots(
     pat: &KktPattern,
     abase: usize,
-    n_ineq_active: usize,
+    active_rows: &[Vec<(usize, f64)>],
     active_bounds: &[(usize, bool)],
-) -> Vec<(usize, usize)> {
-    let mut out = Vec::with_capacity(active_bounds.len());
-    for (k, &(j, _)) in active_bounds.iter().enumerate() {
-        let row = abase + n_ineq_active + k;
+) -> Vec<(Vec<usize>, usize)> {
+    // Column sets, in the same order the rows are emitted.
+    let cols: Vec<Vec<usize>> = active_rows
+        .iter()
+        .map(|row| row.iter().map(|&(c, _)| c).collect())
+        .chain(active_bounds.iter().map(|&(j, _)| vec![j]))
+        .collect();
+    let mut out = Vec::with_capacity(cols.len());
+    for (k, wanted) in cols.iter().enumerate() {
+        let row = abase + k;
         // 1-based in the pattern arrays.
-        let (r1, j1) = ((row + 1) as Index, (j + 1) as Index);
-        let mut coupling = usize::MAX;
+        let r1 = (row + 1) as Index;
+        let mut coupling = Vec::with_capacity(wanted.len());
         let mut diagonal = usize::MAX;
         for (idx, (&a, &b)) in pat.airn.iter().zip(pat.ajcn.iter()).enumerate() {
-            if a == r1 && b == j1 {
-                coupling = idx;
-            } else if a == r1 && b == r1 {
+            if a != r1 {
+                continue;
+            }
+            if b == r1 {
                 diagonal = idx;
+            } else if wanted.contains(&((b as usize) - 1)) {
+                coupling.push(idx);
             }
         }
         debug_assert!(
-            coupling != usize::MAX && diagonal != usize::MAX,
-            "every active bound row has a coupling entry and a diagonal"
+            diagonal != usize::MAX,
+            "every active row has a diagonal entry"
         );
         out.push((coupling, diagonal));
     }
@@ -2176,7 +2211,7 @@ impl QpSensitivity {
             pat.dim, dim,
             "assemble_kkt and finish must agree on the KKT dimension"
         );
-        let release_slots = release_slots(&pat, n + m_eq, active_rows.len(), &active_bounds);
+        let release_slots = release_slots(&pat, n + m_eq, &active_rows, &active_bounds);
         let KktPattern {
             airn: kkt_airn,
             ajcn: kkt_ajcn,
@@ -2541,6 +2576,7 @@ impl QpSensitivity {
             last_residual: Rc::new(Cell::new(f64::NAN)),
             vals_reg: Rc::clone(&self.kkt_vals_reg),
             slots: Rc::clone(&self.release_slots),
+            abase: self.n + self.m_eq,
             base_mult: Rc::new(self.bound_base_mult.clone()),
             released: Rc::new(RefCell::new(None)),
             release_backend: Rc::clone(&self.release_backend),
@@ -2631,6 +2667,42 @@ impl QpSensitivity {
         let (rhs_plain, x_curr, lo, hi, multipliers) =
             self.path_inputs(pin_constraint_indices, deltas);
         let bs = self.backsolver();
+        // How far outside its box the answer has to land before the walk
+        // treats a base-active bound as one the factorization never
+        // enforced. The same floor the release decision uses; this arm has
+        // no bound relaxation to widen it.
+        let eps = RELEASE_FLOOR;
+        if let Some(view) = self.row_limit_view(&bs) {
+            let n_t = view.n_observers();
+            let (Some(rhs_lift), Some((x_aug, lo_aug, hi_aug)), Some(mult_aug)) = (
+                view.lift_rhs(&rhs_plain),
+                view.primal_box(&x_curr, &lo, &hi),
+                view.lift_multipliers(&multipliers),
+            ) else {
+                // Unreachable given `row_limit_view`'s own checks; refusing
+                // beats walking a half-built augmented system.
+                return Err(SensError::Refinement(
+                    "row-limit observers could not be lifted into the walk's inputs".to_string(),
+                ));
+            };
+            debug_assert_eq!(x_aug.len(), self.n + n_t);
+            let (dx, segments) = step_along_path(
+                &view,
+                &rhs_lift,
+                &x_aug,
+                &lo_aug,
+                &hi_aug,
+                &mult_aug,
+                max_iter,
+                &[],
+                &[],
+                &[],
+                eps,
+            )
+            .map_err(SensError::Refinement)?;
+            self.last_residual = Some(bs.last_residual());
+            return Ok((dx[..self.n].to_vec(), segments));
+        }
         let (dx, segments) = step_along_path(
             &bs,
             &rhs_plain,
@@ -2642,15 +2714,78 @@ impl QpSensitivity {
             &[],
             &[],
             &[],
-            // How far outside its box the answer has to land before the
-            // walk treats a base-active bound as one the factorization
-            // never enforced. The same floor the release decision uses;
-            // this arm has no bound relaxation to widen it.
-            RELEASE_FLOOR,
+            eps,
         )
         .map_err(SensError::Refinement)?;
         self.last_residual = Some(bs.last_residual());
         Ok((dx[..self.n].to_vec(), segments))
+    }
+
+    /// What a [`PathSegment`] returned by
+    /// [`parametric_step_path`](Self::parametric_step_path) refers to.
+    ///
+    /// `PathSegment::var_row` is a primal KKT row, and on this arm the primal
+    /// prefix is the `x` block followed by one **observer** coordinate per
+    /// inequality row (gh#929). Reading a segment without this conversion
+    /// silently turns "inequality row 2 became binding" into "variable
+    /// `n + 2`", which is the index-space failure `/sens-review` entry 1 is
+    /// about — so the mapping is a method rather than a note in the docs.
+    pub fn path_segment_target(&self, seg: &PathSegment) -> PathTarget {
+        if seg.var_row < self.n {
+            PathTarget::Variable(seg.var_row)
+        } else {
+            PathTarget::InequalityRow(seg.var_row - self.n)
+        }
+    }
+
+    /// The inequality rows of this problem as watched limits, wrapped around
+    /// `bs`, or `None` when the augmentation does not apply.
+    ///
+    /// `None` in three cases, each of them a real answer rather than a
+    /// shortcut:
+    ///
+    /// * **no inequality rows**, so there is nothing a row limit could add;
+    /// * **a conic block is present.** `active_rows` is then not a set of `G`
+    ///   rows at all — it is the cone's normal at the boundary point, or the
+    ///   whole block at an apex — so `active_ineq` names provenance and not
+    ///   the active object. An observer on `Gⱼ x ≤ hⱼ` would be watching a
+    ///   limit the solve is not enforcing that way, and its "release" would
+    ///   neutralize a row that is a combination of several. The conic arm
+    ///   keeps the unaugmented walk it had.
+    /// * **[`RowLimitView::new`] refuses**, which on this arm can only mean
+    ///   the base reported a `natural_units_factor` it does not have. Falling
+    ///   back rather than erroring keeps a shape nobody has produced from
+    ///   turning a working call into a failure.
+    fn row_limit_view(&self, bs: &QpKktBacksolver) -> Option<RowLimitView<QpKktBacksolver>> {
+        if !self.cone_kinds.is_empty() {
+            return None;
+        }
+        let m_ineq = self.prob.m_ineq();
+        if m_ineq == 0 {
+            return None;
+        }
+        let mut coefs: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m_ineq];
+        for t in &self.prob.g {
+            coefs[t.row].push((t.col, t.val));
+        }
+        let mut gx = vec![0.0; m_ineq];
+        self.prob.g_mul(&self.base_x, &mut gx);
+        // `active_rows` is emitted first in the active block, so the k-th
+        // active inequality row's multiplier sits at `n + m_eq + k`.
+        let abase = self.n + self.m_eq;
+        let rows: Vec<WatchedRow> = (0..m_ineq)
+            .map(|i| WatchedRow {
+                coefficients: std::mem::take(&mut coefs[i]),
+                limit: self.prob.h[i],
+                base_value: gx[i],
+                active: self
+                    .active_ineq
+                    .iter()
+                    .position(|&a| a == i)
+                    .map(|k| (abase + k, self.base_z[i])),
+            })
+            .collect();
+        RowLimitView::new(bs.clone(), self.n, rows)
     }
 
     /// The shared inputs the path and bounded modes both need: the compound
@@ -4282,8 +4417,13 @@ pub struct QpKktBacksolver {
     /// The factored (regularized) values of the *unreleased* system; a release
     /// starts from these and neutralizes the released rows.
     vals_reg: Rc<Vec<f64>>,
-    /// Per active bound, the `(coupling, diagonal)` value slots to neutralize.
-    slots: Rc<Vec<(usize, usize)>>,
+    /// Per active row (inequality rows then bound rows), the
+    /// `(couplings, diagonal)` value slots to neutralize. Indexed by
+    /// `row - abase`.
+    slots: Rc<Vec<(Vec<usize>, usize)>>,
+    /// First compound row of the active block, `n + m_eq`. The offset that
+    /// turns a released multiplier row into an index into [`Self::slots`].
+    abase: usize,
     /// Per active bound, its oriented base multiplier — what
     /// `solve_released_step` moves onto the variable's `x` row.
     base_mult: Rc<Vec<f64>>,
@@ -4351,14 +4491,14 @@ impl SensBacksolver for QpKktBacksolver {
     /// and every pin and release would read a mis-scaled multiplier against a
     /// natural-units step.
     ///
-    /// **And it is currently unguarded, measured rather than assumed.** Making
-    /// this return a non-identity vector turns *nothing* in the crate red,
-    /// because the only consumer is the release half of `refine_step_onto_bounds`
-    /// and [`supports_release`](Self::supports_release) is `false` here. So the
-    /// value is correct and untested at the same time. The phase that turns
-    /// release on is the phase that makes it load-bearing, and it owes this a
-    /// guard — a leg comparing a released step against a re-solve, which cannot
-    /// pass with a mis-scaled `F`.
+    /// **And it was unguarded for as long as nothing read it.** While
+    /// [`supports_release`](Self::supports_release) was `false` here, making
+    /// this return a non-identity vector turned *nothing* in the crate red:
+    /// the value was correct and untested at the same time. Release is on now,
+    /// so the release half of `refine_step_onto_bounds` and the path walk both
+    /// read it, and `convex_sens_release.rs` compares a released step against a
+    /// re-solve — which cannot pass with a mis-scaled `F`. Keep that shape of
+    /// guard for anything that later reads this.
     ///
     /// `the_step_is_unmoved_by_internal_equilibration` guards the neighbouring
     /// and weaker claim that `dx/db` itself does not depend on whether the
@@ -4420,14 +4560,19 @@ impl QpKktBacksolver {
         let mut vals_reg = (*self.vals_reg).clone();
         let mut vals_true = (*self.vals_true).clone();
         for &row in key {
-            let Some(k) = self.bound_at(row) else {
+            let Some(k) = row
+                .checked_sub(self.abase)
+                .filter(|&k| k < self.slots.len())
+            else {
                 return false;
             };
-            let (coupling, diagonal) = self.slots[k];
-            vals_reg[coupling] = 0.0;
-            vals_true[coupling] = 0.0;
-            vals_reg[diagonal] = -1.0;
-            vals_true[diagonal] = -1.0;
+            let (coupling, diagonal) = &self.slots[k];
+            for &c in coupling {
+                vals_reg[c] = 0.0;
+                vals_true[c] = 0.0;
+            }
+            vals_reg[*diagonal] = -1.0;
+            vals_true[*diagonal] = -1.0;
         }
         let mut slot = self.released.borrow_mut();
         match slot.as_mut() {
@@ -4491,9 +4636,20 @@ impl QpKktBacksolver {
             // row carries the bound's side with — `−z` for a lower bound,
             // `+z` for an upper one. Mirrors the NLP arm's
             // `shift_released_rhs`, which is the reference for this convention.
+            //
+            // A released *inequality* row is skipped, not refused: it has no
+            // variable of its own in this space to move its force onto. The
+            // caller that can release one is
+            // [`RowLimitView`](pounce_sens_core::rowlimit::RowLimitView),
+            // which adjoins the observer coordinate `t = Gⱼx` that *is* that
+            // variable and adds the shift there, in its own frame, before
+            // this solve ever sees the right-hand side. Refusing here instead
+            // would make a correct caller fail; the row set itself is already
+            // validated by `ensure_released`, so a row that reaches this loop
+            // and is not a bound is an active inequality row and nothing else.
             for &row in &key {
                 let Some(k) = self.bound_at(row) else {
-                    return false;
+                    continue;
                 };
                 let b = &self.bound_rows[k];
                 if b.var_row >= self.dim {

--- a/crates/pounce-convex/tests/issue_928_convex_path_leaves_the_box.rs
+++ b/crates/pounce-convex/tests/issue_928_convex_path_leaves_the_box.rs
@@ -76,11 +76,14 @@
 //!
 //! - **The conic arm.** Second-order-cone blocks are not `BoundRow`s;
 //!   `convex_sens_release.rs` owns what release means there.
-//! - **Constraint rows.** `G` rows carry no bound metadata here, so a
-//!   limit written as a row is watched by nothing on this arm --
-//!   gh#929. The NLP arm's half of that is fixed;
-//!   `pounce-sensitivity/tests/issue_928_a_limit_written_as_a_row.rs`
-//!   is the map a convex fix would follow.
+//! - **Constraint rows.** This fixture's only limits are variable
+//!   bounds, so nothing here reaches the observer coordinates
+//!   `rowlimit::RowLimitView` adjoins for a limit written as a `G`
+//!   row. That is gh#929, fixed, and
+//!   `issue_929_row_limit_on_the_convex_arm.rs` owns it -- including
+//!   the measurement that the augmentation is inert when no row limit
+//!   is reached, which is what says this file's numbers are unmoved
+//!   by it.
 //! - **Scaling.** Unscaled, like every other convex sensitivity test.
 //! - **Magnitude.** Two variables. The largest convex fixture in the
 //!   corpus is 534 columns and `benchmarks/qp` reaches 93 263.

--- a/crates/pounce-convex/tests/issue_928_convex_path_leaves_the_box.rs
+++ b/crates/pounce-convex/tests/issue_928_convex_path_leaves_the_box.rs
@@ -1,0 +1,332 @@
+//! Where the convex arm stands on gh#928 -- measured, and not where
+//! it was assumed to stand.
+//!
+//! The convex arm reaches `step_along_path` through
+//! `QpSensitivity::parametric_step_path`, and it passes `weak_rows`
+//! as `&[]` unconditionally:
+//!
+//! ```text
+//! step_along_path(&bs, .., max_iter, &[], &[], &[], RELEASE_FLOOR)
+//! //                                          ^^^ weak_rows
+//! ```
+//!
+//! On the NLP arm an empty `weak_rows` is exactly the gh#928 hazard:
+//! the classifier certified nothing, so a bound the walk marks
+//! base-active is neither enforced by the factorization nor watched by
+//! the reach scan, and the answer runs outside the box. Reading that
+//! `&[]` and expecting the same hazard here is the natural inference.
+//! It is wrong, and this file is the measurement that says so.
+//!
+//! # The two regimes, and why neither leaks
+//!
+//! The arm decides activity with a **hard threshold on the
+//! multiplier** -- the `1e-7` handed to `QpSensitivity::build` -- and
+//! a bound it calls active is *pinned*, not damped. There is no
+//! order-one `Sigma` sitting between "enforced" and "ignored", which
+//! is the crack gh#928 falls through. So:
+//!
+//! * **Pinned** (`z_ub` above the threshold): the variable does not
+//!   move at all, `dx0 == 0` to working precision. An answer that does
+//!   not move cannot leave the box.
+//! * **Free** (`z_ub` below it): the bound is not base-active, the
+//!   reach scan watches it, and a step that presses into it records a
+//!   breakpoint and stops there. Measured below: the plain step
+//!   overshoots to `0.55` and the walk returns `0.5`.
+//!
+//! The box repair added for gh#928 is therefore **inert on this arm**,
+//! and that is a fact worth a test rather than a comment: if the arm
+//! ever moves to a barrier-style `Sigma`, the pinned regime stops
+//! being pinned and the hazard becomes real here too. The first test
+//! below is what would notice.
+//!
+//! # The cost of pinning, which is not zero
+//!
+//! Pinning freezes the variable at its **base point**, not at its
+//! bound, so across the kink the answer is short by exactly the base
+//! slack. Measured over five orders of `delta`, `err/slack` is
+//! `1.0000` in every row. That is not a violation and not a wrong
+//! active set -- it is the arm answering for the barrier problem at
+//! the `mu` its solve stopped at, and the base point really is that
+//! far from the bound. It is recorded here because it is invisible to
+//! a box check by construction: the error points *into* the feasible
+//! region.
+//!
+//! Note the floor. Below `delta = 1e-3` the base slack stops tracking
+//! `delta` and settles at about `5.2e-5`, the distance the interior
+//! point method's own convergence leaves; the error settles with it.
+//! So the accuracy of a crossing step on this arm is set by the base
+//! solve's tolerance, not by the perturbation.
+//!
+//! # The fixture
+//!
+//! ```text
+//! min  ½(x0² + x1²)   s.t.  x0 + x1 = b,  0 ≤ x0 ≤ ½,  x1 ≥ 0
+//! ```
+//!
+//! Unconstrained by the box the optimum splits `b` evenly, so
+//!
+//! ```text
+//! b <= 1:  x = (b/2, b/2)
+//! b >= 1:  x = (1/2, b - 1/2)
+//! ```
+//!
+//! with the kink at `b = 1`, where `x0` reaches its upper bound.
+//!
+//! # What this file is NOT evidence about
+//!
+//! - **The conic arm.** Second-order-cone blocks are not `BoundRow`s;
+//!   `convex_sens_release.rs` owns what release means there.
+//! - **Constraint rows.** `G` rows carry no bound metadata here, so a
+//!   limit written as a row is watched by nothing on this arm --
+//!   gh#929. The NLP arm's half of that is fixed;
+//!   `pounce-sensitivity/tests/issue_928_a_limit_written_as_a_row.rs`
+//!   is the map a convex fix would follow.
+//! - **Scaling.** Unscaled, like every other convex sensitivity test.
+//! - **Magnitude.** Two variables. The largest convex fixture in the
+//!   corpus is 534 columns and `benchmarks/qp` reaches 93 263.
+
+use pounce_convex::QpOptions;
+use pounce_convex::ipm::solve_qp_ipm;
+use pounce_convex::qp::{QpProblem, QpStatus, Triplet};
+use pounce_convex::sensitivity::QpSensitivity;
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn tri(row: usize, col: usize, val: f64) -> Triplet {
+    Triplet { row, col, val }
+}
+
+/// `x0`'s upper bound, and the kink's location in `b`.
+const UB0: f64 = 0.5;
+const KINK: f64 = 2.0 * UB0;
+
+fn kinked_qp(b: f64) -> QpProblem {
+    QpProblem {
+        n: 2,
+        p_lower: vec![tri(0, 0, 1.0), tri(1, 1, 1.0)],
+        c: vec![0.0, 0.0],
+        a: vec![tri(0, 0, 1.0), tri(0, 1, 1.0)],
+        b: vec![b],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![UB0, f64::INFINITY],
+    }
+}
+
+fn closed_form(b: f64) -> [f64; 2] {
+    if b <= KINK {
+        [b / 2.0, b / 2.0]
+    } else {
+        [UB0, b - UB0]
+    }
+}
+
+/// Solve the perturbed problem outright, two orders tighter than the
+/// base solve, and check it against the closed form so a wrong oracle
+/// cannot certify a wrong walk.
+fn oracle(b: f64) -> Vec<f64> {
+    let opts = QpOptions {
+        tol: 1e-11,
+        ..Default::default()
+    };
+    let sol = solve_qp_ipm(&kinked_qp(b), &opts, backend);
+    assert_eq!(sol.status, QpStatus::Optimal, "the oracle must converge");
+    let want = closed_form(b);
+    for i in 0..2 {
+        assert!(
+            (sol.x[i] - want[i]).abs() < 1e-6,
+            "the oracle disagrees with the closed form at b={b}: {:?} vs {want:?}",
+            sol.x,
+        );
+    }
+    sol.x
+}
+
+fn base_sens(b: f64) -> (QpSensitivity, Vec<f64>) {
+    let prob = kinked_qp(b);
+    let opts = QpOptions::default();
+    let sol = solve_qp_ipm(&prob, &opts, backend);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    let x = sol.x.clone();
+    match QpSensitivity::build(&prob, &sol, &opts, 1e-7, backend) {
+        Ok(s) => (s, x),
+        Err(e) => panic!("the fixture must build a sensitivity, got {e:?}"),
+    }
+}
+
+/// Bases in the **pinned** regime: `z_ub` above `QpSensitivity`'s
+/// activity threshold. Chosen by measurement, not by formula -- the
+/// slack floors at the base solve's own convergence below `1e-3`.
+const PINNED_DELTAS: [f64; 5] = [1e-2, 1e-3, 1e-4, 1e-5, 1e-6];
+
+/// Bases in the **free** regime, where the reach scan owns the bound.
+const FREE_DELTAS: [f64; 4] = [0.15, 0.12, 0.1, 0.08];
+
+/// The step, at each base: large enough that truth is past the kink.
+const DP: f64 = 0.2;
+
+/// The threshold handed to `QpSensitivity::build` throughout this file,
+/// and the thing that separates the two regimes.
+const ACTIVITY_TOL: f64 = 1e-7;
+
+fn slack_and_z(b: f64) -> (f64, f64) {
+    let sol = solve_qp_ipm(&kinked_qp(b), &QpOptions::default(), backend);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    (UB0 - sol.x[0], sol.z_ub[0])
+}
+
+/// The regimes are real and the grids land in them. Without this every
+/// test below could be measuring the same regime twice.
+#[test]
+fn the_two_grids_straddle_the_activity_threshold() {
+    for delta in PINNED_DELTAS {
+        let (slack, z) = slack_and_z(KINK - delta);
+        assert!(
+            z > ACTIVITY_TOL,
+            "delta={delta} was meant to be in the pinned regime but \
+             z_ub = {z:e} is below the {ACTIVITY_TOL:e} threshold",
+        );
+        assert!(slack > 0.0, "delta={delta}: base must be inside the box");
+    }
+    for delta in FREE_DELTAS {
+        let (_, z) = slack_and_z(KINK - delta);
+        assert!(
+            z < ACTIVITY_TOL,
+            "delta={delta} was meant to be in the free regime but \
+             z_ub = {z:e} is at or above the {ACTIVITY_TOL:e} threshold",
+        );
+    }
+}
+
+/// The pinned regime pins: the variable does not move, so the answer
+/// cannot leave the box, so gh#928's repair has nothing to do here.
+///
+/// The second assertion is the one that matters. It pins the *size* of
+/// what pinning costs -- exactly the base slack -- so that a change to
+/// a barrier-style sigma on this arm shows up as this test failing
+/// rather than as a quiet loss of accuracy nobody measured.
+#[test]
+fn an_active_bound_is_pinned_and_the_step_is_short_by_the_base_slack() {
+    for delta in PINNED_DELTAS {
+        let b = KINK - delta;
+        let (slack, _) = slack_and_z(b);
+        let (mut sens, base) = base_sens(b);
+        let (dx, segs) = sens
+            .parametric_step_path(&[0], &[DP], 64)
+            .expect("parametric_step_path");
+        assert!(
+            dx[0].abs() < 1e-12,
+            "delta={delta}: an active bound on this arm is pinned, so dx0 \
+             must be zero; got {:e}. A nonzero value means the arm now \
+             damps rather than pins, and gh#928's hazard applies here \
+             -- wire `weak_rows` up before relaxing this.",
+            dx[0],
+        );
+        assert_eq!(
+            segs.len(),
+            0,
+            "delta={delta}: a pinned bound is not reached"
+        );
+
+        let truth = oracle(b + DP);
+        let err = (0..2)
+            .map(|i| (base[i] + dx[i] - truth[i]).abs())
+            .fold(0.0, f64::max);
+        assert!(
+            (err / slack - 1.0).abs() < 1e-3,
+            "delta={delta}: the pinned step should be short by exactly the \
+             base slack; err {err:e} against slack {slack:e} (ratio {})",
+            err / slack,
+        );
+    }
+}
+
+/// The free regime: the reach scan catches the crossing, and the walk
+/// is exact where the plain step overshoots.
+#[test]
+fn a_free_bound_that_the_step_presses_into_is_reached_and_held() {
+    for delta in FREE_DELTAS {
+        let b = KINK - delta;
+        let truth = oracle(b + DP);
+        let (mut sens, base) = base_sens(b);
+
+        let plain = sens.parametric_step(&[0], &[DP]);
+        assert!(
+            base[0] + plain[0] > UB0 + 1e-3,
+            "delta={delta}: the plain step must overshoot the bound, or the \
+             walk has nothing to fix; got {}",
+            base[0] + plain[0],
+        );
+
+        let (dx, segs) = sens
+            .parametric_step_path(&[0], &[DP], 64)
+            .expect("parametric_step_path");
+        let got = [base[0] + dx[0], base[1] + dx[1]];
+        assert_eq!(
+            segs.len(),
+            1,
+            "delta={delta}: crossing the kink is one breakpoint, got {segs:?}",
+        );
+        let err = (0..2)
+            .map(|i| (got[i] - truth[i]).abs())
+            .fold(0.0, f64::max);
+        assert!(
+            err < 1e-6,
+            "delta={delta}: walk {got:?} vs re-solve {truth:?}, off by {err:e}",
+        );
+    }
+}
+
+/// Across both regimes, the promise the repair exists to keep.
+#[test]
+fn no_convex_walk_ends_outside_the_box() {
+    for delta in PINNED_DELTAS.iter().chain(FREE_DELTAS.iter()) {
+        let b = KINK - delta;
+        let (mut sens, base) = base_sens(b);
+        let (dx, segs) = sens
+            .parametric_step_path(&[0], &[DP], 64)
+            .expect("parametric_step_path");
+        let x0 = base[0] + dx[0];
+        assert!(
+            x0 <= UB0 + 1e-9,
+            "delta={delta}: the walk returned x0 = {x0} against ub {UB0} \
+             (over by {:e}, {} segments)",
+            x0 - UB0,
+            segs.len(),
+        );
+    }
+}
+
+/// Stepping away from the bound must still reach the re-solve. The
+/// segment here is a *release* -- the base-active multiplier reaching
+/// zero almost immediately -- not a reach, and asserting zero segments
+/// (the first draft of this test) was simply wrong about which event
+/// the walk records.
+#[test]
+fn stepping_away_from_the_bound_reaches_the_resolve() {
+    let b = KINK - 1e-5;
+    let truth = oracle(b - DP);
+    let (mut sens, base) = base_sens(b);
+    let (dx, segs) = sens
+        .parametric_step_path(&[0], &[-DP], 64)
+        .expect("parametric_step_path");
+    let got = [base[0] + dx[0], base[1] + dx[1]];
+    let err = (0..2)
+        .map(|i| (got[i] - truth[i]).abs())
+        .fold(0.0, f64::max);
+    assert!(
+        err < 1e-6,
+        "stepping away: walk {got:?} vs re-solve {truth:?}, off by {err:e} \
+         over {} segments",
+        segs.len(),
+    );
+    assert!(
+        segs.len() <= 1,
+        "at most one event stepping away from a single bound, got {segs:?}",
+    );
+}

--- a/crates/pounce-convex/tests/issue_929_row_limit_on_the_convex_arm.rs
+++ b/crates/pounce-convex/tests/issue_929_row_limit_on_the_convex_arm.rs
@@ -1,0 +1,633 @@
+//! A limit written as a **constraint row**, on the convex arm (gh#929).
+//!
+//! # The gap
+//!
+//! `boundcheck`'s walk decides everything in *primal KKT rows*: `lo`/`hi`
+//! and `x_curr` index the primal prefix of the compound vector, and a
+//! `BoundRow` ties a multiplier row to the primal row it constrains. On the
+//! NLP arm every constraint has such a row — `dⱼ(x) = sⱼ` puts the
+//! constraint's own value in the `s` block — which is what
+//! `pounce-sensitivity/tests/issue_928_a_limit_written_as_a_row.rs` exploits.
+//!
+//! The convex active-set KKT has no `s` block:
+//!
+//! ```text
+//! [ H   Aᵀ  B_aᵀ ] [ dx ]
+//! [ A   0   0    ] [ dy ]
+//! [ B_a 0   0    ] [ dz ]
+//! ```
+//!
+//! An **inactive** `Gⱼx ≤ hⱼ` appears nowhere at all, so a step that drives
+//! it past its limit is not a breakpoint the walk can see. An **active** one
+//! has a multiplier row but no primal coordinate, so it could not be reported
+//! as a `BoundRow` either, and a perturbation that drives its multiplier
+//! negative went on holding a row the solution had left. Both halves are
+//! measured below, on the same fixture, against a re-solve.
+//!
+//! # The fix, and why it costs no factorization
+//!
+//! `pounce_sens_core::rowlimit::RowLimitView` adjoins `t = G_w x` through a
+//! multiplier, immediately after the `x` block so it lands inside the primal
+//! prefix the walk indexes. The adjoined block is triangular:
+//! `dmu = r_t`, one base back-solve on `r_x + G_wᵀ r_t`, then
+//! `dt = G_w dx + r_mu`. The base factor is untouched. Releasing an active
+//! row is still the base's own row neutralization — generalized here from one
+//! `±1` coupling to a whole `G` row, which is why the fixture's row has **two**
+//! nonzeros rather than one.
+//!
+//! # The fixture
+//!
+//! ```text
+//! min ½‖x‖²   s.t.  x₀+x₁+x₂+x₃ = b,   x₀ + x₂ ≤ 1,   x₁ ≤ 0.8
+//! ```
+//!
+//! One equality (the parameter), one **row** limit, one **variable bound** —
+//! so every test here is simultaneously a regression guard that wrapping the
+//! backsolver did not take variable-bound handling away. In closed form:
+//!
+//! ```text
+//! b ≤ 2.0        x = (b/4, b/4, b/4, b/4)
+//! 2.0 ≤ b ≤ 2.6  x = (0.5, (b−1)/2, 0.5, (b−1)/2)
+//! b ≥ 2.6        x = (0.5, 0.8, 0.5, b−1.8)
+//! ```
+//!
+//! The row binds at `b = 2.0` and the bound at `b = 2.6`, in that order going
+//! up and in the reverse order coming down, so a single perturbation exercises
+//! reach-a-row, reach-a-bound, release-a-row and release-a-bound.
+//!
+//! # What was measured
+//!
+//! | direction | before | after | truth |
+//! |---|---|---|---|
+//! | `b: 0 → 4` | `x₀+x₂ = 2.133`, **1.133 past the limit** | `x₀+x₂ = 1.000` | 1.0 |
+//! | `b: 4 → 0` | `(0.5, −0.5, 0.5, −0.5)`, row still pinned | `(0, 0, 0, 0)` | `(0,0,0,0)` |
+//! | `b: 2 → 1` | `(0.5, 2.0e-5, 0.5, 2.0e-5)` | `(0.25, 0.25, 0.25, 0.25)` | `(0.25,…)` |
+//!
+//! The third row is a **different branch**: there the row is in the active set
+//! with a multiplier of `4.1e-5`, so the release happens at fraction `8.2e-5`
+//! rather than in the middle of the walk. Per the branch rule in CLAUDE.md, a
+//! fixture that only ever released a healthy multiplier would say nothing
+//! about it.
+//!
+//! # Mutation table
+//!
+//! Every row was **run**, not predicted, and the right-hand column is the
+//! test list the run printed. Two of them go red only in
+//! `pounce-sens-core`'s own unit tests, marked `[core]`: `r_mu` and the
+//! observer *ordering* are both unreachable from this arm — `lift_rhs`
+//! zeroes the `mu` block and this fixture has a single watched row, so
+//! every ordering of one observer is the same ordering. That is the branch
+//! rule again, and it is why `rowlimit.rs` carries a two-row unit fixture
+//! of its own rather than leaning on this file.
+//!
+//! | mutation | tests that go red |
+//! |---|---|
+//! | `primal_box` stops appending the observers, so they fall outside the walk's primal prefix — the effect adjoining them at the *end* of the compound vector would have | `a_row_the_step_would_cross_stops_the_walk`, `an_active_row_whose_multiplier_turns_is_released`, `a_barely_active_row_is_released_at_once`, `the_variable_bound_is_still_released_through_the_view` |
+//! | observer box sides swapped (`limit` as the lower bound) | six of the twelve, including `the_observers_are_inert_when_no_limit_is_reached` — the walk stops at fraction ≈ 0 on a step that crosses nothing |
+//! | `base_value` set to `0` rather than `Gⱼ·x` | `a_barely_active_row_is_released_at_once` |
+//! | `RowLimitView::fold` drops the `G_wᵀ r_t` fold | `a_row_the_step_would_cross_stops_the_walk`, `releasing_a_row_moves_its_force_onto_the_observer` |
+//! | `RowLimitView::unfold` drops `r_mu` from `dt` | `the_triangular_solve_is_the_augmented_system` `[core]` |
+//! | the observers are numbered in reverse, so an active row watches its neighbour | `each_active_row_keeps_its_own_observer` `[core]` |
+//! | `WatchedRow::active` left `None` for active rows | `an_active_row_whose_multiplier_turns_is_released`, `a_barely_active_row_is_released_at_once`, `the_variable_bound_is_still_released_through_the_view` |
+//! | `release_slots` neutralizes only the first coupling of a row | those three plus `releasing_a_row_moves_its_force_onto_the_observer` — the fixture's row has two nonzeros, so a half-neutralized row is still coupled to `x₂` |
+//! | `solve_released_inner`'s shift refuses a non-bound row instead of skipping it | `releasing_a_row_moves_its_force_onto_the_observer` |
+//! | base bound rows dropped from `RowLimitView::bound_rows` | `the_variable_bound_is_still_released_through_the_view`, `an_active_row_whose_multiplier_turns_is_released` |
+//! | base entries dropped from `RowLimitView::lift_multipliers` | the same two — the walk releases a row only when it is in *both* lists, which is why one type owns both |
+//! | the augmentation is applied on the conic path too | `a_conic_model_keeps_the_unaugmented_walk`, on its `boundary-far` leg |
+//!
+//! # What this file is NOT evidence about
+//!
+//! - **Scaling.** Unscaled, like every convex sensitivity test.
+//!   `RowLimitView::new` refuses a base reporting a `natural_units_factor`
+//!   rather than guessing an entry for the observer rows, and no convex base
+//!   reports one, so that refusal is unexercised here.
+//! - **The conic arm's own row limits.** `a_conic_model_keeps_the_unaugmented_walk`
+//!   pins that the augmentation is *skipped* there; it says nothing about what
+//!   watching a cone face would mean. `convex_sens_release.rs` owns release on
+//!   that arm. The guard is deliberately all-or-nothing: a **mixed partition**
+//!   whose orthant rows are ordinary `Gⱼx ≤ hⱼ` loses its observers too,
+//!   because one cone block anywhere sets `cone_kinds`. That is a known
+//!   conservative choice, not a covered case — no fixture here has a mixed
+//!   partition.
+//! - **Magnitude.** Four variables and one row. The largest convex fixture in
+//!   the corpus is 534 columns and `benchmarks/qp` reaches 93 263; the
+//!   observer block costs `O(nnz(G))` per back-solve and nothing here bounds
+//!   that at scale.
+//! - **Two-sided rows.** `WatchedRow` is one-sided on purpose; a range row is
+//!   two watched rows and no fixture here has one.
+//! - **`parametric_step_bounded` on this arm**, which is *not* augmented and
+//!   still carries the whole defect. Measured on this file's own fixture, at
+//!   `activity_tol = 1e-7` and `bound_eps = 1e-8`: walking `b: 0 -> 4` it
+//!   returns `x0 + x2 = 2.1333`, **1.1333 past the stated cap of 1.0**, and
+//!   coming back `b: 4 -> 0` it leaves `(0.5, -0.5, 0.5, -0.5)` with the row
+//!   still pinned at `1.0` where the truth is the origin -- the same two
+//!   numbers the module docs quote as the walk's *pre*-gh#929 behaviour.
+//!   Wiring the view in is not the same edit as it was for the walk: this
+//!   entry point returns `refine_step_onto_bounds`'s mixed list of released
+//!   multiplier rows and pinned primal rows, so augmenting it shifts the
+//!   meaning of half that list and needs an API decision plus a fixture of
+//!   its own. The NLP arm has no such gap, because gh#928 widened its box
+//!   globally rather than through a view.
+//! - **Rows with no `x` coefficients**, empty `G`, or `m_ineq = 0` — the
+//!   augmentation is skipped for the last of these and the rest are unbuilt.
+
+use pounce_convex::QpOptions;
+use pounce_convex::cones::ConeSpec;
+use pounce_convex::ipm::{solve_qp_ipm, solve_socp_ipm};
+use pounce_convex::qp::{QpProblem, QpSolution, QpStatus, Triplet};
+use pounce_convex::sensitivity::{PathTarget, QpSensitivity};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+use pounce_sens_core::backsolver::SensBacksolver;
+use pounce_sens_core::boundcheck::{BoundMultiplier, PathSegment, step_along_path};
+use pounce_sens_core::rowlimit::{RowLimitView, WatchedRow};
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn tri(row: usize, col: usize, val: f64) -> Triplet {
+    Triplet { row, col, val }
+}
+
+/// The row's limit, and the variable bound's.
+const H0: f64 = 1.0;
+const UB1: f64 = 0.8;
+/// Activity threshold handed to `QpSensitivity::build`.
+const ACTIVITY_TOL: f64 = 1e-7;
+/// The same floor `parametric_step_path` walks with.
+const EPS: f64 = 1e-8;
+
+fn model(b: f64) -> QpProblem {
+    QpProblem {
+        n: 4,
+        p_lower: (0..4).map(|i| tri(i, i, 1.0)).collect(),
+        c: vec![0.0; 4],
+        a: (0..4).map(|j| tri(0, j, 1.0)).collect(),
+        b: vec![b],
+        // Two nonzeros on purpose: a one-nonzero row cannot tell a release
+        // that neutralizes the whole row from one that neutralizes its first
+        // entry.
+        g: vec![tri(0, 0, 1.0), tri(0, 2, 1.0)],
+        h: vec![H0],
+        lb: vec![f64::NEG_INFINITY; 4],
+        ub: vec![f64::INFINITY, UB1, f64::INFINITY, f64::INFINITY],
+    }
+}
+
+fn closed_form(b: f64) -> [f64; 4] {
+    if b <= 2.0 {
+        [b / 4.0; 4]
+    } else if b <= 2.6 {
+        [0.5, (b - 1.0) / 2.0, 0.5, (b - 1.0) / 2.0]
+    } else {
+        [0.5, UB1, 0.5, b - 1.8]
+    }
+}
+
+fn solved(b: f64, tol: f64) -> QpSolution {
+    let opts = QpOptions {
+        tol,
+        ..Default::default()
+    };
+    let sol = solve_qp_ipm(&model(b), &opts, backend);
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "the fixture must solve at b={b}"
+    );
+    sol
+}
+
+/// The perturbed problem solved outright, two orders tighter than the base
+/// solve, and cross-checked against the closed form so a wrong oracle cannot
+/// certify a wrong walk.
+fn oracle(b: f64) -> Vec<f64> {
+    let sol = solved(b, 1e-13);
+    let want = closed_form(b);
+    for j in 0..4 {
+        assert!(
+            (sol.x[j] - want[j]).abs() < 1e-8,
+            "the oracle disagrees with the closed form at b={b}: {:?} vs {want:?}",
+            sol.x,
+        );
+    }
+    sol.x.clone()
+}
+
+/// The walk, and the point it lands on.
+fn walk(b0: f64, delta: f64) -> (Vec<f64>, Vec<PathSegment>, QpSensitivity) {
+    let prob = model(b0);
+    let sol = solved(b0, QpOptions::default().tol);
+    let mut sens = QpSensitivity::build(&prob, &sol, &QpOptions::default(), ACTIVITY_TOL, backend)
+        .expect("the fixture must build a sensitivity");
+    let (dx, segments) = sens
+        .parametric_step_path(&[0], &[delta], 64)
+        .expect("the walk must answer");
+    let x = sol.x.iter().zip(&dx).map(|(a, d)| a + d).collect();
+    (x, segments, sens)
+}
+
+/// The same walk with the observers taken away: `step_along_path` driven
+/// straight against `QpKktBacksolver`, which is exactly what
+/// `parametric_step_path` did before gh#929. This is the "before" column of
+/// the table in the module docs, recomputed rather than quoted.
+fn walk_unaugmented(b0: f64, delta: f64) -> Vec<f64> {
+    let prob = model(b0);
+    let sol = solved(b0, QpOptions::default().tol);
+    let sens = QpSensitivity::build(&prob, &sol, &QpOptions::default(), ACTIVITY_TOL, backend)
+        .expect("the fixture must build a sensitivity");
+    let bs = sens.backsolver();
+    let mut rhs = vec![0.0; bs.dim()];
+    rhs[prob.n] = delta;
+    let lo: Vec<f64> = (0..prob.n).map(|j| prob.lb[j]).collect();
+    let hi: Vec<f64> = (0..prob.n).map(|j| prob.ub[j]).collect();
+    let mults: Vec<BoundMultiplier> = bs
+        .bound_rows()
+        .unwrap_or(&[])
+        .iter()
+        .map(|br| BoundMultiplier {
+            row: br.row,
+            base: if br.lower {
+                sol.z_lb[br.var_row]
+            } else {
+                sol.z_ub[br.var_row]
+            },
+        })
+        .collect();
+    let (dx, _) = step_along_path(&bs, &rhs, &sol.x, &lo, &hi, &mults, 64, &[], &[], &[], EPS)
+        .expect("the unaugmented walk answers too — wrongly, which is the point");
+    sol.x.iter().zip(&dx).map(|(a, d)| a + d).collect()
+}
+
+fn row_value(x: &[f64]) -> f64 {
+    x[0] + x[2]
+}
+
+fn max_err(got: &[f64], want: &[f64]) -> f64 {
+    got.iter()
+        .zip(want)
+        .fold(0.0f64, |a, (g, w)| a.max((g - w).abs()))
+}
+
+// ---------------------------------------------------------------------------
+
+/// Without this the fixture could be measuring a solver bug rather than a
+/// sensitivity one. Every `b` this file uses as an oracle target appears here.
+#[test]
+fn the_closed_form_and_the_solver_agree_at_every_oracle_target() {
+    for b in [0.0, 0.4, 1.0, 3.0, 4.0] {
+        let _ = oracle(b);
+    }
+}
+
+/// The two kinks — `b = 2.0` where the row binds and `b = 2.6` where the
+/// bound does — are **bases** here, never oracle targets, and they are where
+/// the interior-point method's own convergence is loosest: measured `8.7e-8`
+/// and `8.3e-8` at `tol = 1e-13`, against the `1e-8` every non-degenerate
+/// target clears. Quoting those numbers is the point — `8.7e-8` is also the
+/// accuracy floor of `a_barely_active_row_the_step_presses_into_stays`, which
+/// starts at `b = 2.0`.
+#[test]
+fn the_kink_bases_are_where_the_solver_is_loosest() {
+    for b in [2.0, 2.6] {
+        let sol = solved(b, 1e-13);
+        let err = max_err(&sol.x, &closed_form(b));
+        assert!(err < 1e-6, "the kink solve at b={b} is off by {err:e}");
+        assert!(
+            err > 1e-9,
+            "if the kink at b={b} now solves as tightly as the rest, this test \
+             has stopped describing anything: err = {err:e}",
+        );
+    }
+}
+
+/// The reach half: a step that would take an **inactive** row past its limit
+/// stops there instead.
+#[test]
+fn a_row_the_step_would_cross_stops_the_walk() {
+    let (x, segments, sens) = walk(0.0, 4.0);
+    let want = oracle(4.0);
+    assert!(
+        max_err(&x, &want) < 1e-9,
+        "walk {x:?} does not reproduce the re-solve {want:?}",
+    );
+    assert!(
+        row_value(&x) <= H0 + 1e-9,
+        "the answer is {:.6} past the row limit",
+        row_value(&x) - H0,
+    );
+
+    // Both breakpoints, in the order the closed form puts them: the row at
+    // b = 2.0 and the bound at b = 2.6.
+    let targets: Vec<(PathTarget, f64, bool)> = segments
+        .iter()
+        .map(|s| (sens.path_segment_target(s), s.at, s.pinned))
+        .collect();
+    assert_eq!(
+        targets.len(),
+        2,
+        "expected two breakpoints, got {targets:?}"
+    );
+    assert_eq!(targets[0].0, PathTarget::InequalityRow(0), "{targets:?}");
+    assert!((targets[0].1 - 0.5).abs() < 1e-6, "{targets:?}");
+    assert!(targets[0].2, "the row is reached and held: {targets:?}");
+    assert_eq!(targets[1].0, PathTarget::Variable(1), "{targets:?}");
+    assert!((targets[1].1 - 0.65).abs() < 1e-6, "{targets:?}");
+    assert!(targets[1].2, "the bound is reached and held: {targets:?}");
+}
+
+/// The same step without observers, which is what the arm did before. Kept as
+/// a live measurement so the size of the defect is a number this file
+/// computes rather than a claim it repeats.
+#[test]
+fn the_unaugmented_walk_runs_past_the_row() {
+    let x = walk_unaugmented(0.0, 4.0);
+    let over = row_value(&x) - H0;
+    assert!(
+        over > 1.0,
+        "the pre-gh#929 walk was supposed to overshoot the row limit by ~1.13, \
+         got {over:e} from {x:?}",
+    );
+    assert!((over - 1.1333333).abs() < 1e-5, "measured overshoot {over}");
+    // And it is not a small perturbation of the truth either.
+    assert!(max_err(&x, &oracle(4.0)) > 1.0, "{x:?}");
+}
+
+/// The release half: an **active** row whose multiplier turns negative is let
+/// go, and the walk finishes on the re-solve.
+#[test]
+fn an_active_row_whose_multiplier_turns_is_released() {
+    let (x, segments, sens) = walk(4.0, -4.0);
+    let want = oracle(0.0);
+    assert!(
+        max_err(&x, &want) < 1e-9,
+        "walk {x:?} does not reproduce the re-solve {want:?}",
+    );
+    let targets: Vec<(PathTarget, f64, bool)> = segments
+        .iter()
+        .map(|s| (sens.path_segment_target(s), s.at, s.pinned))
+        .collect();
+    assert_eq!(
+        targets.len(),
+        2,
+        "expected two breakpoints, got {targets:?}"
+    );
+    // Coming down, the bound goes first (b = 2.6) and the row second
+    // (b = 2.0) — the reverse of the ascending order.
+    assert_eq!(targets[0].0, PathTarget::Variable(1), "{targets:?}");
+    assert!((targets[0].1 - 0.35).abs() < 1e-6, "{targets:?}");
+    assert!(!targets[0].2, "the bound is released: {targets:?}");
+    assert_eq!(targets[1].0, PathTarget::InequalityRow(0), "{targets:?}");
+    assert!((targets[1].1 - 0.5).abs() < 1e-6, "{targets:?}");
+    assert!(!targets[1].2, "the row is released: {targets:?}");
+}
+
+/// The bound release is the same test's other half, named so the mutation
+/// table can point at it: strip the base's own rows out of the wrapper and
+/// `x₁` never leaves `0.8`.
+#[test]
+fn the_variable_bound_is_still_released_through_the_view() {
+    let (x, _, _) = walk(4.0, -4.0);
+    assert!(
+        x[1].abs() < 1e-9,
+        "x₁ should have come off its 0.8 bound and landed at 0, got {}",
+        x[1],
+    );
+}
+
+/// Before the fix the same step kept the row pinned for the whole walk.
+#[test]
+fn the_unaugmented_walk_holds_a_row_the_solution_has_left() {
+    let x = walk_unaugmented(4.0, -4.0);
+    assert!(
+        (row_value(&x) - H0).abs() < 1e-8,
+        "the pre-gh#929 walk was supposed to hold the row at its limit, \
+         got {:.9} from {x:?}",
+        row_value(&x),
+    );
+    assert!(
+        max_err(&x, &oracle(0.0)) > 0.4,
+        "and to be far from the truth: {x:?}",
+    );
+}
+
+/// A **different branch** of the release rule: the row is in the active set
+/// but its multiplier is `4.1e-5`, so the release is immediate rather than
+/// mid-walk. A fixture that only ever released a healthy multiplier would be
+/// silent about this one.
+#[test]
+fn a_barely_active_row_is_released_at_once() {
+    let base = solved(2.0, QpOptions::default().tol);
+    let z = base.z[0];
+    assert!(
+        z > ACTIVITY_TOL && z < 1e-3,
+        "this test needs a barely-active row; z = {z:e}",
+    );
+
+    let (x, segments, sens) = walk(2.0, -1.0);
+    let want = oracle(1.0);
+    assert!(
+        max_err(&x, &want) < 1e-8,
+        "walk {x:?} does not reproduce the re-solve {want:?}",
+    );
+    assert_eq!(segments.len(), 1, "{segments:?}");
+    assert_eq!(
+        sens.path_segment_target(&segments[0]),
+        PathTarget::InequalityRow(0),
+    );
+    assert!(!segments[0].pinned, "{segments:?}");
+    assert!(
+        segments[0].at < 1e-3,
+        "the release should be essentially immediate, got {}",
+        segments[0].at,
+    );
+
+    // Before the fix: the row stayed pinned and the whole perturbation went
+    // into the two free variables.
+    let before = walk_unaugmented(2.0, -1.0);
+    assert!(
+        max_err(&before, &want) > 0.2,
+        "the pre-gh#929 answer was supposed to be far off: {before:?}",
+    );
+}
+
+/// The other side of the same base point: the row is active and truth keeps
+/// it active, so the observers must not invent a breakpoint.
+#[test]
+fn a_barely_active_row_the_step_presses_into_stays() {
+    let (x, segments, sens) = walk(2.0, 1.0);
+    let want = oracle(3.0);
+    // The base solve sits 4.1e-5 inside the row, and a pinned row freezes the
+    // answer at the base point rather than at the limit — the cost of pinning
+    // that `issue_928_convex_path_leaves_the_box.rs` measures. So the
+    // tolerance here is the base solve's own distance from the limit, not the
+    // walk's accuracy.
+    assert!(max_err(&x, &want) < 1e-3, "walk {x:?} vs {want:?}");
+    assert!(
+        row_value(&x) <= H0 + 1e-9,
+        "the answer must not leave the row: {:.9}",
+        row_value(&x),
+    );
+    let targets: Vec<PathTarget> = segments
+        .iter()
+        .map(|s| sens.path_segment_target(s))
+        .collect();
+    assert_eq!(targets, vec![PathTarget::Variable(1)], "{segments:?}");
+}
+
+/// A walk that crosses nothing must return the answer it returned before the
+/// observers existed — bit for bit, because the adjoined block is exactly
+/// triangular and contributes nothing when `r_t` and `r_mu` are zero.
+#[test]
+fn the_observers_are_inert_when_no_limit_is_reached() {
+    let (x, segments, _) = walk(0.0, 0.4);
+    assert!(segments.is_empty(), "{segments:?}");
+    let before = walk_unaugmented(0.0, 0.4);
+    assert_eq!(
+        x, before,
+        "the observer block changed an answer it does not touch",
+    );
+    assert!(max_err(&x, &oracle(0.4)) < 1e-9, "{x:?}");
+}
+
+/// The conic path keeps the unaugmented walk, on purpose: there `active_rows`
+/// is the cone's normal at the boundary point — or the whole block at an apex
+/// — not a row of `G`, and `active_ineq` names the rows a block *contributed*
+/// rather than the active object. An observer on `Gⱼx ≤ hⱼ` would be watching
+/// a limit the solve is not enforcing that way, and would read a multiplier
+/// row belonging to something else.
+///
+/// The fixtures are `convex_soc_sensitivity.rs`'s two, both with closed-form
+/// derivatives. The **apex** is the one that catches the mutation: there every
+/// `G` row sits exactly at its `h = 0`, so observers would be born at their
+/// limits and manufacture breakpoints out of a step that has none. On the
+/// boundary fixture the rows are slack and the augmentation would be inert —
+/// which is exactly why one conic fixture is not enough.
+#[test]
+fn a_conic_model_keeps_the_unaugmented_walk() {
+    let opts = QpOptions {
+        tol: 1e-11,
+        ..Default::default()
+    };
+    let cones = [ConeSpec::SecondOrder(3)];
+    let db = 1e-3;
+
+    // Boundary: s = (t, x₀, x₁) = h − Gx with h = 0; dx₀/db = dx₁/db = ½.
+    let boundary = QpProblem {
+        n: 3,
+        p_lower: vec![tri(0, 0, 1.0), tri(1, 1, 1.0), tri(2, 2, 1.0)],
+        c: vec![-1.0, -0.2, 0.0],
+        a: vec![tri(0, 0, 1.0), tri(0, 1, 1.0)],
+        b: vec![1.0],
+        g: vec![tri(0, 2, -1.0), tri(1, 0, -1.0), tri(2, 1, -1.0)],
+        h: vec![0.0, 0.0, 0.0],
+        lb: vec![],
+        ub: vec![],
+    };
+    // Apex: the cost on t crushes the block to its tip, pinning x₀ = x₁ = t = 0,
+    // so the equality hands the whole perturbation to x₂: dx/db = (0,0,1,0).
+    let apex = QpProblem {
+        n: 4,
+        p_lower: vec![tri(0, 0, 1.0), tri(1, 1, 1.0), tri(2, 2, 1.0)],
+        c: vec![0.0, 0.0, -1.0, 5.0],
+        a: vec![tri(0, 0, 1.0), tri(0, 2, 1.0)],
+        b: vec![1.0],
+        g: vec![tri(0, 3, -1.0), tri(1, 0, -1.0), tri(2, 1, -1.0)],
+        h: vec![0.0, 0.0, 0.0],
+        lb: vec![],
+        ub: vec![],
+    };
+
+    for (name, prob, db, want) in [
+        ("boundary", boundary.clone(), db, vec![0.5, 0.5]),
+        // Far enough to drive x₁ (base 0.3) through zero. `-x₁ ≤ 0` is `G`
+        // row 2, and reading it as a limit is exactly the mistake: the cone
+        // constrains ‖(x₀,x₁)‖, not the sign of x₁, so an observer there
+        // manufactures a breakpoint at fraction 0.75 out of a step that has
+        // none.
+        ("boundary-far", boundary, -0.8, vec![0.5, 0.5]),
+        ("apex", apex, db, vec![0.0, 0.0, 1.0, 0.0]),
+    ] {
+        let sol = solve_socp_ipm(&prob, &cones, &opts, backend);
+        assert_eq!(sol.status, QpStatus::Optimal, "{name}");
+        let mut sens =
+            QpSensitivity::build_conic(&prob, &cones, &sol, &opts, ACTIVITY_TOL, backend)
+                .unwrap_or_else(|e| panic!("{name} must build a sensitivity, got {e:?}"));
+        let (dx, segments) = sens
+            .parametric_step_path(&[0], &[db], 64)
+            .unwrap_or_else(|e| panic!("the {name} walk must still answer, got {e:?}"));
+        assert!(
+            segments.is_empty(),
+            "{name}: the conic walk must record no breakpoints, got {segments:?}",
+        );
+        for (j, w) in want.iter().enumerate() {
+            assert!(
+                (dx[j] / db - w).abs() < 1e-6,
+                "{name}: dx{j}/db = {}, want {w}",
+                dx[j] / db,
+            );
+        }
+    }
+}
+
+/// The release **shift** — `solve_released_step`, the fix-relax half — routed
+/// through the observer.
+///
+/// The walk never reaches it: along a path a multiplier is already zero where
+/// it is released, so there is no force to move. `RowLimitView` still has to
+/// get it right, because the shift is what makes a *one-shot* release
+/// meaningful, and it is the one place where the base backsolver has to
+/// tolerate a released row that is not one of its own `BoundRow`s.
+///
+/// The check is a number, not a restatement of the code. At `b = 4` the base
+/// point is `(0.5, 0.8, 0.5, 2.2)` with the row active at `z = 1.7`. Release
+/// the row, keep the bound pinned, perturb nothing: the answer is the optimum
+/// of `min ½‖x‖²` subject to `Σx = 4` and `x₁ = 0.8`, which is
+/// `(16/15, 0.8, 16/15, 16/15)`. So `dx = (0.5667, 0, 0.5667, −1.1333)`.
+#[test]
+fn releasing_a_row_moves_its_force_onto_the_observer() {
+    let prob = model(4.0);
+    let sol = solved(4.0, QpOptions::default().tol);
+    let sens = QpSensitivity::build(&prob, &sol, &QpOptions::default(), ACTIVITY_TOL, backend)
+        .expect("the fixture must build a sensitivity");
+    let bs = sens.backsolver();
+    let n = prob.n;
+    // The k-th active inequality row's multiplier sits at `n + m_eq + k`, and
+    // row 0 is the only active one here.
+    let mult_row = n + prob.b.len();
+    let view = RowLimitView::new(
+        bs,
+        n,
+        vec![WatchedRow {
+            coefficients: vec![(0, 1.0), (2, 1.0)],
+            limit: H0,
+            base_value: sol.x[0] + sol.x[2],
+            active: Some((mult_row, sol.z[0])),
+        }],
+    )
+    .expect("the view must build");
+
+    let released = vec![view.from_base(mult_row).expect("the row lifts")];
+    let rhs = vec![0.0; view.dim()];
+    let mut lhs = vec![0.0; view.dim()];
+    assert!(
+        view.solve_released_step(&released, &rhs, &mut lhs),
+        "the released step must answer",
+    );
+    let want = [16.0 / 15.0 - 0.5, 0.0, 16.0 / 15.0 - 0.5, 16.0 / 15.0 - 2.2];
+    for j in 0..n {
+        assert!(
+            (lhs[j] - want[j]).abs() < 1e-6,
+            "dx = {:?}, want {want:?}",
+            &lhs[..n],
+        );
+    }
+    // And the observer reports the row leaving its limit by the same amount.
+    let dt = lhs[n];
+    assert!(
+        (dt - (want[0] + want[2])).abs() < 1e-6,
+        "the observer read {dt}, but dx moved the row by {}",
+        want[0] + want[2],
+    );
+}

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -291,10 +291,19 @@ impl PySolver {
     ///
     /// * a row below `dims[0]` is a variable pinned at its bound, and
     ///   the row is its var-x index;
+    /// * a row in `[dims[0], dims[0] + dims[1])` is a **constraint's
+    ///   own limit** held -- a limit written as `g(x) <= cap` bounds
+    ///   the row's slack, not any variable, so the pin lands in the
+    ///   `s` block and subtracting `dims[0]` gives the inequality's
+    ///   position there (gh#928). Indexing a variable vector with it
+    ///   returns a neighbouring variable's answer, which is why the
+    ///   block has to be decided before the value is used;
     /// * a row at or above `dims[0] + dims[1] + dims[2] + dims[3]` is a
     ///   bound multiplier driven to zero, which releases that bound and
     ///   is the opposite action. Subtracting that offset gives its
-    ///   position in the `z_l` block, or in `z_u` past `dims[4]`.
+    ///   position in the `z_l` block, then `z_u`, `v_l`, `v_u` in
+    ///   turn past `dims[4]`, `dims[5]`, `dims[6]` -- the `v` halves
+    ///   being the release of a constraint's own limit.
     ///
     /// No other block appears. The list is empty when the plain step
     /// already respects every bound, and the step is then the plain
@@ -372,11 +381,22 @@ impl PySolver {
     ///
     /// `segments` is one tuple per breakpoint crossed, in the order
     /// crossed, as `(fraction, var_row, lower, pinned)`. `fraction` is
-    /// how far along the perturbation the change happened, `var_row`
-    /// is the variable's row in the factor's x block for every kind of
-    /// change, `lower` is `True` when the bound involved is the lower
-    /// one, and `pinned` is `True` for a variable reaching a bound and
-    /// `False` for a variable leaving one.
+    /// how far along the perturbation the change happened, `lower` is
+    /// `True` when the bound involved is the lower one, and `pinned`
+    /// is `True` for a quantity reaching a bound and `False` for one
+    /// leaving it.
+    ///
+    /// `var_row` names the bounded quantity as a **primal KKT row**,
+    /// the same for a hold and for a release, and the primal blocks
+    /// are `x` then `s`. So read it against `block_dims()`: below
+    /// `dims[0]` it is a variable's var-x index; at or above it, the
+    /// event is on a **constraint's own limit** -- a `g(x) <= cap`
+    /// bounds the row's slack rather than any variable -- and
+    /// `var_row - dims[0]` is that inequality's position in the `s`
+    /// block (gh#928). A consumer that indexes a variable-length
+    /// vector with `var_row` must check the block first; doing it by
+    /// value alone returns a neighbouring variable's answer, which is
+    /// the gh#450 hazard.
     ///
     /// `max_iter` caps the breakpoints crossed, and is in practice a
     /// budget on factorizations, since a pin is a back-solve against
@@ -494,6 +514,13 @@ impl PySolver {
     /// the caller (var-x rows the direction holds) instead of searched
     /// for, as `(dx, segments)`. Study surface for an externally
     /// solved eq. 14 QP.
+    ///
+    /// `held_var_rows` is var-x and stays var-x: this surface decides
+    /// the *directional* question, which is posed over variables. The
+    /// returned `segments` carry the wider domain the walk itself
+    /// uses -- see `parametric_step_path` for how to read `var_row`
+    /// against `block_dims()`, since a breakpoint here can still land
+    /// on a constraint's own limit.
     #[pyo3(signature = (pin_constraint_indices, deltas, held_var_rows, max_iter=16))]
     fn parametric_step_path_decided<'py>(
         &self,
@@ -747,6 +774,26 @@ impl PySolver {
         })?;
         let gs = validate_pins(&g_indices, s.m)?;
         let rows = s.inner.d_multiplier_rows(&gs).map_err(solver_error_to_py)?;
+        Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
+    }
+
+    /// Rows of the compound KKT vector holding each inequality's
+    /// **slack**, for the given 0-based constraint (`g`) indices;
+    /// `None` for a row that is not an inequality.
+    ///
+    /// The primal counterpart of `inequality_multiplier_rows`, and the
+    /// discriminator for a `parametric_step_path` segment whose
+    /// `var_row` is at or above `block_dims()[0]`: a limit written as
+    /// `g(x) <= cap` bounds this slack rather than any variable, so
+    /// the breakpoint carries an `s`-block row (gh#928). Indexing a
+    /// variable-length vector with it returns a neighbouring
+    /// variable's answer.
+    fn slack_rows(&self, g_indices: Vec<i64>) -> PyResult<Vec<Option<i64>>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("slack_rows: no converged factor (call solve() first)")
+        })?;
+        let gs = validate_pins(&g_indices, s.m)?;
+        let rows = s.inner.d_slack_rows(&gs).map_err(solver_error_to_py)?;
         Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
     }
 

--- a/crates/pounce-sens-core/src/backsolver.rs
+++ b/crates/pounce-sens-core/src/backsolver.rs
@@ -112,6 +112,40 @@ pub trait SensBacksolver {
         false
     }
 
+    /// [`Self::solve_released`] with each **primal** KKT row in
+    /// `pinned` carrying an extra diagonal stiff enough to hold that
+    /// coordinate in place.
+    ///
+    /// This is not the pin the walk applies -- that one is a Schur row
+    /// on top of the factored system, and it is exact. This is the
+    /// *operator* that pin is applied to, for the case where the
+    /// released system on its own has no inverse for a Schur
+    /// complement to be built from: releasing a bound takes its
+    /// `Sigma` off the diagonal, and on a model with no curvature two
+    /// released variables sharing a constraint are left with linearly
+    /// dependent stationarity rows (gh#930).
+    ///
+    /// Adding the diagonal back regularizes exactly those rows, and
+    /// costs nothing in accuracy, because the Schur pin then holds the
+    /// same coordinates at zero: `Eᵀw = 0` annihilates the term that
+    /// was added, so the pinned system solved is the released one
+    /// after all. The diagonal has to be *reachable* -- large enough
+    /// that the regularized operator is invertible, small enough that
+    /// the row's own couplings survive it, which is the gh#737
+    /// ceiling.
+    ///
+    /// `false` by default, which leaves the caller reporting the
+    /// Schur pin's failure.
+    fn solve_released_pinned(
+        &self,
+        _released: &[usize],
+        _pinned: &[usize],
+        _rhs: &[Number],
+        _lhs: &mut [Number],
+    ) -> bool {
+        false
+    }
+
     /// Whether [`Self::solve_released`] is implemented.
     fn supports_release(&self) -> bool {
         false

--- a/crates/pounce-sens-core/src/backsolver.rs
+++ b/crates/pounce-sens-core/src/backsolver.rs
@@ -119,15 +119,29 @@ pub trait SensBacksolver {
 }
 
 /// One bound-multiplier row of the compound KKT vector, resolved to
-/// the variable it constrains.
+/// the primal quantity it constrains.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BoundRow {
     /// Row of the compound KKT vector holding the multiplier.
     pub row: usize,
-    /// Var-x row of the variable that bound constrains.
+    /// **Primal KKT row** of the quantity that bound constrains: a
+    /// row of the `x` block for a variable bound (`z_l` / `z_u`), and
+    /// a row of the `s` block for a constraint's limit (`v_l` /
+    /// `v_u`), which bounds the slack rather than a variable.
+    ///
+    /// The field is named for the case it had when only variable
+    /// bounds were reported, and below `dims[0]` the two spaces
+    /// coincide, so a var-x reader that never sees a slack row is
+    /// still correct. That is not an accident to rely on quietly:
+    /// **a consumer that indexes a var-x-length vector with this must
+    /// first check `var_row < dims[0]`**, because a slack row's value
+    /// is a valid index into nothing. `Solver::weakly_active_bounds`
+    /// and `step_along_path`'s base-activity table both carry that
+    /// check explicitly.
     pub var_row: usize,
-    /// `true` for a lower bound (`z_l`), `false` for an upper (`z_u`).
-    /// The x row carries the two with opposite signs.
+    /// `true` for a lower bound (`z_l` / `v_l`), `false` for an upper
+    /// (`z_u` / `v_u`). The primal row carries the two with opposite
+    /// signs.
     pub lower: bool,
 }
 

--- a/crates/pounce-sens-core/src/boundcheck.rs
+++ b/crates/pounce-sens-core/src/boundcheck.rs
@@ -1147,6 +1147,15 @@ const NO_BOUND_HI: Number = 1e19;
 /// rows changed at its start stay barred from changing back.
 const PATH_MIN_SEGMENT: Number = 1e-12;
 
+/// How many times the walk may re-run after finding its own answer
+/// outside the box. Each pass adds at least one bound row to the
+/// watch list and costs a fresh walk, so this is a budget on
+/// factorizations; termination comes from the list growing, not
+/// from the cap. Simultaneous unheld bounds are what consume it,
+/// and a degenerate vertex of a few coordinates is the realistic
+/// case.
+const PATH_MAX_BOX_REPAIRS: usize = 8;
+
 /// One breakpoint the path stopped at.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PathSegment {
@@ -1248,6 +1257,7 @@ pub fn step_along_path<B>(
     forced_active: &[usize],
     initial_holds: &[(usize, bool)],
     weak_rows: &[usize],
+    eps: Number,
 ) -> Result<(Vec<Number>, Vec<PathSegment>), String>
 where
     B: crate::backsolver::SensBacksolver + Clone,
@@ -1333,6 +1343,197 @@ where
         .flatten()
         .filter_map(|slot| *slot)
         .collect();
+
+    // The walk owes its caller a point inside the box, and the reach
+    // scan above is the only thing that keeps that promise. A bound the
+    // factorization enforces only SOFTLY -- sigma of order one rather
+    // than order 1/mu -- is skipped by that scan as though it were
+    // held, and then holds nothing, so the direction carries the
+    // variable straight through it and no breakpoint is recorded
+    // (gh#852). `weak_rows` is the caller's list of exactly those
+    // bounds, and it is only ever as good as the activity classifier
+    // that built it: where the Hessian diagonal falls below the
+    // identification floor every bound classifies UNIDENTIFIED,
+    // `weakly_active_bounds` returns an empty list, and the scan skips
+    // a bound nothing is holding. That is not an exotic model -- it is
+    // every LP, and every model whose cost is linear in the coordinate
+    // that reaches the bound.
+    //
+    // So the walk does not rely on being told. It runs, compares its
+    // own answer against the box, and treats a base-active bound the
+    // answer CROSSED as proof that the factorization did not enforce
+    // it -- measured on the result rather than inferred from a
+    // curvature that, in this regime, is precisely what cannot be
+    // measured. Such a bound joins the watch list and the walk repeats
+    // with a breakpoint available there.
+    //
+    // Seeded from `weak_rows` rather than replacing it. Measured: the
+    // box check below rediscovers most of what the seed supplies, but
+    // not all -- a stale sigma that damps a coordinate at a later
+    // breakpoint is a RATE error, and the coordinate never leaves its
+    // box, so there is nothing for a box check to observe. The seed
+    // catches what the classifier can name and the check catches what
+    // it cannot.
+    //
+    // The watch list only grows and is bounded by the number of bound
+    // rows, so this terminates; the cap is a budget on factorizations,
+    // not the termination argument.
+    //
+    // A re-walk that FAILS is reported, not swallowed. The tempting
+    // thing is to keep the answer already in hand, but that answer is
+    // out of the box -- being out of the box is why there was a second
+    // walk at all -- and handing it back silently is precisely the
+    // defect this loop exists to remove. A caller told the repair
+    // failed can re-solve; a caller handed a point past a generator's
+    // rating with no breakpoint and no error cannot even know to ask.
+    //
+    // A pass that cannot GROW the list is a different matter and keeps
+    // its answer. There the violated coordinate has no base-active
+    // bound row on the side it left, so the reach scan was already
+    // watching that bound and the walk stopped where it could: the
+    // overshoot is some other condition -- an exhausted `max_iter`,
+    // most likely -- and not the one this loop claims to fix. Erroring
+    // there would change behaviour on a condition the fix has no
+    // evidence about.
+    let setup = WalkSetup {
+        rhs_plain,
+        x_curr,
+        lo,
+        hi,
+        n_x,
+        n_full,
+        max_iter,
+        mult_nat,
+        bound_rows,
+        can_release,
+        base_active_row,
+        base_active_rows,
+        initial_holds,
+    };
+    let mut watch: Vec<usize> = weak_rows.to_vec();
+    let mut best = walk_once(backsolver, &setup, &watch)?;
+    for _ in 0..PATH_MAX_BOX_REPAIRS {
+        let mut grew = false;
+        for (i, _, _) in bound_violations(
+            setup.x_curr,
+            &best.0[..setup.n_x],
+            setup.lo,
+            setup.hi,
+            eps,
+            &[],
+        ) {
+            // Which side it left, read off the answer rather than the
+            // base point: the base point is ON the bound here, so its
+            // slack cannot say which way the walk went.
+            let side = usize::from(setup.x_curr[i] + best.0[i] > setup.hi[i]);
+            if let Some(r) = setup.base_active_row[i][side]
+                && !watch.contains(&r)
+            {
+                watch.push(r);
+                grew = true;
+            }
+        }
+        if !grew {
+            break;
+        }
+        best = walk_once(backsolver, &setup, &watch).map_err(|e| {
+            format!(
+                "step_along_path: the walk left the box and the repair failed \
+                 (watching {watch:?}): {e}"
+            )
+        })?;
+    }
+
+    // The walk owes its caller a point inside the box, so an answer
+    // still outside one here is wrong however it got there -- the
+    // repair ran out of budget, or the crossing was at a bound the
+    // base-point split did not call active and so there was no row to
+    // add. Returning it is exactly gh#928's own failure mode, a
+    // violation with nothing in the record naming it, so say so
+    // instead. Neither arm is reachable from any fixture in the
+    // corpus; that is the reason to report rather than to trust them.
+    //
+    // Except when the caller capped the walk. `max_iter` is a cap on
+    // segments, and a walk that spent it stopped early BY REQUEST:
+    // `max_iter = 0` is the plain linear step, which is outside the
+    // box whenever the bound binds, and was a legal thing to ask for
+    // before this repair existed. Measured, not reasoned: on the
+    // gh#928 LP reproducer `max_iter = 0` returns a point 1e-2 past
+    // the bound, and turning that into an error would blame the
+    // repair for the caller's own budget. A truncated walk keeps the
+    // old contract; only an untruncated one makes the promise.
+    if best.1.len() >= max_iter {
+        return Ok(best);
+    }
+    let left = bound_violations(
+        setup.x_curr,
+        &best.0[..setup.n_x],
+        setup.lo,
+        setup.hi,
+        eps,
+        &[],
+    );
+    if let Some((i, bnd, past)) = left.first() {
+        return Err(format!(
+            "step_along_path: the walk ended outside variable {i}'s bound \
+             {bnd} by {past:e} and the repair could not reach it \
+             (watched {} rows over at most {PATH_MAX_BOX_REPAIRS} passes, \
+             {} segments of a {max_iter} cap)",
+            watch.len(),
+            best.1.len()
+        ));
+    }
+    Ok(best)
+}
+
+/// Everything [`walk_once`] reads that a repair pass does not change:
+/// the base point, its box, and the base-activity split decided once
+/// above. Bundled rather than passed loose because the walk runs more
+/// than once and the argument list is the part that would drift.
+struct WalkSetup<'a> {
+    rhs_plain: &'a [Number],
+    x_curr: &'a [Number],
+    lo: &'a [Number],
+    hi: &'a [Number],
+    n_x: usize,
+    n_full: usize,
+    max_iter: usize,
+    mult_nat: Vec<BoundMultiplier>,
+    bound_rows: Option<Vec<crate::backsolver::BoundRow>>,
+    can_release: bool,
+    base_active_row: Vec<[Option<usize>; 2]>,
+    base_active_rows: Vec<usize>,
+    initial_holds: &'a [(usize, bool)],
+}
+
+/// One pass of the walk, under the weak-row set it is given.
+///
+/// Split out of [`step_along_path`] so the box check there can run it
+/// again with a bound the first pass proved unheld. Every pass starts
+/// from the base point: the accumulated step, the holds and the
+/// released list are all local, so a repair pass is a fresh walk and
+/// not a continuation of the one that missed the crossing.
+fn walk_once<B>(
+    backsolver: &B,
+    su: &WalkSetup<'_>,
+    weak_rows: &[usize],
+) -> Result<(Vec<Number>, Vec<PathSegment>), String>
+where
+    B: crate::backsolver::SensBacksolver + Clone,
+{
+    let rhs_plain = su.rhs_plain;
+    let x_curr = su.x_curr;
+    let lo = su.lo;
+    let hi = su.hi;
+    let n_x = su.n_x;
+    let n_full = su.n_full;
+    let max_iter = su.max_iter;
+    let mult_nat = &su.mult_nat;
+    let bound_rows = &su.bound_rows;
+    let can_release = su.can_release;
+    let base_active_row = &su.base_active_row;
+    let base_active_rows = &su.base_active_rows;
+    let initial_holds = su.initial_holds;
 
     let mut acc = vec![0.0; n_full];
     let mut t = 0.0_f64;
@@ -1459,7 +1660,7 @@ where
         // Base activity comes from the table above; which rows have
         // since been released stays a live check.
         if can_release {
-            for m in &mult_nat {
+            for m in mult_nat {
                 if released.contains(&m.row)
                     || changed_here.contains(&m.row)
                     || !base_active_rows.contains(&m.row)

--- a/crates/pounce-sens-core/src/boundcheck.rs
+++ b/crates/pounce-sens-core/src/boundcheck.rs
@@ -881,6 +881,7 @@ where
         let view = ReleasedView {
             base: backsolver.clone(),
             rows: released.to_vec(),
+            pinned: Vec::new(),
         };
         let mut pin_app = SensApplication::new(mk(rows.clone())?, view, opts);
         let mut du = vec![0.0; rows.len()];
@@ -1103,6 +1104,12 @@ where
 struct ReleasedView<B: crate::backsolver::SensBacksolver + Clone> {
     base: B,
     rows: Vec<usize>,
+    /// Primal rows whose diagonal the *operator* stiffens, empty for
+    /// the ordinary released view. See
+    /// [`crate::backsolver::SensBacksolver::solve_released_pinned`]:
+    /// this is not the pin, it is the regularization that lets the pin
+    /// be applied at all (gh#930).
+    pinned: Vec<usize>,
 }
 
 impl<B: crate::backsolver::SensBacksolver + Clone> crate::backsolver::SensBacksolver
@@ -1112,6 +1119,11 @@ impl<B: crate::backsolver::SensBacksolver + Clone> crate::backsolver::SensBackso
         self.base.dim()
     }
     fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
+        if !self.pinned.is_empty() {
+            return self
+                .base
+                .solve_released_pinned(&self.rows, &self.pinned, rhs, lhs);
+        }
         // Nothing released is the converged system, so ask for it
         // directly: routing an empty set through `solve_released` asks
         // a backsolver that cannot release for something it does not
@@ -1857,6 +1869,108 @@ pub struct WeakBound {
     pub lower: bool,
 }
 
+/// Which operator a caller wants the walk's Schur pin applied to.
+///
+/// The pin is the same in all three cases: solve `K w - E du = r`
+/// subject to `Eᵀ w = 0`. What varies is the `K` it rides on, and
+/// [`Preferred`](PathOperator::Preferred) is the only one a solver
+/// should use -- the other two exist so a test can name the operator
+/// it is measuring instead of inferring which one ran.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PathOperator {
+    /// The plain released system, falling back to the regularized one
+    /// when it fails or does not hold the pins. What the walk uses.
+    Preferred,
+    /// The plain released system, and nothing else. Fails outright on
+    /// a working set that leaves it singular.
+    Plain,
+    /// The released system with the pinned rows' diagonals raised
+    /// until it is invertible. Always answers where the plain one
+    /// does, with the same answer, at the cost of a refactorization
+    /// per solve.
+    Regularized,
+}
+
+/// Pin residual (see [`pin_residual`]) below which the plain operator
+/// is taken without trying the regularized one.
+///
+/// It is a **shortcut threshold, not a correctness one**: above it
+/// both operators are run and the one that holds the pins better is
+/// returned, so setting it too low costs a refactorization and never
+/// costs an answer. Its job is to keep the common case -- a walk whose
+/// Schur pin works -- on the cached factorization.
+///
+/// The two populations it sits between were measured on the gh#928
+/// two-soft-bounds model, over the pinned solves its three curvature
+/// arms take:
+///
+/// ```text
+/// pin took     0, 1.4e-16, 1.5e-16, 1.8e-16, 1.9e-16   (n = 14)
+/// pin missed   8.1e-9, 1.0e-1, 1.0e0   (n = 3, plus one outright refusal)
+/// ```
+///
+/// `1e-11` is five orders above the worst residual a pin that took
+/// leaves and three below the smallest one it misses by. An earlier
+/// draft used `1e-8` and let the `8.1e-9` case through -- which is how
+/// that row came to be measured rather than assumed.
+const PIN_TAKE_RTOL: Number = 1e-11;
+
+/// How much of the pinned rows' motion the correction failed to
+/// remove, as a fraction of the motion it was asked to remove.
+///
+/// `want` is what those rows read *before* the correction, which is
+/// the pin's own right-hand side. Referencing the residual to it, and
+/// not to the step as a whole, is the whole point: the compound
+/// vector's multiplier rows run at `Sigma` scale -- `1e11` on the
+/// gh#930 fixture -- so a residual divided by `max |d|` reads `3e-12`
+/// on a pin that missed its target by 200%.
+fn pin_residual(d: &[Number], pinned: &[usize], want: &[Number]) -> Number {
+    let after = pinned
+        .iter()
+        .filter_map(|&i| d.get(i))
+        .fold(0.0, |a: Number, v| a.max(v.abs()));
+    if after == 0.0 {
+        return 0.0;
+    }
+    let before = want.iter().fold(0.0, |a: Number, v| a.max(v.abs()));
+    after / before.max(after)
+}
+
+/// The step for the whole perturbation under the active set the path
+/// has reached, taking whichever of the two operators actually holds
+/// the pins.
+///
+/// The Schur complement is `-Eᵀ K⁻¹ E` on the *released* system, so
+/// `K⁻¹` has to exist before a single hold is applied. Releasing a
+/// bound takes that bound's `Sigma` off the diagonal, and on a model
+/// with no curvature there two released variables sharing a constraint
+/// are left with linearly dependent stationarity rows (gh#930).
+/// Putting the diagonal back where the holds sit regularizes exactly
+/// those rows and changes no answer, since the pin the Schur
+/// complement then applies holds those coordinates at zero and
+/// annihilates the term that was added.
+///
+/// **The plain operator does not always announce that it was
+/// singular.** How loudly it fails depends on how rank-deficient it
+/// is, which is a property of the model rather than of the defect: on
+/// the gh#930 fixture two zero-curvature released rows coincide and
+/// the augmented solve refuses outright, while adding curvature to a
+/// *third* variable leaves the deficiency at one, the factorization
+/// absorbs it, and the answer comes back `Ok` with the held variable
+/// `1e-5` off its bound -- the silent half of the same defect. So the
+/// choice between the operators is made on the pinned rows'
+/// **residual**, not on whether the solve returned an error.
+///
+/// The regularized operator is second because it is not free: its
+/// diagonal is rebuilt per solve, so the factorization cache misses
+/// and every back-solve in the segment re-factors. A walk whose Schur
+/// pin works must keep taking the plain one.
+///
+/// The last two arms never return less than the old contract did: a
+/// direction the plain operator produced is still returned when
+/// neither operator holds the pins, so a caller that used to get an
+/// answer and let [`step_along_path`]'s box repair judge it still
+/// does.
 pub fn path_direction<B>(
     backsolver: &B,
     rhs_plain: &[Number],
@@ -1866,20 +1980,56 @@ pub fn path_direction<B>(
 where
     B: crate::backsolver::SensBacksolver + Clone,
 {
+    let plain = path_direction_on(backsolver, rhs_plain, released, pinned, false);
+    if matches!(&plain, Ok((_, _, res)) if *res <= PIN_TAKE_RTOL) {
+        return plain.map(|(d, du, _)| (d, du));
+    }
+    let reg = path_direction_on(backsolver, rhs_plain, released, pinned, true);
+    match (plain, reg) {
+        (Ok(p), Ok(r)) => Ok(if r.2 < p.2 { (r.0, r.1) } else { (p.0, p.1) }),
+        (Ok(p), Err(_)) => Ok((p.0, p.1)),
+        (Err(_), Ok(r)) => Ok((r.0, r.1)),
+        (Err(e), Err(_)) => Err(e),
+    }
+}
+
+/// [`path_direction`] against one of the two operators the pin can be
+/// applied to: the plain released system, or that system with the
+/// pinned rows' diagonals raised enough to make it invertible.
+///
+/// Both take the *same* Schur pin afterwards, so both answer the same
+/// question and report the hold forces in the same units -- which is
+/// what lets a walk that switches between them mid-path keep
+/// accumulating one multiplier per hold.
+fn path_direction_on<B>(
+    backsolver: &B,
+    rhs_plain: &[Number],
+    released: &[usize],
+    pinned: &[usize],
+    regularized: bool,
+) -> Result<(Vec<Number>, Vec<Number>, Number), String>
+where
+    B: crate::backsolver::SensBacksolver + Clone,
+{
+    use crate::backsolver::SensBacksolver;
     use crate::sens_app::{SensApplication, SensOptions};
 
     let n_full = backsolver.dim();
-    let mut d = vec![0.0; n_full];
-    let ok = if released.is_empty() {
-        backsolver.solve(rhs_plain, &mut d)
-    } else {
-        backsolver.solve_released(released, rhs_plain, &mut d)
+    let view = ReleasedView {
+        base: backsolver.clone(),
+        rows: released.to_vec(),
+        pinned: if regularized {
+            pinned.to_vec()
+        } else {
+            Vec::new()
+        },
     };
-    if !ok {
+    let mut d = vec![0.0; n_full];
+    if !view.solve(rhs_plain, &mut d) {
         return Err("step_along_path: back-solve failed".into());
     }
     if pinned.is_empty() {
-        return Ok((d, Vec::new()));
+        return Ok((d, Vec::new(), 0.0));
     }
     // Hold each variable where the path left it, on its bound, by
     // asking the augmented system for the correction that takes its
@@ -1891,10 +2041,6 @@ where
     let opts = SensOptions {
         run_sens: true,
         ..SensOptions::default()
-    };
-    let view = ReleasedView {
-        base: backsolver.clone(),
-        rows: released.to_vec(),
     };
     let mut app = SensApplication::new(mk(rows.clone())?, view, opts);
     let rhs: Vec<Number> = pinned.iter().map(|&i| d[i]).collect();
@@ -1908,5 +2054,32 @@ where
     for (k, v) in d.iter_mut().enumerate() {
         *v += corr[k];
     }
-    Ok((d, du))
+    let res = pin_residual(&d, pinned, &rhs);
+    Ok((d, du, res))
+}
+
+/// [`path_direction`] against an operator the caller names.
+///
+/// [`PathOperator::Preferred`] is exactly [`path_direction`]; the
+/// other two skip the choice. The walk itself always takes
+/// `Preferred`.
+pub fn path_direction_with<B>(
+    backsolver: &B,
+    rhs_plain: &[Number],
+    released: &[usize],
+    pinned: &[usize],
+    operator: PathOperator,
+) -> Result<(Vec<Number>, Vec<Number>), String>
+where
+    B: crate::backsolver::SensBacksolver + Clone,
+{
+    match operator {
+        PathOperator::Preferred => path_direction(backsolver, rhs_plain, released, pinned),
+        PathOperator::Plain => path_direction_on(backsolver, rhs_plain, released, pinned, false)
+            .map(|(d, du, _)| (d, du)),
+        PathOperator::Regularized => {
+            path_direction_on(backsolver, rhs_plain, released, pinned, true)
+                .map(|(d, du, _)| (d, du))
+        }
+    }
 }

--- a/crates/pounce-sens-core/src/boundcheck.rs
+++ b/crates/pounce-sens-core/src/boundcheck.rs
@@ -1148,13 +1148,27 @@ const NO_BOUND_HI: Number = 1e19;
 const PATH_MIN_SEGMENT: Number = 1e-12;
 
 /// How many times the walk may re-run after finding its own answer
-/// outside the box. Each pass adds at least one bound row to the
-/// watch list and costs a fresh walk, so this is a budget on
-/// factorizations; termination comes from the list growing, not
-/// from the cap. Simultaneous unheld bounds are what consume it,
-/// and a degenerate vertex of a few coordinates is the realistic
-/// case.
-const PATH_MAX_BOX_REPAIRS: usize = 8;
+/// outside the box.
+///
+/// This is not a tuned number. A pass that adds nothing stops the
+/// loop, the only rows it can add are entries of the base-activity
+/// table, and a row already watched is never added twice -- so the
+/// loop cannot run more times than that table has entries, and
+/// passing the table's length as the budget makes the exhausted arm
+/// unreachable by construction rather than unreached by luck. That
+/// matters because the exhausted arm returns an error, and an error
+/// on a correct model would be a regression the corpus could not see.
+///
+/// Measured for the record, by capping this to `.min(1)` and
+/// re-running: a budget of **1** clears every Rust test in
+/// `pounce-sens-core`, `pounce-sensitivity` and `pounce-py`, both
+/// gh#928 files included -- 0 failures. The bound below is therefore
+/// slack over that population; it is here so that "the budget ran
+/// out" is a statement about the model rather than about this
+/// constant.
+fn path_box_repair_budget(base_active_rows: usize) -> usize {
+    base_active_rows
+}
 
 /// One breakpoint the path stopped at.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1263,7 +1277,14 @@ where
     B: crate::backsolver::SensBacksolver + Clone,
 {
     let n_full = backsolver.dim();
-    let n_x = x_curr.len().min(lo.len()).min(hi.len());
+    // The PRIMAL PREFIX, not the `x` block. `bound_context` hands over
+    // a box spanning `x` then `s`, which are contiguous in the
+    // compound vector, because a limit written as a constraint row is
+    // a bound on the slack and has to be watched like any other
+    // (gh#928). Everything below indexes the box, the base point and
+    // the step by the same primal KKT row, so one length covers all
+    // three and the walk needs no second index space.
+    let n_p = x_curr.len().min(lo.len()).min(hi.len());
     if rhs_plain.len() != n_full {
         return Err("step_along_path: rhs length is not the KKT dimension".into());
     }
@@ -1314,10 +1335,14 @@ where
     // What stays live at every consumer is the released list: a
     // base-active bound whose row has been released is no longer in
     // the factorization, from that fraction on.
-    let mut base_active_row: Vec<[Option<usize>; 2]> = vec![[None, None]; n_x];
+    let mut base_active_row: Vec<[Option<usize>; 2]> = vec![[None, None]; n_p];
     if let Some(rows) = bound_rows.as_ref() {
         for br in rows {
-            if br.var_row >= n_x {
+            // `var_row` is a primal KKT row, so this is a range check
+            // against the box the caller supplied, not a block filter.
+            // A caller that hands over an `x`-only box still gets the
+            // old behaviour: its constraint-row bounds fall out here.
+            if br.var_row >= n_p {
                 continue;
             }
             let slack_base = if br.lower {
@@ -1400,7 +1425,7 @@ where
         x_curr,
         lo,
         hi,
-        n_x,
+        n_p,
         n_full,
         max_iter,
         mult_nat,
@@ -1411,12 +1436,13 @@ where
         initial_holds,
     };
     let mut watch: Vec<usize> = weak_rows.to_vec();
+    let budget = path_box_repair_budget(setup.base_active_rows.len());
     let mut best = walk_once(backsolver, &setup, &watch)?;
-    for _ in 0..PATH_MAX_BOX_REPAIRS {
+    for _ in 0..budget {
         let mut grew = false;
         for (i, _, _) in bound_violations(
             setup.x_curr,
-            &best.0[..setup.n_x],
+            &best.0[..setup.n_p],
             setup.lo,
             setup.hi,
             eps,
@@ -1450,8 +1476,10 @@ where
     // base-point split did not call active and so there was no row to
     // add. Returning it is exactly gh#928's own failure mode, a
     // violation with nothing in the record naming it, so say so
-    // instead. Neither arm is reachable from any fixture in the
-    // corpus; that is the reason to report rather than to trust them.
+    // instead. The budget arm is unreachable by construction (see
+    // `path_box_repair_budget`); the no-row-to-add arm is reachable in
+    // principle and is not reached by any fixture in the corpus. That
+    // is the reason to report rather than to trust them.
     //
     // Except when the caller capped the walk. `max_iter` is a cap on
     // segments, and a walk that spent it stopped early BY REQUEST:
@@ -1467,18 +1495,24 @@ where
     }
     let left = bound_violations(
         setup.x_curr,
-        &best.0[..setup.n_x],
+        &best.0[..setup.n_p],
         setup.lo,
         setup.hi,
         eps,
         &[],
     );
     if let Some((i, bnd, past)) = left.first() {
+        // `i` is a primal KKT row, so it names a variable only while
+        // it is inside the `x` block; past that it is a constraint's
+        // own slack. Saying which costs nothing and saves the reader
+        // from reading a slack index as a variable index (gh#450).
         return Err(format!(
-            "step_along_path: the walk ended outside variable {i}'s bound \
+            "step_along_path: the walk ended outside primal row {i}'s bound \
              {bnd} by {past:e} and the repair could not reach it \
-             (watched {} rows over at most {PATH_MAX_BOX_REPAIRS} passes, \
-             {} segments of a {max_iter} cap)",
+             (watched {} rows over at most {budget} passes, \
+             {} segments of a {max_iter} cap). Rows below the `x` block's \
+             length are variables; at or above it they are constraint \
+             slacks, so read the row against `block_dims()`.",
             watch.len(),
             best.1.len()
         ));
@@ -1495,7 +1529,8 @@ struct WalkSetup<'a> {
     x_curr: &'a [Number],
     lo: &'a [Number],
     hi: &'a [Number],
-    n_x: usize,
+    /// Length of the primal prefix (`x` then `s`) the box covers.
+    n_p: usize,
     n_full: usize,
     max_iter: usize,
     mult_nat: Vec<BoundMultiplier>,
@@ -1525,7 +1560,7 @@ where
     let x_curr = su.x_curr;
     let lo = su.lo;
     let hi = su.hi;
-    let n_x = su.n_x;
+    let n_p = su.n_p;
     let n_full = su.n_full;
     let max_iter = su.max_iter;
     let mult_nat = &su.mult_nat;
@@ -1624,7 +1659,7 @@ where
         // release below. "Actually enforces" is the distinction the
         // `factor_holds` comment below draws, and it is narrower than
         // "active at the base".
-        for i in 0..n_x {
+        for i in 0..n_p {
             if holds.iter().any(|h| h.row == i) || changed_here.contains(&i) {
                 continue;
             }

--- a/crates/pounce-sens-core/src/lib.rs
+++ b/crates/pounce-sens-core/src/lib.rs
@@ -9,6 +9,9 @@
 //!
 //! * [`boundcheck`] — fix-relax refinement, path following through
 //!   active-set breakpoints, and the directional derivative at a kink.
+//! * [`rowlimit`] — an observer block that gives a limit written as a
+//!   *constraint row* the primal coordinate `boundcheck` decides in,
+//!   for engines whose KKT has no slack block (gh#929).
 //! * [`sens_app`] — the sIPOPT `SensApplication` driver, the reduced-Hessian
 //!   entry point, and the option registrations.
 //! * [`p_calculator`], [`schur_data`], [`schur_driver`], [`step_calc`],
@@ -54,6 +57,7 @@ pub mod backsolver;
 pub mod boundcheck;
 pub mod p_calculator;
 pub mod reduced_hessian;
+pub mod rowlimit;
 pub mod schur_data;
 pub mod schur_driver;
 pub mod sens_app;

--- a/crates/pounce-sens-core/src/rowlimit.rs
+++ b/crates/pounce-sens-core/src/rowlimit.rs
@@ -1,0 +1,646 @@
+//! Watching a limit that is written as a **constraint row**, on an
+//! engine whose KKT has no slack block (gh#929).
+//!
+//! # The gap
+//!
+//! [`crate::boundcheck`]'s walk and refinement decide everything in
+//! *primal KKT rows*: the box `lo`/`hi` and the base point `x_curr`
+//! index the primal prefix of the compound vector, and a
+//! [`BoundRow`](crate::backsolver::BoundRow) ties a multiplier row to
+//! the primal row it constrains. That is what lets the NLP arm watch a
+//! constraint's own limit — there, `dⱼ(x) = sⱼ` makes the limit a
+//! bound on a coordinate the KKT already carries, which is the gh#928
+//! fix.
+//!
+//! An active-set KKT has no such coordinate. `pounce-convex` assembles
+//!
+//! ```text
+//! [ H   Aᵀ  B_aᵀ ] [ dx ]
+//! [ A   0   0    ] [ dy ]
+//! [ B_a 0   0    ] [ dz ]
+//! ```
+//!
+//! where `B_a` holds the *active* rows only. A row `Gⱼ x ≤ hⱼ` that is
+//! **inactive** appears nowhere at all, so a step that drives `Gⱼ x`
+//! past `hⱼ` is not a breakpoint the walk can see — it is silence, and
+//! the answer comes back infeasible. An **active** row has a
+//! multiplier row but still no primal coordinate, so it cannot be
+//! reported as a `BoundRow` either, and a perturbation that drives its
+//! multiplier negative holds a row the solution has left.
+//!
+//! # The observer block
+//!
+//! This wrapper gives each watched row a coordinate of its own. For
+//! watched rows `G_w` it presents the augmented system
+//!
+//! ```text
+//! [ Kxx   0   Kxr  -G_wᵀ ] [ dx    ]   [ r_x   ]
+//! [ 0     0   0     I    ] [ dt    ] = [ r_t   ]
+//! [ Krx   0   Krr   0    ] [ drest ]   [ r_rest]
+//! [ -G_w  I   0     0    ] [ dmu   ]   [ r_mu  ]
+//! ```
+//!
+//! which is the base system with `t = G_w x` adjoined through a
+//! multiplier `mu` (Lagrangian term `muᵀ(t − G_w x)`). `t` sits
+//! immediately after the `x` block, so it lands inside the primal
+//! prefix the walk indexes, and carries the box `(−∞, h]`.
+//!
+//! **It costs no factorization.** The block is triangular in the
+//! adjoined variables:
+//!
+//! ```text
+//! dmu = r_t
+//! K [dx; drest] = [r_x + G_wᵀ r_t ; r_rest]      <- the base solve
+//! dt  = G_w dx + r_mu
+//! ```
+//!
+//! so one base back-solve and two sparse mat-vecs answer it, released
+//! or not. Nothing about the base factor changes, and an active row's
+//! release is still the base's own row-neutralization: the observer
+//! reads `dt = G_w dx + r_mu` whether or not the row it observes is
+//! being enforced.
+//!
+//! # Why the shift needs no special case
+//!
+//! [`SensBacksolver::solve_released_step`] moves a released
+//! multiplier onto the primal row it was acting on. Here that primal
+//! row is `tⱼ`, and `r_t` reaches the `x` rows as `G_wᵀ r_t` — which
+//! is exactly `zⱼ Gⱼᵀ`, the force the released row was applying. The
+//! observer's own algebra performs the conversion, so this file adds
+//! the shift in `t` and never writes a `G` row into an `x` right-hand
+//! side by hand.
+//!
+//! # Index spaces
+//!
+//! Two live here at once, which is the shape gh#450 and gh#764 say to
+//! be careful about. [`RowLimitView::to_base`] and
+//! [`RowLimitView::from_base`] are the only conversions, both total
+//! functions with an explicit `None` for the adjoined rows, and every
+//! read of a base-indexed vector goes through one of them.
+
+use pounce_common::types::Number;
+
+use crate::backsolver::{BoundRow, SensBacksolver};
+
+/// One watched limit: a sparse row `Σ coef·x[col] ≤ limit`, and the
+/// KKT row of its multiplier when the base system already enforces it.
+#[derive(Clone, Debug)]
+pub struct WatchedRow {
+    /// The row's nonzeros as `(column, coefficient)`, in the `x`
+    /// block's index space.
+    pub coefficients: Vec<(usize, Number)>,
+    /// The row's right-hand side, which becomes the observer's upper
+    /// bound. A row written `≥` must be negated by the caller before
+    /// it gets here; this type is one-sided on purpose, because a
+    /// two-sided row is two watched rows and pretending otherwise
+    /// hides which side a breakpoint belongs to.
+    pub limit: Number,
+    /// The value of `Σ coef·x[col]` at the base point.
+    pub base_value: Number,
+    /// `Some((multiplier_row, base_multiplier))` when the base system
+    /// carries this row in its active set, where `multiplier_row` is
+    /// in the **base** index space. `None` for an inactive row, which
+    /// the walk can then only reach and hold, never release.
+    pub active: Option<(usize, Number)>,
+}
+
+/// A [`SensBacksolver`] that adjoins an observer coordinate to each
+/// watched row of its base. See the module docs.
+#[derive(Clone)]
+pub struct RowLimitView<B> {
+    base: B,
+    n_x: usize,
+    rows: Vec<WatchedRow>,
+    /// The base's dimension, cached because it appears in every
+    /// conversion.
+    base_dim: usize,
+    /// Every releasable row this view offers the walk, in **this
+    /// view's** index space: the base's own bound rows shifted past the
+    /// observers, then one per watched row the base holds active.
+    ///
+    /// The concatenation is built here rather than left to the caller
+    /// because the walk reads a single slice and can only release what
+    /// it finds in it — a view that reported only its own rows would
+    /// silently take variable-bound releases away from the arm it
+    /// wraps.
+    bound_rows: Vec<BoundRow>,
+    /// Per watched row the base holds active: `(multiplier row in this
+    /// view's space, observer row, base multiplier)`, for the release
+    /// shift. Not parallel to [`Self::bound_rows`], which also carries
+    /// the base's.
+    shifts: Vec<(usize, usize, Number)>,
+}
+
+impl<B: SensBacksolver> RowLimitView<B> {
+    /// Wrap `base`, whose `x` block is `n_x` wide, with one observer
+    /// per entry of `rows`.
+    ///
+    /// `None` when the wrapper cannot be built honestly:
+    ///
+    /// * `n_x` past the base dimension, or a coefficient column past
+    ///   `n_x` — the caller's index space is not the one it thinks;
+    /// * an `active` multiplier row outside the base's non-`x` rows;
+    /// * **the base reports a
+    ///   [`natural_units_factor`](SensBacksolver::natural_units_factor)**.
+    ///   The observer rows have no entry in it, and inventing one
+    ///   would put a scaled right-hand side into an unscaled Schur
+    ///   complement. Refusing is the honest answer; the convex arm,
+    ///   the only caller, always answers `None` there because its KKT
+    ///   is assembled from raw problem data.
+    pub fn new(base: B, n_x: usize, rows: Vec<WatchedRow>) -> Option<Self> {
+        let base_dim = base.dim();
+        if n_x > base_dim || base.natural_units_factor().is_some() {
+            return None;
+        }
+        let n_t = rows.len();
+        let mut bound_rows: Vec<BoundRow> = Vec::new();
+        // The base's own rows first, shifted into this space. A base
+        // bound row whose `var_row` is not in the `x` block cannot be
+        // re-expressed here, because the observers were inserted
+        // immediately after `x`; refuse rather than mis-map it.
+        if let Some(base_rows) = base.bound_rows() {
+            for b in base_rows {
+                if b.var_row >= n_x || b.row < n_x || b.row >= base_dim {
+                    return None;
+                }
+                bound_rows.push(BoundRow {
+                    row: b.row + n_t,
+                    var_row: b.var_row,
+                    lower: b.lower,
+                });
+            }
+        }
+        let mut shifts = Vec::new();
+        for (j, r) in rows.iter().enumerate() {
+            if r.coefficients.iter().any(|&(c, _)| c >= n_x) {
+                return None;
+            }
+            if let Some((row, mult)) = r.active {
+                // An active row's multiplier lives in the base's
+                // non-primal rows; one inside the `x` block is a
+                // caller confusing the two spaces.
+                if row < n_x || row >= base_dim {
+                    return None;
+                }
+                let obs = n_x + j;
+                bound_rows.push(BoundRow {
+                    row: row + n_t,
+                    var_row: obs,
+                    // `G x ≤ h` is an upper limit on the observer.
+                    lower: false,
+                });
+                shifts.push((row + n_t, obs, mult));
+            }
+        }
+        Some(Self {
+            base,
+            n_x,
+            rows,
+            base_dim,
+            bound_rows,
+            shifts,
+        })
+    }
+
+    /// Number of observers, which is also the offset every base row at
+    /// or past the `x` block moves by.
+    pub fn n_observers(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// This view's row for a base row. Total, and the only place the
+    /// `+ n_t` shift is written.
+    pub fn from_base(&self, base_row: usize) -> Option<usize> {
+        if base_row < self.n_x {
+            Some(base_row)
+        } else if base_row < self.base_dim {
+            Some(base_row + self.rows.len())
+        } else {
+            None
+        }
+    }
+
+    /// The base row behind a row of this view, or `None` for an
+    /// adjoined `t` or `mu` row — which is a real answer, not a
+    /// failure: those rows exist only here.
+    pub fn to_base(&self, row: usize) -> Option<usize> {
+        let n_t = self.rows.len();
+        if row < self.n_x {
+            Some(row)
+        } else if row < self.n_x + n_t {
+            None
+        } else if row < self.base_dim + n_t {
+            Some(row - n_t)
+        } else {
+            None
+        }
+    }
+
+    /// The walk's box and base point over the primal prefix `x` then
+    /// `t`, given the base's own `x`-block box and point.
+    ///
+    /// Returned rather than assembled by the caller so that the
+    /// observer's bounds and the observer's ordering cannot drift
+    /// apart from the ones [`Self::new`] built the `BoundRow`s
+    /// against.
+    pub fn primal_box(
+        &self,
+        x_curr: &[Number],
+        lo: &[Number],
+        hi: &[Number],
+    ) -> Option<(Vec<Number>, Vec<Number>, Vec<Number>)> {
+        if x_curr.len() != self.n_x || lo.len() != self.n_x || hi.len() != self.n_x {
+            return None;
+        }
+        let mut x = x_curr.to_vec();
+        let mut l = lo.to_vec();
+        let mut h = hi.to_vec();
+        for r in &self.rows {
+            x.push(r.base_value);
+            l.push(Number::NEG_INFINITY);
+            h.push(r.limit);
+        }
+        Some((x, l, h))
+    }
+
+    /// A base-space right-hand side lifted into this view's space.
+    pub fn lift_rhs(&self, base_rhs: &[Number]) -> Option<Vec<Number>> {
+        if base_rhs.len() != self.base_dim {
+            return None;
+        }
+        let mut out = vec![0.0; self.dim()];
+        for (i, &v) in base_rhs.iter().enumerate() {
+            let row = self.from_base(i)?;
+            out[row] = v;
+        }
+        Some(out)
+    }
+
+    /// Every releasable row of this view, base and watched alike, in
+    /// this view's index space. Same slice
+    /// [`SensBacksolver::bound_rows`] returns.
+    pub fn all_bound_rows(&self) -> &[BoundRow] {
+        &self.bound_rows
+    }
+
+    /// The walk's multiplier list for this view: the base's own entries
+    /// lifted, then one per watched row the base holds active.
+    ///
+    /// Built here rather than by the caller so it cannot fall out of
+    /// step with [`Self::all_bound_rows`] — the walk releases a row
+    /// only when it finds it in *both* lists, so a row present in one
+    /// and missing from the other is a release that silently never
+    /// happens.
+    pub fn lift_multipliers(
+        &self,
+        base: &[crate::boundcheck::BoundMultiplier],
+    ) -> Option<Vec<crate::boundcheck::BoundMultiplier>> {
+        let mut out = Vec::with_capacity(base.len() + self.shifts.len());
+        for m in base {
+            out.push(crate::boundcheck::BoundMultiplier {
+                row: self.from_base(m.row)?,
+                base: m.base,
+            });
+        }
+        for &(row, _, mult) in &self.shifts {
+            out.push(crate::boundcheck::BoundMultiplier { row, base: mult });
+        }
+        Some(out)
+    }
+
+    /// Split a view-space right-hand side into the base solve's
+    /// right-hand side and the pieces the observer needs afterwards.
+    ///
+    /// `dmu = r_t`, and the base sees `r_x + G_wᵀ r_t`.
+    fn fold(&self, rhs: &[Number]) -> (Vec<Number>, Vec<Number>, Vec<Number>) {
+        let n_t = self.rows.len();
+        let r_t = rhs[self.n_x..self.n_x + n_t].to_vec();
+        let r_mu = rhs[self.base_dim + n_t..].to_vec();
+        let mut base_rhs = vec![0.0; self.base_dim];
+        base_rhs[..self.n_x].copy_from_slice(&rhs[..self.n_x]);
+        base_rhs[self.n_x..].copy_from_slice(&rhs[self.n_x + n_t..self.base_dim + n_t]);
+        for (j, r) in self.rows.iter().enumerate() {
+            let v = r_t[j];
+            if v != 0.0 {
+                for &(c, coef) in &r.coefficients {
+                    base_rhs[c] += coef * v;
+                }
+            }
+        }
+        (base_rhs, r_t, r_mu)
+    }
+
+    /// Scatter a base answer back into this view's space and fill the
+    /// observer rows: `dt = G_w dx + r_mu`, `dmu = r_t`.
+    fn unfold(&self, base_lhs: &[Number], r_t: &[Number], r_mu: &[Number], lhs: &mut [Number]) {
+        let n_t = self.rows.len();
+        lhs[..self.n_x].copy_from_slice(&base_lhs[..self.n_x]);
+        lhs[self.n_x + n_t..self.base_dim + n_t].copy_from_slice(&base_lhs[self.n_x..]);
+        for (j, r) in self.rows.iter().enumerate() {
+            let gx: Number = r
+                .coefficients
+                .iter()
+                .map(|&(c, coef)| coef * base_lhs[c])
+                .sum();
+            lhs[self.n_x + j] = gx + r_mu[j];
+            lhs[self.base_dim + n_t + j] = r_t[j];
+        }
+    }
+
+    /// Common body of the three solves: fold, run `f` on the base
+    /// system, unfold.
+    fn around<F>(&self, rhs: &[Number], lhs: &mut [Number], f: F) -> bool
+    where
+        F: FnOnce(&[Number], &mut [Number]) -> bool,
+    {
+        if rhs.len() != self.dim() || lhs.len() != self.dim() {
+            return false;
+        }
+        let (base_rhs, r_t, r_mu) = self.fold(rhs);
+        let mut base_lhs = vec![0.0; self.base_dim];
+        if !f(&base_rhs, &mut base_lhs) {
+            return false;
+        }
+        self.unfold(&base_lhs, &r_t, &r_mu, lhs);
+        true
+    }
+
+    /// `released`, in the base's index space, or `None` if any entry
+    /// is an adjoined row — which no caller should produce, since the
+    /// only releasable rows this view reports are base multiplier rows.
+    fn released_in_base(&self, released: &[usize]) -> Option<Vec<usize>> {
+        released.iter().map(|&r| self.to_base(r)).collect()
+    }
+}
+
+impl<B: SensBacksolver> SensBacksolver for RowLimitView<B> {
+    fn dim(&self) -> usize {
+        self.base_dim + 2 * self.rows.len()
+    }
+
+    fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
+        self.around(rhs, lhs, |b, l| self.base.solve(b, l))
+    }
+
+    /// `None`, and guaranteed rather than assumed:
+    /// [`RowLimitView::new`] refuses a base that reports one, because
+    /// the observer rows have no honest entry in it.
+    fn natural_units_factor(&self) -> Option<&[Number]> {
+        None
+    }
+
+    fn bound_rows(&self) -> Option<&[BoundRow]> {
+        Some(&self.bound_rows)
+    }
+
+    fn supports_release(&self) -> bool {
+        self.base.supports_release()
+    }
+
+    fn solve_released(&self, released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
+        let Some(key) = self.released_in_base(released) else {
+            return false;
+        };
+        self.around(rhs, lhs, |b, l| self.base.solve_released(&key, b, l))
+    }
+
+    /// The released step, with the observer carrying the shift.
+    ///
+    /// A released *row*'s multiplier is moved onto its observer row —
+    /// `r_t[j] += z` for the upper-limit orientation every watched row
+    /// has — and [`RowLimitView::fold`] then delivers it to the `x`
+    /// rows as `z Gⱼᵀ`. A released *variable bound* is not this view's
+    /// business and is left to the base's own shift.
+    fn solve_released_step(&self, released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
+        if rhs.len() != self.dim() {
+            return false;
+        }
+        let Some(key) = self.released_in_base(released) else {
+            return false;
+        };
+        let mut rhs = rhs.to_vec();
+        for &(row, obs, mult) in &self.shifts {
+            if !released.contains(&row) {
+                continue;
+            }
+            rhs[row] = 0.0;
+            rhs[obs] += mult;
+        }
+        self.around(&rhs, lhs, |b, l| self.base.solve_released_step(&key, b, l))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backsolver::DenseLuBacksolver;
+
+    /// A dense stand-in for a factored KKT that also answers the
+    /// release half of the trait, by refactoring with the released
+    /// rows neutralized the way a real backsolver does.
+    ///
+    /// It carries no bound rows of its own, so `solve_released_step`
+    /// has nothing to shift and coincides with `solve_released` — which
+    /// is the point: every shift these tests observe is one
+    /// [`RowLimitView`] put there.
+    struct Base {
+        n: usize,
+        k: Vec<Number>,
+        rows: Vec<BoundRow>,
+    }
+
+    impl Base {
+        fn factor(&self, released: &[usize]) -> Option<DenseLuBacksolver> {
+            let mut k = self.k.clone();
+            for &r in released {
+                for j in 0..self.n {
+                    k[r * self.n + j] = 0.0;
+                    k[j * self.n + r] = 0.0;
+                }
+                k[r * self.n + r] = -1.0;
+            }
+            DenseLuBacksolver::from_dense(self.n, &k).ok()
+        }
+    }
+
+    impl SensBacksolver for Base {
+        fn dim(&self) -> usize {
+            self.n
+        }
+        fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
+            self.factor(&[]).is_some_and(|f| f.solve(rhs, lhs))
+        }
+        fn bound_rows(&self) -> Option<&[BoundRow]> {
+            Some(&self.rows)
+        }
+        fn supports_release(&self) -> bool {
+            true
+        }
+        fn solve_released(&self, released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
+            self.factor(released).is_some_and(|f| f.solve(rhs, lhs))
+        }
+        fn solve_released_step(
+            &self,
+            released: &[usize],
+            rhs: &[Number],
+            lhs: &mut [Number],
+        ) -> bool {
+            self.solve_released(released, rhs, lhs)
+        }
+    }
+
+    /// `n_x = 3`, two further rows, symmetric and nonsingular.
+    fn base(rows: Vec<BoundRow>) -> Base {
+        #[rustfmt::skip]
+        let k = vec![
+            2.0, 0.3, -0.4,  1.0, 0.0,
+            0.3, 1.7,  0.2,  0.0, 1.0,
+           -0.4, 0.2,  2.5,  1.0, 1.0,
+            1.0, 0.0,  1.0,  0.0, 0.0,
+            0.0, 1.0,  1.0,  0.0, 0.0,
+        ];
+        Base { n: 5, k, rows }
+    }
+
+    fn watched(active: Option<(usize, Number)>, coefficients: Vec<(usize, Number)>) -> WatchedRow {
+        WatchedRow {
+            coefficients,
+            limit: 1.0,
+            base_value: 0.25,
+            active,
+        }
+    }
+
+    /// The triangular solve is the augmented system, not merely
+    /// something that resembles it.
+    ///
+    /// The claim is checked against a dense factorization of the whole
+    /// `9 × 9` operator the module docs write out, on a right-hand side
+    /// with **all four blocks nonzero**. The `r_mu` block is the reason:
+    /// nothing on the convex arm ever produces one — `lift_rhs` zeroes
+    /// it — so `unfold` dropping `+ r_mu[j]` is invisible to every
+    /// integration test in the repo and visible here.
+    #[test]
+    fn the_triangular_solve_is_the_augmented_system() {
+        let n_x = 3;
+        let rows = vec![
+            watched(None, vec![(0, 1.0), (2, -0.5)]),
+            watched(None, vec![(1, 2.0)]),
+        ];
+        let b = base(Vec::new());
+        let base_k = b.k.clone();
+        let base_dim = b.n;
+        let n_t = rows.len();
+        let view = RowLimitView::new(b, n_x, rows.clone()).expect("the view must build");
+        let dim = view.dim();
+        assert_eq!(dim, base_dim + 2 * n_t);
+
+        // Assemble the augmented operator densely, in this view's row
+        // order: x, t, rest, mu.
+        let t0 = n_x;
+        let mu0 = base_dim + n_t;
+        let mut a = vec![0.0; dim * dim];
+        let view_of = |i: usize| if i < n_x { i } else { i + n_t };
+        for i in 0..base_dim {
+            for j in 0..base_dim {
+                a[view_of(i) * dim + view_of(j)] = base_k[i * base_dim + j];
+            }
+        }
+        for (j, r) in rows.iter().enumerate() {
+            // `I` in the t-row block against mu, and in the mu-row block
+            // against t.
+            a[(t0 + j) * dim + mu0 + j] = 1.0;
+            a[(mu0 + j) * dim + t0 + j] = 1.0;
+            for &(c, coef) in &r.coefficients {
+                a[c * dim + mu0 + j] = -coef;
+                a[(mu0 + j) * dim + c] = -coef;
+            }
+        }
+        let dense =
+            DenseLuBacksolver::from_dense(dim, &a).expect("the augmented system is regular");
+
+        let rhs: Vec<Number> = (0..dim).map(|i| 0.7 - 0.31 * (i as Number)).collect();
+        let mut want = vec![0.0; dim];
+        assert!(dense.solve(&rhs, &mut want));
+        let mut got = vec![0.0; dim];
+        assert!(view.solve(&rhs, &mut got));
+        for i in 0..dim {
+            assert!(
+                (got[i] - want[i]).abs() < 1e-10,
+                "row {i}: view {got:?} vs dense {want:?}",
+            );
+        }
+    }
+
+    /// Each active watched row gets **its own** observer, and the
+    /// release shift lands on that one.
+    ///
+    /// Both halves need two rows with different coefficients to say
+    /// anything: with a single watched row every ordering of the
+    /// observers is the same ordering, which is exactly the shape the
+    /// convex fixture has.
+    #[test]
+    fn each_active_row_keeps_its_own_observer() {
+        let n_x = 3;
+        let (m0, m1) = (0.75, 0.2);
+        let rows = vec![
+            watched(Some((3, m0)), vec![(0, 1.0), (2, -0.5)]),
+            watched(Some((4, m1)), vec![(1, 2.0)]),
+        ];
+        let n_t = rows.len();
+        let b = base(Vec::new());
+        let reference = base(Vec::new());
+        let view = RowLimitView::new(b, n_x, rows.clone()).expect("the view must build");
+
+        // Multiplier row `3 + n_t` observes `n_x + 0`, `4 + n_t` observes
+        // `n_x + 1` — not the other way round.
+        assert_eq!(
+            view.all_bound_rows(),
+            &[
+                BoundRow {
+                    row: 3 + n_t,
+                    var_row: n_x,
+                    lower: false
+                },
+                BoundRow {
+                    row: 4 + n_t,
+                    var_row: n_x + 1,
+                    lower: false
+                },
+            ],
+        );
+        let lifted = view
+            .lift_multipliers(&[])
+            .expect("an empty base list still lifts");
+        assert_eq!(lifted.len(), 2);
+        for (got, want) in lifted.iter().zip([(3 + n_t, m0), (4 + n_t, m1)]) {
+            assert_eq!((got.row, got.base), want);
+        }
+
+        // Release the *first* row against a zero right-hand side. Its
+        // multiplier is the only force left, and `fold` delivers it as
+        // `m0 · G₀ᵀ` — so the answer is the released base solve on that
+        // vector, and would differ if the shift had landed on the other
+        // observer.
+        let released = vec![3 + n_t];
+        let mut got = vec![0.0; view.dim()];
+        assert!(view.solve_released_step(&released, &vec![0.0; view.dim()], &mut got));
+
+        let mut want_rhs = vec![0.0; 5];
+        for &(c, coef) in &rows[0].coefficients {
+            want_rhs[c] += coef * m0;
+        }
+        let mut want = vec![0.0; 5];
+        assert!(reference.solve_released(&[3], &want_rhs, &mut want));
+        for i in 0..n_x {
+            assert!(
+                (got[i] - want[i]).abs() < 1e-10,
+                "x row {i}: {got:?} vs {want:?}",
+            );
+        }
+        assert!(
+            got[..n_x].iter().any(|v| v.abs() > 1e-6),
+            "the shift must actually move something: {got:?}",
+        );
+    }
+}

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -803,6 +803,96 @@ impl PdSensBacksolver {
         true
     }
 
+    /// The diagonal a *path* pin puts on one primal KKT row: the
+    /// stiffest entry the row's own couplings still survive, which is
+    /// [`sigma_pin_cap`] of the largest constraint coefficient the row
+    /// carries.
+    ///
+    /// A variable in no constraint row reports no ceiling at all
+    /// (gh#653), and `INFINITY` here is not a stiffer pin but a `NaN`
+    /// in the factorization. Those get the scalar the `s` diagonal is
+    /// built under, `sigma_pin_cap(1.0)` -- unit coupling, and a pin
+    /// the coordinate moves under by `eps * SIGMA_PIN_HEADROOM` per
+    /// unit of force, which is roundoff.
+    ///
+    /// The addend is the ceiling itself rather than something under
+    /// it, so [`pinned_entry`] returns the ceiling exactly and the
+    /// capped diagonal differs from the uncapped one by the factor
+    /// `cap / (had + cap)`. On a bound the walk *reaches* -- the only
+    /// kind it pins -- `had` is the base point's barrier term for a
+    /// bound that was inactive there, order one against a ceiling of
+    /// order `1e13`, so that factor is `1 - 1e-13` and the multiplier
+    /// rows need no [`Self::rescale_bound_multipliers`] pass.
+    fn path_pin_add(&self, row: usize) -> Number {
+        let cap = if row < self.dims[0] {
+            self.sigma
+                .cap_x
+                .get(row)
+                .copied()
+                .unwrap_or(Number::INFINITY)
+        } else {
+            sigma_pin_cap(1.0)
+        };
+        if cap.is_finite() {
+            cap
+        } else {
+            sigma_pin_cap(1.0)
+        }
+    }
+
+    /// Body of [`SensBacksolver::solve_released_pinned`]: the
+    /// released solve, with each pinned primal row's diagonal raised
+    /// to [`Self::path_pin_add`].
+    ///
+    /// # Why raising the diagonal costs nothing in accuracy
+    ///
+    /// This is the *operator*, not the pin. The caller applies the
+    /// same exact Schur row on top of it -- `K w - E du = r`,
+    /// `Eᵀ w = 0` -- and `Eᵀ w = 0` says every pinned coordinate of
+    /// `w` is zero, so the term this function added,
+    /// `Σ_pin E Eᵀ w`, is identically zero at the solution. The
+    /// system actually solved is the released one, and `du` comes back
+    /// in the very same frame and units the unregularized pin reports
+    /// it in. Nothing has to be converted, and a walk that takes the
+    /// plain operator on one segment and this one on the next keeps
+    /// accumulating a single `h.mult`.
+    ///
+    /// What the added diagonal buys is that `K⁻¹` exists at all.
+    /// Releasing a bound takes its `Sigma` off the diagonal; on a
+    /// model with no curvature two released variables sharing a
+    /// constraint row are left with linearly dependent stationarity
+    /// rows, and a Schur complement `-Eᵀ K⁻¹ E` cannot be built from a
+    /// singular `K` (gh#930). The diagonal has to be reachable, not
+    /// merely large -- [`Self::path_pin_add`] is the gh#737 ceiling,
+    /// the stiffest entry the row's own couplings survive.
+    ///
+    /// `issue_930_two_curvature_free_releases.rs` measures the two
+    /// operators against each other on a fixture where both run, and
+    /// the answer against a re-solve at the perturbed parameter.
+    fn solve_released_pinned_inner(
+        &self,
+        released: &[usize],
+        pinned: &[usize],
+        rhs: &[Number],
+        lhs: &mut [Number],
+    ) -> bool {
+        if pinned.is_empty() {
+            return false;
+        }
+        let n_p = self.dims[0] + self.dims[1];
+        // A pin is a primal row by contract; anything past the `s`
+        // block is a multiplier row and has no diagonal to raise.
+        if pinned.iter().any(|&r| r >= n_p) {
+            return false;
+        }
+        let pins: Vec<(usize, Number)> =
+            pinned.iter().map(|&r| (r, self.path_pin_add(r))).collect();
+        let Some((sigma_x, sigma_s)) = self.active_set_sigmas(released, &pins) else {
+            return false;
+        };
+        self.solve_released_prebuilt(released, sigma_x, sigma_s, None, rhs, lhs, false)
+    }
+
     /// The barrier's **primal** diagonals with each released bound's
     /// own `z / s` taken off the quantity it constrains -- rebuilt
     /// rather than subtracted, since a quantity bounded on both sides
@@ -882,10 +972,13 @@ impl PdSensBacksolver {
     /// which is every call this had before constraint rows were
     /// reported and every call on a model with no inequality limits.
     ///
-    /// `pinned` stays var-x: a pin is a Schur row for the path and the
-    /// corrector's own bound check, neither of which pins a slack, and
-    /// a slack row arriving here would land on the wrong diagonal
-    /// silently. The guard below rejects it instead.
+    /// `pinned` is a **primal** KKT row, not a var-x row, and the two
+    /// spaces coincide only below `dims[0]`. A constraint's own limit
+    /// is a bound on its slack (gh#928), so its pin belongs on the `s`
+    /// diagonal; writing it into the `x` diagonal at whatever index it
+    /// happens to equal is the gh#450 neighbouring-variable hazard one
+    /// block over. The loop below decides the block rather than
+    /// assuming it.
     fn active_set_sigmas(
         &self,
         released: &[usize],
@@ -2561,6 +2654,16 @@ impl SensBacksolver for PdSensBacksolver {
 
     fn solve_released_step(&self, released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
         self.solve_released_inner(released, rhs, lhs, true)
+    }
+
+    fn solve_released_pinned(
+        &self,
+        released: &[usize],
+        pinned: &[usize],
+        rhs: &[Number],
+        lhs: &mut [Number],
+    ) -> bool {
+        self.bound_vars.is_some() && self.solve_released_pinned_inner(released, pinned, rhs, lhs)
     }
 
     /// Solve `K · lhs = rhs` against the converged factor, in

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -158,6 +158,21 @@ pub struct PdSensBacksolver {
     sigma: EffectiveSigma,
 }
 
+/// Which of the four bound-multiplier blocks a compound KKT row falls
+/// in. Produced by [`PdSensBacksolver::bound_block_of`], which is the
+/// only place the block offsets are computed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BoundBlock {
+    /// `z_l`: lower bound on a variable.
+    ZL,
+    /// `z_u`: upper bound on a variable.
+    ZU,
+    /// `v_l`: lower limit on an inequality row, carried by its slack.
+    VL,
+    /// `v_u`: upper limit on an inequality row, likewise.
+    VU,
+}
+
 /// The barrier diagonals the sensitivity path factors with, after both
 /// corrections that stand between the calculated quantities and the
 /// matrix: gh#654's choice of *frame*, and gh#737's ceiling on how
@@ -253,6 +268,14 @@ struct DeclaredFrameBarrier {
     /// to rebuild it in the same frame.
     slack_x_l: Vec<Number>,
     slack_x_u: Vec<Number>,
+    /// The same two, for the `s` block and the `pd_l` / `pd_u` spaces.
+    /// A released **constraint** limit rebuilds its slack's `Σ` entry
+    /// exactly as a released variable bound does, and a rebuild that
+    /// reached for the live relaxed slacks while the diagonal it was
+    /// patching came from the declared frame would mix the two frames
+    /// in one vector -- the gh#654 defect, one block over.
+    slack_s_l: Vec<Number>,
+    slack_s_u: Vec<Number>,
 }
 
 /// Left/right diagonal pair for the natural-units back-solve; see the
@@ -460,7 +483,7 @@ impl PdSensBacksolver {
             &*curr.z_u,
             dims[0],
         );
-        let (sigma_s, _, _) = declared_frame_sigma(
+        let (sigma_s, slack_s_l, slack_s_u) = declared_frame_sigma(
             &*nlp_ref.pd_l(),
             &*nlp_ref.pd_u(),
             &*curr.s,
@@ -475,6 +498,8 @@ impl PdSensBacksolver {
             sigma_s,
             slack_x_l,
             slack_x_u,
+            slack_s_l,
+            slack_s_u,
         }))
     }
 
@@ -705,10 +730,15 @@ impl PdSensBacksolver {
         if released.is_empty() {
             return self.solve(rhs, lhs);
         }
-        let Some(sigma) = self.released_sigma_x(released) else {
+        // Both diagonals: a released row can bound a slack rather than
+        // a variable, and taking its `z / s` off the `x` block would
+        // leave the constraint limit still enforced (gh#928). `None`
+        // in the `s` slot is the ordinary case and keeps the cached
+        // factorization key.
+        let Some((sigma, sigma_s)) = self.released_sigmas(released) else {
             return false;
         };
-        self.solve_released_prebuilt(released, sigma, None, None, rhs, lhs, shift)
+        self.solve_released_prebuilt(released, sigma, sigma_s, None, rhs, lhs, shift)
     }
 
     /// [`Self::solve_released_inner`] with the released `Σ` supplied by
@@ -773,21 +803,62 @@ impl PdSensBacksolver {
         true
     }
 
-    /// The barrier's `x` diagonal with each released bound's own `z / s`
-    /// taken off the variable it constrains -- subtracted rather than
-    /// zeroed, since a variable bounded on both sides contributes twice
-    /// and only one side is being released.
+    /// The barrier's **primal** diagonals with each released bound's
+    /// own `z / s` taken off the quantity it constrains -- rebuilt
+    /// rather than subtracted, since a quantity bounded on both sides
+    /// contributes twice and only one side is being released.
+    ///
+    /// The second slot is the `s`-block diagonal a released
+    /// **constraint** limit needs, and is `None` when nothing in
+    /// `released` bounds a slack.
     ///
     /// Both the starting diagonal and the slacks the surviving sides are
     /// rebuilt from come from the frame the held iterate belongs to
     /// (gh#654): mixing a declared-frame `Σ` with relaxed-frame slacks
     /// would leave the released variable pinned in one frame and its
     /// neighbours in the other.
-    pub(crate) fn released_sigma_x(
+    ///
+    /// `None` is load-bearing rather than a shortcut: the
+    /// factorization cache keys on the diagonal object's tag, so
+    /// handing back a freshly built `s` vector that is numerically
+    /// identical to the cached one would re-factorize every solve.
+    pub(crate) fn released_sigmas(
         &self,
         released: &[usize],
-    ) -> Option<Rc<dyn pounce_linalg::Vector>> {
-        self.active_set_sigma_x(released, &[])
+    ) -> Option<(
+        Rc<dyn pounce_linalg::Vector>,
+        Option<Rc<dyn pounce_linalg::Vector>>,
+    )> {
+        self.active_set_sigmas(released, &[])
+    }
+
+    /// Which bound block a multiplier row falls in, and its index
+    /// inside that block's compressed vector.
+    ///
+    /// `bound_variable_rows` emits the four groups in block order and
+    /// records only the compound row, so this is where a row is turned
+    /// back into "the `k`th entry of `z_u`". Doing that arithmetic at
+    /// the use site is what the `z`-only version did -- `row -
+    /// base_row - dims[4]` -- and that expression silently returns a
+    /// `z_u` index for a `v_l` row, which is a real number that
+    /// indexes a real vector and is wrong.
+    fn bound_block_of(&self, row: usize) -> Option<(BoundBlock, usize)> {
+        let z_l = self.dims[0] + self.dims[1] + self.dims[2] + self.dims[3];
+        let z_u = z_l + self.dims[4];
+        let v_l = z_u + self.dims[5];
+        let v_u = v_l + self.dims[6];
+        let end = v_u + self.dims[7];
+        if row >= z_l && row < z_u {
+            Some((BoundBlock::ZL, row - z_l))
+        } else if row >= z_u && row < v_l {
+            Some((BoundBlock::ZU, row - z_u))
+        } else if row >= v_l && row < v_u {
+            Some((BoundBlock::VL, row - v_l))
+        } else if row >= v_u && row < end {
+            Some((BoundBlock::VU, row - v_u))
+        } else {
+            None
+        }
     }
 
     /// [`Self::released_sigma_x`], also raising the diagonal on
@@ -795,42 +866,74 @@ impl PdSensBacksolver {
     ///
     /// The two directions an active set can move are the same
     /// modification to one diagonal. A bound that leaves has its
-    /// `z / s` taken off the variable it constrains, and a bound that
+    /// `z / s` taken off the quantity it constrains, and a bound that
     /// becomes active has one put on, so a single vector describes
     /// both and a single factorization serves the whole correction.
     /// The two arguments are in different index spaces and both are
     /// `usize`: `released` holds compound KKT rows of bound
     /// multipliers, `pinned` holds var-x rows. Passing one where the
     /// other belongs is not a type error and will not be caught here.
-    pub(crate) fn active_set_sigma_x(
+    ///
+    /// Returns both primal diagonals, because a released row can bound
+    /// a slack rather than a variable (gh#928): `g(x) <= cap` puts its
+    /// multiplier in `v_u` and its `z / s` on the `s` diagonal, and
+    /// releasing it has to come off the block it was added to. The `s`
+    /// half is `None` whenever `released` touches no slack bound,
+    /// which is every call this had before constraint rows were
+    /// reported and every call on a model with no inequality limits.
+    ///
+    /// `pinned` stays var-x: a pin is a Schur row for the path and the
+    /// corrector's own bound check, neither of which pins a slack, and
+    /// a slack row arriving here would land on the wrong diagonal
+    /// silently. The guard below rejects it instead.
+    fn active_set_sigmas(
         &self,
         released: &[usize],
         pinned: &[(usize, Number)],
-    ) -> Option<Rc<dyn pounce_linalg::Vector>> {
+    ) -> Option<(
+        Rc<dyn pounce_linalg::Vector>,
+        Option<Rc<dyn pounce_linalg::Vector>>,
+    )> {
         use pounce_linalg::dense_vector::DenseVectorSpace;
         let rows = self.bound_vars.as_deref()?;
-        let base_row = rows.first()?.row;
         let dense = |v: Rc<dyn pounce_linalg::Vector>| -> Option<Vec<Number>> {
             v.as_any()
                 .downcast_ref::<DenseVector>()
                 .map(|d| d.expanded_values())
         };
-        let mut sigma = dense(self.barrier_sigma_x())?;
-        let (slack_l, slack_u) = match self.declared.as_ref() {
-            Some(d) => (d.slack_x_l.clone(), d.slack_x_u.clone()),
+        let n_x = self.dims[0];
+        let mut sigma_x = dense(self.barrier_sigma_x())?;
+        // Built only if a slack bound is actually released; see
+        // `released_sigmas` on why an untouched `None` matters.
+        let mut sigma_s: Option<Vec<Number>> = None;
+        let (slack_x_l, slack_x_u, slack_s_l, slack_s_u) = match self.declared.as_ref() {
+            Some(d) => (
+                d.slack_x_l.clone(),
+                d.slack_x_u.clone(),
+                d.slack_s_l.clone(),
+                d.slack_s_u.clone(),
+            ),
             None => {
                 let cq_ref = self.cq.borrow();
-                let l = dense(cq_ref.curr_slack_x_l())?;
-                let u = dense(cq_ref.curr_slack_x_u())?;
-                (l, u)
+                (
+                    dense(cq_ref.curr_slack_x_l())?,
+                    dense(cq_ref.curr_slack_x_u())?,
+                    dense(cq_ref.curr_slack_s_l())?,
+                    dense(cq_ref.curr_slack_s_u())?,
+                )
             }
         };
-        let (z_l, z_u) = {
+        let (z_l, z_u, v_l, v_u) = {
             let d = self.data.borrow();
             let curr = d.curr.as_ref()?;
-            (dense(Rc::clone(&curr.z_l))?, dense(Rc::clone(&curr.z_u))?)
+            (
+                dense(Rc::clone(&curr.z_l))?,
+                dense(Rc::clone(&curr.z_u))?,
+                dense(Rc::clone(&curr.v_l))?,
+                dense(Rc::clone(&curr.v_u))?,
+            )
         };
-        // Rebuild each released variable's entry from its bounds that
+        // Rebuild each released quantity's entry from its bounds that
         // stay active, rather than subtracting the released bound's
         // `z / s` from the cached total. The subtraction differences
         // two numbers of order `z / s`, 1e7 and up at a tightly
@@ -845,11 +948,12 @@ impl PdSensBacksolver {
                 if released.contains(&other.row) {
                     continue;
                 }
-                let k = other.row - base_row - if other.lower { 0 } else { self.dims[4] };
-                let (z, s) = if other.lower {
-                    (*z_l.get(k)?, *slack_l.get(k)?)
-                } else {
-                    (*z_u.get(k)?, *slack_u.get(k)?)
+                let (blk, k) = self.bound_block_of(other.row)?;
+                let (z, s) = match blk {
+                    BoundBlock::ZL => (*z_l.get(k)?, *slack_x_l.get(k)?),
+                    BoundBlock::ZU => (*z_u.get(k)?, *slack_x_u.get(k)?),
+                    BoundBlock::VL => (*v_l.get(k)?, *slack_s_l.get(k)?),
+                    BoundBlock::VU => (*v_u.get(k)?, *slack_s_u.get(k)?),
                 };
                 if s == 0.0 || !s.is_finite() {
                     return None;
@@ -859,29 +963,57 @@ impl PdSensBacksolver {
             // Under the same ceiling the rest of the diagonal is held
             // to (gh#737): a rebuilt entry is `z/s` off the iterate
             // like any other, and a released variable is the one most
-            // likely to be reached through a constraint row.
-            let cap = self
-                .sigma
-                .cap_x
-                .get(br.var_row)
-                .copied()
-                .unwrap_or(Number::INFINITY);
-            *sigma.get_mut(br.var_row)? = fresh.min(cap);
+            // likely to be reached through a constraint row. The `s`
+            // block's ceiling is the scalar its diagonal was built
+            // under, `sigma_pin_cap(1.0)`, exactly as at construction.
+            if br.var_row < n_x {
+                let cap = self
+                    .sigma
+                    .cap_x
+                    .get(br.var_row)
+                    .copied()
+                    .unwrap_or(Number::INFINITY);
+                *sigma_x.get_mut(br.var_row)? = fresh.min(cap);
+            } else {
+                let ss = match sigma_s.as_mut() {
+                    Some(v) => v,
+                    None => sigma_s.insert(dense(self.barrier_sigma_s())?),
+                };
+                *ss.get_mut(br.var_row - n_x)? = fresh.min(sigma_pin_cap(1.0));
+            }
         }
         for &(var_row, add) in pinned {
-            let cap = self
-                .sigma
-                .cap_x
-                .get(var_row)
-                .copied()
-                .unwrap_or(Number::INFINITY);
-            let slot = sigma.get_mut(var_row)?;
-            *slot = pinned_entry(*slot, add, cap);
+            // `var_row` is a *primal* KKT row, so it reaches past the
+            // `x` block into `s` for a constraint's own limit. Writing
+            // one into the `x` diagonal at whatever index it happens
+            // to equal is the gh#450 neighbouring-variable hazard, so
+            // the block is decided here rather than assumed.
+            if var_row < n_x {
+                let cap = self
+                    .sigma
+                    .cap_x
+                    .get(var_row)
+                    .copied()
+                    .unwrap_or(Number::INFINITY);
+                let slot = sigma_x.get_mut(var_row)?;
+                *slot = pinned_entry(*slot, add, cap);
+            } else {
+                // Same ceiling the `s` diagonal was built under.
+                let ss = match sigma_s.as_mut() {
+                    Some(v) => v,
+                    None => sigma_s.insert(dense(self.barrier_sigma_s())?),
+                };
+                let slot = ss.get_mut(var_row - n_x)?;
+                *slot = pinned_entry(*slot, add, sigma_pin_cap(1.0));
+            }
         }
-        let space = DenseVectorSpace::new(sigma.len() as Index);
-        let mut out = DenseVector::new(space);
-        out.values_mut().copy_from_slice(&sigma);
-        Some(Rc::new(out) as Rc<dyn pounce_linalg::Vector>)
+        let pack = |vals: &[Number]| -> Rc<dyn pounce_linalg::Vector> {
+            let space = DenseVectorSpace::new(vals.len() as Index);
+            let mut out = DenseVector::new(space);
+            out.values_mut().copy_from_slice(vals);
+            Rc::new(out) as Rc<dyn pounce_linalg::Vector>
+        };
+        Some((pack(&sigma_x), sigma_s.as_deref().map(pack)))
     }
 
     /// Zero the released multipliers' own rows of a scaled-space
@@ -898,9 +1030,9 @@ impl PdSensBacksolver {
         let Some(rows) = self.bound_vars.as_deref() else {
             return false;
         };
-        let Some(base_row) = rows.first().map(|b| b.row) else {
+        if rows.is_empty() {
             return false;
-        };
+        }
         let d = self.data.borrow();
         let Some(curr) = d.curr.as_ref() else {
             return false;
@@ -910,22 +1042,38 @@ impl PdSensBacksolver {
                 .downcast_ref::<DenseVector>()
                 .map(|x| x.expanded_values())
         };
-        let (Some(z_l), Some(z_u)) = (dense(&curr.z_l), dense(&curr.z_u)) else {
+        let (Some(z_l), Some(z_u), Some(v_l), Some(v_u)) = (
+            dense(&curr.z_l),
+            dense(&curr.z_u),
+            dense(&curr.v_l),
+            dense(&curr.v_u),
+        ) else {
             return false;
         };
         for &r in released {
             let Some(br) = rows.iter().find(|b| b.row == r) else {
                 return false;
             };
-            let k = r - base_row - if br.lower { 0 } else { self.dims[4] };
-            let Some(&z) = (if br.lower { z_l.get(k) } else { z_u.get(k) }) else {
+            // Which block the row lives in decides which multiplier
+            // vector to read; `br.var_row` is already the compound row
+            // of the primal quantity that carries it, `x` block or `s`
+            // block, so the shift below needs no second case.
+            let Some((blk, k)) = self.bound_block_of(r) else {
+                return false;
+            };
+            let Some(&z) = (match blk {
+                BoundBlock::ZL => z_l.get(k),
+                BoundBlock::ZU => z_u.get(k),
+                BoundBlock::VL => v_l.get(k),
+                BoundBlock::VU => v_u.get(k),
+            }) else {
                 return false;
             };
             if r >= rhs.len() || br.var_row >= rhs.len() {
                 return false;
             }
             rhs[r] = 0.0;
-            // the sign the x row carries this side's multiplier with
+            // the sign the primal row carries this side's multiplier with
             rhs[br.var_row] += if br.lower { -z } else { z };
         }
         true
@@ -1064,17 +1212,28 @@ impl PdSensBacksolver {
                 *v = c;
             }
         }
-        for &(var_row, add) in pinned {
-            let c = caps.get(var_row).copied().unwrap_or(Number::INFINITY);
-            let slot = x.get_mut(var_row)?;
-            *slot = pinned_entry(*slot, add, c);
-            *base_x.get_mut(var_row)? += add;
-        }
         let mut s = dense(live_s)?;
-        let base_s = s.clone();
+        let mut base_s = s.clone();
         for v in s.iter_mut() {
             if *v > cap_s {
                 *v = cap_s;
+            }
+        }
+        // `var_row` is a *primal* KKT row and the primal blocks are
+        // `x` then `s`, so a pin on a constraint's own limit lands in
+        // the second diagonal. Indexing `x` with it would be the
+        // gh#450 neighbouring-entry hazard one block over.
+        for &(var_row, add) in pinned {
+            if var_row < self.dims[0] {
+                let c = caps.get(var_row).copied().unwrap_or(Number::INFINITY);
+                let slot = x.get_mut(var_row)?;
+                *slot = pinned_entry(*slot, add, c);
+                *base_x.get_mut(var_row)? += add;
+            } else {
+                let k = var_row - self.dims[0];
+                let slot = s.get_mut(k)?;
+                *slot = pinned_entry(*slot, add, cap_s);
+                *base_s.get_mut(k)? += add;
             }
         }
         let pack = |vals: Vec<Number>| -> Rc<dyn pounce_linalg::Vector> {
@@ -1109,20 +1268,57 @@ impl PdSensBacksolver {
         self.pack_public(&scaled).ok().map(|iv| iv.freeze())
     }
 
-    /// Var-x row behind each `z_l` then `z_u` entry, through the
-    /// `px_l` / `px_u` expansions. `None` when either is not an
-    /// `ExpansionMatrix` or reports the wrong length -- the release
-    /// half then stays off rather than guessing a mapping.
+    /// The primal KKT row behind every bound multiplier: `z_l`, `z_u`
+    /// through the `px_l` / `px_u` expansions into the `x` block, then
+    /// `v_l`, `v_u` through `pd_l` / `pd_u` into the `s` block.
+    /// `None` when any of the four is not an `ExpansionMatrix` or
+    /// reports the wrong length -- the release half then stays off
+    /// rather than guessing a mapping.
+    ///
+    /// The `v` half is here because a limit written as a **constraint
+    /// row** -- `g(x) <= cap` -- is a bound like any other, on the
+    /// slack rather than on a variable, and reporting only the `z`
+    /// half left every such limit watched by nothing: no breakpoint,
+    /// no release, and a step straight through the cap with an empty
+    /// record (gh#928). The `s` block sits immediately after `x` in
+    /// the compound vector, so the (x, s) prefix is one contiguous box
+    /// and the walk needs no second index space to cover it -- which
+    /// is exactly why `var_row` is documented as a primal KKT row
+    /// rather than a var-x one.
+    ///
+    /// The four groups are emitted in block order, so
+    /// [`Self::bound_row_offsets`] can recover which block a row
+    /// belongs to and its position within that block without this
+    /// function storing either.
     fn bound_variable_rows(
         nlp: &Rc<RefCell<dyn IpoptNlp>>,
         dims: &[usize; 8],
     ) -> Option<Rc<Vec<crate::backsolver::BoundRow>>> {
         let nlp_ref = nlp.borrow();
         let z_l_off = dims[0] + dims[1] + dims[2] + dims[3];
-        let mut out = Vec::with_capacity(dims[4] + dims[5]);
-        for (pm, n_v, off, lower) in [
-            (nlp_ref.px_l(), dims[4], z_l_off, true),
-            (nlp_ref.px_u(), dims[5], z_l_off + dims[4], false),
+        let v_l_off = z_l_off + dims[4] + dims[5];
+        let mut out = Vec::with_capacity(dims[4] + dims[5] + dims[6] + dims[7]);
+        // (expansion, block width, multiplier-row offset, lower?,
+        //  primal-block base, primal-block width)
+        for (pm, n_v, off, lower, base, width) in [
+            (nlp_ref.px_l(), dims[4], z_l_off, true, 0, dims[0]),
+            (
+                nlp_ref.px_u(),
+                dims[5],
+                z_l_off + dims[4],
+                false,
+                0,
+                dims[0],
+            ),
+            (nlp_ref.pd_l(), dims[6], v_l_off, true, dims[0], dims[1]),
+            (
+                nlp_ref.pd_u(),
+                dims[7],
+                v_l_off + dims[6],
+                false,
+                dims[0],
+                dims[1],
+            ),
         ] {
             if n_v == 0 {
                 continue;
@@ -1136,12 +1332,12 @@ impl PdSensBacksolver {
             }
             for (k, &p) in pos.iter().enumerate() {
                 let p = p as usize;
-                if p >= dims[0] {
+                if p >= width {
                     return None;
                 }
                 out.push(crate::backsolver::BoundRow {
                     row: off + k,
-                    var_row: p,
+                    var_row: base + p,
                     lower,
                 });
             }

--- a/crates/pounce-sensitivity/src/corrector.rs
+++ b/crates/pounce-sensitivity/src/corrector.rs
@@ -409,6 +409,18 @@ pub(crate) fn run(
     let dim = bs.dim();
     let off = bs.offsets_public();
     let n_x = bs.block_dims()[0];
+    // The primal prefix: `x` then `s`, contiguous. Bound rows carry a
+    // primal KKT row, so a constraint's own limit lands in the second
+    // half, and `bound_context`'s box spans exactly this range.
+    let n_p = n_x + bs.block_dims()[1];
+    if lo.len() != n_p || hi.len() != n_p {
+        return Err(SolverError::SensComputationFailed(format!(
+            "corrector: the box spans {} entries, but the primal prefix (x then s) \
+             is {n_p}. The bound rows carry primal KKT rows, so the box must cover \
+             both blocks.",
+            lo.len()
+        )));
+    }
     let rows = bs
         .bound_rows()
         .ok_or_else(|| SolverError::SensComputationFailed("corrector: no bound rows".into()))?
@@ -603,8 +615,13 @@ pub(crate) fn run(
         }
         iterations += 1;
 
-        let (sl, dsl) = slacks_and_directions(&rows, &iterate[..n_x], &dir[..n_x], lo, hi, true);
-        let (su, dsu) = slacks_and_directions(&rows, &iterate[..n_x], &dir[..n_x], lo, hi, false);
+        // The whole primal prefix, not just `x`: a bound row's
+        // `var_row` reaches into the `s` block when the limit is
+        // written as a constraint row, and `lo`/`hi` from
+        // `bound_context` span the same (x, s) prefix (gh#928).
+        // Truncating at `n_x` would index past the end for those rows.
+        let (sl, dsl) = slacks_and_directions(&rows, &iterate[..n_p], &dir[..n_p], lo, hi, true);
+        let (su, dsu) = slacks_and_directions(&rows, &iterate[..n_p], &dir[..n_p], lo, hi, false);
         let alpha_p =
             fraction_to_boundary(&sl, &dsl, &[]).min(fraction_to_boundary(&su, &dsu, &[]));
         let alpha_d = fraction_to_boundary(

--- a/crates/pounce-sensitivity/src/lib.rs
+++ b/crates/pounce-sensitivity/src/lib.rs
@@ -94,8 +94,8 @@ pub use pounce_sens_core;
 // `crate::backsolver::SensBacksolver` spellings in `solver.rs`, `activity.rs`
 // and `corrector.rs` needed no edit at all.
 pub use pounce_sens_core::{
-    backsolver, boundcheck, p_calculator, reduced_hessian, schur_data, schur_driver, sens_app,
-    step_calc,
+    backsolver, boundcheck, p_calculator, reduced_hessian, rowlimit, schur_data, schur_driver,
+    sens_app, step_calc,
 };
 
 pub use algorithm_backsolver::PdSensBacksolver;

--- a/crates/pounce-sensitivity/src/lib.rs
+++ b/crates/pounce-sensitivity/src/lib.rs
@@ -93,6 +93,7 @@ pub use pounce_sens_core;
 // `pounce-cli` and for this crate's own tests, and the internal
 // `crate::backsolver::SensBacksolver` spellings in `solver.rs`, `activity.rs`
 // and `corrector.rs` needed no edit at all.
+pub use pounce_sens_core::boundcheck::PathOperator;
 pub use pounce_sens_core::{
     backsolver, boundcheck, p_calculator, reduced_hessian, rowlimit, schur_data, schur_driver,
     sens_app, step_calc,

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -70,13 +70,24 @@ pub const BARRIER_SIGN: Number = -1.0;
 /// The bound geometry the bound-aware parametric steps share. See
 /// [`Solver::bound_context`].
 struct BoundContext {
-    /// Length of the primal block.
+    /// Length of the `x` block: how much of the box below is
+    /// variables, and how much of a step is the caller's answer.
     n_x: usize,
-    /// Lower bounds over the primal block, in the model's own units.
+    /// Lower bounds over the `(x, s)` prefix of the compound KKT
+    /// vector, in the model's own units.
+    ///
+    /// The `s` half is the limits of the inequality rows, `d_l`. A
+    /// limit written as a constraint — `g(x) <= cap` — is a bound like
+    /// any other, on the row's slack instead of on a variable, and
+    /// leaving it out of the box is what let a step walk straight
+    /// through a cap with no breakpoint and no warning (gh#928). The
+    /// two blocks are adjacent in the compound vector, so the box is
+    /// one contiguous slice and a consumer needs no second index
+    /// space; `n_x` is where it changes meaning.
     lo: Vec<Number>,
-    /// Upper bounds, likewise.
+    /// Upper bounds, likewise: variable `x_u` then row `d_u`.
     hi: Vec<Number>,
-    /// The converged primal point, truncated to the primal block.
+    /// The converged point over that same `(x, s)` prefix.
     x_curr: Vec<Number>,
     /// How far outside a bound still counts as on it.
     eps: Number,
@@ -84,7 +95,10 @@ struct BoundContext {
     /// is released. Always the solve's own margin, whatever `eps` is.
     release_eps: Number,
     /// Bound multipliers at the base point, in the solve's own
-    /// coordinates, with the compound row each occupies.
+    /// coordinates, with the compound row each occupies: `z_l`, `z_u`,
+    /// then `v_l`, `v_u`. The `v` half is what lets an active
+    /// constraint limit be *released* when a step drives its
+    /// multiplier through zero, the mirror of the `s` half of the box.
     mults: Vec<crate::boundcheck::BoundMultiplier>,
 }
 
@@ -92,9 +106,12 @@ impl BoundContext {
     /// Distance from the base point to each bound, for one var-x row.
     ///
     /// Typed because the callers read a full-x `ActivityReport` in the
-    /// same scope: `lo`, `hi` and `x_curr` are all primal-block length,
-    /// and indexing them with a full-x value is the swap `crate::index`
-    /// exists to prevent.
+    /// same scope: indexing `lo` / `hi` / `x_curr` with a full-x value
+    /// is the swap `crate::index` exists to prevent. Those three now
+    /// run past the `x` block into `s`, so the type is doing more work
+    /// than it was: a var-x row is in range for the whole box and a
+    /// full-x row that overshoots `n_x` no longer runs off the end,
+    /// it silently reads a slack.
     fn slacks_at(&self, row: VarX) -> (Number, Number) {
         let i = row.get();
         (self.x_curr[i] - self.lo[i], self.hi[i] - self.x_curr[i])
@@ -1352,9 +1369,28 @@ impl Solver {
         };
 
         let released: Vec<usize> = weak.iter().map(|w| w.row).collect();
-        let sigma = bs
-            .released_sigma_x(&released)
+        // `weak` comes from `weakly_active_bounds`, which is keyed by
+        // a var-x row and so can only ever name a bound in the `x`
+        // block. Constraint-row limits (gh#928) live in the `s` block
+        // and would need the second diagonal below; releasing one here
+        // with the `s` diagonal left at its base value would solve a
+        // system that still enforces the bound it claims to have
+        // released, silently. Asked for rather than assumed: the
+        // second slot is `None` exactly when nothing in `released`
+        // touched the `s` block, so a non-`None` here means the
+        // premise this arm rests on has stopped holding.
+        let (sigma, sigma_s) = bs
+            .released_sigmas(&released)
             .ok_or_else(|| fail("released sigma unavailable"))?;
+        if sigma_s.is_some() {
+            return Err(fail(
+                "a released bound reached the `s` block. The directional \
+                 decision is built on `weakly_active_bounds`, whose rows are \
+                 var-x, so this cannot happen without that contract having \
+                 changed -- and releasing an `s`-block bound needs the slack \
+                 diagonal this arm does not carry.",
+            ));
+        }
         if work + 1 > max_iter {
             // Nothing is engaged before the all-released solve, so
             // this fires only at a budget of zero, and the floor is
@@ -1708,8 +1744,18 @@ impl Solver {
             let lower = s_lo <= s_hi;
             // a table lookup, so a space-swap here would fail loudly
             let var_row = row.get();
+            // `rows` now carries constraint-row limits too, whose
+            // `var_row` is an `s`-block row (gh#928). They can never
+            // match here -- `map.rows()` runs over the `x` block, so
+            // `var_row < ctx.n_x`, and every `s` row is at or above it
+            // -- but that is a property of two index ranges not
+            // overlapping, which is exactly the kind of thing that
+            // silently stops being true. Said out loud so it is a
+            // filter rather than a coincidence.
+            debug_assert!(var_row < ctx.n_x);
             if let Some(br) = rows
                 .iter()
+                .filter(|b| b.var_row < ctx.n_x)
                 .find(|b| b.var_row == var_row && b.lower == lower)
             {
                 out.push(crate::boundcheck::WeakBound {
@@ -1738,15 +1784,28 @@ impl Solver {
     fn bound_context(&self, bound_eps: Option<Number>) -> Result<BoundContext, SolverError> {
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
-        let n_x = state.backsolver.block_dims()[0];
+        let dims = state.backsolver.block_dims();
+        let n_x = dims[0];
+        let n_s = dims[1];
 
         // Expanded once, before any re-solve: reading the compressed
         // form means borrowing the NLP, and the solves below re-borrow
         // it.
-        let (mut lo, mut hi) = {
+        //
+        // Both primal blocks, in one pass over the same borrow: `x`
+        // against `x_l` / `x_u` through `px_l` / `px_u`, and `s`
+        // against `d_l` / `d_u` through `pd_l` / `pd_u`. The second
+        // half is gh#928's subject — an inequality row's limit is a
+        // bound on its slack, and a box that stopped at `n_x` left
+        // every such limit unwatched.
+        let (mut lo, mut hi, s_lo, s_hi) = {
             let (_, _, nlp) = state.backsolver.activity_handles();
             let nl = nlp.borrow();
-            crate::boundcheck::expand_bounds(n_x, &nl.px_l(), &nl.px_u(), nl.x_l(), nl.x_u())
+            let (lo, hi) =
+                crate::boundcheck::expand_bounds(n_x, &nl.px_l(), &nl.px_u(), nl.x_l(), nl.x_u());
+            let (s_lo, s_hi) =
+                crate::boundcheck::expand_bounds(n_s, &nl.pd_l(), &nl.pd_u(), nl.d_l(), nl.d_u());
+            (lo, hi, s_lo, s_hi)
         };
         // Those bounds bound the algorithm's `x̃ = d ⊙ x`, while
         // `state.x` and the step are both in the model's own units
@@ -1765,6 +1824,49 @@ impl Solver {
                 let (a, b) = (lo[i] / di, hi[i] / di);
                 lo[i] = a.min(b);
                 hi[i] = a.max(b);
+            }
+        }
+
+        // The `s` block gets the same treatment for the row scaling it
+        // was solved under. `F` — the vector every back-solve
+        // post-multiplies its answer by — is `1/dd_r` on the `s` rows,
+        // so a scaled quantity times `F` is the natural one, which is
+        // exactly the conversion the `x` block just made by dividing
+        // by `d`. Using `F` rather than re-reading `d_scale` keeps
+        // this pinned to the same numbers the step arrives in: the
+        // point of the conversion is that `x_curr`, the box and the
+        // step agree, not that the arithmetic matches a formula.
+        //
+        // The base slack `s* - d_l` is scale-invariant in sign but not
+        // in size, and it is compared against a multiplier that gets
+        // the same treatment inside the walk, so both sides move
+        // together. `variable_scaling_sensitivity.rs` is the general
+        // statement of why that has to be checked rather than assumed.
+        let mut s_curr: Vec<Number> = {
+            let (data, _, _) = state.backsolver.activity_handles();
+            let d = data.borrow();
+            let curr = d.curr.as_ref().ok_or(SolverError::NotConverged)?;
+            crate::vec_util::dense_to_vec(&*curr.s)
+        };
+        let mut s_lo = s_lo;
+        let mut s_hi = s_hi;
+        if s_curr.len() != n_s {
+            return Err(SolverError::BadShape {
+                what: "slack block of the converged iterate",
+                got: s_curr.len(),
+                expected: n_s,
+            });
+        }
+        if let Some(f) = state.backsolver.natural_units_factor() {
+            for i in 0..n_s {
+                let fi = f[n_x + i];
+                if fi == 1.0 {
+                    continue;
+                }
+                s_curr[i] *= fi;
+                let (a, b) = (s_lo[i] * fi, s_hi[i] * fi);
+                s_lo[i] = a.min(b);
+                s_hi[i] = a.max(b);
             }
         }
 
@@ -1799,7 +1901,6 @@ impl Solver {
         // row each one occupies, so a step that drives one negative can
         // release that bound.
         let mults = {
-            let dims = state.backsolver.block_dims();
             let (z_l_off, z_u_off) = (
                 dims[0] + dims[1] + dims[2] + dims[3],
                 dims[0] + dims[1] + dims[2] + dims[3] + dims[4],
@@ -1807,19 +1908,29 @@ impl Solver {
             let (data, _, _) = state.backsolver.activity_handles();
             let d = data.borrow();
             let curr = d.curr.as_ref().ok_or(SolverError::NotConverged)?;
+            let (v_l_off, v_u_off) = (z_u_off + dims[5], z_u_off + dims[5] + dims[6]);
             let mut out = Vec::new();
-            for (off, v) in [(z_l_off, &curr.z_l), (z_u_off, &curr.z_u)] {
+            for (off, v) in [
+                (z_l_off, &curr.z_l),
+                (z_u_off, &curr.z_u),
+                (v_l_off, &curr.v_l),
+                (v_u_off, &curr.v_u),
+            ] {
                 for (k, &base) in crate::vec_util::dense_to_vec(&**v).iter().enumerate() {
                     out.push(crate::boundcheck::BoundMultiplier { row: off + k, base });
                 }
             }
             out
         };
+        lo.extend_from_slice(&s_lo);
+        hi.extend_from_slice(&s_hi);
+        let mut x_curr = state.x[..n_x].to_vec();
+        x_curr.extend_from_slice(&s_curr);
         Ok(BoundContext {
             n_x,
             lo,
             hi,
-            x_curr: state.x[..n_x].to_vec(),
+            x_curr,
             eps,
             release_eps,
             mults,
@@ -1954,6 +2065,38 @@ impl Solver {
                     .backsolver
                     .full_g_to_d_block(g)
                     .map(|pos| y_d_offset + pos)
+            })
+            .collect())
+    }
+
+    /// Flat rows of the compound KKT vector holding an inequality's
+    /// **slack** `s`, for the given 0-based full-g row indices; `None`
+    /// for a row that is not an inequality.
+    ///
+    /// The primal counterpart of [`Self::d_multiplier_rows`], and the
+    /// discriminator a consumer of [`Self::parametric_step_path`]
+    /// needs. A limit written as `g(x) <= cap` bounds this slack
+    /// rather than any variable, so a breakpoint on it carries a
+    /// primal KKT row in the `s` block (gh#928). Reading such a row as
+    /// a var-x index returns a neighbouring variable's answer, the
+    /// gh#450 hazard, so a caller that maps rows back to model objects
+    /// resolves them here.
+    ///
+    /// The `s` block sits immediately after `x`, and is indexed by
+    /// d-block position exactly as `y_d` is, so this row and
+    /// [`Self::d_multiplier_rows`]'s row name the same inequality from
+    /// the two sides of its complementarity pair.
+    pub fn d_slack_rows(&self, g_indices: &[Index]) -> Result<Vec<Option<Index>>, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let s_offset = state.backsolver.block_dims()[0] as Index;
+        Ok(g_indices
+            .iter()
+            .map(|&g| {
+                state
+                    .backsolver
+                    .full_g_to_d_block(g)
+                    .map(|pos| s_offset + pos)
             })
             .collect())
     }

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -58,6 +58,7 @@ use pounce_nlp::return_codes::ApplicationReturnStatus;
 use crate::PdSensBacksolver;
 use crate::activity::{ActivityReport, ReducedActivityReport, ReducedRowActivityReport};
 use crate::backsolver::SensBacksolver;
+use crate::boundcheck::PathOperator;
 use crate::index::{FullXSlice, VarToFull, VarX};
 use crate::schur_data::IndexSchurData;
 use crate::sens_app::{SensApplication, SensOptions};
@@ -1200,6 +1201,59 @@ impl Solver {
             pinned.into_iter().map(|p| p as Index).collect(),
             stop,
         ))
+    }
+
+    /// [`crate::boundcheck::path_direction`] for a working set the
+    /// caller names, and the force each held row carries under it.
+    /// Study surface, and the seam the two pins are measured against
+    /// each other through.
+    ///
+    /// `released_bound_rows` are compound bound-multiplier rows, as
+    /// [`Self::weakly_active_bounds`] reports them;
+    /// `held_primal_rows` are primal rows -- `x` block for a
+    /// variable, `s` block for a constraint's own limit (gh#928).
+    ///
+    /// `operator` picks which *operator* the walk's (single, exact)
+    /// Schur pin is applied to.
+    /// [`Plain`](PathOperator::Plain) is the released system as the
+    /// factorization already holds it -- one factorization for the
+    /// whole segment, and no inverse at all when releasing two
+    /// curvature-free variables that share a row leaves the
+    /// stationarity rows dependent (gh#930).
+    /// [`Regularized`](PathOperator::Regularized) raises the pinned
+    /// diagonals until it is invertible, at the cost of rebuilding
+    /// the diagonal per solve, so the factorization cache misses.
+    /// [`Preferred`](PathOperator::Preferred) is what the walk itself
+    /// runs: the plain one, falling back when it fails *or when its
+    /// pins do not take*, which is not the same test -- see
+    /// [`crate::boundcheck::path_direction`].
+    ///
+    /// Both operators give the same answer: the Schur row enforces
+    /// `Eᵀ w = 0`, which annihilates the added diagonal, so the
+    /// system solved is the released one either way and both return
+    /// values agree in value, frame and units.
+    /// `issue_930_two_curvature_free_releases.rs` measures that.
+    pub fn path_direction_decided(
+        &self,
+        pin_constraint_indices: &[Index],
+        deltas: &[Number],
+        released_bound_rows: &[Index],
+        held_primal_rows: &[Index],
+        operator: PathOperator,
+    ) -> Result<(Vec<Number>, Vec<Number>), SolverError> {
+        let rhs_plain = self.parametric_rhs_full(pin_constraint_indices, deltas)?;
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let released: Vec<usize> = released_bound_rows.iter().map(|&r| r as usize).collect();
+        let held: Vec<usize> = held_primal_rows.iter().map(|&r| r as usize).collect();
+        crate::boundcheck::path_direction_with(
+            &state.backsolver,
+            &rhs_plain,
+            &released,
+            &held,
+            operator,
+        )
+        .map_err(SolverError::SensComputationFailed)
     }
 
     /// The all-released step: the plain parametric step solved with

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -929,6 +929,7 @@ impl Solver {
             &[],
             &[],
             &weak_rows,
+            ctx.eps,
         )
         .map_err(SolverError::SensComputationFailed)?;
         Ok((dx[..ctx.n_x].to_vec(), segments))
@@ -993,6 +994,7 @@ impl Solver {
             &forced_active,
             &holds,
             &weak_rows,
+            ctx.eps,
         )
         .map_err(SolverError::SensComputationFailed)?;
         Ok((dx[..ctx.n_x].to_vec(), segments))

--- a/crates/pounce-sensitivity/tests/issue_928_a_limit_written_as_a_row.rs
+++ b/crates/pounce-sensitivity/tests/issue_928_a_limit_written_as_a_row.rs
@@ -1,0 +1,1055 @@
+//! gh#928, the constraint-row arm: the same limit, written the other
+//! way, was watched by nothing.
+//!
+//! The companion files put the limit on a **variable** -- `x <= 1`
+//! declared in `x_u`. This one writes the identical limit as a
+//! **constraint row**, `g(x) <= cap`, which is how a capacity, a ramp,
+//! a nameplate, or any limit on a computed quantity is normally
+//! stated. The two describe the same feasible set, and before this
+//! branch they were not the same to the sensitivity layer at all:
+//!
+//! * a variable bound's multiplier lives in `z_l` / `z_u`, and the
+//!   quantity it constrains is a row of the `x` block;
+//! * a row's limit bounds the **slack**, so its multiplier lives in
+//!   `v_l` / `v_u`, and the quantity it constrains is a row of the `s`
+//!   block.
+//!
+//! `bound_variable_rows` emitted only the `z` half, and
+//! `bound_context`'s box covered only the `x` block. A row limit was
+//! therefore in no bound row and in no box: the reach scan never saw
+//! it, no breakpoint could name it, the base-activity table had no
+//! entry for it, and gh#928's repair loop had nothing to add to its
+//! watch list. This is not the identification floor the companion
+//! files are about -- it is a whole class of limit that the walk could
+//! not represent, at any curvature.
+//!
+//! ```text
+//! min  0.5 (x - lam)^2
+//! s.t. g0: lam = lam0        (the pin)
+//!      g1: x <= CAP          (the limit, as a ROW)
+//!      x free
+//! ```
+//!
+//! `x` carries no bound of its own, so the cap is reachable only
+//! through `g1`. The optimum is `x = min(lam, CAP)`, with a kink at
+//! `lam = CAP`, and the objective is strictly convex in `x`, so what
+//! the released system does with the cap's barrier term is visible in
+//! the answer rather than masked by an equality.
+//!
+//! # Measured, on this model, at HEAD before the fix
+//!
+//! ```text
+//!  lam0   dp     branch          x         truth    segments
+//!  0.8   +0.5    reach       1.300000000    1.0        []
+//!  0.8   +0.3    reach       1.100000000    1.0        []
+//!  1.3   -0.5    release     1.000000000    0.8        []
+//!  1.3   -0.4    release     1.000000000    0.9        []
+//!  1.0   +0.01   reach       1.004992176    1.0        []
+//!  1.0   -0.01   release     0.994992176    0.99       []
+//!  1.3   +0.2    (neither)   1.000000000    1.0        []
+//!  0.8   -0.2    (neither)   0.600000000    0.6        []
+//! ```
+//!
+//! Three tenths outside a stated cap, with an empty record. That empty
+//! record is the point: a caller cannot even tell the answer is
+//! suspect, which is gh#928's signature one block over. After the fix
+//! every row above is exact to about 1e-10 and carries a segment on
+//! the cap's own slack row. The last two rows touch the cap in neither
+//! direction and are exact both before and after -- the control that
+//! says the machinery is not simply clamping.
+//!
+//! # Both branches, deliberately
+//!
+//! A leg is only evidence about the branch its fixture reaches, and
+//! the walk has two ways to touch a row limit:
+//!
+//! * **reach** -- the base point is below the cap and the step presses
+//!   into it. Needs the row in the scan, in the box, and a Schur hold
+//!   on its `s` row. No backsolver arithmetic: `path_direction` pins
+//!   any KKT row, which is what makes the `(x, s)` prefix a single box
+//!   rather than a second index space.
+//! * **release** -- the base point holds the cap with a multiplier of
+//!   order one and the step drives that multiplier to zero. Needs the
+//!   barrier's **`s`-block diagonal** rebuilt with the released
+//!   entry's `v / s` taken out, which is arithmetic the release half
+//!   did not have. Pre-fix this arm did not merely lose the record: at
+//!   `lam0 = 1.3`, `dp = -0.5` the answer stayed pinned at the cap,
+//!   1.0 against a truth of 0.8, because nothing took the cap's
+//!   stiffness out of the operator.
+//!
+//! # Mutation table
+//!
+//! Every row below was applied to this tree and run; the "what goes
+//! red" column is the observed result, not the intended one. Two of
+//! them came out differently from the way they were first written
+//! down, and both corrections are load-bearing -- see the notes.
+//!
+//! | change | what goes red |
+//! |---|---|
+//! | drop the `pd_l` / `pd_u` groups from `bound_variable_rows` | release, kink, **and the control** -- but *not* reach (note 1) |
+//! | narrow `bound_context`'s box back to the `x` block | reach, release, kink; the control stays green |
+//! | route an `s`-block release into `sigma_x` | release, kink-release, and `releasing_the_row_limit_leaves_the_variable_bound_alone` (note 2) |
+//! | leave `sigma_s` at its base value on a release | the same three, with a different message on the third (note 2) |
+//! | drop the `s`-block offset in `Solver::d_slack_rows` | `the_cap_is_a_row_and_its_primal_row_is_n_x` |
+//! | skip the `s` block's `natural_units_factor` conversion in `bound_context` | `leg_scaling_a_row_limit_is_reached_at_the_same_place_under_a_row_scaling`, and *only* that one (note 4) |
+//! | keep `slacks_and_directions`' `[..n_x]` truncation | **nothing here** -- `cd_split_pin_mapping.rs` catches it (note 3) |
+//!
+//! **Note 1 -- the two halves of the fix are separable, and the
+//! control is the discriminator.** The reach scan reads the box
+//! directly (`for i in 0..n_p` in `walk_once`), so widening
+//! `bound_context`'s box is by itself enough to reach a row limit;
+//! the bound rows are not on that path.
+//! `a_row_limit_the_step_presses_into_is_reached_and_held` therefore
+//! stays green with the `v` groups suppressed. What goes red instead
+//! is `a_step_that_does_not_touch_the_cap_records_nothing`: with no
+//! bound row for the cap, the strongly-held base point has no
+//! base-activity entry, the walk reads the slack as free, and
+//! `lam0 = 1.3, dp = +0.2` -- a step that never approaches the cap --
+//! records a spurious reach at fraction 0.600. So the control is not
+//! a formality. It is the only test in the file that fails when the
+//! base-activity table loses the row, and it is what separates "the
+//! walk can see the cap" from "the walk knows the cap is already
+//! held".
+//!
+//! **Note 2 -- the first model cannot separate mutations 3 and 4, so
+//! there is a second one.** On the model above the two mutations are
+//! bit-identical (`x` 0.9999999999373727 against a re-solve of
+//! 0.7999999999545443, the segment still recorded at fraction 0.600),
+//! because no variable in it carries a bound of its own: `sigma_x` is
+//! identically zero, so misrouting the release into it is
+//! observationally the same as dropping it. That is the gh#450 hazard
+//! in its quiet form -- the wrong write lands somewhere harmless *on
+//! this model*, and a corrector that got the `s` half right while
+//! also corrupting a neighbouring `x` entry would run green.
+//!
+//! No other fixture closes it either:
+//! `issue_928_two_soft_bounds_at_once.rs` is all variable bounds and
+//! has no row limit at all. So the second model below carries both at
+//! once -- `w >= 0` strongly held with multiplier 3 at `x`-block index
+//! 0, and the cap's slack at index `n_x`, which is exactly the index a
+//! misrouted release maps back onto. Measured, the two mutations now
+//! fail `releasing_the_row_limit_leaves_the_variable_bound_alone`
+//! with *different* messages:
+//!
+//! ```text
+//! mutation 3:  `w`'s bound must not move;
+//!              segments [(0.600, 3, false, false), (0.600, 0, true, true)]
+//! mutation 4:  x walked to 0.999999999937373 against a closed form of 0.8
+//! ```
+//!
+//! Under 3 the answer for `x` is *right* and only `w` is wrong, which
+//! is the whole reason the model exists: every other test in this file
+//! reads `x`.
+//!
+//! **Note 3 -- the corrector is not on this file's path.**
+//! `parametric_step_path` does not run `corrector::run`, so restoring
+//! the `[..n_x]` truncation leaves all six tests green. Across the
+//! whole crate exactly one test catches it, and it catches it loudly:
+//! `cd_split_pin_mapping::correct_step_translates_pin_index_through_cd_split`
+//! panics at `corrector.rs:255` with "the len is 3 but the index is
+//! 3". Recorded here because the obvious reading -- that the file
+//! covering the `s`-block bound rows also covers every consumer of
+//! them -- is wrong.
+//!
+//! **Note 4 -- the scaling legs are not vacuous, but only one of
+//! them bites.** Dropping the `s`-block frame conversion reproduces
+//! gh#928's original symptom on the scaled arm exactly:
+//!
+//! ```text
+//! scaled: the walk left the box at 1.2999999998863827, cap 1
+//! ```
+//!
+//! -- the same 1.2999999998 the pre-fix table records, from a
+//! *correct* box that was compared in the wrong frame. The release
+//! leg stays green under that mutation: the release decision is made
+//! on multipliers, and the base slack's frame only reaches the box
+//! comparison, which the reach arm is what exercises. So the release
+//! leg is evidence that the release arithmetic survives a row
+//! scaling, and not evidence about the conversion itself.
+//!
+//! # Not evidence about
+//!
+//! Scaling: this model is unit-scaled, and
+//! `sens_invariance_legs.rs` leg 1 owns that dimension. Index spaces
+//! beyond the one block boundary the file is about:
+//! `cd_split_pin_mapping.rs` owns g-index versus KKT row, and this
+//! model has `m = 2` with one inequality, so the two coincide.
+//! Magnitude at benchmark scale. The convex arm, which has its own
+//! gh#928 file. A row limit that is *also* a variable bound on the
+//! same quantity: both would be watched, and which one the walk picks
+//! is not decided here.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::TNLP;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, ScalingRequest, Solution, SparsityRequest,
+    StartingPoint,
+};
+use pounce_sensitivity::Solver;
+
+/// Column order is `[x, lam]`; the pin is constraint 0 and the cap is
+/// constraint 1.
+const N: usize = 2;
+const PIN: Index = 0;
+const CAP: Number = 1.0;
+/// The cap's full-g row index: the pin is constraint 0, the cap is
+/// constraint 1.
+const CAP_ROW: Index = 1;
+/// The slack row: the `s` block sits immediately after the `x` block,
+/// and there is exactly one inequality, so the cap's primal KKT row is
+/// `n_x`. Asserted in `the_cap_is_a_row_and_its_primal_row_is_n_x`
+/// rather than trusted.
+const SLACK_ROW: usize = N;
+/// How far past a bound counts as outside. `bound_relax_factor` is
+/// zero, so the box is the declared one and this is roundoff headroom.
+const OUT: Number = 1e-9;
+
+struct RowLimit {
+    lam: Number,
+    /// Per-variable and per-row factors for the scaling leg. `None`
+    /// means "hand nothing back", which under `user-scaling` is the
+    /// identity -- the same option, the same objective factor, and the
+    /// only difference between the leg's two arms.
+    scaling: Option<(Vec<Number>, Vec<Number>)>,
+}
+
+impl TNLP for RowLimit {
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        let Some((d, g)) = self.scaling.as_ref() else {
+            return false;
+        };
+        *req.obj_scaling = 1.0;
+        *req.use_x_scaling = true;
+        req.x_scaling.copy_from_slice(d);
+        *req.use_g_scaling = true;
+        req.g_scaling.copy_from_slice(g);
+        true
+    }
+
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: N as Index,
+            m: 2,
+            nnz_jac_g: 2,
+            nnz_h_lag: 3,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        // `x` carries NO bound of its own. The cap is reachable only
+        // through the row, which is the whole point of the file.
+        b.x_l.copy_from_slice(&[-1.0e19; N]);
+        b.x_u.copy_from_slice(&[1.0e19; N]);
+        b.g_l[0] = self.lam;
+        b.g_u[0] = self.lam;
+        // One-sided on purpose: a two-sided row would give the `s`
+        // block a lower bound too and blur which side was reached.
+        b.g_l[1] = -1.0e19;
+        b.g_u[1] = CAP;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = self.lam;
+        sp.x[1] = self.lam;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let r = x[0] - x[1];
+        Some(0.5 * r * r)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let r = x[0] - x[1];
+        g[0] = r;
+        g[1] = -r;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[1];
+        g[1] = x[0];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[1, 0]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, 1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Lower triangle of [[1, -1], [-1, 1]].
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 1]);
+                jcol.copy_from_slice(&[0, 0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[obj_factor, -obj_factor, obj_factor]);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn configured() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    for (k, v) in [
+        ("tol", 1e-10),
+        ("constr_viol_tol", 1e-10),
+        ("compl_inf_tol", 1e-10),
+        ("dual_inf_tol", 1e-8),
+        // Mandatory for every activity accessor, and it is also the
+        // walk's `eps`.
+        ("bound_relax_factor", 0.0),
+    ] {
+        app.options_mut()
+            .set_numeric_value(k, v, true, false)
+            .unwrap();
+    }
+    app.initialize().unwrap();
+    app
+}
+
+fn solved_at(lam: Number) -> Solver {
+    let mut solver = Solver::new(
+        configured(),
+        Rc::new(RefCell::new(RowLimit { lam, scaling: None })) as Rc<RefCell<dyn TNLP>>,
+    );
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve at lam={lam} failed: {status:?}",
+    );
+    solver
+}
+
+/// The closed form. The re-solve is checked against it so a wrong
+/// oracle cannot quietly certify a wrong walk.
+fn closed_form(lam: Number) -> Number {
+    lam.min(CAP)
+}
+
+fn resolve_at(lam: Number) -> Number {
+    let got = solved_at(lam).converged().expect("converged").x[0];
+    let want = closed_form(lam);
+    assert!(
+        (got - want).abs() < 1e-7,
+        "the re-solve disagrees with the closed form at lam={lam}: \
+         {got} vs {want}",
+    );
+    got
+}
+
+struct Walked {
+    /// `x` at the walk's answer, which is also the `g1` row's value --
+    /// the quantity the cap actually bounds.
+    x: Number,
+    segments: Vec<(Number, usize, bool, bool)>,
+    n_x: usize,
+}
+
+impl Walked {
+    /// The events the walk recorded on the cap's own slack row.
+    fn on_the_cap(&self) -> Vec<(Number, bool, bool)> {
+        self.segments
+            .iter()
+            .filter(|&&(_, row, _, _)| row >= self.n_x)
+            .map(|&(at, _, lower, pinned)| (at, lower, pinned))
+            .collect()
+    }
+}
+
+fn walk(lam0: Number, dp: Number) -> Walked {
+    walk_solver(&solved_at(lam0), dp)
+}
+
+fn walk_solver(solver: &Solver, dp: Number) -> Walked {
+    let base = solver.converged().expect("converged").x[0];
+    let n_x = solver.block_dims().expect("block_dims")[0];
+    let (dx, segs) = solver
+        .parametric_step_path(&[PIN], &[dp], 64)
+        .expect("parametric_step_path");
+    Walked {
+        x: base + dx[0],
+        segments: segs
+            .iter()
+            .map(|s| (s.at, s.var_row, s.lower, s.pinned))
+            .collect(),
+        n_x,
+    }
+}
+
+/// The premise, in one place: the cap really is a row, the `s` block
+/// really is one long, and the cap's primal KKT row really is `n_x`.
+/// Every index in this file is read against that.
+#[test]
+fn the_cap_is_a_row_and_its_primal_row_is_n_x() {
+    let solver = solved_at(0.8);
+    let dims = solver.block_dims().expect("block_dims");
+    assert_eq!(
+        dims[0], N,
+        "no variable is removed here, so the `x` block is the model's own \
+         column count",
+    );
+    assert_eq!(
+        dims[1], 1,
+        "the model must have exactly one inequality row, so the `s` block \
+         is one long and the cap's primal row is `n_x`",
+    );
+    assert_eq!(SLACK_ROW, dims[0], "the file's `SLACK_ROW` is stale");
+    // The cap is not a variable bound wearing a row's clothes: `x` has
+    // no declared bound at all, so `z_l` and `z_u` are empty.
+    assert_eq!(
+        (dims[4], dims[5]),
+        (0, 0),
+        "`x` must carry no bound of its own, or the walk could reach the \
+         cap through the `z` half and the file would prove nothing",
+    );
+    assert!(
+        dims[7] >= 1,
+        "the cap's multiplier must be in `v_u`, got block dims {dims:?}",
+    );
+    // The accessor the record's consumer resolves an `s`-block row
+    // with. A segment naming row `SLACK_ROW` is only translatable back
+    // to "the `g1` row" because this map says so, and the map is the
+    // `x` block's width plus the row's position in the `d` block --
+    // dropping the offset returns `0`, a real row in the `x` block,
+    // which is the gh#450 hazard one block over.
+    let slack = solver.d_slack_rows(&[PIN, CAP_ROW]).expect("d_slack_rows");
+    assert_eq!(
+        slack,
+        vec![None, Some(SLACK_ROW as Index)],
+        "the pin is an equality and owns no slack; the cap is the only \
+         inequality and its slack is the first row of the `s` block",
+    );
+}
+
+/// The three base points reach three different activity states on the
+/// same row -- checked, not assumed, because each test below is only
+/// evidence about the branch its base point takes.
+#[test]
+fn the_three_base_points_reach_three_different_states() {
+    use pounce_sensitivity::activity::{INACTIVE, STRONGLY_ACTIVE, WEAKLY_ACTIVE};
+    for (lam, want, sigma_range) in [
+        (0.8, INACTIVE, (0.0, 1e-6)),
+        (1.0, WEAKLY_ACTIVE, (1e-3, 1e3)),
+        (1.3, STRONGLY_ACTIVE, (1e6, Number::INFINITY)),
+    ] {
+        let report = solved_at(lam)
+            .classify_activity()
+            .expect("classify_activity");
+        assert_eq!(
+            report.row_status[1], want,
+            "at lam={lam} the cap's row status is {} and should be {want}",
+            report.row_status[1],
+        );
+        let sigma = report.row_sigma[1];
+        assert!(
+            sigma > sigma_range.0 && sigma < sigma_range.1,
+            "at lam={lam} the cap's row Sigma is {sigma:e}, outside \
+             {sigma_range:?}; the three fixtures are not reaching three \
+             different branches",
+        );
+    }
+}
+
+/// The reach branch: the base point is below the cap and the step
+/// presses into it. Pre-fix this returned 1.3 against a truth of 1.0
+/// with an empty segment list.
+#[test]
+fn a_row_limit_the_step_presses_into_is_reached_and_held() {
+    for &(dp, want_at) in &[(0.5, 0.4), (0.3, 2.0 / 3.0), (0.25, 0.8)] {
+        let w = walk(0.8, dp);
+        assert!(
+            w.x <= CAP + OUT,
+            "dp={dp}: the walk put the `g1` row at {} against a cap of \
+             {CAP}, over by {:e}; segments {:?}",
+            w.x,
+            w.x - CAP,
+            w.segments,
+        );
+        let truth = resolve_at(0.8 + dp);
+        assert!(
+            (w.x - truth).abs() < 1e-7,
+            "dp={dp}: x walked to {} against a re-solve of {truth}",
+            w.x,
+        );
+        // The record has to name what happened. The answer above was
+        // reachable pre-fix only with an empty segment list, which is
+        // the half of gh#928 that makes it silent.
+        let events = w.on_the_cap();
+        assert_eq!(
+            events.len(),
+            1,
+            "dp={dp}: exactly one event on the cap's slack row is expected, \
+             got {:?} (all segments {:?}, n_x = {})",
+            events,
+            w.segments,
+            w.n_x,
+        );
+        let (at, lower, pinned) = events[0];
+        assert!(
+            !lower && pinned,
+            "dp={dp}: the cap is an UPPER limit the walk holds, so the \
+             segment must read lower=false pinned=true; got \
+             lower={lower} pinned={pinned}",
+        );
+        // The cap is hit where `lam` crosses it, which the closed form
+        // fixes exactly: a wrong fraction would still land the endpoint
+        // on the cap and pass every check above.
+        assert!(
+            (at - want_at).abs() < 1e-6,
+            "dp={dp}: the cap is reached at fraction {at}, and `lam` \
+             crosses it at {want_at}",
+        );
+    }
+}
+
+/// The release branch: the base point holds the cap with a multiplier
+/// of order one and the step drives it to zero. This is the arm that
+/// needs the `s`-block barrier diagonal rebuilt -- pre-fix the answer
+/// stayed pinned at 1.0 against a truth of 0.8, because nothing took
+/// the cap's stiffness out of the operator.
+#[test]
+fn a_row_limit_the_step_leaves_is_released() {
+    for &(dp, want_at) in &[(-0.5, 0.6), (-0.4, 0.75), (-0.6, 0.5)] {
+        let w = walk(1.3, dp);
+        let truth = resolve_at(1.3 + dp);
+        assert!(
+            (w.x - truth).abs() < 1e-7,
+            "dp={dp}: x walked to {} against a re-solve of {truth}; \
+             segments {:?}",
+            w.x,
+            w.segments,
+        );
+        // Held at 1.0 is the pre-fix answer, and it is inside the box,
+        // so the box check alone would not catch it. Said separately so
+        // a regression reads as what it is.
+        assert!(
+            w.x < CAP - 1e-3,
+            "dp={dp}: x is still at the cap ({}), so the release did not \
+             reach the operator",
+            w.x,
+        );
+        let events = w.on_the_cap();
+        assert_eq!(
+            events.len(),
+            1,
+            "dp={dp}: leaving the cap is an active-set change and must be \
+             in the record; got {:?} (all segments {:?})",
+            events,
+            w.segments,
+        );
+        let (at, lower, pinned) = events[0];
+        assert!(
+            !lower && !pinned,
+            "dp={dp}: the cap is an UPPER limit the walk releases, so the \
+             segment must read lower=false pinned=false; got \
+             lower={lower} pinned={pinned}",
+        );
+        assert!(
+            (at - want_at).abs() < 1e-6,
+            "dp={dp}: the cap is released at fraction {at}, and its \
+             multiplier reaches zero at {want_at}",
+        );
+    }
+}
+
+/// The kink, both directions. The cap's `Sigma` is order one here, so
+/// the factorization neither enforces it nor ignores it, and the walk
+/// is what decides. Pre-fix both directions were wrong by 5.0e-3 --
+/// half the perturbation -- which is the two-sided average a
+/// degenerate base point produces when nothing watches the bound.
+#[test]
+fn at_the_kink_both_directions_are_decided_by_the_walk() {
+    for &(dp, want_pinned) in &[(0.01, true), (-0.01, false), (0.1, true), (-0.1, false)] {
+        let w = walk(CAP, dp);
+        let truth = resolve_at(CAP + dp);
+        assert!(
+            (w.x - truth).abs() < 1e-7,
+            "dp={dp}: x walked to {} against a re-solve of {truth}; \
+             segments {:?}",
+            w.x,
+            w.segments,
+        );
+        assert!(w.x <= CAP + OUT, "dp={dp}: {} is past the cap", w.x,);
+        let events = w.on_the_cap();
+        assert_eq!(
+            events.len(),
+            1,
+            "dp={dp}: got {:?} (all segments {:?})",
+            events,
+            w.segments,
+        );
+        let (_, lower, pinned) = events[0];
+        assert!(
+            !lower && pinned == want_pinned,
+            "dp={dp}: stepping {} the cap must {} it; got lower={lower} \
+             pinned={pinned}",
+            if dp > 0.0 { "into" } else { "away from" },
+            if want_pinned { "hold" } else { "release" },
+        );
+    }
+}
+
+/// The control: perturbations that touch the cap in neither direction.
+/// These were exact before the fix too, so a test file that only
+/// checked answers could pass on them while the two branches above
+/// were broken.
+#[test]
+fn a_step_that_does_not_touch_the_cap_records_nothing() {
+    for &(lam0, dp) in &[(1.3, 0.2), (0.8, -0.2), (1.3, 0.5), (0.8, -0.5)] {
+        let w = walk(lam0, dp);
+        let truth = resolve_at(lam0 + dp);
+        assert!(
+            (w.x - truth).abs() < 1e-7,
+            "lam0={lam0} dp={dp}: x walked to {} against a re-solve of \
+             {truth}",
+            w.x,
+        );
+        assert!(
+            w.on_the_cap().is_empty(),
+            "lam0={lam0} dp={dp}: nothing happens to the cap here, so the \
+             record must not name it; got {:?}",
+            w.segments,
+        );
+    }
+}
+
+// ---------------------------------------------------------------
+// The second model: a row limit and a live variable bound at once.
+// ---------------------------------------------------------------
+//
+// The model above cannot tell a *misrouted* `s`-block release from a
+// *dropped* one, because it has no variable bound and its `sigma_x`
+// is identically zero -- writing the release into the `x` diagonal
+// lands somewhere inert. That is the gh#450 hazard in its quiet form,
+// and note 2 in the header says so. This model closes it:
+//
+// ```text
+// min  0.5 (x - lam)^2 + 0.5 w^2 + 3 w
+// s.t. g0: lam = lam0        (the pin)
+//      g1: x <= CAP          (the limit, as a row)
+//      w >= 0                (a bound of its own, strongly held)
+//      x, lam free
+// ```
+//
+// Columns are `[w, x, lam]`, so `w` sits at `x`-block index 0 and the
+// cap's slack sits at index `n_x`. `w`'s unconstrained minimum is
+// `-3`, so its lower bound is held with multiplier 3 and a vanishing
+// slack: `sigma_x[0]` is large and *live*. Releasing the cap must not
+// touch it. A release written to `sigma_x[var_row - n_x]` --
+// `sigma_x[0]` -- takes `w`'s own stiffness out of the operator, and
+// `w` walks off its bound toward `-3`. The answer for `x` is
+// unchanged either way, which is what makes this worth a separate
+// model: the wrong write is invisible in the quantity the file's
+// other tests look at.
+
+const N2: usize = 3;
+/// `w`'s column, and the `x`-block index a misrouted release would
+/// land on.
+const W2: usize = 0;
+/// `x`'s column in the second model.
+const X2: usize = 1;
+/// `w`'s pull: its unconstrained minimum is `-W_PULL`.
+const W_PULL: Number = 3.0;
+
+struct RowLimitPlusBound {
+    lam: Number,
+}
+
+impl TNLP for RowLimitPlusBound {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: N2 as Index,
+            m: 2,
+            nnz_jac_g: 2,
+            nnz_h_lag: 4,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[0.0, -1.0e19, -1.0e19]);
+        b.x_u.copy_from_slice(&[1.0e19; N2]);
+        b.g_l[0] = self.lam;
+        b.g_u[0] = self.lam;
+        b.g_l[1] = -1.0e19;
+        b.g_u[1] = CAP;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[W2] = 1.0;
+        sp.x[X2] = self.lam;
+        sp.x[2] = self.lam;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let r = x[X2] - x[2];
+        Some(0.5 * r * r + 0.5 * x[W2] * x[W2] + W_PULL * x[W2])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let r = x[X2] - x[2];
+        g[W2] = x[W2] + W_PULL;
+        g[X2] = r;
+        g[2] = -r;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[2];
+        g[1] = x[X2];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[2, X2 as Index]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, 1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Lower triangle of diag-plus-coupling on `[w, x, lam]`:
+        // (w,w)=1, (x,x)=1, (lam,x)=-1, (lam,lam)=1.
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 2, 2]);
+                jcol.copy_from_slice(&[0, 1, 1, 2]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[obj_factor, obj_factor, -obj_factor, obj_factor]);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn solved_at2(lam: Number) -> Solver {
+    let mut solver = Solver::new(
+        configured(),
+        Rc::new(RefCell::new(RowLimitPlusBound { lam })) as Rc<RefCell<dyn TNLP>>,
+    );
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve at lam={lam} failed: {status:?}",
+    );
+    solver
+}
+
+#[test]
+fn the_second_model_holds_a_variable_bound_and_a_row_limit_at_once() {
+    let solver = solved_at2(1.3);
+    let dims = solver.block_dims().expect("block_dims");
+    assert_eq!(dims[0], N2, "no variable is removed");
+    assert_eq!(dims[1], 1, "one inequality, so one slack");
+    assert_eq!(
+        dims[4], 1,
+        "`w` must carry a lower bound of its own, so `z_l` is one long \
+         and `sigma_x` has a live entry a misrouted release could \
+         corrupt; got block dims {dims:?}",
+    );
+    assert!(dims[7] >= 1, "the cap's multiplier must be in `v_u`");
+    assert_eq!(
+        solver.d_slack_rows(&[CAP_ROW]).expect("d_slack_rows"),
+        vec![Some(N2 as Index)],
+        "the cap's slack must sit at `n_x`, which is the index a \
+         misrouted release maps to `sigma_x[0]` -- `w`'s own entry",
+    );
+    let conv = solver.converged().expect("converged");
+    assert!(
+        (conv.x[W2] - 0.0).abs() < 1e-7,
+        "`w` must sit on its lower bound, got {}",
+        conv.x[W2],
+    );
+    assert!(
+        (conv.x[X2] - CAP).abs() < 1e-7,
+        "`x` must sit on the cap, got {}",
+        conv.x[X2],
+    );
+}
+
+#[test]
+fn releasing_the_row_limit_leaves_the_variable_bound_alone() {
+    // The discriminating case. `dp = -0.5` releases the cap; `w`'s
+    // bound is untouched by that and must stay held. Routing the
+    // release into `sigma_x[0]` zeroes `w`'s barrier stiffness, and
+    // `w` walks off zero toward `-W_PULL` -- while `x` still lands on
+    // the right answer, so nothing else in this file notices.
+    let solver = solved_at2(1.3);
+    let base = solver.converged().expect("converged").x.clone();
+    let dp = -0.5;
+    let (dx, segs) = solver
+        .parametric_step_path(&[PIN], &[dp], 64)
+        .expect("parametric_step_path");
+    let w = base[W2] + dx[W2];
+    let x = base[X2] + dx[X2];
+
+    // The cap is released, so the record must say so exactly once.
+    let cap_segs: Vec<_> = segs
+        .iter()
+        .filter(|s| s.var_row == N2 && !s.pinned)
+        .collect();
+    assert_eq!(
+        cap_segs.len(),
+        1,
+        "the cap must be released exactly once; segments {:?}",
+        segs.iter()
+            .map(|s| (s.at, s.var_row, s.lower, s.pinned))
+            .collect::<Vec<_>>(),
+    );
+    // `w`'s own bound is not part of this step and must never appear.
+    assert!(
+        segs.iter().all(|s| s.var_row != W2),
+        "`w`'s bound must not move; segments {:?}",
+        segs.iter()
+            .map(|s| (s.at, s.var_row, s.lower, s.pinned))
+            .collect::<Vec<_>>(),
+    );
+    assert!(
+        w.abs() < 1e-6,
+        "`w` must stay on its lower bound across the cap's release, \
+         got {w} -- a release written into `sigma_x[{W2}]` takes `w`'s \
+         own stiffness out of the operator and it walks toward \
+         {}",
+        -W_PULL,
+    );
+    // And the answer for `x` is still right, so the assertion above is
+    // the only thing standing between a misrouted write and a green
+    // run.
+    let truth = closed_form(1.3 + dp);
+    assert!(
+        (x - truth).abs() < 1e-6,
+        "x walked to {x} against a closed form of {truth}",
+    );
+}
+
+// ---------------------------------------------------------------
+// Leg 1's dimension, for the `s` block: does a row scaling move the
+// answer?
+// ---------------------------------------------------------------
+//
+// `bound_context` converts the `s` block's box and base point out of
+// the algorithm's frame with `natural_units_factor()`, exactly as the
+// `x` block is converted with `variable_scaling()`. Under unit scaling
+// both conversions are the identity, so every other test in this file
+// -- and the pre-fix table in the header -- is blind to them. That is
+// the corpus-uniform-in-the-dimension-the-change-acts-on shape, and
+// `sens_invariance_legs.rs` leg 1 exists because `205bb67` shipped
+// through exactly it: the corrector "added the scaled iterate to
+// bounds in the model's units, which coincide only at unit scaling,
+// which is every fixture it had."
+//
+// Both arms below run under `user-scaling` with the same option and
+// the same objective factor. The only difference is whether the TNLP
+// hands factors back, per leg 1's discipline. The row factor is the
+// load-bearing one: it is what makes `natural_units_factor` non-unit
+// on the `s` rows.
+
+/// Per-variable factors on `[x, lam]`, spread over decades.
+const D_ROW: [Number; N] = [4.0, 1.0e-2];
+/// Per-row factors on `[g0 (the pin), g1 (the cap)]`. `g1`'s is the
+/// one this leg is about.
+const G_ROW: [Number; 2] = [3.0, 2.5e2];
+
+fn configured_user_scaling() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", "user-scaling", true, false)
+        .unwrap();
+    for (k, v) in [
+        ("tol", 1e-10),
+        ("constr_viol_tol", 1e-10),
+        ("compl_inf_tol", 1e-10),
+        ("dual_inf_tol", 1e-8),
+        ("bound_relax_factor", 0.0),
+    ] {
+        app.options_mut()
+            .set_numeric_value(k, v, true, false)
+            .unwrap();
+    }
+    app.initialize().unwrap();
+    app
+}
+
+fn solved_scaled(lam: Number, scaling: Option<(Vec<Number>, Vec<Number>)>) -> Solver {
+    let mut solver = Solver::new(
+        configured_user_scaling(),
+        Rc::new(RefCell::new(RowLimit { lam, scaling })) as Rc<RefCell<dyn TNLP>>,
+    );
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "scaled solve at lam={lam} failed: {status:?}",
+    );
+    solver
+}
+
+fn scaled_pair(lam: Number) -> (Solver, Solver) {
+    (
+        solved_scaled(lam, None),
+        solved_scaled(lam, Some((D_ROW.to_vec(), G_ROW.to_vec()))),
+    )
+}
+
+#[test]
+fn leg_scaling_the_arms_really_do_run_under_different_factors() {
+    // Assert the split rather than assume it -- an arm that silently
+    // stopped applying its factors would take the whole leg with it,
+    // which is `the_fixtures_take_different_branches`' lesson in
+    // `sens_resolve_oracle.rs`.
+    let (plain, scaled) = scaled_pair(1.3);
+    let dims = scaled.block_dims().expect("block_dims");
+    assert_eq!(dims[1], 1, "the scaled arm must still have one slack");
+    assert!(
+        plain.converged().is_some() && scaled.converged().is_some(),
+        "both arms must converge",
+    );
+    // Same answer in the model's own units, from two different
+    // internal frames.
+    for s in [&plain, &scaled] {
+        let x = s.converged().expect("converged").x[0];
+        assert!(
+            (x - CAP).abs() < 1e-7,
+            "both arms must sit on the cap in natural units, got {x}",
+        );
+    }
+}
+
+#[test]
+fn leg_scaling_a_row_limit_is_reached_at_the_same_place_under_a_row_scaling() {
+    let (plain, scaled) = scaled_pair(0.8);
+    let a = walk_solver(&plain, 0.5);
+    let b = walk_solver(&scaled, 0.5);
+    let truth = closed_form(0.8 + 0.5);
+    for (name, w) in [("plain", &a), ("scaled", &b)] {
+        assert!(
+            w.x <= CAP + OUT,
+            "{name}: the walk left the box at {}, cap {CAP}",
+            w.x,
+        );
+        assert!(
+            (w.x - truth).abs() < 1e-6,
+            "{name}: walked to {} against a closed form of {truth}",
+            w.x,
+        );
+    }
+    let (pa, pb) = (a.on_the_cap(), b.on_the_cap());
+    assert_eq!(
+        (pa.len(), pb.len()),
+        (1, 1),
+        "both arms must record exactly one cap event; plain {pa:?}, scaled {pb:?}",
+    );
+    assert_eq!(
+        (pa[0].1, pa[0].2),
+        (pb[0].1, pb[0].2),
+        "the side and the direction moved under the change of variables",
+    );
+    assert!(
+        (pa[0].0 - pb[0].0).abs() < 1e-6,
+        "the breakpoint moved under the change of variables: plain {}, scaled {}",
+        pa[0].0,
+        pb[0].0,
+    );
+}
+
+#[test]
+fn leg_scaling_a_row_limit_is_released_at_the_same_place_under_a_row_scaling() {
+    // The release arm is the one that reads the `s` diagonal, so it is
+    // the one a frame error in `natural_units_factor` reaches.
+    let (plain, scaled) = scaled_pair(1.3);
+    let a = walk_solver(&plain, -0.5);
+    let b = walk_solver(&scaled, -0.5);
+    let truth = closed_form(1.3 - 0.5);
+    for (name, w) in [("plain", &a), ("scaled", &b)] {
+        assert!(
+            (w.x - truth).abs() < 1e-6,
+            "{name}: walked to {} against a closed form of {truth}",
+            w.x,
+        );
+    }
+    let (pa, pb) = (a.on_the_cap(), b.on_the_cap());
+    assert_eq!(
+        (pa.len(), pb.len()),
+        (1, 1),
+        "both arms must record exactly one cap release; plain {pa:?}, scaled {pb:?}",
+    );
+    assert_eq!((pa[0].1, pa[0].2), (pb[0].1, pb[0].2));
+    assert!(
+        (pa[0].0 - pb[0].0).abs() < 1e-6,
+        "the release breakpoint moved under the change of variables: \
+         plain {}, scaled {}",
+        pa[0].0,
+        pb[0].0,
+    );
+}

--- a/crates/pounce-sensitivity/tests/issue_928_path_leaves_an_unclassifiable_box.rs
+++ b/crates/pounce-sensitivity/tests/issue_928_path_leaves_an_unclassifiable_box.rs
@@ -1,0 +1,558 @@
+//! gh#928: the walk has to notice when its own answer leaves the box.
+//!
+//! gh#852 taught `step_along_path` to keep watching a bound whose
+//! sigma is order ONE rather than order `1/mu` — one the factorization
+//! carries as a finite penalty, so it bends the direction and enforces
+//! nothing. The walk learns which those are from `weak_rows`, which
+//! `Solver::weakly_active_bounds` fills from the activity classifier.
+//!
+//! That leaves the door the classifier cannot see through. `classify`
+//! needs a curvature to divide by, so where the Hessian diagonal falls
+//! under the identification floor every bound comes back
+//! `UNIDENTIFIED`, `weakly_active_bounds` returns an empty list, and
+//! the walk is told nothing. Meanwhile its own base-activity table
+//! marks the bound enforced on a test that is exactly `Sigma > 1`, and
+//! the reach scan skips it. The bound is then neither held by the
+//! factorization nor watched by the path: the direction carries the
+//! variable straight through it, zero breakpoints are recorded, and
+//! the caller is handed a point outside the box with no warning.
+//!
+//! An LP is the whole of that class — a zero Hessian is as
+//! unidentifiable as a diagonal gets — and so is any model whose cost
+//! is linear in the coordinate that reaches the bound, which is what
+//! made this reachable from a production AC-OPF: at linear generation
+//! cost the walk put a generator 33 MW past its nameplate rating, and
+//! adding a quadratic term worth 0.1% of the linear one fixed it by
+//! lifting the diagonal over the floor and nothing else.
+//!
+//! The fix does not extend the classification. It cannot: the
+//! quantity that would discriminate inside `UNIDENTIFIED` is the
+//! curvature that is by hypothesis unmeasurable here, and admitting
+//! the class wholesale also admits `y`'s genuinely enforced bound
+//! below (`UNIDENTIFIED` at `Sigma = 1.1e11`) and makes the augmented
+//! system singular. Instead the walk checks its own answer against the
+//! box and treats a base-active bound the answer CROSSED as measured
+//! proof that the factorization did not enforce it.
+//!
+//! So this file's job is to reach the branch that proof is made on,
+//! and the assertions say in so many words which branch that is:
+//! every test asserts the classifier returned `UNIDENTIFIED` and an
+//! empty weak list, so nothing here is riding on the gh#852 path.
+//! `var_sigma` is what separates the tests, because it is the quantity
+//! the base-activity test actually compares.
+//!
+//! Five tests, one per branch:
+//!
+//! 1. `Sigma > 1`, upper bound, direction presses IN: the exclusion is
+//!    in force, nothing told the walk, and the answer must still land
+//!    on the bound (the defect);
+//! 2. the same on a LOWER bound, which is a different entry of the
+//!    base-activity table and a different side of the repair's own
+//!    side-selection;
+//! 3. `Sigma > 1`, direction presses OUT: the bound genuinely leaves,
+//!    the answer is interior, and no repair may fire;
+//! 4. `Sigma < 1` on the same model and the same classifier verdict:
+//!    the walk never marked the bound active, the reach scan always
+//!    watched it, and the answer was always right. The control that
+//!    isolates `Sigma > 1` as the trigger rather than `UNIDENTIFIED`.
+//! 5. the same model with the walk CAPPED, which is the guard on the
+//!    post-loop box check rather than on the repair. `max_iter = 0`
+//!    asks for the plain linear step, which on this model is the
+//!    defect's own answer — requested deliberately, and legal before
+//!    the repair existed, so it still answers rather than failing.
+//!
+//! Mutation table:
+//!
+//! | change | red |
+//! |---|---|
+//! | return `walk_once`'s answer directly (drop the repair loop) | 1, 2 |
+//! | read the crossed side off the base point's slack, not the answer | 1, 2 |
+//! | hard-code the crossed side to `upper` | 2 |
+//! | seed the watch list empty instead of from `weak_rows` | nothing here; gh#852 test 4 |
+//! | drop the `max_iter` gate on the post-loop check | 5 only |
+//!
+//! That last row is the interesting one, and it was measured rather
+//! than assumed. Dropping the `weak_rows` seed leaves four of gh#852's
+//! five tests green, because the box check rediscovers those bounds by
+//! observation — the seed is nearly redundant for them. It is not
+//! redundant for their test 4, which is a *rate* error: a stale sigma
+//! damps a coordinate at a later breakpoint without ever pushing it
+//! out of its box, so there is no violation for a box check to see.
+//! The seed catches what the classifier can name; the box check
+//! catches what it cannot; neither covers the other, and this file is
+//! evidence only about the second.
+//!
+//! Every answer is checked against a re-solve at the perturbed
+//! parameter, which for an LP is exact.
+//!
+//! What this file is NOT evidence about:
+//!
+//! * **The failed-re-walk arm.** When a repair pass errors the wrapper
+//!   propagates it rather than handing back the answer in hand — that
+//!   answer is out of the box, which is why there was a second walk,
+//!   and returning it silently is the defect itself. No fixture here
+//!   reaches that arm: the repair only ever admits a bound the answer
+//!   crossed, and releasing one of those keeps this model
+//!   nonsingular. It is a guard, and it is unexercised, so this file
+//!   is not evidence that the message it produces is reachable.
+//! * **The `!grew` arm and the exhausted cap**, where the answer is
+//!   still outside a bound but no base-active row explains it, or the
+//!   repair spent `PATH_MAX_BOX_REPAIRS` passes. Both now report
+//!   instead of returning the point, because returning it is gh#928's
+//!   own signature — a violation with nothing in the record naming
+//!   it. Test 5 pins the one case that must NOT report, a walk the
+//!   caller capped; no fixture reaches the arms that do.
+//! * **How small a violation still fires the repair.** The check
+//!   inherits `ctx.eps` — the solve's `bound_relax_factor`, floored at
+//!   `1e-9` — which is the crate's existing definition of "outside a
+//!   bound" and the one `parametric_step_bounded` already uses. It is
+//!   an *absolute length in the model's units*, so on a model whose
+//!   variables are scaled to `1e-9` or below the check is vacuous.
+//!   The failure mode there is the pre-fix behaviour rather than a new
+//!   one, and the alternative — a relative margin — would be a second,
+//!   inconsistent definition of the same word. The violations that
+//!   motivated the fix are nowhere near it: `1e-2` on a unit box here,
+//!   and 33 MW on a 170 MW rating in the AC-OPF.
+//! * **The cap.** `PATH_MAX_BOX_REPAIRS` bounds the number of walks,
+//!   not the termination, which comes from the watch list growing.
+//!   Both models here repair in one pass, so nothing measures a second.
+//! * **Constraint rows.** This is a *variable bound*, and the repair
+//!   reads `lo` / `hi` over the x block, so it says nothing about a
+//!   limit written as a row instead. Measured on this same LP with
+//!   `x <= 1` moved from the bound to a constraint: the step lands
+//!   `1e-2` past the row with zero segments, and `linear`, `bounded`,
+//!   `directional`, `release_all` and `path` all miss it identically.
+//!   That is a scope limit of the whole active-set layer rather than
+//!   of this repair — path segments are declared in var-x — and it is
+//!   filed separately. Do not read a green file here as covering it.
+//! * **Index spaces.** The parameter stays in the x block, so var-x
+//!   rows and model columns coincide. `cd_split_pin_mapping.rs` and
+//!   `sens_invariance_legs.rs` leg 3 own that dimension.
+//! * **Scaling.** Both arms run unit-scaled. `sens_invariance_legs.rs`
+//!   leg 1 owns it.
+//! * **Magnitude.** `dp = 1e-2` against a base slack of `1e-6`, so the
+//!   answer is four orders off the base point in `y` and the assertions
+//!   have no room to pass on a predictor that returned the base point.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::TNLP;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+};
+use pounce_sensitivity::Solver;
+use pounce_sensitivity::activity::UNIDENTIFIED;
+
+/// The smallest model that reaches the defect: a linear program with
+/// the parameter carried as a third variable pinned by an equality.
+///
+/// ```text
+/// min  s x + 2 y
+/// s.t. g0: s x + y - lam = 0
+///      g1: lam = lam0            (the pin)
+///      x in [0, 1] for s = +1, in [-1, 0] for s = -1;  y >= 0
+/// ```
+///
+/// With `u = s x` in `[0, 1]` this is `min u + 2 y` subject to
+/// `u + y = lam`, so `u` is the cheap unit and the solution is
+///
+/// ```text
+/// lam <= 1:  u = lam,  y = 0
+/// lam >= 1:  u = 1,    y = lam - 1
+/// ```
+///
+/// The two branches meet at `lam = 1`, where `u` sits on its bound
+/// with a vanishing multiplier. `s` chooses which of `x`'s two bounds
+/// that is, so the same kink is reachable from either side of the
+/// base-activity table.
+///
+/// The Hessian is identically zero. That is the point: there is no
+/// curvature for `classify` to divide by, so every bound in this model
+/// is `UNIDENTIFIED` no matter how firmly it is held.
+struct PinnedLp {
+    /// `+1.0` puts the kink on `x`'s upper bound, `-1.0` on its lower.
+    s: Number,
+    lam: Number,
+}
+
+impl TNLP for PinnedLp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 3,
+            m: 2,
+            nnz_jac_g: 4,
+            nnz_h_lag: 1,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        // The kinked bound is x's upper for s = +1 and its lower for
+        // s = -1; the other side of the box is slack either way.
+        b.x_l[0] = if self.s > 0.0 { 0.0 } else { -1.0 };
+        b.x_u[0] = if self.s > 0.0 { 1.0 } else { 0.0 };
+        b.x_l[1] = 0.0;
+        b.x_u[1] = 1.0e19;
+        b.x_l[2] = -1.0e19;
+        b.x_u[2] = 1.0e19;
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        b.g_l[1] = self.lam;
+        b.g_u[1] = self.lam;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.5 * self.s;
+        sp.x[1] = 0.5;
+        sp.x[2] = self.lam;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(self.s * x[0] + 2.0 * x[1])
+    }
+
+    fn eval_grad_f(&mut self, _x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = self.s;
+        g[1] = 2.0;
+        g[2] = 0.0;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = self.s * x[0] + x[1] - x[2];
+        g[1] = x[2];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let rs: [Index; 4] = [0, 0, 0, 1];
+                let cs: [Index; 4] = [0, 1, 2, 2];
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = self.s;
+                values[1] = 1.0;
+                values[2] = -1.0;
+                values[3] = 1.0;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        _obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Everything is linear, so the Lagrangian Hessian is zero. One
+        // structural entry, carrying that zero, is what puts every
+        // bound in this model below the identification floor.
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 0;
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 0.0;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn configured() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    for (k, v) in [("print_level", 0)] {
+        app.options_mut()
+            .set_integer_value(k, v, true, false)
+            .unwrap();
+    }
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    for (k, v) in [
+        ("tol", 1e-10),
+        ("constr_viol_tol", 1e-10),
+        ("compl_inf_tol", 1e-10),
+        ("dual_inf_tol", 1e-8),
+        // Mandatory for every activity accessor: the classifier reads
+        // slacks, and a relaxed solve shifts them. It also sets the
+        // walk's own `eps`, the margin a violation has to clear before
+        // the repair fires.
+        ("bound_relax_factor", 0.0),
+    ] {
+        app.options_mut()
+            .set_numeric_value(k, v, true, false)
+            .unwrap();
+    }
+    app.initialize().unwrap();
+    app
+}
+
+fn solved_at(s: Number, lam: Number) -> Solver {
+    let mut solver = Solver::new(
+        configured(),
+        Rc::new(RefCell::new(PinnedLp { s, lam })) as Rc<RefCell<dyn TNLP>>,
+    );
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve at s={s} lam={lam} failed: {status:?}",
+    );
+    solver
+}
+
+/// `(x, y)` at the exact solution for `lam`.
+fn resolve_at(s: Number, lam: Number) -> [Number; 2] {
+    let x = solved_at(s, lam)
+        .converged()
+        .expect("converged state")
+        .x
+        .clone();
+    [x[0], x[1]]
+}
+
+/// What the walk actually did, plus the two facts that say which
+/// branch it did it on: `x`'s activity class and its `Sigma`.
+struct Walked {
+    xy: [Number; 2],
+    segments: usize,
+    status: i8,
+    sigma: Number,
+    weak: usize,
+}
+
+/// Solve at `lam0`, classify, then walk to `lam0 + dp`. The pin is
+/// constraint 1.
+fn walk(s: Number, lam0: Number, dp: Number) -> Walked {
+    let solver = solved_at(s, lam0);
+    let base = solver.converged().expect("converged state").x.clone();
+    let report = solver.classify_activity().expect("classify_activity");
+    let weak = solver.weakly_active_bounds().expect("weakly_active_bounds");
+    let (dx, segs) = solver
+        .parametric_step_path(&[1], &[dp], 64)
+        .expect("parametric_step_path");
+    Walked {
+        xy: [base[0] + dx[0], base[1] + dx[1]],
+        segments: segs.len(),
+        status: report.var_status[X_ROW],
+        sigma: report.var_sigma[X_ROW],
+        weak: weak.len(),
+    }
+}
+
+/// The var-x row of `x`, whose bound is the kinked one. The pin
+/// variable is not removed from the x block, so var-x rows and model
+/// columns coincide here.
+const X_ROW: usize = 0;
+
+/// Both sides of the kink are checked against a re-solve, which for an
+/// LP is exact, so the tolerance is numerical rather than modelling.
+const TOL: Number = 1e-9;
+
+/// Every test asserts the classifier told the walk nothing. Without
+/// this the file would pass on the gh#852 path and prove nothing about
+/// gh#928.
+fn assert_the_classifier_is_blind(w: &Walked) {
+    assert_eq!(
+        w.status, UNIDENTIFIED,
+        "the fixture must reach the unclassifiable branch, got status {} \
+         (a nonzero Hessian diagonal would take the gh#852 path instead)",
+        w.status,
+    );
+    assert_eq!(
+        w.weak, 0,
+        "`weakly_active_bounds` must be empty here, or the walk is being \
+         told about the bound and this file tests gh#852, not gh#928",
+    );
+}
+
+#[test]
+fn the_walk_stays_inside_a_box_the_classifier_cannot_certify() {
+    // The defect. Base one slack-unit below the kink, with the slack
+    // chosen so Sigma clears 1 and the base-activity table marks the
+    // bound enforced; then press into it. Truth holds x on the bound
+    // and puts the whole step into y.
+    let (lam0, dp) = (1.0 - 1e-6, 1e-2);
+    let truth = resolve_at(1.0, lam0 + dp);
+    let w = walk(1.0, lam0, dp);
+
+    assert_the_classifier_is_blind(&w);
+    assert!(
+        w.sigma > 1.0,
+        "the fixture must sit above the walk's base-activity test \
+         (Sigma > 1), got {} -- below it the reach scan already \
+         watches the bound and there is no defect to fix",
+        w.sigma,
+    );
+    assert!(
+        (truth[0] - 1.0).abs() < TOL && (truth[1] - (dp - 1e-6)).abs() < TOL,
+        "the re-solve should hold the bound and spend the step on y: {truth:?}",
+    );
+    // The headline: pre-fix this returned x = 1.009999, a hundredth
+    // outside a box whose width is 1, and reported no breakpoint at all.
+    assert!(
+        w.xy[0] <= 1.0 + TOL,
+        "the walk returned a point outside x's box: x = {} against ub 1 \
+         (segments {})",
+        w.xy[0],
+        w.segments,
+    );
+    let err = (w.xy[0] - truth[0]).abs().max((w.xy[1] - truth[1]).abs());
+    assert!(
+        err < TOL,
+        "the walk should reproduce the re-solve, off by {err}: {:?} against {truth:?}",
+        w.xy,
+    );
+    // Reaching the bound is an active-set change and the record has to
+    // say so. Zero segments was half the defect: a caller with no
+    // breakpoint has nothing to tell it the answer needs checking.
+    assert!(
+        w.segments > 0,
+        "reaching the bound is a breakpoint and must be recorded",
+    );
+}
+
+#[test]
+fn the_lower_side_is_watched_too() {
+    // The same kink on x's LOWER bound: a different entry of the
+    // base-activity table, and the other side of the repair's own
+    // choice of which bound the answer crossed.
+    let (lam0, dp) = (1.0 - 1e-6, 1e-2);
+    let truth = resolve_at(-1.0, lam0 + dp);
+    let w = walk(-1.0, lam0, dp);
+
+    assert_the_classifier_is_blind(&w);
+    assert!(w.sigma > 1.0, "Sigma = {} must clear 1", w.sigma);
+    assert!(
+        (truth[0] + 1.0).abs() < TOL,
+        "the re-solve should hold the lower bound: {truth:?}",
+    );
+    assert!(
+        w.xy[0] >= -1.0 - TOL,
+        "the walk returned a point outside x's box: x = {} against lb -1 \
+         (segments {})",
+        w.xy[0],
+        w.segments,
+    );
+    let err = (w.xy[0] - truth[0]).abs().max((w.xy[1] - truth[1]).abs());
+    assert!(
+        err < TOL,
+        "the walk should reproduce the re-solve, off by {err}: {:?} against {truth:?}",
+        w.xy,
+    );
+    assert!(w.segments > 0, "reaching the bound is a breakpoint");
+}
+
+#[test]
+fn a_capped_walk_keeps_the_old_contract() {
+    // The repair promises a point inside the box, and reports rather
+    // than returning one outside it -- but only when the walk was
+    // allowed to finish. `max_iter` caps segments, so `max_iter = 0`
+    // asks for the plain linear step, which on this model IS outside
+    // the box: that is the whole defect, requested deliberately. It
+    // was a legal thing to ask for before the repair existed, so it
+    // still answers rather than failing.
+    //
+    // This is the guard on the post-loop check, and it is the only
+    // arm of that check any fixture reaches. Remove the `max_iter`
+    // gate and this test goes red while every other test in the file
+    // stays green -- the cost of leaving it out is a caller who
+    // capped the walk being told the repair failed.
+    let (lam0, dp) = (1.0 - 1e-6, 1e-2);
+    let solver = solved_at(1.0, lam0);
+    let base = solver.converged().expect("converged state").x.clone();
+
+    let (dx, segs) = solver
+        .parametric_step_path(&[1], &[dp], 0)
+        .expect("a capped walk answers rather than reporting");
+    assert_eq!(segs.len(), 0, "a zero cap takes no segments");
+    assert!(
+        base[0] + dx[0] > 1.0 + TOL,
+        "the capped answer is the linear step, which is past the bound: {}",
+        base[0] + dx[0],
+    );
+
+    // One segment is enough to reach the bound, so the cap stops
+    // binding and the answer comes back inside.
+    let (dx, segs) = solver
+        .parametric_step_path(&[1], &[dp], 1)
+        .expect("parametric_step_path");
+    assert_eq!(segs.len(), 1);
+    assert!(
+        base[0] + dx[0] <= 1.0 + TOL,
+        "one segment is enough: {}",
+        base[0] + dx[0],
+    );
+}
+
+#[test]
+fn a_direction_that_leaves_the_bound_is_not_repaired() {
+    // The other branch of the reach scan, from the same base point:
+    // press AWAY from the kink and the bound genuinely leaves. The
+    // answer is interior, so the box check finds nothing and the
+    // repair is a no-op -- which is what keeps it inert on every model
+    // that was already right.
+    let (lam0, dp) = (1.0 - 1e-6, -1e-2);
+    let truth = resolve_at(1.0, lam0 + dp);
+    let w = walk(1.0, lam0, dp);
+
+    assert_the_classifier_is_blind(&w);
+    assert!(w.sigma > 1.0, "Sigma = {} must clear 1", w.sigma);
+    assert!(
+        truth[0] < 1.0 - 1e-3 && truth[1].abs() < TOL,
+        "the re-solve should come off the bound and leave y at zero: {truth:?}",
+    );
+    let err = (w.xy[0] - truth[0]).abs().max((w.xy[1] - truth[1]).abs());
+    assert!(
+        err < TOL,
+        "the walk should reproduce the re-solve, off by {err}: {:?} against {truth:?}",
+        w.xy,
+    );
+}
+
+#[test]
+fn below_the_activity_threshold_the_scan_already_watched_it() {
+    // The control. Same model, same perturbation, same `UNIDENTIFIED`
+    // verdict and same empty weak list -- only Sigma differs, and it
+    // falls below 1. The walk never marked the bound enforced, the
+    // reach scan watched it all along, and this case was correct
+    // before the fix. It is here so the file cannot be read as
+    // "`UNIDENTIFIED` is the trigger": Sigma is.
+    let (lam0, dp) = (1.0 - 1e-5, 1e-2);
+    let truth = resolve_at(1.0, lam0 + dp);
+    let w = walk(1.0, lam0, dp);
+
+    assert_the_classifier_is_blind(&w);
+    assert!(
+        w.sigma < 1.0,
+        "the control must sit BELOW the base-activity test, got Sigma = {} \
+         -- if the solve drifted above 1 this stopped being a control",
+        w.sigma,
+    );
+    let err = (w.xy[0] - truth[0]).abs().max((w.xy[1] - truth[1]).abs());
+    assert!(
+        err < TOL,
+        "the walk should reproduce the re-solve, off by {err}: {:?} against {truth:?}",
+        w.xy,
+    );
+}

--- a/crates/pounce-sensitivity/tests/issue_928_two_soft_bounds_at_once.rs
+++ b/crates/pounce-sensitivity/tests/issue_928_two_soft_bounds_at_once.rs
@@ -1,0 +1,569 @@
+//! gh#928, the multi-bound arm: two unclassifiable bounds on one walk.
+//!
+//! `issue_928_path_leaves_an_unclassifiable_box.rs` is a one-bound
+//! model. That leaves the corpus uniform in exactly the dimension the
+//! repair loop acts on -- it adds rows to a watch list and re-walks,
+//! so a model with one candidate row cannot distinguish "adds the
+//! right row" from "adds the only row". This file is the second
+//! fixture the branch rule asks for, not a duplicate of the first.
+//!
+//! It also reaches a branch the one-bound file cannot. The rejected
+//! alternative fix -- admit every `UNIDENTIFIED` bound to the weak
+//! list and let the factorization sort it out -- does not merely give
+//! a worse answer here, it *fails to solve*:
+//!
+//! ```text
+//! step_along_path: augmented solve failed (holds [1, 0], released [6, 7])
+//! ```
+//!
+//! because it releases a bound that is genuinely enforced (`Sigma`
+//! around `1e11`) alongside one that is not. The model below carries
+//! both kinds at once on purpose, so that alternative stays rejected
+//! by a test rather than by a memory.
+//!
+//! ```text
+//! min  x + 2 y + 3 w
+//! s.t. g0: x + y + w - lam = 0
+//!      g1: lam = lam0            (the pin)
+//!      x in [0, 1],  y in [0, 1],  w >= 0
+//! ```
+//!
+//! Cheapest-first: `x` fills to 1, then `y` to 1, then `w` runs
+//! unbounded. So
+//!
+//! ```text
+//! lam <= 1:      x = lam,  y = 0,        w = 0
+//! 1 <= lam <= 2: x = 1,    y = lam - 1,  w = 0
+//! lam >= 2:      x = 1,    y = 1,        w = lam - 2
+//! ```
+//!
+//! with kinks at `lam = 1` and `lam = 2`. Just below `lam = 2` the two
+//! upper bounds are in different states in the same solve: `x`'s is
+//! firmly held (its reduced cost is `2 - 1 = 1` against a vanishing
+//! slack) while `y`'s is at the kink. Just above, both are held and
+//! `w`'s lower bound is the kink. The Lagrangian Hessian is
+//! identically zero, so none of them can be classified.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::TNLP;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+};
+use pounce_sensitivity::Solver;
+use pounce_sensitivity::activity::UNIDENTIFIED;
+
+/// Column order is `[x, y, w, lam]`; the pin is constraint 1.
+const N: usize = 4;
+const PIN: Index = 1;
+const COST: [Number; N] = [1.0, 2.0, 3.0, 0.0];
+const LO: [Number; N] = [0.0, 0.0, 0.0, -1.0e19];
+const HI: [Number; N] = [1.0, 1.0, 1.0e19, 1.0e19];
+
+struct TwoSoftBounds {
+    lam: Number,
+    /// Per-variable curvature on `[x, y, w]`. Zero is the LP this file
+    /// is about; a nonzero entry is used by one test to demonstrate
+    /// *which* variables' curvature the walk's released system needs.
+    curv: [Number; 3],
+}
+
+impl TNLP for TwoSoftBounds {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: N as Index,
+            m: 2,
+            nnz_jac_g: 5,
+            nnz_h_lag: 3,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&LO);
+        b.x_u.copy_from_slice(&HI);
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        b.g_l[1] = self.lam;
+        b.g_u[1] = self.lam;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.5;
+        sp.x[1] = 0.5;
+        sp.x[2] = 0.5;
+        sp.x[3] = self.lam;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let lin: Number = COST.iter().zip(x).map(|(c, xi)| c * xi).sum();
+        let quad: Number = self
+            .curv
+            .iter()
+            .zip(x)
+            .map(|(c, xi)| 0.5 * c * xi * xi)
+            .sum();
+        Some(lin + quad)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g.copy_from_slice(&COST);
+        for (i, c) in self.curv.iter().enumerate() {
+            g[i] += c * x[i];
+        }
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] + x[1] + x[2] - x[3];
+        g[1] = x[3];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0, 0, 0, 1]);
+                jcol.copy_from_slice(&[0, 1, 2, 3, 3]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, 1.0, 1.0, -1.0, 1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Structurally present so the classifier has a diagonal to
+        // divide by, and (for the LP this file is about) carrying zero,
+        // so it finds it below the identification floor.
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 2]);
+                jcol.copy_from_slice(&[0, 1, 2]);
+            }
+            SparsityRequest::Values { values } => {
+                for (v, c) in values.iter_mut().zip(self.curv) {
+                    *v = obj_factor * c;
+                }
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn configured() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    for (k, v) in [
+        ("tol", 1e-10),
+        ("constr_viol_tol", 1e-10),
+        ("compl_inf_tol", 1e-10),
+        ("dual_inf_tol", 1e-8),
+        // Mandatory for every activity accessor, and it is also the
+        // walk's `eps` -- the margin a violation clears before the
+        // repair fires.
+        ("bound_relax_factor", 0.0),
+    ] {
+        app.options_mut()
+            .set_numeric_value(k, v, true, false)
+            .unwrap();
+    }
+    app.initialize().unwrap();
+    app
+}
+
+fn solved_at(lam: Number) -> Solver {
+    solved_curved_at(lam, [0.0; 3])
+}
+
+fn solved_curved_at(lam: Number, curv: [Number; 3]) -> Solver {
+    let mut solver = Solver::new(
+        configured(),
+        Rc::new(RefCell::new(TwoSoftBounds { lam, curv })) as Rc<RefCell<dyn TNLP>>,
+    );
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve at lam={lam} curv={curv:?} failed: {status:?}",
+    );
+    solver
+}
+
+/// The closed form above, which is what the re-solve reproduces. Used
+/// to check the re-solve itself, so a wrong oracle cannot quietly
+/// certify a wrong walk.
+fn closed_form(lam: Number) -> [Number; 3] {
+    [
+        lam.clamp(0.0, 1.0),
+        (lam - 1.0).clamp(0.0, 1.0),
+        (lam - 2.0).max(0.0),
+    ]
+}
+
+fn resolve_at(lam: Number) -> [Number; 3] {
+    let x = solved_at(lam).converged().expect("converged").x.clone();
+    let got = [x[0], x[1], x[2]];
+    let want = closed_form(lam);
+    for i in 0..3 {
+        assert!(
+            (got[i] - want[i]).abs() < 1e-7,
+            "the re-solve disagrees with the closed form at lam={lam}: \
+             {got:?} vs {want:?}",
+        );
+    }
+    got
+}
+
+struct Walked {
+    xyw: [Number; 3],
+    segments: usize,
+    status: [i8; 3],
+    weak: usize,
+}
+
+fn walk(lam0: Number, dp: Number) -> Walked {
+    let solver = solved_at(lam0);
+    let base = solver.converged().expect("converged").x.clone();
+    let report = solver.classify_activity().expect("classify_activity");
+    let weak = solver.weakly_active_bounds().expect("weakly_active_bounds");
+    let (dx, segs) = solver
+        .parametric_step_path(&[PIN], &[dp], 64)
+        .expect("parametric_step_path");
+    Walked {
+        xyw: [base[0] + dx[0], base[1] + dx[1], base[2] + dx[2]],
+        segments: segs.len(),
+        status: [
+            report.var_status[0],
+            report.var_status[1],
+            report.var_status[2],
+        ],
+        weak: weak.len(),
+    }
+}
+
+/// Nothing in this model is classifiable, so the walk is on its own.
+/// Without this the file could pass on the gh#852 path.
+fn assert_the_classifier_is_blind(w: &Walked) {
+    assert_eq!(
+        w.status, [UNIDENTIFIED; 3],
+        "every bound here must be unclassifiable, got {:?}",
+        w.status,
+    );
+    assert_eq!(
+        w.weak, 0,
+        "`weakly_active_bounds` must be empty, or this file is testing \
+         gh#852 rather than gh#928",
+    );
+}
+
+/// Box violation, worst first, in the units of the model.
+fn outside(xyw: &[Number; 3]) -> Vec<(usize, Number)> {
+    let mut v: Vec<(usize, Number)> = (0..3)
+        .filter_map(|i| {
+            let past = (LO[i] - xyw[i]).max(xyw[i] - HI[i]);
+            (past > 1e-9).then_some((i, past))
+        })
+        .collect();
+    v.sort_by(|a, b| b.1.total_cmp(&a.1));
+    v
+}
+
+/// The grid: both sides of both kinks, over five orders of slack, and
+/// both directions at two magnitudes. Pre-fix this returns points
+/// outside the box on 48 of the 192 combinations it generates in the
+/// Python probe this file is the Rust form of; the count here is
+/// smaller only because the Rust fixture drops the redundant
+/// magnitudes.
+fn grid() -> Vec<(Number, Number)> {
+    let mut out = Vec::new();
+    for kink in [1.0, 2.0] {
+        for sgn in [-1.0, 1.0] {
+            for d in [1e-8, 1e-6, 1e-4, 1e-3] {
+                for dp in [-1e-1, -1e-2, 1e-2, 1e-1] {
+                    out.push((kink + sgn * d, dp));
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn no_walk_on_the_grid_ends_outside_the_box() {
+    // The defect, over the whole grid rather than at one point: a
+    // model carrying two unclassifiable upper bounds returns a point
+    // outside one of them. Pre-fix, a quarter of these do.
+    let mut blind = 0usize;
+    for (lam0, dp) in grid() {
+        let w = walk(lam0, dp);
+        if w.status == [UNIDENTIFIED; 3] && w.weak == 0 {
+            blind += 1;
+        }
+        let bad = outside(&w.xyw);
+        assert!(
+            bad.is_empty(),
+            "lam0={lam0} dp={dp}: the walk ended outside the box \
+             (variable {}, past by {:e}); x={:?}, segments {}",
+            bad[0].0,
+            bad[0].1,
+            w.xyw,
+            w.segments,
+        );
+    }
+    assert_eq!(
+        blind,
+        grid().len(),
+        "every point on this grid must reach the unclassifiable branch",
+    );
+}
+
+#[test]
+fn the_walk_reproduces_the_resolve_on_the_whole_grid() {
+    // Staying inside the box is necessary, not sufficient: a walk that
+    // stopped at the bound and refused to spend the rest of the step
+    // is also in the box and also wrong. The model is piecewise linear
+    // in `lam`, so a correct walk matches the re-solve exactly, and
+    // the tolerance below is numerical rather than modelling.
+    for (lam0, dp) in grid() {
+        let truth = resolve_at(lam0 + dp);
+        let w = walk(lam0, dp);
+        assert_the_classifier_is_blind(&w);
+        let err = (0..3)
+            .map(|i| (w.xyw[i] - truth[i]).abs())
+            .fold(0.0, Number::max);
+        assert!(
+            err < 1e-7,
+            "lam0={lam0} dp={dp}: walk {:?} vs re-solve {truth:?} \
+             (worst coordinate off by {err:e}, segments {})",
+            w.xyw,
+            w.segments,
+        );
+    }
+}
+
+#[test]
+fn crossing_two_kinks_is_exact_when_one_bound_is_released() {
+    // A step long enough to cross both kinks. Starting just ABOVE the
+    // first one, `x` is already on its bound and only `y`'s lower has
+    // to leave the barrier, so the walk's released system stays
+    // nonsingular and the answer is exact over three segments. This is
+    // the two-kink case the repair does handle; the next test is the
+    // one it does not.
+    let (lam0, dp) = (1.0 + 1e-6, 1.2);
+    let truth = resolve_at(lam0 + dp);
+    assert!(
+        truth[0] > 0.99 && truth[1] > 0.99 && truth[2] > 0.0,
+        "the fixture must cross both kinks: {truth:?}",
+    );
+    let w = walk(lam0, dp);
+    assert_the_classifier_is_blind(&w);
+    assert!(
+        outside(&w.xyw).is_empty(),
+        "the walk left the box crossing two kinks: {:?}",
+        w.xyw,
+    );
+    let err = (0..3)
+        .map(|i| (w.xyw[i] - truth[i]).abs())
+        .fold(0.0, Number::max);
+    assert!(
+        err < 1e-7,
+        "walk {:?} vs re-solve {truth:?}, off by {err:e} over {} segments",
+        w.xyw,
+        w.segments,
+    );
+    assert!(
+        w.segments >= 2,
+        "crossing two kinks should record at least two breakpoints, got {}",
+        w.segments,
+    );
+}
+
+/// The walk's released system, and why two releases can kill it.
+///
+/// Holding a bound the path reached is a Schur pin applied to the
+/// factored released system `K`, so `K` itself has to be invertible
+/// *before* the pins go on. Releasing a bound takes that bound's
+/// `Sigma` out of `K`'s diagonal. On a model with no curvature the
+/// diagonal is then exactly zero, and the stationarity rows of two
+/// such released variables that share a constraint become linearly
+/// dependent -- for the model here, both read `y_c0 = rhs`. `K` is
+/// singular, the Schur solve cannot run, and the walk reports.
+///
+/// That is a limit of the hold-and-release architecture (gh#852,
+/// tracked open as gh#930), not
+/// of the box repair: pre-fix this same step returned a point outside
+/// the box in silence, which is worse. The repair turned a wrong
+/// answer into a refusal, and the refusal is what this test pins --
+/// together with the measurement that says the cause is what the
+/// paragraph above claims.
+#[test]
+fn two_releases_without_curvature_are_refused_not_answered() {
+    // Below the first kink, stepping past the second. The walk has to
+    // release BOTH x's upper (reached and held) and y's lower (its
+    // multiplier hits zero), and neither variable has curvature.
+    let (lam0, dp) = (1.0 - 1e-6, 1.2);
+    let solver = solved_at(lam0);
+    let err = solver.parametric_step_path(&[PIN], &[dp], 64).expect_err(
+        "two curvature-free releases must be refused; returning an \
+             answer here means either the architecture changed -- in \
+             which case assert the answer instead -- or the box check \
+             stopped firing, which is gh#928 back again",
+    );
+    let err = format!("{err:?}");
+    assert!(
+        err.contains("step_along_path"),
+        "the refusal must name the walk that produced it: {err}",
+    );
+
+    // The cause, measured rather than argued: curvature on exactly the
+    // two RELEASED variables makes the same step exact, and the same
+    // amount of curvature on the third variable does not. If only the
+    // first of these held, "the released system is singular" would be
+    // indistinguishable from "any regularization helps".
+    let truth = resolve_at(lam0 + dp);
+    for (label, curv, want_ok) in [
+        ("on the two released variables", [1e-3, 1e-3, 0.0], true),
+        ("on the third variable only", [0.0, 0.0, 1e-3], false),
+    ] {
+        let s = solved_curved_at(lam0, curv);
+        let base = s.converged().expect("converged").x.clone();
+        let got = s.parametric_step_path(&[PIN], &[dp], 64);
+        match (got, want_ok) {
+            (Ok((dx, segs)), true) => {
+                let xyw = [base[0] + dx[0], base[1] + dx[1], base[2] + dx[2]];
+                let e = (0..3)
+                    .map(|i| (xyw[i] - truth[i]).abs())
+                    .fold(0.0, Number::max);
+                assert!(
+                    e < 1e-5,
+                    "curvature {label} should make the step exact, got \
+                     {xyw:?} vs {truth:?} (off by {e:e}, {} segments)",
+                    segs.len(),
+                );
+            }
+            (Err(_), false) => {}
+            (Ok(_), false) => panic!(
+                "curvature {label} should NOT rescue the step -- if it \
+                 does, the released system's singularity is not what \
+                 refuses this walk and the doc comment above is wrong",
+            ),
+            (Err(e), true) => panic!("curvature {label} should rescue the step: {e:?}"),
+        }
+    }
+}
+
+#[test]
+fn a_firmly_held_bound_is_not_released_alongside_a_soft_one() {
+    // Why the repair watches what the answer crossed rather than
+    // admitting every unclassifiable bound. Just below lam = 2, x's
+    // upper bound is genuinely enforced -- reduced cost 1 against a
+    // vanishing slack, so `Sigma` is enormous -- while y's is at the
+    // kink. Both read UNIDENTIFIED. The rejected fix released both and
+    // the augmented solve failed outright; this one steps down, which
+    // holds x and moves y, and gets the re-solve.
+    let (lam0, dp) = (2.0 - 1e-6, -1e-1);
+    let solver = solved_at(lam0);
+    let report = solver.classify_activity().expect("classify_activity");
+    assert_eq!(
+        [report.var_status[0], report.var_status[1]],
+        [UNIDENTIFIED, UNIDENTIFIED],
+        "both upper bounds must be unclassifiable for the point to stand",
+    );
+    assert!(
+        report.var_sigma[0] > 1e6 * report.var_sigma[1].max(1.0),
+        "x's bound must be the firmly held one and y's the soft one: \
+         Sigma = {:e} vs {:e}",
+        report.var_sigma[0],
+        report.var_sigma[1],
+    );
+
+    let truth = resolve_at(lam0 + dp);
+    let base = solver.converged().expect("converged").x.clone();
+    let (dx, segs) = solver
+        .parametric_step_path(&[PIN], &[dp], 64)
+        .expect("the walk must solve, not fail in the augmented system");
+    let got = [base[0] + dx[0], base[1] + dx[1], base[2] + dx[2]];
+    let err = (0..3)
+        .map(|i| (got[i] - truth[i]).abs())
+        .fold(0.0, Number::max);
+    assert!(
+        err < 1e-7,
+        "walk {got:?} vs re-solve {truth:?}, off by {err:e} over {} segments",
+        segs.len(),
+    );
+    assert!(
+        (got[0] - 1.0).abs() < 1e-7,
+        "x must stay on its firmly held bound, got {}",
+        got[0],
+    );
+}
+
+// # Mutation table
+//
+// Every row was run. A test that goes red for a change is evidence
+// about that change; a row with no red test is a change this file
+// cannot see, and is listed as such rather than omitted.
+//
+// | change                                                        | red                        |
+// |---------------------------------------------------------------|----------------------------|
+// | budget the repair loop at zero passes                          | grid (both)                |
+// | seed the watch list empty instead of from `weak_rows`          | nothing here; gh#852 test 4 |
+// | read the crossed side off the base point, not the answer       | grid (both)                |
+// | let the singular released system return its garbage answer     | `two_releases_...`         |
+// | regularize the released system on every walk                   | `two_releases_...` (the third-variable arm passes, so the "on the two released variables" arm is what pins the cause) |
+// | drop the closed-form check inside `resolve_at`                 | nothing; it guards the oracle, not the walk |
+//
+// `crossing_two_kinks_is_exact_when_one_bound_is_released` stays
+// green when the repair is disabled entirely. That is deliberate and
+// worth naming: it is a test of the hold-and-release architecture
+// crossing two kinks, not of the box repair, and it is here as the
+// control for the test that follows it.
+//
+// # What this file is not evidence about
+//
+// * **The repair budget.** Measured, a budget of one pass suffices for
+//   every fixture here and in
+//   `issue_928_path_leaves_an_unclassifiable_box.rs`; the shipped
+//   budget is the base-activity table's length, which is slack. No
+//   fixture reaches a second pass, so the second pass is untested.
+// * **Constraint rows.** Every limit here is written as a variable
+//   bound, so nothing here exercises the `v_l` / `v_u` half of the
+//   bound rows or the `s`-block release diagonal.
+//   `issue_928_a_limit_written_as_a_row.rs` owns that arm.
+// * **The refusal's blast radius.** `two_releases_...` pins that the
+//   walk refuses rather than answers, not that refusing is the best
+//   possible behaviour; gh#930 tracks answering it. Pre-fix this step returned a point outside the
+//   box in silence; a later change that makes the walk *answer* it
+//   correctly should replace that test with an equality assertion, not
+//   delete it.
+// * **Scaling.** Everything here runs unit-scaled. Leg 1 of
+//   `sens_invariance_legs.rs` owns that dimension.
+// * **Magnitude.** Four variables. The largest convex fixture in the
+//   corpus is 534 columns and `benchmarks/qp` reaches 93 263; nothing
+//   here bounds what happens there.

--- a/crates/pounce-sensitivity/tests/issue_928_two_soft_bounds_at_once.rs
+++ b/crates/pounce-sensitivity/tests/issue_928_two_soft_bounds_at_once.rs
@@ -404,7 +404,7 @@ fn crossing_two_kinks_is_exact_when_one_bound_is_released() {
     );
 }
 
-/// The walk's released system, and why two releases can kill it.
+/// The walk's released system, and what two releases do to it.
 ///
 /// Holding a bound the path reached is a Schur pin applied to the
 /// factored released system `K`, so `K` itself has to be invertible
@@ -413,68 +413,85 @@ fn crossing_two_kinks_is_exact_when_one_bound_is_released() {
 /// diagonal is then exactly zero, and the stationarity rows of two
 /// such released variables that share a constraint become linearly
 /// dependent -- for the model here, both read `y_c0 = rhs`. `K` is
-/// singular, the Schur solve cannot run, and the walk reports.
+/// singular and the Schur solve cannot run.
 ///
-/// That is a limit of the hold-and-release architecture (gh#852,
-/// tracked open as gh#930), not
-/// of the box repair: pre-fix this same step returned a point outside
-/// the box in silence, which is worse. The repair turned a wrong
-/// answer into a refusal, and the refusal is what this test pins --
-/// together with the measurement that says the cause is what the
-/// paragraph above claims.
+/// Three answers have stood here in turn, and the order is the point.
+/// Pre-gh#928 the step returned a point outside the box in silence.
+/// gh#928's box repair turned that into a refusal -- better, and what
+/// this test used to pin. gh#930 turns the refusal into the answer,
+/// by putting the same exact Schur pin on a *regularized* operator:
+/// `Eᵀ w = 0` annihilates the diagonal that was added to make `K`
+/// invertible, so the system solved is the released one after all.
+///
+/// So this is now an equality assertion against the re-solve, which
+/// is what the file's own "not evidence about" section said a change
+/// that answered this walk would owe. The curvature arms stay,
+/// because they are the measurement that says what the obstruction
+/// *was*: they are the two regularizations that were available
+/// before, and the answer has to be continuous across them.
+/// `issue_930_two_curvature_free_releases.rs` owns the rest.
 #[test]
-fn two_releases_without_curvature_are_refused_not_answered() {
+fn two_releases_without_curvature_are_answered_not_refused() {
     // Below the first kink, stepping past the second. The walk has to
     // release BOTH x's upper (reached and held) and y's lower (its
     // multiplier hits zero), and neither variable has curvature.
     let (lam0, dp) = (1.0 - 1e-6, 1.2);
+    let truth = resolve_at(lam0 + dp);
     let solver = solved_at(lam0);
-    let err = solver.parametric_step_path(&[PIN], &[dp], 64).expect_err(
-        "two curvature-free releases must be refused; returning an \
-             answer here means either the architecture changed -- in \
-             which case assert the answer instead -- or the box check \
-             stopped firing, which is gh#928 back again",
+    let base = solver.converged().expect("converged").x.clone();
+    let (dx, segs) = solver.parametric_step_path(&[PIN], &[dp], 64).expect(
+        "two curvature-free releases must be answered; a refusal here \
+         means the regularized operator gh#930 falls back to stopped \
+         being reachable",
     );
-    let err = format!("{err:?}");
+    let got = [base[0] + dx[0], base[1] + dx[1], base[2] + dx[2]];
+    let err = (0..3)
+        .map(|i| (got[i] - truth[i]).abs())
+        .fold(0.0, Number::max);
     assert!(
-        err.contains("step_along_path"),
-        "the refusal must name the walk that produced it: {err}",
+        err < 1e-9,
+        "walk {got:?} vs re-solve {truth:?}, off by {err:e} over {} segments",
+        segs.len(),
+    );
+    // The pin is stiff, not infinite, so the held coordinate creeps by
+    // the roundoff of its own couplings. That has to stay inside the
+    // box, which is the property gh#928 exists to defend.
+    for (i, &v) in got.iter().enumerate().take(2) {
+        assert!(
+            v <= 1.0 + 1e-12 && v >= -1e-12,
+            "coordinate {i} left the box at {v}",
+        );
+    }
+    assert!(
+        segs.len() >= 2,
+        "the walk crosses two kinks, so it must record breakpoints: {}",
+        segs.len(),
     );
 
-    // The cause, measured rather than argued: curvature on exactly the
-    // two RELEASED variables makes the same step exact, and the same
-    // amount of curvature on the third variable does not. If only the
-    // first of these held, "the released system is singular" would be
-    // indistinguishable from "any regularization helps".
-    let truth = resolve_at(lam0 + dp);
-    for (label, curv, want_ok) in [
-        ("on the two released variables", [1e-3, 1e-3, 0.0], true),
-        ("on the third variable only", [0.0, 0.0, 1e-3], false),
+    // The obstruction, measured rather than argued: curvature on
+    // exactly the two RELEASED variables is what used to rescue this
+    // step, and the same amount on the third variable did not. Both
+    // now answer -- the regularization is no longer the model's job --
+    // and all three agree, which is the continuity claim.
+    for (label, curv) in [
+        ("on the two released variables", [1e-3, 1e-3, 0.0]),
+        ("on the third variable only", [0.0, 0.0, 1e-3]),
     ] {
         let s = solved_curved_at(lam0, curv);
-        let base = s.converged().expect("converged").x.clone();
-        let got = s.parametric_step_path(&[PIN], &[dp], 64);
-        match (got, want_ok) {
-            (Ok((dx, segs)), true) => {
-                let xyw = [base[0] + dx[0], base[1] + dx[1], base[2] + dx[2]];
-                let e = (0..3)
-                    .map(|i| (xyw[i] - truth[i]).abs())
-                    .fold(0.0, Number::max);
-                assert!(
-                    e < 1e-5,
-                    "curvature {label} should make the step exact, got \
-                     {xyw:?} vs {truth:?} (off by {e:e}, {} segments)",
-                    segs.len(),
-                );
-            }
-            (Err(_), false) => {}
-            (Ok(_), false) => panic!(
-                "curvature {label} should NOT rescue the step -- if it \
-                 does, the released system's singularity is not what \
-                 refuses this walk and the doc comment above is wrong",
-            ),
-            (Err(e), true) => panic!("curvature {label} should rescue the step: {e:?}"),
-        }
+        let b = s.converged().expect("converged").x.clone();
+        let (dx, segs) = s
+            .parametric_step_path(&[PIN], &[dp], 64)
+            .unwrap_or_else(|e| panic!("curvature {label} must still answer: {e:?}"));
+        let xyw = [b[0] + dx[0], b[1] + dx[1], b[2] + dx[2]];
+        let e = (0..3)
+            .map(|i| (xyw[i] - got[i]).abs())
+            .fold(0.0, Number::max);
+        assert!(
+            e < 1e-5,
+            "curvature {label} must agree with the curvature-free walk, \
+             got {xyw:?} vs {got:?} (off by {e:e}, {} segments)",
+            segs.len(),
+        );
     }
 }
 
@@ -535,8 +552,9 @@ fn a_firmly_held_bound_is_not_released_alongside_a_soft_one() {
 // | budget the repair loop at zero passes                          | grid (both)                |
 // | seed the watch list empty instead of from `weak_rows`          | nothing here; gh#852 test 4 |
 // | read the crossed side off the base point, not the answer       | grid (both)                |
-// | let the singular released system return its garbage answer     | `two_releases_...`         |
-// | regularize the released system on every walk                   | `two_releases_...` (the third-variable arm passes, so the "on the two released variables" arm is what pins the cause) |
+// | let the singular released system return its garbage answer     | `two_releases_...` (box)   |
+// | make `solve_released_pinned` return `false` (gh#930 fallback off) | `two_releases_...`       |
+// | drop the `Eᵀw = 0` Schur row and keep only the raised diagonal  | `two_releases_...` (equality) |
 // | drop the closed-form check inside `resolve_at`                 | nothing; it guards the oracle, not the walk |
 //
 // `crossing_two_kinks_is_exact_when_one_bound_is_released` stays
@@ -556,12 +574,13 @@ fn a_firmly_held_bound_is_not_released_alongside_a_soft_one() {
 //   bound, so nothing here exercises the `v_l` / `v_u` half of the
 //   bound rows or the `s`-block release diagonal.
 //   `issue_928_a_limit_written_as_a_row.rs` owns that arm.
-// * **The refusal's blast radius.** `two_releases_...` pins that the
-//   walk refuses rather than answers, not that refusing is the best
-//   possible behaviour; gh#930 tracks answering it. Pre-fix this step returned a point outside the
-//   box in silence; a later change that makes the walk *answer* it
-//   correctly should replace that test with an equality assertion, not
-//   delete it.
+// * **The regularized operator's own properties.**
+//   `two_releases_...` pins that the walk answers this step and that
+//   the answer is the re-solve. It says nothing about *how far* the
+//   fallback stretches -- how singular an operator the gh#737 ceiling
+//   can still lift, what the two operators cost against each other,
+//   or that they agree on a step where both run.
+//   `issue_930_two_curvature_free_releases.rs` owns all of that.
 // * **Scaling.** Everything here runs unit-scaled. Leg 1 of
 //   `sens_invariance_legs.rs` owns that dimension.
 // * **Magnitude.** Four variables. The largest convex fixture in the

--- a/crates/pounce-sensitivity/tests/issue_930_two_curvature_free_releases.rs
+++ b/crates/pounce-sensitivity/tests/issue_930_two_curvature_free_releases.rs
@@ -1,0 +1,695 @@
+//! gh#930: two curvature-free releases, and the operator the pin rides on.
+//!
+//! # The obstruction
+//!
+//! The path walk holds a bound it reached by applying a Schur row to
+//! the *factored released system*: solve `K w - E du = r` subject to
+//! `Eᵀ w = 0`, where `E` picks the held primal rows. The Schur
+//! complement it builds is `-Eᵀ K⁻¹ E`, so `K⁻¹` has to exist before
+//! a single hold goes on.
+//!
+//! Releasing a bound takes that bound's `Sigma` off `K`'s diagonal.
+//! On a model with no curvature the diagonal is then exactly zero, and
+//! two released variables that share a constraint row are left with
+//! *linearly dependent* stationarity rows. `K` is singular, and the
+//! walk reported:
+//!
+//! ```text
+//! step_along_path: augmented solve failed (holds [0, 1], released [9, 7])
+//! ```
+//!
+//! That refusal was gh#928's improvement on the silence that preceded
+//! it -- the same step used to return a point outside the box without
+//! comment. It was still a refusal.
+//!
+//! # The fix, and why it costs nothing in accuracy
+//!
+//! The pin is not what changed. What changed is the operator it is
+//! applied to: on a failure the walk retries against
+//! `K_reg = K_released + Σ_pin E Eᵀ`, whose pinned diagonals are
+//! raised until it is invertible. The *same* Schur row then goes on
+//! top, and `Eᵀ w = 0` says every pinned coordinate of `w` is zero --
+//! which annihilates the term that was added. The system actually
+//! solved is
+//!
+//! ```text
+//! K_released w - E du = r,     Eᵀ w = 0
+//! ```
+//!
+//! the released one, exactly, with `du` in the identical frame and
+//! units. Nothing is converted, and a walk that takes the plain
+//! operator on one segment and the regularized one on the next is
+//! still accumulating a single `h.mult` per hold.
+//!
+//! `Σ_pin` is the gh#737 ceiling (`sigma_pin_cap` of the row's largest
+//! constraint coefficient): the stiffest diagonal the row's own
+//! couplings still survive. Stiff and reachable, not infinite -- the
+//! held coordinate creeps by roundoff, which is what
+//! `the_pin_is_stiff_not_infinite` bounds.
+//!
+//! # What is measured here
+//!
+//! * the previously-refused walk against a **re-solve at the
+//!   perturbed parameter** (`/sens-review` entry 5: the only guard
+//!   that reads an outside number);
+//! * that the plain operator really is singular on this walk, so the
+//!   fallback is reached rather than decorative;
+//! * that the two operators **agree** on a working set where both run
+//!   -- in `d` and in `du`, which is the claim that lets the walk
+//!   switch between them mid-path;
+//! * both branches of *how* the plain operator fails. Rank deficiency
+//!   two and it refuses; deficiency one and the factorization absorbs
+//!   it, the solve returns `Ok`, and a held row comes back holding a
+//!   fifth of the step. The second is why the fallback is triggered on
+//!   the pinned rows' residual and not on the error.
+//!
+//! # The fixture
+//!
+//! ```text
+//! min  x + 2 y + 3 w
+//! s.t. g0: x + y + w - lam = 0
+//!      g1: lam = lam0            (the pin)
+//!      x in [0, 1],  y in [0, 1],  w >= 0
+//! ```
+//!
+//! Cheapest-first, so `x` fills to 1, then `y` to 1, then `w` runs:
+//!
+//! ```text
+//! lam <= 1:      x = lam,  y = 0,        w = 0
+//! 1 <= lam <= 2: x = 1,    y = lam - 1,  w = 0
+//! lam >= 2:      x = 1,    y = 1,        w = lam - 2
+//! ```
+//!
+//! The Lagrangian Hessian is identically zero, so no bound here can be
+//! classified and the walk is on its own. Basing just below `lam = 1`
+//! and stepping past `lam = 2` makes it release `x`'s upper bound
+//! (reached and then held) *and* `y`'s lower bound (its multiplier
+//! hits zero) -- two curvature-free releases sharing `g0`.
+//!
+//! One test perturbs it: a little curvature on `w` **only**. `x` and
+//! `y`, whose bounds are the released ones, still have none, so their
+//! rows are still dependent -- but `w`'s is no longer dependent on
+//! them, and that one rank is the whole difference between a refusal
+//! and a silently wrong answer.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::TNLP;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+};
+use pounce_sensitivity::activity::UNIDENTIFIED;
+use pounce_sensitivity::{PathOperator, Solver};
+
+/// Column order is `[x, y, w, lam]`; the pin is constraint 1.
+const N: usize = 4;
+const PIN: Index = 1;
+const COST: [Number; N] = [1.0, 2.0, 3.0, 0.0];
+const LO: [Number; N] = [0.0, 0.0, 0.0, -1.0e19];
+const HI: [Number; N] = [1.0, 1.0, 1.0e19, 1.0e19];
+
+struct TwoReleases {
+    lam: Number,
+    /// Per-variable curvature on `[x, y, w]`. All zero is the model
+    /// the file is about; `the_plain_operator_can_also_fail_silently`
+    /// puts a little on `w` alone, which leaves the two released rows
+    /// dependent but drops the deficiency from two to one.
+    curv: [Number; 3],
+}
+
+impl TNLP for TwoReleases {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: N as Index,
+            m: 2,
+            nnz_jac_g: 5,
+            nnz_h_lag: 3,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&LO);
+        b.x_u.copy_from_slice(&HI);
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        b.g_l[1] = self.lam;
+        b.g_u[1] = self.lam;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.5;
+        sp.x[1] = 0.5;
+        sp.x[2] = 0.5;
+        sp.x[3] = self.lam;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let lin: Number = COST.iter().zip(x).map(|(c, xi)| c * xi).sum();
+        let quad: Number = self
+            .curv
+            .iter()
+            .zip(x)
+            .map(|(c, xi)| 0.5 * c * xi * xi)
+            .sum();
+        Some(lin + quad)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g.copy_from_slice(&COST);
+        for (i, c) in self.curv.iter().enumerate() {
+            g[i] += c * x[i];
+        }
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] + x[1] + x[2] - x[3];
+        g[1] = x[3];
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _nx: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0, 0, 0, 1]);
+                jcol.copy_from_slice(&[0, 1, 2, 3, 3]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[1.0, 1.0, 1.0, -1.0, 1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Structurally present so the classifier has a diagonal to
+        // divide by, and carrying zero, so it finds it below the
+        // identification floor. That zero is the whole subject here.
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 2]);
+                jcol.copy_from_slice(&[0, 1, 2]);
+            }
+            SparsityRequest::Values { values } => {
+                for (v, c) in values.iter_mut().zip(self.curv) {
+                    *v = obj_factor * c;
+                }
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn configured() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    for (k, v) in [
+        ("tol", 1e-10),
+        ("constr_viol_tol", 1e-10),
+        ("compl_inf_tol", 1e-10),
+        ("dual_inf_tol", 1e-8),
+        // Mandatory for every activity accessor, and it is also the
+        // walk's `eps`.
+        ("bound_relax_factor", 0.0),
+    ] {
+        app.options_mut()
+            .set_numeric_value(k, v, true, false)
+            .unwrap();
+    }
+    app.initialize().unwrap();
+    app
+}
+
+fn solved_at(lam: Number) -> Solver {
+    solved_curved_at(lam, [0.0; 3])
+}
+
+fn solved_curved_at(lam: Number, curv: [Number; 3]) -> Solver {
+    let mut solver = Solver::new(
+        configured(),
+        Rc::new(RefCell::new(TwoReleases { lam, curv })) as Rc<RefCell<dyn TNLP>>,
+    );
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve at lam={lam} curv={curv:?} failed: {status:?}",
+    );
+    solver
+}
+
+/// The closed form above. The re-solve is checked against it so a
+/// wrong oracle cannot quietly certify a wrong walk.
+fn closed_form(lam: Number) -> [Number; 3] {
+    [
+        lam.clamp(0.0, 1.0),
+        (lam - 1.0).clamp(0.0, 1.0),
+        (lam - 2.0).max(0.0),
+    ]
+}
+
+fn resolve_at(lam: Number) -> [Number; 3] {
+    let x = solved_at(lam).converged().expect("converged").x.clone();
+    let got = [x[0], x[1], x[2]];
+    let want = closed_form(lam);
+    for i in 0..3 {
+        assert!(
+            (got[i] - want[i]).abs() < 1e-7,
+            "the re-solve disagrees with the closed form at lam={lam}: \
+             {got:?} vs {want:?}",
+        );
+    }
+    got
+}
+
+/// The bound-multiplier rows this file names, derived from
+/// `block_dims` rather than written down, and asserted to be the shape
+/// the prose describes.
+///
+/// The KKT blocks are `[x, s, y_c, y_d, z_L, z_U, v_L, v_U]`. Every
+/// variable here carries a lower bound so `z_L` is `[x, y, w]`; only
+/// `x` and `y` carry an upper one so `z_U` is `[x, y]`. Reading one
+/// block's `k`th row as another's is gh#450, which is why this is
+/// computed and checked instead of hard-coded.
+struct Rows {
+    y_lo: usize,
+    x_hi: usize,
+}
+
+fn rows_of(solver: &Solver) -> Rows {
+    let d = solver.block_dims().expect("block_dims");
+    assert_eq!(
+        d,
+        [4, 0, 2, 0, 3, 2, 0, 0],
+        "the fixture's KKT shape changed; every row index below is derived \
+         from it and the prose names which variable each one is",
+    );
+    let z_l = d[0] + d[1] + d[2] + d[3];
+    let z_u = z_l + d[4];
+    // `z_L` is `[x, y, w]`, so `x`'s lower bound is `z_l` itself and
+    // `y`'s is the row after it. Only `x`'s lower bound goes unnamed
+    // below, because nothing here releases it.
+    Rows {
+        y_lo: z_l + 1,
+        x_hi: z_u,
+    }
+}
+
+/// Just below the first kink, stepping past the second: the walk must
+/// release `x`'s upper bound and `y`'s lower one, and neither has
+/// curvature.
+const LAM0: Number = 1.0 - 1e-6;
+const DP: Number = 1.2;
+
+#[test]
+fn the_classifier_is_blind_here() {
+    // Without this the file could be passing on the gh#852 weak-row
+    // path rather than the one it describes.
+    let solver = solved_at(LAM0);
+    let report = solver.classify_activity().expect("classify_activity");
+    assert_eq!(
+        [
+            report.var_status[0],
+            report.var_status[1],
+            report.var_status[2]
+        ],
+        [UNIDENTIFIED; 3],
+        "every bound here must be unclassifiable",
+    );
+    assert!(
+        solver
+            .weakly_active_bounds()
+            .expect("weakly_active_bounds")
+            .is_empty(),
+        "`weakly_active_bounds` must be empty, or the walk is not on its own",
+    );
+}
+
+/// The plain released operator is genuinely singular on this working
+/// set, so the fallback is reached rather than decorative.
+///
+/// This is the test that keeps the fix honest. Every other test here
+/// would stay green if `path_direction` had simply started succeeding
+/// for some unrelated reason; this one names the operator that fails
+/// and the operator that does not.
+#[test]
+fn the_plain_operator_is_singular_and_the_regularized_one_is_not() {
+    let solver = solved_at(LAM0);
+    let r = rows_of(&solver);
+    let released = [r.x_hi as Index, r.y_lo as Index];
+    let held = [0 as Index, 1 as Index];
+
+    let plain = solver.path_direction_decided(&[PIN], &[DP], &released, &held, PathOperator::Plain);
+    let reg =
+        solver.path_direction_decided(&[PIN], &[DP], &released, &held, PathOperator::Regularized);
+
+    // `path_direction` itself falls back internally, so the plain
+    // operator has to be asked for by name to see it fail. It is not
+    // reachable through `parametric_step_path` any more, by design.
+    assert!(
+        plain.is_err(),
+        "releasing two curvature-free variables that share g0 must leave \
+         the plain operator singular -- if it does not, this fixture has \
+         stopped reaching the branch the file is about",
+    );
+    let msg = format!("{:?}", plain.unwrap_err());
+    assert!(
+        msg.contains("augmented solve failed"),
+        "the failure must be the Schur solve, not something upstream: {msg}",
+    );
+    let (d, du) = reg.expect("the regularized operator must answer");
+    assert_eq!(du.len(), held.len(), "one force per hold");
+    for &h in &held {
+        let h = h as usize;
+        assert!(
+            d[h].abs() < 1e-9,
+            "the Schur row must hold primal row {h} at zero, got {}",
+            d[h],
+        );
+    }
+}
+
+/// The two operators are the same answer where both run.
+///
+/// This is the claim that lets a walk take one on one segment and the
+/// other on the next while accumulating a single multiplier per hold:
+/// `Eᵀ w = 0` annihilates the diagonal the regularized operator adds,
+/// so the system solved is the released one either way.
+#[test]
+fn the_two_operators_agree_where_both_run() {
+    let solver = solved_at(LAM0);
+    let r = rows_of(&solver);
+    // Working sets the *plain* operator survives: at most one
+    // curvature-free release, so the stationarity rows stay
+    // independent.
+    let cases: [(&str, Vec<Index>, Vec<Index>); 4] = [
+        ("nothing released, x held", vec![], vec![0]),
+        ("nothing released, x and y held", vec![], vec![0, 1]),
+        ("x's upper released, y held", vec![r.x_hi as Index], vec![1]),
+        ("y's lower released, x held", vec![r.y_lo as Index], vec![0]),
+    ];
+    for (label, released, held) in cases {
+        let (d0, u0) = solver
+            .path_direction_decided(&[PIN], &[DP], &released, &held, PathOperator::Plain)
+            .unwrap_or_else(|e| panic!("{label}: the plain operator must run here: {e:?}"));
+        let (d1, u1) = solver
+            .path_direction_decided(&[PIN], &[DP], &released, &held, PathOperator::Regularized)
+            .unwrap_or_else(|e| panic!("{label}: the regularized operator must run here: {e:?}"));
+        let scale = d0.iter().fold(1.0 as Number, |a, v| a.max(v.abs()));
+        let ed = (0..d0.len())
+            .map(|i| (d0[i] - d1[i]).abs())
+            .fold(0.0, Number::max);
+        assert!(
+            ed < 1e-9 * scale,
+            "{label}: the two operators must give the same direction, off \
+             by {ed:e} (scale {scale:e})",
+        );
+        let uscale = u0.iter().fold(1.0 as Number, |a, v| a.max(v.abs()));
+        let eu = (0..u0.len())
+            .map(|i| (u0[i] - u1[i]).abs())
+            .fold(0.0, Number::max);
+        assert!(
+            eu < 1e-9 * uscale,
+            "{label}: the two operators must report the same hold force, \
+             off by {eu:e} (scale {uscale:e}) -- {u0:?} vs {u1:?}",
+        );
+    }
+    // And the pin is not vacuous on these sets: at least one of them
+    // has to carry a force, or "they agree" is agreement about zero.
+    let (_, u) = solver
+        .path_direction_decided(&[PIN], &[DP], &[], &[0], PathOperator::Preferred)
+        .expect("plain");
+    assert!(
+        u.iter().any(|v| v.abs() > 1e-6),
+        "the held row must actually be carrying a force: {u:?}",
+    );
+}
+
+/// The step gh#930 refused, against a re-solve at the perturbed
+/// parameter.
+///
+/// `/sens-review` entry 5: this is the only number here that the
+/// sensitivity layer did not produce. Internal consistency cannot
+/// catch a step that is self-consistently wrong, and a regularized
+/// operator is exactly the shape of change that could be.
+#[test]
+fn the_refused_walk_reproduces_the_resolve() {
+    let solver = solved_at(LAM0);
+    let base = solver.converged().expect("converged").x.clone();
+    let (dx, segs) = solver
+        .parametric_step_path(&[PIN], &[DP], 64)
+        .expect("the walk must answer, not refuse");
+    let got = [base[0] + dx[0], base[1] + dx[1], base[2] + dx[2]];
+    let truth = resolve_at(LAM0 + DP);
+    let err = (0..3)
+        .map(|i| (got[i] - truth[i]).abs())
+        .fold(0.0, Number::max);
+    assert!(
+        err < 1e-9,
+        "walk {got:?} vs re-solve {truth:?}, off by {err:e} over {} segments",
+        segs.len(),
+    );
+    assert!(
+        segs.len() >= 2,
+        "crossing two kinks must record breakpoints, got {}",
+        segs.len(),
+    );
+}
+
+/// The same, swept: both kinks, both directions, several slacks.
+///
+/// One `(lam0, dp)` is a fixture; a sweep is the claim that the
+/// fallback is not tuned to one working set. Every combination that
+/// crosses at least one kink is included, including the ones that
+/// never reach the fallback at all -- a fix that broke the ordinary
+/// path to rescue this one would show up here.
+#[test]
+fn the_walk_reproduces_the_resolve_across_the_grid() {
+    let mut worst: (Number, Number, Number) = (0.0, 0.0, 0.0);
+    let mut answered = 0usize;
+    for slack in [1e-2, 1e-4, 1e-6, 1e-8] {
+        for kink in [1.0, 2.0] {
+            for side in [-1.0, 1.0] {
+                let lam0 = kink + side * slack;
+                for dp in [-1.5, -0.7, -0.2, 0.2, 0.7, 1.5] {
+                    if lam0 + dp < 0.05 {
+                        continue;
+                    }
+                    let solver = solved_at(lam0);
+                    let base = solver.converged().expect("converged").x.clone();
+                    let (dx, _) = solver
+                        .parametric_step_path(&[PIN], &[dp], 64)
+                        .unwrap_or_else(|e| {
+                            panic!("lam0={lam0} dp={dp}: the walk must answer: {e:?}")
+                        });
+                    let got = [base[0] + dx[0], base[1] + dx[1], base[2] + dx[2]];
+                    let truth = resolve_at(lam0 + dp);
+                    let err = (0..3)
+                        .map(|i| (got[i] - truth[i]).abs())
+                        .fold(0.0, Number::max);
+                    answered += 1;
+                    if err > worst.0 {
+                        worst = (err, lam0, dp);
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        answered >= 40,
+        "the grid must actually run: {answered} combinations",
+    );
+    assert!(
+        worst.0 < 1e-7,
+        "worst disagreement with the re-solve {:e} at lam0={} dp={} over \
+         {answered} combinations",
+        worst.0,
+        worst.1,
+        worst.2,
+    );
+}
+
+/// The **silent** half of the same defect, and the branch the choice
+/// between the operators is actually made on.
+///
+/// How loudly the plain operator fails is a property of the model, not
+/// of the defect. With every variable curvature-free the two released
+/// stationarity rows coincide *and* `w`'s is dependent on them too:
+/// deficiency two, the augmented solve refuses, and
+/// `the_plain_operator_is_singular_and_the_regularized_one_is_not`
+/// pins that. Put a little curvature on `w` alone and `x`'s and `y`'s
+/// rows still coincide -- deficiency one -- and the factorization
+/// absorbs it: the solve returns `Ok`, and the held row it was asked
+/// to keep at zero comes back holding a fifth of the step.
+///
+/// So `path_direction` cannot decide between the operators on whether
+/// the solve errored. It decides on the pinned rows' **residual**,
+/// which is `pin_residual` in `pounce-sens-core`, referenced to the
+/// motion the pin was asked to remove and not to the compound
+/// vector's norm -- the multiplier rows here run at `3e11`, and a
+/// residual divided by that reads `3e-12` on a pin that missed by
+/// 200%.
+///
+/// Without this test the file would be evidence about one branch of a
+/// two-branch rule, which is the shape this repo has shipped defects
+/// through more than once.
+#[test]
+fn the_plain_operator_can_also_fail_silently() {
+    // Curvature on `w` only: `x` and `y`, the two variables whose
+    // bounds are released, still have none.
+    let solver = solved_curved_at(LAM0, [0.0, 0.0, 1e-3]);
+    let r = rows_of(&solver);
+    let released = [r.x_hi as Index, r.y_lo as Index];
+    let held = [0 as Index, 1 as Index];
+
+    let (d_plain, _) = solver
+        .path_direction_decided(&[PIN], &[DP], &released, &held, PathOperator::Plain)
+        .expect(
+            "this is the SILENT branch: the plain operator must return an              answer here, or the fixture has drifted onto the loud one and              the residual test below proves nothing",
+        );
+    let moved = d_plain[0].abs().max(d_plain[1].abs());
+    assert!(
+        moved > 1e-3,
+        "the plain operator must leave a held row visibly off zero for          this test to have a subject, got {:e} and {:e}",
+        d_plain[0],
+        d_plain[1],
+    );
+
+    // What the walk actually runs holds them, having noticed.
+    let (d, du) = solver
+        .path_direction_decided(&[PIN], &[DP], &released, &held, PathOperator::Preferred)
+        .expect("the preferred operator must answer");
+    assert_eq!(du.len(), held.len(), "one force per hold");
+    for &h in &held {
+        let h = h as usize;
+        assert!(
+            d[h].abs() < 1e-12 * moved,
+            "primal row {h} must be held at zero, got {:e} against the              plain operator's {:e}",
+            d[h],
+            moved,
+        );
+    }
+
+    // And the walk end to end, which is what a user sees. Before the
+    // residual test this returned a point 1.0e-5 outside `y`'s upper
+    // bound, and gh#928's repair turned that into a refusal rather
+    // than an answer.
+    let base = solver.converged().expect("converged").x.clone();
+    let truth = resolve_at(LAM0 + DP);
+    let (dx, segs) = solver
+        .parametric_step_path(&[PIN], &[DP], 64)
+        .expect("the walk must answer on the silent branch too");
+    let got = [base[0] + dx[0], base[1] + dx[1], base[2] + dx[2]];
+    let err = (0..3)
+        .map(|i| (got[i] - truth[i]).abs())
+        .fold(0.0, Number::max);
+    assert!(
+        err < 1e-9,
+        "walk {got:?} vs re-solve {truth:?}, off by {err:e} over {} segments",
+        segs.len(),
+    );
+}
+
+/// The pin is stiff, not infinite, and the creep it allows stays
+/// inside the box.
+///
+/// `Σ_pin` is the gh#737 ceiling, not `INFINITY` -- an infinite
+/// diagonal is a `NaN` in the factorization, not a stiffer pin. So a
+/// held coordinate moves by roundoff under the force it carries, and
+/// the property gh#928 exists to defend is that the roundoff points
+/// *inward* far enough that the answer never leaves the box by more
+/// than the walk's own `eps`.
+#[test]
+fn the_pin_is_stiff_not_infinite() {
+    let solver = solved_at(LAM0);
+    let base = solver.converged().expect("converged").x.clone();
+    let (dx, _) = solver
+        .parametric_step_path(&[PIN], &[DP], 64)
+        .expect("the walk must answer");
+    for i in 0..2 {
+        let v = base[i] + dx[i];
+        let past = (LO[i] - v).max(v - HI[i]);
+        assert!(
+            past < 1e-11,
+            "coordinate {i} left the box by {past:e} (at {v})",
+        );
+    }
+    assert!(
+        base[2] + dx[2] >= -1e-11,
+        "w left its lower bound at {}",
+        base[2] + dx[2],
+    );
+}
+
+// # Mutation table
+//
+// Every row was run against this file. A row with no red test is a
+// change this file cannot see, and is listed as such rather than
+// omitted.
+//
+// | change                                                          | red |
+// |-----------------------------------------------------------------|-----|
+// | `solve_released_pinned` returns `false` (no fallback)            | `the_plain_operator_...`, `the_refused_walk_...`, `the_pin_is_stiff_...` |
+// | drop the Schur row and keep only the raised diagonal (penalty pin) | `the_two_operators_agree_...` (`du` leaks ~1%, `d` on the held rows reads 3.8e-3 instead of 0) |
+// | `path_pin_add` returns `INFINITY` instead of the gh#737 ceiling  | `the_plain_operator_...` (`NaN` out of the factorization) |
+// | `path_pin_add` returns 1.0 (a reachable but limp diagonal)       | `the_two_operators_agree_...` |
+// | regularize on the *first* attempt instead of on failure          | nothing here; it is a cost regression, not a wrong answer -- the factorization cache keys on the sigma tag, so every back-solve in the segment re-factors |
+// | fall back only on `Err`, not on the pin residual                 | `the_plain_operator_can_also_fail_silently` (the walk refuses with `y` 1.0e-5 outside its bound) |
+// | `PIN_TAKE_RTOL` loosened to `1e-8`                               | `the_plain_operator_can_also_fail_silently` -- the residual it has to catch is `8.1e-9`, and this was the draft threshold |
+// | `pin_residual` divides by `max |d|` instead of by the pin's own rhs | `the_plain_operator_can_also_fail_silently`; the multiplier rows run at `3e11`, so a 200% miss reads `3e-12` |
+// | return `plain` whenever it is `Ok`, instead of the smaller residual | `the_plain_operator_can_also_fail_silently` |
+// | accept multiplier rows as pins (drop the `r >= n_p` guard)       | nothing here; every pin this fixture makes is primal. `issue_928_a_limit_written_as_a_row.rs` owns the `s` block |
+// | swap `x_hi` and `y_lo` in `rows_of`                              | `rows_of`'s own `block_dims` assertion does not catch it; `the_plain_operator_...` does, because the swapped set is not singular |
+//
+// # What this file is not evidence about
+//
+// * **How singular an operator the ceiling can lift.** One dependent
+//   pair, one shared row. A model whose released system is singular
+//   in a direction the pinned rows do not span is not rescued by this
+//   fallback at all, and nothing here says otherwise -- the walk would
+//   report the same failure it used to.
+// * **Scaling.** Everything here runs unit-scaled. `Σ_pin` is built
+//   from the constraint coefficients in the frame the factor lives
+//   in, so a scaled model reaches a different ceiling; leg 1 of
+//   `sens_invariance_legs.rs` owns that dimension.
+// * **Cost.** The regularized operator rebuilds its diagonal per
+//   solve and therefore misses the factorization cache. That it is
+//   the *second* choice is asserted by nothing here.
+// * **The convex arm.** `pounce-convex` reaches `step_along_path`
+//   through its own backsolver, which does not implement
+//   `solve_released_pinned`, so on a convex model with this shape the
+//   preferred operator has only the plain one to offer.
+//   `crates/pounce-convex/tests/` owns that arm.
+// * **Where the two residual populations separate on a large model.**
+//   `PIN_TAKE_RTOL` sits between `1.9e-16` and `8.1e-9` as measured
+//   on four-variable models. It is a *shortcut* threshold -- above it
+//   both operators run and the better-pinned answer is returned -- so
+//   a large model that lands between them pays a refactorization and
+//   not an answer. That is a claim about the code path, not a
+//   measurement, and nothing here measures it.
+// * **Magnitude.** Four variables and one shared row.

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -440,8 +440,10 @@ refinement's own test is. Unset, it is how far outside the solve itself
 was willing to settle, so nothing moves for a caller who does not set
 it. A constraint row keeps its own floor, and a bound is released when
 the step drives its multiplier negative past the solve's own margin,
-whatever `bound_eps` is. `mode="path"` reads no such margin, and
-passing it under `linear` or `path` warns.
+whatever `bound_eps` is. `mode="path"` does not take one — it uses the
+solve's own margin internally, to decide when its answer has ended up
+outside the box (gh#928) — and passing `bound_eps` under `linear` or
+`path` warns.
 
 `max_pdpert` refuses rather than answering when the converged factor
 carries an inertia correction above the value given, since every
@@ -694,6 +696,28 @@ breakpoint to stop it, and only a downstream clamp put it back --
 moving the crossing coordinate and nothing coupled to it. The repair
 landed in the walk itself, which both the decided and the undecided
 callers go through, so `"release_all"` inherited it.
+
+That repair learns which bounds are weak from the activity classifier,
+which leaves the case the classifier cannot see. `classify` needs a
+curvature to divide by, so where the Hessian diagonal falls below the
+identification floor every bound comes back `unidentified`,
+`weakly_active_bounds()` returns nothing, and the walk is told nothing
+— while its own base-activity test still bars the bound from the reach
+scan. That is not a corner: it is every LP, and every model whose cost
+is linear in the coordinate that reaches the bound. On a five-bus
+AC-OPF at the load where a generator reaches its rating, with the
+linear generation cost that dispatch normally uses, `path` predicted
+202.98 MW against a 170 MW nameplate and recorded no breakpoint at all;
+a quadratic cost term worth 0.1% of the linear one changes nothing
+physical and fixes it, by lifting the diagonal over the floor.
+
+So since gh#928 the walk does not rely on being told. It compares its
+own answer against the box and treats a base-active bound the answer
+crossed as evidence the factorization never enforced it, then walks
+again with a breakpoint available there. The two mechanisms are
+complementary rather than redundant: the classifier's list catches a
+stale barrier diagonal that damps a coordinate at a later breakpoint
+without ever pushing it out of its box, which a box check cannot see.
 
 `"one_sided"` takes the single-sided value the thresholds produce,
 bit-identical to the behavior without the argument. On the CSTR held

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -550,10 +550,38 @@ for c in sens_active_set_changes(m, [(m.setpoint, 3.0)]):
 ```
 
 Each entry holds the fraction of the perturbation at which the change
-happens, the variable, which bound (`"lower"` or `"upper"`), and
-whether the variable `"reaches"` it or `"leaves"` it. The first
-entry's fraction is how much of the perturbation the held solve's
+happens, the quantity whose limit it is, which bound (`"lower"` or
+`"upper"`), and whether it `"reaches"` the limit or `"leaves"` it. The
+first entry's fraction is how much of the perturbation the held solve's
 active set survives unchanged.
+
+The `.var` field is not always a `Var`. A limit written as a
+constraint row — `m.cap = Constraint(expr=m.x <= 1.0)`, which is how a
+capacity, a ramp or a nameplate is normally stated — bounds that row's
+**slack** rather than any variable, so the entry names the
+`Constraint`:
+
+```python
+c = sens_active_set_changes(m, [(m.p, 1.3)])[0]
+c.var is m.cap      # True, a Constraint, not a Var
+c.bound             # "upper"
+c.action            # "reaches"
+```
+
+Both forms produce the same `bound` and `action` values, and both are
+walked the same way, so a caller that only prints the record needs no
+change; one that looks the entry up in a map of variables must check
+what it got. Before gh#928 a row limit was in no bound row at all: the
+walk could not reach it, could not release it, and recorded nothing
+when it walked past — on the model above, `x` went to 1.3 against a
+true 1.0 with an empty record. That was independent of degeneracy;
+any model stating a limit as a row was exposed. The Rust and Python
+APIs report the same thing one level down, where a segment's `var_row`
+is a **primal KKT row**: below `block_dims()[0]` it is a variable's
+var-x index, at or above it the limit is a row's and
+`slack_rows()` is what resolves it back to a constraint. Indexing a
+variable-length vector by that number instead returns a neighbouring
+variable's answer, which is the gh#450 hazard.
 
 Where the two modes settle the same active set they give the same
 prediction. Where the changes are spread out along the perturbation

--- a/pyomo-pounce/tests/test_path.py
+++ b/pyomo-pounce/tests/test_path.py
@@ -259,3 +259,93 @@ def test_the_record_requires_a_session():
     m = linked()
     with pytest.raises(RuntimeError, match="no sensitivity session"):
         sens_active_set_changes(m, [(m.p, 2.0)])
+
+
+# ---------------------------------------------------------------------
+# gh#928: the same limit written as a constraint row.
+#
+# `x <= 1` as a bound and `cap: x <= 1` as a row describe the same
+# feasible set, but the second bounds the row's SLACK rather than any
+# variable, so its multiplier is in `v_u` and its primal KKT row is in
+# the `s` block. Before gh#928 the row form was in no bound row and in
+# no box: the walk could not reach it, could not release it, and
+# recorded nothing when it walked past. These tests are the Python end
+# of that, and they are also what pins the record's own widening -- the
+# entry names a Constraint, not a Var, and resolving the row against
+# the variable map would return a neighbouring variable (gh#450).
+# ---------------------------------------------------------------------
+
+
+def capped(p=0.8):
+    """`x` tracks `p` with the limit stated as a ROW, not a bound.
+
+    Strictly convex in `x` and unbounded as a variable, so the limit is
+    reachable only through `cap` and the answer is `min(p, 1)`.
+    """
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=p, mutable=True)
+    m.x = pyo.Var(initialize=0.5)
+    m.cap = pyo.Constraint(expr=m.x <= 1.0)
+    m.obj = pyo.Objective(expr=0.5 * (m.x - m.p) ** 2)
+    declare_sens_param(m.p)
+    return m
+
+
+def capped_solved(p=0.8):
+    m = capped(p)
+    pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+def test_a_row_limit_the_step_reaches_is_named_by_its_constraint():
+    """Pre-fix: x walked to 1.3 against a truth of 1.0, silently."""
+    m = capped_solved(0.8)
+    est = sens_solution(m, [(m.p, 1.3)], mode="path")
+    assert est[m.x] == pytest.approx(1.0, abs=1e-6)
+    rec = sens_active_set_changes(m, [(m.p, 1.3)])
+    assert len(rec) == 1
+    c = rec[0]
+    # The record must name the CONSTRAINT. Resolving an `s`-block row
+    # against the variable map is the gh#450 neighbouring-entry bug,
+    # and here it would name `x` -- a plausible, wrong answer.
+    assert c.var is m.cap
+    assert c.bound == "upper"
+    assert c.action == "reaches"
+    assert c.fraction == pytest.approx(0.4, abs=1e-6)
+
+
+def test_a_row_limit_the_step_leaves_is_released():
+    """Pre-fix: x stayed pinned at 1.0 against a truth of 0.8, because
+    nothing took the cap's stiffness out of the operator."""
+    m = capped_solved(1.3)
+    est = sens_solution(m, [(m.p, 0.8)], mode="path")
+    assert est[m.x] == pytest.approx(0.8, abs=1e-6)
+    rec = sens_active_set_changes(m, [(m.p, 0.8)])
+    assert len(rec) == 1
+    c = rec[0]
+    assert c.var is m.cap
+    assert c.bound == "upper"
+    assert c.action == "leaves"
+    assert c.fraction == pytest.approx(0.6, abs=1e-6)
+
+
+def test_a_step_that_does_not_touch_the_row_limit_records_nothing():
+    """The control: exact before the fix too, so a test that only
+    checked answers would pass here while both cases above were broken."""
+    m = capped_solved(0.8)
+    est = sens_solution(m, [(m.p, 0.6)], mode="path")
+    assert est[m.x] == pytest.approx(0.6, abs=1e-6)
+    assert sens_active_set_changes(m, [(m.p, 0.6)]) == []
+
+
+def test_slack_rows_is_the_discriminator_for_a_row_limit():
+    """The accessor that tells a consumer which block a segment's row
+    is in, checked against the segment the walk actually emits."""
+    m = capped_solved(0.8)
+    sess = m._pounce_sens.session
+    n_x = sess.solver.block_dims[0]
+    slack = sess.solver.slack_rows(list(range(len(sess.con_names))))
+    rows = [r for r in slack if r is not None]
+    assert rows, "the model has an inequality, so some row has a slack"
+    assert all(r >= n_x for r in rows), (
+        f"a slack row must be in the `s` block, past n_x={n_x}: {rows}")

--- a/python/pounce/sensitivity/_step.py
+++ b/python/pounce/sensitivity/_step.py
@@ -1089,6 +1089,16 @@ def solution_report(session, pin_rows, deltas, max_iter=None,
 #: an order-one penalty that bends the step without enforcing anything,
 #: so a perturbation pressing into it is a breakpoint like any other
 #: (gh#852).
+#:
+#: `var` names the quantity the bound is on, and it is not always a
+#: variable: a limit written as a constraint row, `g(x) <= cap`, bounds
+#: that row's SLACK, and its entry names the constraint instead
+#: (gh#928). The two are told apart by what the object is -- a
+#: `Constraint` rather than a `Var` under `pyomo_pounce`, a row name
+#: rather than a column name in the base session -- and both kinds of
+#: limit produce the same `bound` and `action` values. The field keeps
+#: its name so that unpacking a record written before row limits were
+#: reachable still works.
 ActiveSetChange = namedtuple(
     "ActiveSetChange", ["fraction", "var", "bound", "action"])
 
@@ -1164,19 +1174,40 @@ def active_set_changes(session, pin_rows, deltas, predictor_iter=16,
         _, segments = session.solver.parametric_step_path(
             pin_idx, deltas, predictor_iter)
 
-    # segments carry var-x rows (the factor's x block); var_names is
-    # full-x, so invert the same map scatter_x applies
+    # A segment names its bounded quantity by PRIMAL KKT row, and the
+    # primal blocks are x then s. Below n_x it is a variable, in var-x
+    # (var_names is full-x, so invert the map scatter_x applies). At or
+    # above it the limit is a constraint's own -- g(x) <= cap bounds
+    # the row's slack, not any variable -- and resolving it against the
+    # variable map would return a NEIGHBOURING variable, the gh#450
+    # hazard. gh#928 is what made the second case reachable.
+    n_x = session.solver.block_dims[0]
     full_of = {row: full
                for full, row in enumerate(session._primal_row_map())
                if row is not None}
+    slack_of = None
     out = []
-    for frac, var_row, lower, pinned in segments:
-        full = full_of[var_row]
-        name = session.var_names[full]
-        comp = session.var_key(full)
+    for frac, row, lower, pinned in segments:
+        if row < n_x:
+            full = full_of[row]
+            key = session.var_key(full)
+            if key is None:
+                key = session.var_names[full]
+        else:
+            if slack_of is None:
+                # Built only when a row limit actually moves, so the
+                # common all-variables path costs no extra call.
+                slack_of = {
+                    r: g
+                    for g, r in enumerate(session.solver.slack_rows(
+                        list(range(len(session.con_names)))))
+                    if r is not None}
+            key = session.row_key(slack_of[row])
+            if key is None:
+                key = session.con_names[slack_of[row]]
         out.append(ActiveSetChange(
             fraction=float(frac),
-            var=comp if comp is not None else name,
+            var=key,
             bound="lower" if lower else "upper",
             action="reaches" if pinned else "leaves",
         ))


### PR DESCRIPTION
`parametric_step_path` could return a point outside a stated bound, with
no breakpoint recorded and no warning. **Three independent routes** reach
that same signature — a bound the classifier cannot certify, a limit
written as a constraint row on the NLP arm, and the same limit on the
convex arm — and this branch closes all three. A fourth half turns the
one case the walk *refused* into an answer.

Halves one and two fix #928. Half three is #929, filed because the
convex arm is a different structure rather than a shared code path. Half
four is #930, which this branch filed against itself and then closed.

Fixes #928
Fixes #929
Fixes #930

## Half one — a bound the classifier cannot certify (commit 1)

The walk learned which bounds the factorization carries as a finite
penalty rather than enforces from `weakly_active_bounds`. Where there is
no curvature to divide by, every bound classifies `UNIDENTIFIED`, that
list comes back empty, and the walk's own base-activity test — exactly
`Sigma > 1` — bars the bound from the reach scan anyway. The bound is
then neither held by the factorization nor watched by the path, and the
direction carries the variable straight through it. That is every LP,
and every model whose cost is linear in the coordinate that reaches the
bound.

Measured on a five-bus AC-OPF at the load where a generator reaches its
rating: at linear generation cost — the normal case in dispatch — the
walk predicted **202.98 MW against a 170 MW nameplate**, zero segments.
Adding a quadratic term worth 0.1% of the linear one at that output
changes nothing physical and fixes it, by lifting the diagonal over the
floor. On a three-variable LP reproducer, **11 of 37** base points
returned a point outside the box, relative violation up to 0.9999.

The fix does not rely on being told. `step_along_path` compares its own
answer against the box, treats a base-active bound the answer *crossed*
as measured proof the factorization did not enforce it, adds that row to
the watch list, and walks again. Threshold-free, and a no-op whenever
the first walk already lands inside the box — which is the entire
pre-existing corpus.

Widening the classifier was considered and rejected: admitting
`UNIDENTIFIED` wholesale also admits genuinely enforced bounds
(`Sigma = 1.1e11` on the same LP) and makes the augmented system
singular.

## Half two — a limit written as a constraint row (commit 2)

The broader half: **it needs no degeneracy at all.**

`x <= 1` as a variable bound and `cap: g(x) <= 1` as a row describe the
same feasible set. They were not the same thing to the layer. A variable
bound's multiplier lives in `z_l`/`z_u` and constrains a row of the `x`
block; a row's limit bounds the **slack**, so its multiplier lives in
`v_l`/`v_u` and constrains a row of the `s` block. `bound_variable_rows`
emitted only the `z` half and `bound_context`'s box covered only the `x`
block, so a row limit had no entry in the reach scan, no entry in the
base-activity table, no breakpoint it could be recorded as, and nothing
for half one's box repair to add to its watch list.

Measured on `min 0.5 (x - p)^2` s.t. `x <= 1` written as a row, `x`
otherwise free:

| base | step to | before | true |
|---|---|---|---|
| `p = 0.8` | `p = 1.3` | `x = 1.300000000`, empty segment list | `1.000000000` |
| `p = 1.3` | `p = 0.8` | `x` **pinned at 1.0** | `0.8` |
| at the kink | either side | wrong by half the perturbation | — |

The reverse direction is worse than a lost record: the answer is wrong
*and* the record is empty. All three are now exact to ~1e-10 and carry a
segment naming the cap.

What kept the repair small: blocks `x` and `s` are **contiguous** in the
compound KKT vector, so the `(x, s)` prefix is one box and the walk
needs no second index space; and `path_direction` already pins a generic
Schur unit row on any KKT row, so the reach half needed no backsolver
arithmetic at all. The release half did — the `s`-block barrier diagonal
is rebuilt with the released entry's `v/s` taken out, and stays `None`
when no slack bound is released, because the factorization cache keys on
that object's identity.

### The API consequence, stated plainly

`BoundRow.var_row` — and so `PathSegment.var_row`, and a `pinned` row
from `parametric_step_bounded` — is now a **primal KKT row**: below
`block_dims()[0]` it names a variable, at or above it the limit is a
constraint's own. Indexing a variable-length vector by that number
returns a *neighbouring* variable's answer (the gh#450 hazard), so every
consumer inside the crate decides the block first. The new
`slack_rows()` accessor (`Solver::d_slack_rows`) resolves such a row
back to its inequality — the primal counterpart of
`inequality_multiplier_rows`. In `pyomo-pounce`, a
`sens_active_set_changes()` entry for a row limit has `.var` naming the
`Constraint`.

## Half three — the same limit on the convex arm (commit 3)

Fixes #929. Half two works because the NLP KKT already carries
`dⱼ(x) = sⱼ`, so every constraint has a primal coordinate for the walk to
index. The convex active-set KKT

```text
[ H   Aᵀ  B_aᵀ ] [ dx ]
[ A   0   0    ] [ dy ]
[ B_a 0   0    ] [ dz ]
```

has none. An **inactive** `Gⱼx ≤ hⱼ` appears in it nowhere at all, so a
step driving it past its limit was silent and the answer came back
infeasible; an **active** one has a multiplier row but no primal
coordinate, so a perturbation driving that multiplier negative went on
holding a row the solution had left.

`pounce_sens_core::rowlimit::RowLimitView` adjoins an observer
`t = G_w x` through a multiplier, immediately after the `x` block so it
lands inside the primal prefix the walk indexes. The adjoined block is
**triangular** — `dmu = r_t`, one base back-solve on `r_x + G_wᵀ r_t`,
then `dt = G_w dx + r_mu` — so the base factorization is untouched and
**the fix costs no factorization**. Releasing an active row generalizes
the arm's existing row neutralization from a single `±1` coupling to a
whole `G` row, reusing the symbolic factor.

Measured on `min ½‖x‖²` s.t. `Σx = b`, `x₀ + x₂ ≤ 1`, `x₁ ≤ 0.8`, whose
closed form is known on all three branches:

| walk | before | true |
|---|---|---|
| `b: 0 → 4` | `x₀ + x₂ = 2.133`, **1.133 past the cap**, empty segment list | `1.000`, segments at fraction `0.5` (row) and `0.65` (bound) |
| `b: 4 → 0` | `(0.5, −0.5, 0.5, −0.5)`, row still pinned at `1.0` | the origin, to `2.1e-14` |

A third base reaches the **other branch** — the row already active with a
multiplier of `4.1e-5`, released at fraction `8.2e-5` rather than
mid-walk — measured separately, per the branch rule.

The augmentation is **skipped whenever any cone block is present**,
because there `active_rows` is a cone normal (or, at an apex, the whole
block) and `active_ineq` is provenance rather than a `G` row; pinned by a
leg that walks a boundary SOC far enough to drive a coordinate the cone
does not sign-constrain through zero. The guard is deliberately
all-or-nothing, so a **mixed** partition loses its observers too — a
known conservative choice, named in the fixture's scope list, not a
covered case.

`QpSensitivity::path_segment_target` resolves a segment to
`PathTarget::Variable` or `PathTarget::InequalityRow` — this arm's
counterpart of `slack_rows()` — so a consumer cannot read a row index as
a column index.

### What half three does NOT cover, measured

`QpSensitivity::parametric_step_bounded` is **not** augmented and still
carries the whole defect: on the same fixture it returns
`x₀ + x₂ = 2.1333` against a cap of `1.0`, and in reverse leaves the row
pinned at `1.0` where the truth is the origin — the same two numbers the
table above quotes as the walk's *pre*-fix behaviour. It is a different
edit rather than the same one: that entry point returns
`refine_step_onto_bounds`'s **mixed** list of released multiplier rows
and pinned primal rows, so adjoining observers shifts the meaning of half
that list and needs an API decision and a fixture of its own. The NLP arm
has no matching gap, because half two widened its box globally rather
than through a view. Recorded with its numbers in the fixture's scope
list and the CHANGELOG rather than left silent.

## Half four — two curvature-free releases (commit 4)

Fixes #930, which this branch itself filed. Releasing a bound takes its
`Sigma` off the diagonal; with no curvature there the diagonal is exactly
zero, and two released variables sharing a constraint row are left with
linearly dependent stationarity rows. `K` is singular, the Schur pin
cannot go on, and the walk reported `augmented solve failed`.

**The pin did not change — the operator it rides on did.** On failure the
walk retries against `K_released + Σ_pin E Eᵀ`, whose pinned diagonals are
raised until it inverts, and the same Schur row goes on top. `Eᵀw = 0`
annihilates exactly the term that was added, so the system actually
solved is the released one, in the identical frame and units; a walk that
takes the plain operator on one segment and the regularized one on the
next still accumulates a single `h.mult` per hold. `Σ_pin` is the gh#737
ceiling, so the held coordinate creeps by roundoff rather than being
infinitely stiff — bounded by a test rather than asserted.

The fallback triggers on the **pinned rows' residual**, not on the
factorization returning an error, and is referenced to the pin's own
right-hand side rather than to `max|d|`. Both choices are load-bearing
and both were measured: at rank deficiency one the plain factorization
**absorbs the singularity, returns `Ok`**, and hands back a held row
carrying a fifth of the step — while the multiplier rows run at `3e11`,
so a 200% miss reads `3e-12` against `max|d|`.

The answer is checked against a **re-solve at the perturbed parameter**,
the only guard in the layer that reads a number the sensitivity code did
not produce. Accordingly
`two_releases_without_curvature_are_refused_not_answered` becomes
`..._are_answered_not_refused`, an equality assertion against that
re-solve — which is what that file's own "not evidence about" section
said a change answering this walk would owe. Its curvature arms stay, as
the measurement of what the obstruction *was* and the continuity claim
across it.

## Also changed

- The box-repair budget is the base-activity table's length rather than
  a fixed constant, which makes the exhausted arm unreachable *by
  construction* instead of unreached by luck. Measured by capping it to
  `.min(1)` and re-running: a budget of 1 clears every Rust test in
  `pounce-sens-core`, `pounce-sensitivity` and `pounce-py`, 0 failures.
- A walk that releases two bounds at once with no curvature in the
  released coordinates was **refused** rather than answered. That was
  filed as #930 and is now fixed on this branch — see half four.

## Not covered

- **`QpSensitivity::parametric_step_bounded`** — measured above, under
  half three.
- **The conic arm's own row limits.** Half three's augmentation is
  *skipped* there by design; `convex_sens_release.rs` owns what release
  means on that arm.
- **Two-sided (range) rows.** `WatchedRow` is one-sided on purpose; a
  range row is two watched rows and no fixture here has one.
- **Magnitude.** Four variables and one row on the convex fixture. The
  largest convex fixture in the corpus is 534 columns and
  `benchmarks/qp` reaches 93 263; the observer block costs `O(nnz(G))`
  per back-solve and nothing here bounds that at scale.

## Adversarial testing

Seven mutations were applied to the tree and measured; every source file
was restored and `cmp`-verified afterwards. **Two rows of the new
fixture's mutation table were false and are rewritten with what was
observed:**

- Dropping the `pd_l`/`pd_u` groups leaves *reach* **green** — the reach
  scan reads the box directly, so the box widening rather than the bound
  rows is what enables reach — and instead fails the supposed control,
  which records a spurious segment. That control is the genuine
  base-activity-table discriminator.
- Restoring `slacks_and_directions`' `[..n_x]` truncation fails
  **nothing** in the new file (`parametric_step_path` never runs
  `corrector::run`). Across the workspace exactly one test catches it:
  `cd_split_pin_mapping`.

Two coverage holes the mutations exposed are closed by new assertions,
not noted: a `d_slack_rows` offset check, and a second model
(`RowLimitPlusBound`) that separates a *misrouted* `s`-block release
from a *dropped* one — mutations 3 and 4 were bit-identical on model 1
because `sigma_x` is identically zero there. A `/sens-review` entry-2
gap is closed by three new `user-scaling` legs, whose non-vacuity is
itself confirmed by mutation 7.

## Gates

- `issue_928_a_limit_written_as_a_row.rs` 11/11;
  `issue_928_path_leaves_an_unclassifiable_box.rs`,
  `issue_928_two_soft_bounds_at_once.rs` (7, now the equality assertion),
  `issue_928_convex_path_leaves_the_box.rs` (5) all green.
- The two new fixtures: `issue_929_row_limit_on_the_convex_arm.rs` 12/12,
  `issue_930_two_curvature_free_releases.rs` 7/7.
- Invariance legs `sens_invariance_legs` 24, `sens_resolve_oracle` 12,
  `cd_split_pin_mapping` 4, `variable_scaling_sensitivity` 9.
- `cargo test -p pounce-sens-core -p pounce-sensitivity -p pounce-convex -p pounce-py --release --no-fail-fast`:
  94 binaries, 0 failed.
- `cargo clippy` at CI's exact gate: exit 0. `cargo fmt --check` clean.
- `make python-ext` rebuilt from this code, staleness guard active and
  never bypassed. `pytest python/tests` 1477 passed;
  `pytest pyomo-pounce/tests` 544 passed, 11 skipped.
- `scripts/sweep-fixtures.sh`, both legs, run **twice**: the first two
  commits against a `fc1a3686` worktree, and commits 3–4 against a
  `33a96d44` worktree. **194 fixture-legs each, empty diff both times.**
  Re-run rather than inherited, because half three touches
  `pounce-convex` and CLAUDE.md is explicit that "convex path, so the
  sweep does not cover it" is the reasoning that shipped gh#760. Expected
  to be empty here for a different reason than gh#760's: the edit is in
  `sensitivity.rs`, not `ipm.rs`, and `QpSensitivity` is built only
  *after* a solve, so no swept fixture reaches this code at all. That
  makes it evidence of no collateral damage and not evidence about the
  fix — the fixtures above are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5CB3GErgSn6qJtXERRWbm

