### PR TITLE
fix(sensitivity): the convex refinement watches a limit written as a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,6 +460,43 @@ changes.
 
 ### Fixed
 
+- **A limit written as a constraint row is refined too, on the convex arm**
+  ([#929](https://github.com/jkitchin/pounce/issues/929) follow-up).
+  gh#929 taught `QpSensitivity::parametric_step_path` — the walk — about
+  limits written as `Gⱼ x ≤ hⱼ` rather than as variable bounds, and left
+  `parametric_step_bounded` — the one-shot fix-relax — carrying the whole
+  defect. An active-set KKT has no primal coordinate for a constraint row,
+  and an *inactive* row appears in it nowhere at all, so the refinement had
+  nothing to pin and nothing to release.
+
+  Measured on a four-variable QP whose cap `x₀ + x₂ ≤ 1` is a row: stepping
+  the right-hand side `0 → 4` the refinement returned `x₀ + x₂ = 2.133`,
+  **1.133 past the stated cap**, having correctly pinned the *variable*
+  bound it crossed on the way — which is what made the answer plausible.
+  Coming back, `4 → 0`, it left `(0.5, −0.5, 0.5, −0.5)` with the row still
+  reported binding where the truth is the origin: wrong answer *and* wrong
+  record. Both directions now reproduce a re-solve at the perturbed
+  right-hand side to `< 1e-8`, exactly rather than approximately — the whole
+  active set of the target is reached in one shot, and for a QP fix-relax
+  with the right active set *is* the re-solve.
+
+  The fix reuses gh#929's `RowLimitView` rather than adding machinery: the
+  observer block is triangular in the adjoined variables, so it costs two
+  sparse mat-vecs and **no extra factorization**. `RowLimitView::lift_step`
+  is new — the plain step is already in hand at that point, so lifting it
+  beats a second back-solve. The augmentation is skipped, and the plain
+  refinement kept, wherever the walk skips it, notably on the conic arm.
+
+  The row list `parametric_step_bounded` returns is **mixed**: a released
+  limit is named by its multiplier row, a pinned one by its primal row, and
+  a primal row at or past `n` is now an *observer* rather than a variable.
+  Indexing a variable-length vector by one of these numbers returns a
+  neighbouring variable's answer — the gh#450 hazard — so
+  `QpSensitivity::refined_row_target` is the single decoder, returning the
+  new `RefinedRow { target: PathTarget, released: bool }`. The method has no
+  callers outside this crate's tests and no Python binding, so nothing
+  downstream changes.
+
 - **`curve_fit(sensitivity="exact")`, and two accuracy defects in
   `dpopt_ddata` ([#923](https://github.com/jkitchin/pounce/issues/923),
   [#925](https://github.com/jkitchin/pounce/issues/925)).** The influence

--- a/crates/pounce-convex/src/sensitivity.rs
+++ b/crates/pounce-convex/src/sensitivity.rs
@@ -1367,17 +1367,12 @@ fn soc_boundary_curvature(
         .collect()
 }
 
-/// Post-optimal sensitivity for a solved convex QP.
+/// What a condition reported by a convex parametric query is about.
 ///
-/// Holds the factored active-set KKT system at the optimum. Build it once
-/// from a [`QpProblem`] and its [`QpSolution`], then call
-/// [`parametric_step`](Self::parametric_step) for each parameter
-/// perturbation — the factorization is reused across queries.
-/// What a [`PathSegment`] of a convex parametric walk is about.
-///
-/// The walk reports a primal KKT row, and this arm's primal prefix is the `x`
-/// block followed by one observer coordinate per inequality row (gh#929).
-/// [`QpSensitivity::path_segment_target`] is the only conversion.
+/// Both the walk and the refinement report a primal KKT row, and this arm's
+/// primal prefix is the `x` block followed by one observer coordinate per
+/// inequality row (gh#929). [`QpSensitivity::path_segment_target`] and
+/// [`QpSensitivity::refined_row_target`] are the only conversions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PathTarget {
     /// Variable `x[j]` reached or left one of its own bounds.
@@ -1386,6 +1381,33 @@ pub enum PathTarget {
     InequalityRow(usize),
 }
 
+/// One entry of the row list
+/// [`parametric_step_bounded`](QpSensitivity::parametric_step_bounded)
+/// returns, resolved.
+///
+/// That list is **mixed**: `refine_step_onto_bounds` reports a release by its
+/// *multiplier* row and a pin by its *primal* row, in one `Vec<usize>`. The
+/// two spaces do not overlap, so the number alone is decodable — but only by
+/// code that knows the layout, which is exactly the shape `/sens-review`
+/// entry 1 is about. [`QpSensitivity::refined_row_target`] does the decoding
+/// once and hands back both halves.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RefinedRow {
+    /// The variable or inequality row the condition belongs to.
+    pub target: PathTarget,
+    /// `true` when the refinement **released** this limit — the base solve
+    /// held it and the perturbation drove its multiplier negative — and
+    /// `false` when it **pinned** it, holding a coordinate the plain step
+    /// would have carried past its limit.
+    pub released: bool,
+}
+
+/// Post-optimal sensitivity for a solved convex QP.
+///
+/// Holds the factored active-set KKT system at the optimum. Build it once
+/// from a [`QpProblem`] and its [`QpSolution`], then call
+/// [`parametric_step`](Self::parametric_step) for each parameter
+/// perturbation — the factorization is reused across queries.
 pub struct QpSensitivity {
     n: usize,
     m_eq: usize,
@@ -2592,15 +2614,34 @@ impl QpSensitivity {
     /// satisfies the constraints. This instead pins the crossing coordinate at
     /// its bound and re-solves, so the others move with it.
     ///
-    /// Returns `(dx, pinned_variables, stop_reason)`. The computation is
+    /// Returns `(dx, rows, stop_reason)`. The computation is
     /// `pounce_sens_core::boundcheck::refine_step_onto_bounds` — the same code
     /// the NLP arm runs, reached through [`backsolver`](Self::backsolver)
     /// rather than reimplemented.
     ///
-    /// In this phase the refinement **pins only**: a bound whose multiplier the
-    /// step drives negative is not released (see
-    /// [`QpKktBacksolver::supports_release`]), so a perturbation pulling a
-    /// variable off a bound is still held there.
+    /// It **pins and releases**: a bound whose multiplier the step drives
+    /// negative is taken out of the active set, because
+    /// [`QpKktBacksolver::supports_release`] answers `true`.
+    ///
+    /// **A limit written as a constraint row is refined too** (gh#929, and its
+    /// follow-up on this entry point).
+    /// A row `Gⱼ x ≤ hⱼ` has no primal coordinate in this arm's KKT — an
+    /// inactive one appears nowhere at all — so the refinement had nothing to
+    /// pin and nothing to release, and a step that crossed such a row came back
+    /// past it in silence. The same [`RowLimitView`] the walk uses adjoins an
+    /// observer `tⱼ = Gⱼ x` with box `(−∞, hⱼ]`, at the cost of two sparse
+    /// mat-vecs and no extra factorization. The augmentation is skipped, and
+    /// the plain unaugmented refinement kept, exactly where
+    /// [`row_limit_view`](Self::row_limit_view) says so — notably on the conic
+    /// arm.
+    ///
+    /// `rows` is therefore **mixed and in the augmented index space**: a
+    /// released limit is named by its multiplier row and a pinned one by its
+    /// primal row, and a primal row at or past `n` is an observer rather than a
+    /// variable. Do not index a variable-length vector by one of these numbers
+    /// — that is the gh#450 hazard, and it returns a neighbouring variable's
+    /// answer. [`refined_row_target`](Self::refined_row_target) is the only
+    /// conversion.
     pub fn parametric_step_bounded(
         &mut self,
         pin_constraint_indices: &[usize],
@@ -2625,7 +2666,38 @@ impl QpSensitivity {
         let n = self.n;
         let (_, x_curr, lo, hi, multipliers) = self.path_inputs(pin_constraint_indices, deltas);
         let bs = self.backsolver();
-        let (dx, pinned, stop) = refine_step_onto_bounds(
+        if let Some(view) = self.row_limit_view(&bs) {
+            let (Some(dx_lift), Some(rhs_lift), Some((x_aug, lo_aug, hi_aug)), Some(mult_aug)) = (
+                view.lift_step(&dx_full),
+                view.lift_rhs(&rhs_plain),
+                view.primal_box(&x_curr, &lo, &hi),
+                view.lift_multipliers(&multipliers),
+            ) else {
+                // Unreachable given `row_limit_view`'s own checks; refusing
+                // beats refining against a half-built augmented system.
+                return Err(SensError::Refinement(
+                    "row-limit observers could not be lifted into the refinement's inputs"
+                        .to_string(),
+                ));
+            };
+            debug_assert_eq!(x_aug.len(), n + view.n_observers());
+            let (dx, rows, stop) = refine_step_onto_bounds(
+                &view,
+                &dx_lift,
+                &x_aug,
+                &lo_aug,
+                &hi_aug,
+                &mult_aug,
+                &rhs_lift,
+                bound_eps,
+                RELEASE_FLOOR,
+                max_iter,
+            )
+            .map_err(SensError::Refinement)?;
+            self.last_residual = Some(bs.last_residual());
+            return Ok((dx[..n].to_vec(), rows, stop));
+        }
+        let (dx, rows, stop) = refine_step_onto_bounds(
             &bs,
             &dx_full,
             &x_curr,
@@ -2639,7 +2711,7 @@ impl QpSensitivity {
         )
         .map_err(SensError::Refinement)?;
         self.last_residual = Some(bs.last_residual());
-        Ok((dx[..n].to_vec(), pinned, stop))
+        Ok((dx[..n].to_vec(), rows, stop))
     }
 
     /// The perturbation applied **a little at a time**, stopping at each point
@@ -2736,6 +2808,45 @@ impl QpSensitivity {
         } else {
             PathTarget::InequalityRow(seg.var_row - self.n)
         }
+    }
+
+    /// What one entry of the row list from
+    /// [`parametric_step_bounded`](Self::parametric_step_bounded) refers to,
+    /// and whether the refinement pinned it or released it.
+    ///
+    /// That list carries **two index spaces at once**: a release is reported
+    /// by the limit's *multiplier* row and a pin by its *primal* row. This is
+    /// the only decoder, for the same reason
+    /// [`path_segment_target`](Self::path_segment_target) is the walk's — a
+    /// caller doing it inline turns "inequality row 2 was released" into
+    /// "variable `n + 2` was pinned", plausibly and silently.
+    ///
+    /// The view is rebuilt here rather than cached so the mapping cannot drift
+    /// from the one the refinement actually ran against; when the augmentation
+    /// was skipped, the base's own bound rows answer instead, so a conic
+    /// result decodes through this method too.
+    ///
+    /// `None` for a row that is neither a primal row of the query nor a
+    /// releasable limit — which no result of `parametric_step_bounded`
+    /// contains, so it means the caller passed a number from somewhere else.
+    pub fn refined_row_target(&self, row: usize) -> Option<RefinedRow> {
+        let bs = self.backsolver();
+        let (n_t, bound_rows): (usize, Vec<BoundRow>) = match self.row_limit_view(&bs) {
+            Some(view) => (view.n_observers(), view.all_bound_rows().to_vec()),
+            None => (0, bs.bound_rows().unwrap_or(&[]).to_vec()),
+        };
+        let released = row >= self.n + n_t;
+        let primal = if released {
+            bound_rows.iter().find(|b| b.row == row)?.var_row
+        } else {
+            row
+        };
+        let target = if primal < self.n {
+            PathTarget::Variable(primal)
+        } else {
+            PathTarget::InequalityRow(primal - self.n)
+        };
+        Some(RefinedRow { target, released })
     }
 
     /// The inequality rows of this problem as watched limits, wrapped around

--- a/crates/pounce-convex/tests/issue_929_row_limit_on_the_convex_arm.rs
+++ b/crates/pounce-convex/tests/issue_929_row_limit_on_the_convex_arm.rs
@@ -63,8 +63,22 @@
 //! | `b: 4 → 0` | `(0.5, −0.5, 0.5, −0.5)`, row still pinned | `(0, 0, 0, 0)` | `(0,0,0,0)` |
 //! | `b: 2 → 1` | `(0.5, 2.0e-5, 0.5, 2.0e-5)` | `(0.25, 0.25, 0.25, 0.25)` | `(0.25,…)` |
 //!
-//! The third row is a **different branch**: there the row is in the active set
-//! with a multiplier of `4.1e-5`, so the release happens at fraction `8.2e-5`
+//! and the same two directions through `parametric_step_bounded`, which was
+//! augmented in a follow-up commit on the same branch:
+//!
+//! | direction | before | after | truth |
+//! |---|---|---|---|
+//! | `b: 0 → 4` | `x₀+x₂ = 2.133`, **1.133 past the limit**, `x₁` pinned correctly on the way | reproduces the re-solve to `< 1e-8` | 1.0 |
+//! | `b: 4 → 0` | `(0.5, −0.5, 0.5, −0.5)`, row reported binding | reproduces the re-solve to `< 1e-8` | `(0,0,0,0)` |
+//!
+//! Both are **exact**, not close: the target's whole active set is reached in
+//! one shot, and for a QP fix-relax with the right active set is the re-solve.
+//! The "before" column of each is recomputed here by
+//! `refined_unaugmented`, which drives `refine_step_onto_bounds` straight
+//! against `QpKktBacksolver`, rather than quoted.
+//!
+//! The third row of the first table is a **different branch**: there the row
+//! is in the active set with a multiplier of `4.1e-5`, so the release happens at fraction `8.2e-5`
 //! rather than in the middle of the walk. Per the branch rule in CLAUDE.md, a
 //! fixture that only ever released a healthy multiplier would say nothing
 //! about it.
@@ -83,7 +97,7 @@
 //! | mutation | tests that go red |
 //! |---|---|
 //! | `primal_box` stops appending the observers, so they fall outside the walk's primal prefix — the effect adjoining them at the *end* of the compound vector would have | `a_row_the_step_would_cross_stops_the_walk`, `an_active_row_whose_multiplier_turns_is_released`, `a_barely_active_row_is_released_at_once`, `the_variable_bound_is_still_released_through_the_view` |
-//! | observer box sides swapped (`limit` as the lower bound) | six of the twelve, including `the_observers_are_inert_when_no_limit_is_reached` — the walk stops at fraction ≈ 0 on a step that crosses nothing |
+//! | observer box sides swapped (`limit` as the lower bound) | nine of the eighteen, including both inertness controls (`the_observers_are_inert_when_no_limit_is_reached`, `the_observers_add_nothing_to_a_refinement_that_reaches_no_limit`) — the walk stops at fraction ≈ 0 and the refinement pins, on a step that crosses nothing |
 //! | `base_value` set to `0` rather than `Gⱼ·x` | `a_barely_active_row_is_released_at_once` |
 //! | `RowLimitView::fold` drops the `G_wᵀ r_t` fold | `a_row_the_step_would_cross_stops_the_walk`, `releasing_a_row_moves_its_force_onto_the_observer` |
 //! | `RowLimitView::unfold` drops `r_mu` from `dt` | `the_triangular_solve_is_the_augmented_system` `[core]` |
@@ -94,6 +108,10 @@
 //! | base bound rows dropped from `RowLimitView::bound_rows` | `the_variable_bound_is_still_released_through_the_view`, `an_active_row_whose_multiplier_turns_is_released` |
 //! | base entries dropped from `RowLimitView::lift_multipliers` | the same two — the walk releases a row only when it is in *both* lists, which is why one type owns both |
 //! | the augmentation is applied on the conic path too | `a_conic_model_keeps_the_unaugmented_walk`, on its `boundary-far` leg |
+//! | `parametric_step_bounded` keeps the unaugmented backsolver — the refinement's defect restored | `a_row_the_refinement_would_cross_stops_it`, `an_active_row_the_refinement_releases` |
+//! | `RowLimitView::lift_step` zero-fills the observers instead of evaluating `dt = G_w dx` | `a_row_the_refinement_would_cross_stops_it`; `lifting_a_step_agrees_with_solving_it` `[core]`. The release direction stays **green** — its condition is read off the multiplier, not the observer's motion — so the reach test is the only one here that sees it |
+//! | `refined_row_target` reports every row as a pin, dropping the release lookup | `an_active_row_the_refinement_releases` |
+//! | `refined_row_target` maps with `n_t = 0`, the pre-gh#929 layout, so an observer decodes as a variable | `a_row_the_refinement_would_cross_stops_it` |
 //!
 //! # What this file is NOT evidence about
 //!
@@ -115,19 +133,21 @@
 //!   that at scale.
 //! - **Two-sided rows.** `WatchedRow` is one-sided on purpose; a range row is
 //!   two watched rows and no fixture here has one.
-//! - **`parametric_step_bounded` on this arm**, which is *not* augmented and
-//!   still carries the whole defect. Measured on this file's own fixture, at
-//!   `activity_tol = 1e-7` and `bound_eps = 1e-8`: walking `b: 0 -> 4` it
-//!   returns `x0 + x2 = 2.1333`, **1.1333 past the stated cap of 1.0**, and
-//!   coming back `b: 4 -> 0` it leaves `(0.5, -0.5, 0.5, -0.5)` with the row
-//!   still pinned at `1.0` where the truth is the origin -- the same two
-//!   numbers the module docs quote as the walk's *pre*-gh#929 behaviour.
-//!   Wiring the view in is not the same edit as it was for the walk: this
-//!   entry point returns `refine_step_onto_bounds`'s mixed list of released
-//!   multiplier rows and pinned primal rows, so augmenting it shifts the
-//!   meaning of half that list and needs an API decision plus a fixture of
-//!   its own. The NLP arm has no such gap, because gh#928 widened its box
-//!   globally rather than through a view.
+//! - **The rest of the convex corpus.** `parametric_step_bounded`'s augmented
+//!   branch is reached **3 times across every test in `pounce-convex`**
+//!   (measured, by an `eprintln` in the branch), and all three are this
+//!   file's own. `convex_sens_release.rs`, `convex_sens_backsolver.rs` and
+//!   `convex_soc_sensitivity.rs` reach it **zero** times — they are conic, or
+//!   have no inequality rows. So their staying green across that follow-up is
+//!   evidence of no collateral damage and *not* evidence about the fix; the
+//!   fixture below is the only evidence there is.
+//! - **The mixed list's two spaces, beyond one entry each.** The list
+//!   `parametric_step_bounded` returns names a release by its multiplier row
+//!   and a pin by its primal row, and `refined_row_target` is the only
+//!   decoder. Every case here returns exactly two entries of one kind — two
+//!   pins going up, two releases coming down. A result mixing a release and a
+//!   pin in the same list is decodable by construction (the two ranges do not
+//!   overlap) but is not exercised by any fixture.
 //! - **Rows with no `x` coefficients**, empty `G`, or `m_ineq = 0` — the
 //!   augmentation is skipped for the last of these and the rest are unbuilt.
 
@@ -135,11 +155,13 @@ use pounce_convex::QpOptions;
 use pounce_convex::cones::ConeSpec;
 use pounce_convex::ipm::{solve_qp_ipm, solve_socp_ipm};
 use pounce_convex::qp::{QpProblem, QpSolution, QpStatus, Triplet};
-use pounce_convex::sensitivity::{PathTarget, QpSensitivity};
+use pounce_convex::sensitivity::{PathTarget, QpSensitivity, RefinedRow};
 use pounce_feral::FeralSolverInterface;
 use pounce_linsol::SparseSymLinearSolverInterface;
 use pounce_sens_core::backsolver::SensBacksolver;
-use pounce_sens_core::boundcheck::{BoundMultiplier, PathSegment, step_along_path};
+use pounce_sens_core::boundcheck::{
+    BoundMultiplier, PathSegment, RefineStop, refine_step_onto_bounds, step_along_path,
+};
 use pounce_sens_core::rowlimit::{RowLimitView, WatchedRow};
 
 fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
@@ -630,4 +652,243 @@ fn releasing_a_row_moves_its_force_onto_the_observer() {
         "the observer read {dt}, but dx moved the row by {}",
         want[0] + want[2],
     );
+}
+
+// ---------------------------------------------------------------------------
+// The one-shot refinement.
+//
+// `parametric_step_path` walks; `parametric_step_bounded` repairs a single
+// linear predictor. gh#929 taught the first about row limits and left the
+// second carrying the whole defect, which this section closes. The two
+// entry points reach different code — the walk re-forms its direction at each
+// breakpoint and never has a multiplier left to move, while the refinement
+// decides every condition at the base point and needs
+// `solve_released_step`'s shift, the one
+// `releasing_a_row_moves_its_force_onto_the_observer` pins at unit level.
+// ---------------------------------------------------------------------------
+
+/// The refinement, and the point it lands on — the counterpart of [`walk`].
+fn refined(b0: f64, delta: f64) -> (Vec<f64>, Vec<usize>, RefineStop, QpSensitivity) {
+    let prob = model(b0);
+    let sol = solved(b0, QpOptions::default().tol);
+    let mut sens = QpSensitivity::build(&prob, &sol, &QpOptions::default(), ACTIVITY_TOL, backend)
+        .expect("the fixture must build a sensitivity");
+    let (dx, rows, stop) = sens
+        .parametric_step_bounded(&[0], &[delta], EPS, 32)
+        .expect("the refinement must answer");
+    let x = sol.x.iter().zip(&dx).map(|(a, d)| a + d).collect();
+    (x, rows, stop, sens)
+}
+
+/// The same refinement with the observers taken away: `refine_step_onto_bounds`
+/// driven straight against `QpKktBacksolver`, which is exactly what
+/// `parametric_step_bounded` did before this section existed. The "before"
+/// column, recomputed rather than quoted — the counterpart of
+/// [`walk_unaugmented`].
+fn refined_unaugmented(b0: f64, delta: f64) -> Vec<f64> {
+    let prob = model(b0);
+    let sol = solved(b0, QpOptions::default().tol);
+    let sens = QpSensitivity::build(&prob, &sol, &QpOptions::default(), ACTIVITY_TOL, backend)
+        .expect("the fixture must build a sensitivity");
+    let bs = sens.backsolver();
+    let mut rhs = vec![0.0; bs.dim()];
+    rhs[prob.n] = delta;
+    let mut dx_plain = vec![0.0; bs.dim()];
+    assert!(bs.solve(&rhs, &mut dx_plain), "the plain step must answer");
+    let lo: Vec<f64> = (0..prob.n).map(|j| prob.lb[j]).collect();
+    let hi: Vec<f64> = (0..prob.n).map(|j| prob.ub[j]).collect();
+    let mults: Vec<BoundMultiplier> = bs
+        .bound_rows()
+        .unwrap_or(&[])
+        .iter()
+        .map(|br| BoundMultiplier {
+            row: br.row,
+            base: if br.lower {
+                sol.z_lb[br.var_row]
+            } else {
+                sol.z_ub[br.var_row]
+            },
+        })
+        .collect();
+    let (dx, _, _) =
+        refine_step_onto_bounds(&bs, &dx_plain, &sol.x, &lo, &hi, &mults, &rhs, EPS, EPS, 32)
+            .expect("the unaugmented refinement answers too — wrongly, which is the point");
+    sol.x.iter().zip(&dx).map(|(a, d)| a + d).collect()
+}
+
+/// The reach half. `b: 0 -> 4` crosses the row at `b = 2.0` and the bound at
+/// `b = 2.6`; pinning both is the whole active set of the target, so for a QP
+/// the one-shot answer is not an approximation — it is the re-solve.
+#[test]
+fn a_row_the_refinement_would_cross_stops_it() {
+    let (x, rows, stop, sens) = refined(0.0, 4.0);
+    let want = oracle(4.0);
+    assert!(
+        max_err(&x, &want) < 1e-8,
+        "the refinement {x:?} does not reproduce the re-solve {want:?}",
+    );
+    assert!(
+        row_value(&x) <= H0 + 1e-8,
+        "the answer is {:.6} past the row limit",
+        row_value(&x) - H0,
+    );
+    assert_eq!(stop, RefineStop::Settled, "rows {rows:?}");
+
+    // Both conditions are pins, and the row is named as a row.
+    let targets: Vec<RefinedRow> = rows
+        .iter()
+        .map(|&r| {
+            sens.refined_row_target(r)
+                .unwrap_or_else(|| panic!("row {r} must resolve, from {rows:?}"))
+        })
+        .collect();
+    assert_eq!(targets.len(), 2, "{targets:?}");
+    assert!(targets.iter().all(|t| !t.released), "{targets:?}");
+    assert!(
+        targets
+            .iter()
+            .any(|t| t.target == PathTarget::InequalityRow(0)),
+        "the row limit must be reported as a row: {targets:?}",
+    );
+    assert!(
+        targets.iter().any(|t| t.target == PathTarget::Variable(1)),
+        "the variable bound must still be reported: {targets:?}",
+    );
+}
+
+/// The size of the defect, as a number this file computes.
+#[test]
+fn the_unaugmented_refinement_runs_past_the_row() {
+    let x = refined_unaugmented(0.0, 4.0);
+    let over = row_value(&x) - H0;
+    assert!(
+        (over - 1.1333333).abs() < 1e-5,
+        "the pre-fix refinement was supposed to overshoot the row limit by \
+         ~1.1333, got {over} from {x:?}",
+    );
+    // It is not a small perturbation of the truth either — and note that it
+    // pinned `x₁` correctly on the way, which is what made it plausible.
+    assert!(max_err(&x, &oracle(4.0)) > 0.5, "{x:?}");
+    assert!((x[1] - UB1).abs() < 1e-8, "{x:?}");
+}
+
+/// The release half, which is the one the walk cannot stand in for: here the
+/// row's multiplier is still `1.7` when the decision is taken, so
+/// `solve_released_step`'s shift has real force to move.
+#[test]
+fn an_active_row_the_refinement_releases() {
+    let (x, rows, stop, sens) = refined(4.0, -4.0);
+    let want = oracle(0.0);
+    assert!(
+        max_err(&x, &want) < 1e-8,
+        "the refinement {x:?} does not reproduce the re-solve {want:?}",
+    );
+    assert_eq!(stop, RefineStop::Settled, "rows {rows:?}");
+
+    let targets: Vec<RefinedRow> = rows
+        .iter()
+        .map(|&r| {
+            sens.refined_row_target(r)
+                .unwrap_or_else(|| panic!("row {r} must resolve, from {rows:?}"))
+        })
+        .collect();
+    assert_eq!(targets.len(), 2, "{targets:?}");
+    assert!(
+        targets.iter().all(|t| t.released),
+        "both limits are released, not pinned: {targets:?}",
+    );
+    assert!(
+        targets
+            .iter()
+            .any(|t| t.target == PathTarget::InequalityRow(0)),
+        "the row must be among the released: {targets:?}",
+    );
+    assert!(
+        targets.iter().any(|t| t.target == PathTarget::Variable(1)),
+        "the bound release must survive the augmentation: {targets:?}",
+    );
+}
+
+/// The reverse direction's "before" column, which is worse than a lost
+/// record: the answer is wrong *and* the report says the cap is binding.
+#[test]
+fn the_unaugmented_refinement_holds_a_row_the_solution_has_left() {
+    let x = refined_unaugmented(4.0, -4.0);
+    assert!(
+        (row_value(&x) - H0).abs() < 1e-8,
+        "the pre-fix refinement was supposed to hold the row at its limit, \
+         got {:.9} from {x:?}",
+        row_value(&x),
+    );
+    let want = [0.5, -0.5, 0.5, -0.5];
+    assert!(
+        max_err(&x, &want) < 1e-6,
+        "the pre-fix answer was measured at {want:?}, got {x:?}",
+    );
+    assert!(
+        max_err(&x, &oracle(0.0)) > 0.4,
+        "and far from the truth: {x:?}"
+    );
+}
+
+/// A step that reaches nothing must be the plain step, or the observers are
+/// manufacturing conditions rather than watching for them. The counterpart of
+/// `the_observers_are_inert_when_no_limit_is_reached`.
+#[test]
+fn the_observers_add_nothing_to_a_refinement_that_reaches_no_limit() {
+    let (x, rows, stop, _) = refined(0.0, 0.4);
+    assert!(
+        rows.is_empty(),
+        "no condition should have been added: {rows:?}"
+    );
+    assert_eq!(stop, RefineStop::Settled);
+    let want = oracle(0.4);
+    assert!(
+        max_err(&x, &want) < 1e-9,
+        "{x:?} should be the plain step, which here is exact: {want:?}",
+    );
+}
+
+/// The conic guard, on the refinement rather than the walk. `row_limit_view`
+/// is one helper, but a gate that is only ever exercised through one caller
+/// is only evidence about that caller — the apex fixture is the one that
+/// would notice, since there every `G` row sits at its `h = 0` and observers
+/// would be born at their limits.
+#[test]
+fn a_conic_model_keeps_the_unaugmented_refinement() {
+    let opts = QpOptions {
+        tol: 1e-11,
+        ..Default::default()
+    };
+    let cones = [ConeSpec::SecondOrder(3)];
+    let apex = QpProblem {
+        n: 4,
+        p_lower: vec![tri(0, 0, 1.0), tri(1, 1, 1.0), tri(2, 2, 1.0)],
+        c: vec![0.0, 0.0, -1.0, 5.0],
+        a: vec![tri(0, 0, 1.0), tri(0, 2, 1.0)],
+        b: vec![1.0],
+        g: vec![tri(0, 3, -1.0), tri(1, 0, -1.0), tri(2, 1, -1.0)],
+        h: vec![0.0, 0.0, 0.0],
+        lb: vec![],
+        ub: vec![],
+    };
+    let db = 1e-3;
+    let sol = solve_socp_ipm(&apex, &cones, &opts, backend);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    let mut sens = QpSensitivity::build_conic(&apex, &cones, &sol, &opts, ACTIVITY_TOL, backend)
+        .expect("the apex must build a sensitivity");
+    let (dx, rows, _) = sens
+        .parametric_step_bounded(&[0], &[db], EPS, 32)
+        .expect("the conic refinement must still answer");
+    assert!(
+        rows.is_empty(),
+        "the conic arm must add no row conditions, got {rows:?}",
+    );
+    for (j, w) in [0.0, 0.0, 1.0, 0.0].iter().enumerate() {
+        assert!(
+            (dx[j] / db - w).abs() < 1e-6,
+            "dx{j}/db = {}, want {w}",
+            dx[j] / db,
+        );
+    }
 }

--- a/crates/pounce-sens-core/src/rowlimit.rs
+++ b/crates/pounce-sens-core/src/rowlimit.rs
@@ -276,6 +276,31 @@ impl<B: SensBacksolver> RowLimitView<B> {
         Some(out)
     }
 
+    /// A base-space **solution** lifted into this view's space, the
+    /// left-hand-side counterpart of [`Self::lift_rhs`].
+    ///
+    /// The observer coordinate of a step is `dt = G_w dx`, and the
+    /// adjoined multiplier of a step whose right-hand side came through
+    /// `lift_rhs` is zero — that right-hand side puts nothing in the
+    /// `t` or `mu` rows. So this is [`Self::unfold`] with both those
+    /// pieces zero, written that way rather than open-coded so a lifted
+    /// step cannot drift from what [`SensBacksolver::solve`] returns
+    /// for the same input. `lifting_a_step_agrees_with_solving_it`
+    /// is what holds the two together.
+    ///
+    /// A caller that already has the base step in hand — every one
+    /// does, since the plain step is what the refinement corrects —
+    /// pays two sparse mat-vecs here instead of a second back-solve.
+    pub fn lift_step(&self, base_lhs: &[Number]) -> Option<Vec<Number>> {
+        if base_lhs.len() != self.base_dim {
+            return None;
+        }
+        let zeros = vec![0.0; self.rows.len()];
+        let mut out = vec![0.0; self.dim()];
+        self.unfold(base_lhs, &zeros, &zeros, &mut out);
+        Some(out)
+    }
+
     /// Every releasable row of this view, base and watched alike, in
     /// this view's index space. Same slice
     /// [`SensBacksolver::bound_rows`] returns.
@@ -579,6 +604,69 @@ mod tests {
     /// anything: with a single watched row every ordering of the
     /// observers is the same ordering, which is exactly the shape the
     /// convex fixture has.
+    /// [`RowLimitView::lift_step`] is the cheap route to the augmented
+    /// plain step, and cheap is only worth having if it is the same
+    /// answer: a caller with the base step in hand skips a back-solve
+    /// by using it.
+    ///
+    /// The mutation this catches is the tempting one — lifting a step
+    /// by zero-filling the observers instead of evaluating
+    /// `dt = G_w dx`. That reads as a step whose watched rows do not
+    /// move at all, so nothing ever reaches a limit and the caller is
+    /// back to the defect it was fixing, with no error anywhere.
+    #[test]
+    fn lifting_a_step_agrees_with_solving_it() {
+        let n_x = 3;
+        let rows = vec![
+            watched(None, vec![(0, 1.0), (2, -0.5)]),
+            watched(Some((3, 0.7)), vec![(1, 2.0)]),
+        ];
+        let b = base(Vec::new());
+        let base_dim = b.n;
+        let view = RowLimitView::new(b, n_x, rows).expect("the view must build");
+
+        // A base-space right-hand side, lifted, solved in the view.
+        let base_rhs: Vec<Number> = vec![0.4, -1.1, 0.9, 0.3, -0.6];
+        let lifted_rhs = view.lift_rhs(&base_rhs).expect("the rhs lifts");
+        let mut want = vec![0.0; view.dim()];
+        assert!(view.solve(&lifted_rhs, &mut want), "the view must solve");
+
+        // The same thing from the base answer alone.
+        let mut base_lhs = vec![0.0; base_dim];
+        assert!(
+            view.base.solve(&base_rhs, &mut base_lhs),
+            "the base must solve",
+        );
+        let got = view.lift_step(&base_lhs).expect("the step lifts");
+
+        for (i, (g, w)) in got.iter().zip(&want).enumerate() {
+            assert!(
+                (g - w).abs() < 1e-10,
+                "row {i}: lift_step {g} against solve {w}\n{got:?}\n{want:?}",
+            );
+        }
+        // Not vacuous: the observers actually moved.
+        assert!(
+            got[n_x..n_x + 2].iter().any(|v| v.abs() > 1e-6),
+            "the observers read {:?}, so this test would pass on a \
+             zero-filling lift",
+            &got[n_x..n_x + 2],
+        );
+    }
+
+    /// Length is the only thing `lift_step` can refuse, and refusing is
+    /// the point: a base answer of the wrong width is a caller holding
+    /// the view's own vector by mistake, which would otherwise scatter
+    /// into the observer rows.
+    #[test]
+    fn lift_step_refuses_a_vector_that_is_not_the_base() {
+        let rows = vec![watched(None, vec![(0, 1.0)])];
+        let view = RowLimitView::new(base(Vec::new()), 3, rows).expect("the view must build");
+        assert!(view.lift_step(&vec![0.0; view.dim()]).is_none());
+        assert!(view.lift_step(&[]).is_none());
+        assert!(view.lift_step(&vec![0.0; 5]).is_some());
+    }
+
     #[test]
     fn each_active_row_keeps_its_own_observer() {
         let n_x = 3;


### PR DESCRIPTION
`QpSensitivity::parametric_step_bounded` — the convex arm's one-shot
fix-relax — could return a point past a limit written as a constraint
row, with no record that anything was crossed. #931 fixed exactly this
for the *walk* and left the refinement carrying the whole defect; the
`issue_929_...` fixture file recorded the gap rather than closing it,
and this closes it.

Follow-up to #929 / #931. No issue was filed for it; the gap was
recorded in that file's "What this file is NOT evidence about" block,
which this PR rewrites.

## The defect

An active-set KKT has no primal coordinate for a constraint row:

```text
[ H   Aᵀ  B_aᵀ ]
[ A   0   0    ]
[ B_a 0   0    ]
```

`B_a` holds the *active* rows only, so a row `Gⱼ x ≤ hⱼ` that is
**inactive** appears nowhere at all. The refinement had nothing to pin.
An **active** row has a multiplier row but still no primal coordinate,
so it could not be reported as a `BoundRow` either, and a perturbation
driving its multiplier negative held a row the solution had left.

Measured on a four-variable QP whose cap `x₀ + x₂ ≤ 1` is written as a
row, with a variable bound `x₁ ≤ 0.8` that the same perturbation also
crosses. Both "before" columns are **recomputed** by the new
`refined_unaugmented` helper — `refine_step_onto_bounds` driven straight
against `QpKktBacksolver` — rather than quoted:

| direction | before | after | truth |
|---|---|---|---|
| `b: 0 → 4` | `x₀+x₂ = 2.133`, **1.133 past the stated cap** | reproduces the re-solve to `< 1e-8` | 1.0 |
| `b: 4 → 0` | `(0.5, −0.5, 0.5, −0.5)`, row reported binding | reproduces the re-solve to `< 1e-8` | `(0,0,0,0)` |

The forward case is the one worth dwelling on: it pinned the *variable*
bound correctly on the way, which is what made a wrong answer look like
a right one. The reverse is worse than a lost record — the answer is
wrong **and** the report says the cap is binding.

Both are now **exact**, not close. The whole active set of the target is
reached in one shot, and for a QP fix-relax with the right active set
*is* the re-solve.

## The change

Three pieces, all small, because #929 built the machinery for this:

* **`RowLimitView::lift_step`** (new, `pounce-sens-core`). The plain step
  is already in hand when the refinement starts — it is the thing being
  corrected — so lifting it costs two sparse mat-vecs instead of a second
  back-solve. Written as `unfold` with the `t` and `mu` pieces zero
  rather than open-coded, so a lifted step cannot drift from what
  `SensBacksolver::solve` returns for the same input;
  `lifting_a_step_agrees_with_solving_it` holds the two together.
* **`parametric_step_bounded` routes through `row_limit_view`**, the same
  helper the walk uses, with the same skip conditions — notably the conic
  arm, where `active_rows` holds a cone normal rather than a set of `G`
  rows. The observer block is triangular in the adjoined variables, so
  this costs **no extra factorization**.
* **`RefinedRow { target: PathTarget, released: bool }` and
  `QpSensitivity::refined_row_target`.**

### The API consequence, stated plainly

The `Vec<usize>` `parametric_step_bounded` returns is **mixed**:
`refine_step_onto_bounds` names a release by its *multiplier* row and a
pin by its *primal* row, and after this change a primal row at or past
`n` is an **observer** rather than a variable. The two ranges do not
overlap, so the number is decodable — but only by code that knows the
layout, and indexing a variable-length vector by one of them returns a
*neighbouring* variable's answer. That is the #450 hazard and
`/sens-review` entry 1. So there is exactly one decoder,
`refined_row_target`, on the precedent `path_segment_target` set for the
walk. It rebuilds the view rather than caching a map, so the mapping
cannot drift from the one the refinement actually ran against, and it
decodes a conic (unaugmented) result too.

The method has **no callers outside this crate's tests** — `PyQpSensitivity`
exposes only `parametric_step`, and `pounce-py`'s `parametric_step_bounded`
is the NLP `Solver`'s — so nothing downstream changes.

### Also fixed

Two doc defects in the same file, both pre-existing: the "Post-optimal
sensitivity for a solved convex QP" paragraph had been attached to
`PathTarget`, leaving `QpSensitivity` itself undocumented; and
`parametric_step_bounded` still said the refinement "**pins only**" when
`QpKktBacksolver::supports_release` has answered `true` for some time.

## Adversarial testing

Four mutations, every one **run** and the file restored and `cmp`-verified
afterwards, with the red list taken from what the run printed:

| mutation | tests that go red |
|---|---|
| `parametric_step_bounded` keeps the unaugmented backsolver — the defect restored | `a_row_the_refinement_would_cross_stops_it`, `an_active_row_the_refinement_releases` |
| `lift_step` zero-fills the observers instead of evaluating `dt = G_w dx` | `a_row_the_refinement_would_cross_stops_it`; `lifting_a_step_agrees_with_solving_it` `[core]` |
| `refined_row_target` reports every row as a pin, dropping the release lookup | `an_active_row_the_refinement_releases` |
| `refined_row_target` maps with `n_t = 0`, the pre-#929 layout, so an observer decodes as a variable | `a_row_the_refinement_would_cross_stops_it` |

The second row carries an asymmetry worth recording rather than
smoothing over: zero-filling `lift_step` leaves the **release** direction
green, because that condition is read off the multiplier and not off the
observer's motion. The reach test is the only one here that sees it.

Re-measuring the pre-existing "observer box sides swapped" row on the
enlarged file also moved it, 6/12 → **9/18**, and it now takes down both
inertness controls.

## Which branch the fixture reaches — the part that is not evidence

Per the branch rule in CLAUDE.md, I measured rather than assumed. With an
`eprintln` in the new branch, `parametric_step_bounded`'s augmented path
is reached **3 times across every test in `pounce-convex`**, and all three
are this file's own. `convex_sens_release.rs`, `convex_sens_backsolver.rs`
and `convex_soc_sensitivity.rs` reach it **zero** times — they are conic,
or have no inequality rows.

So their staying green is evidence of **no collateral damage and nothing
more**; the new fixture is the only evidence there is about the fix
itself. That is now written into the file's NOT-evidence block, along
with the note that no fixture returns a list mixing a release and a pin
together.

## Gates

- `issue_929_row_limit_on_the_convex_arm` **18/18** (6 new tests, 2 new helpers).
- `cargo test -p pounce-sensitivity -p pounce-py -p pounce-convex -p pounce-sens-core --release --no-fail-fast`: **96 binaries, 0 failed.**
- Invariance legs `sens_invariance_legs` 24, `sens_resolve_oracle` 12,
  `cd_split_pin_mapping` 4, `variable_scaling_sensitivity` 9 — all green.
- `cargo clippy` at CI's exact gate: **exit 0**. `cargo fmt --check` clean.
- `scripts/sweep-fixtures.sh`, both legs, head against an `a8ba895b`
  worktree: **194 fixture-legs each, empty diff.** Expected, and stated
  as a limit rather than a result — `refine_step_onto_bounds` is reached
  only from sensitivity accessors, never from a solve — so it is
  evidence of no collateral damage and not evidence about the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnRrvCSQou9Fkh1yoNZLnn
